### PR TITLE
Fix for HUE-1666 - Design/Query name and description reverting on save

### DIFF
--- a/apps/beeswax/src/beeswax/templates/execute.mako
+++ b/apps/beeswax/src/beeswax/templates/execute.mako
@@ -733,9 +733,9 @@ ${layout.menubar(section='query')}
 
       $("#saveQuery").click(function () {
         $("<input>").attr("type", "hidden").attr("name", "saveform-name")
-                .attr("value", $("#query-name").data('value')).appendTo($("#advancedSettingsForm"));
+                .attr("value", $("#query-name").text()).appendTo($("#advancedSettingsForm"));
         $("<input>").attr("type", "hidden").attr("name", "saveform-desc")
-                .attr("value", $("#query-description").data('value')).appendTo($("#advancedSettingsForm"));
+                .attr("value", $("#query-description").text()).appendTo($("#advancedSettingsForm"));
         $("<input>").attr("type", "hidden").attr("name", "saveform-save").attr("value", "Save").appendTo($("#advancedSettingsForm"));
         checkAndSubmit();
       });


### PR DESCRIPTION
RE: HUE-1666

Reading content of query-name and query-description element instead of value works all the time, and not just if you haven't changed the values prior to a save.
