### PR TITLE
[jobbrowser] Sort jobs by date by default

### DIFF
--- a/apps/jobbrowser/src/jobbrowser/templates/jobs.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/jobs.mako
@@ -110,7 +110,7 @@ ${ components.menubar() }
       "bAutoWidth": false,
       "sDom": "<'row'r>t<'row-fluid'<'dt-pages'p><'dt-records'i>>",
       "aaSorting": [
-        [1, "desc"]
+        [10, "desc"]
       ],
       "bProcessing": true,
       "bDeferRender": true,


### PR DESCRIPTION
Show newest jobs first.

Currently jobs are sorted by lexicographical value. Which means e.g. '9' > '11' and leads to confusion - users can't see their latest jobs.

My proposal is to show latest jobs first.
