### PR TITLE
HUE-1666 Query/Design name and description not saving

### DIFF
--- a/apps/beeswax/src/beeswax/templates/execute.mako
+++ b/apps/beeswax/src/beeswax/templates/execute.mako
@@ -700,9 +700,9 @@ ${layout.menubar(section='query')}
 
       $("#saveQuery").click(function () {
         $("<input>").attr("type", "hidden").attr("name", "saveform-name")
-                .attr("value", $("#query-name").data("data-value")).appendTo($("#advancedSettingsForm"));
+                .attr("value", $("#query-name").data("value")).appendTo($("#advancedSettingsForm"));
         $("<input>").attr("type", "hidden").attr("name", "saveform-desc")
-                .attr("value", $("#query-description").data("data-value")).appendTo($("#advancedSettingsForm"));
+                .attr("value", $("#query-description").data("value")).appendTo($("#advancedSettingsForm"));
         $("<input>").attr("type", "hidden").attr("name", "saveform-save").attr("value", "Save").appendTo($("#advancedSettingsForm"));
         checkAndSubmit();
       });


### PR DESCRIPTION
Can't change the query/design name or description.

When doing a "Save as..." for a new query/design, saves it with a blank name and description.

There was a patch in HUE-1573, but it didn't seem to resolve the issue.
