### PR TITLE
HUE-1574 mako template engine setting error : 'ascii' codec can't decode...

### DIFF
--- a/desktop/core/src/desktop/lib/django_mako.py
+++ b/desktop/core/src/desktop/lib/django_mako.py
@@ -64,7 +64,7 @@ class DesktopLookup(TemplateCollection):
                             output_encoding=i18n.get_site_encoding(),
                             input_encoding=i18n.get_site_encoding(),
                             encoding_errors=ENCODING_ERRORS,
-                            default_filters=['unicode', 'escape'], 
+                            default_filters=['decode.utf8', 'unicode', 'escape'],
                             imports=IMPORTS)
     # TODO(philip): Make a django_aware default filter, that understands
     # django safe strings.  See http://www.makotemplates.org/docs/filtering.html.


### PR DESCRIPTION
... byte error

https://issues.cloudera.org/browse/HUE-1574
