### PR TITLE
Some browser(opera) does not seem to catch 'onbeforeunload' event.

### DIFF
--- a/apps/beeswax/src/beeswax/templates/watch_results.mako
+++ b/apps/beeswax/src/beeswax/templates/watch_results.mako
@@ -686,7 +686,7 @@ $(document).ready(function () {
   });
 
   % if app_name == 'impala':
-    window.onbeforeunload = function(e) {
+    window.onload = function(e) {
       $.ajax({url: "${ url(app_name + ':close_operation', query.id) }", type: 'post', async: false});
     }
   % endif


### PR DESCRIPTION
It is better to use 'onload' event than 'onbeforeunload' event.
