### PR TITLE
Allow saving hive results to fully-qualified name

### DIFF
--- a/apps/beeswax/src/beeswax/common.py
+++ b/apps/beeswax/src/beeswax/common.py
@@ -24,7 +24,7 @@ import re
 from django import forms
 
 
-HIVE_IDENTIFER_REGEX = re.compile("^[a-zA-Z0-9]\w*$")
+HIVE_IDENTIFER_REGEX = re.compile("(^[a-zA-Z0-9]\w*\.)?[a-zA-Z0-9]\w*$")
 
 DL_FORMATS = [ 'csv', 'xls' ]
 

--- a/apps/beeswax/src/beeswax/forms.py
+++ b/apps/beeswax/src/beeswax/forms.py
@@ -111,7 +111,16 @@ class SaveResultsForm(DependencyAwareForm):
         if tbl:
           try:
             if self.db is not None:
-              self.db.get_table('default', tbl) # Assumes 'default' DB
+              db_name = 'default'
+              name_parts = tbl.split(".")
+              if len(name_parts) == 1:
+                tbl_name = tbl
+              elif len(name_parts) == 2:
+                db_name, tbl_name = name_parts
+              else:
+                self._errors['target_table'] = self.error_class([_('Invalid table name')])
+
+              self.db.get_table(db_name, tbl_name)
             self._errors['target_table'] = self.error_class([_('Table already exists')])
             del cleaned_data['target_table']
           except Exception:

--- a/apps/beeswax/src/beeswax/server/dbms.py
+++ b/apps/beeswax/src/beeswax/server/dbms.py
@@ -243,6 +243,10 @@ class HiveServer2Dbms(object):
     design = query_history.design.get_design()
     database = design.query['database']
 
+    name_parts = target_table.split(".")
+    if len(name_parts) == 2:
+      database, target_table = name_parts
+
     # Case 1: Hive Server 2 backend or results straight from an existing table
     if result_meta.in_tablename:
       self.use(database)


### PR DESCRIPTION
This is a draft of the changes needed. I'm a bit new to Django so while I emulated what I saw in other parts of forms.py, I'm not certain that it's correct. Also, I couldn't find the grammar/rule for Hive database names, so the regex just reuses the rule for table names (alphanumeric, no leading underscore).
