### PR TITLE
Update describe_table.mako

### DIFF
--- a/apps/metastore/src/metastore/templates/describe_table.mako
+++ b/apps/metastore/src/metastore/templates/describe_table.mako
@@ -156,8 +156,8 @@ ${ components.menubar() }
                   <tbody>
                     % for name, value in table.properties:
                       <tr>
-                        <td>${ name }</td>
-                        <td>${ value }</td>
+                        <td>${ smart_unicode(name) }</td>
+                        <td>${ smart_unicode(value) }</td>
                       </tr>
                      % endfor
                   </tbody>


### PR DESCRIPTION
if value.contains(chinese):
    print "'ascii' codec can't decode byte 0xe4 in position 0: ordinal not in range(128)"
