### PR TITLE
[beeswax] Generates wrong syntax when SerDe is used

### DIFF
--- a/apps/beeswax/src/beeswax/templates/create_table_statement.mako
+++ b/apps/beeswax/src/beeswax/templates/create_table_statement.mako
@@ -74,9 +74,9 @@ ROW FORMAT \
     MAP KEYS TERMINATED BY '${table["map_key_terminator"] | n}'
 %     endif
 %   else:
-  SERDE ${table["serde_name"] | n}
+  SERDE '${table["serde_name"] | n}'
 %     if table["serde_properties"]:
-  WITH SERDEPROPERTIES ${table["serde_properties"] | n}
+  WITH SERDEPROPERTIES (${table["serde_properties"] | n})
 %     endif
 %   endif
 % endif


### PR DESCRIPTION
If SerDe is using as record format it generates next query:

``` sql
FORMAT SERDE org.apache.hadoop.hive.contrib.serde2.RegexSerDe
WITH SERDEPROPERTIES "input.regex" = "...", "output.format.string" = "..."
```

Where it needs to be:

``` sql
FORMAT SERDE 'org.apache.hadoop.hive.contrib.serde2.RegexSerDe'
WITH SERDEPROPERTIES ("input.regex" = "...", "output.format.string" = "...")
```

In placeholders and help blocks of SerDe properties fields there are no quotes and brackets, so it could be confusing to user to add them manually.
