### PR TITLE
Fix postgresql Table and Column fetch queries in RDBMS App Navigator

### DIFF
--- a/desktop/libs/librdbms/src/librdbms/server/postgresql_lib.py
+++ b/desktop/libs/librdbms/src/librdbms/server/postgresql_lib.py
@@ -88,13 +88,13 @@ class PostgreSQLClient(BaseRDMSClient):
   def get_tables(self, database, table_names=[]):
     # Doesn't use database and only retrieves tables for database currently in use.
     cursor = self.connection.cursor()
-    cursor.execute("SELECT table_schema,table_name FROM information_schema.tables")
+    cursor.execute("SELECT table_name FROM information_schema.tables WHERE table_schema='%s'" % database)
     self.connection.commit()
     return [row[0] for row in cursor.fetchall()]
 
 
   def get_columns(self, database, table):
     cursor = self.connection.cursor()
-    cursor.execute("SHOW COLUMNS %s.%s" % (database, table))
+    cursor.execute("SELECT column_name FROM information_schema.columns WHERE table_schema='%s' and table_name='%s'" % (database, table))
     self.connection.commit()
     return [row[0] for row in cursor.fetchall()]


### PR DESCRIPTION
The query sent to Postgres in get_tables was erroneous and thus returned only database_name to the Navigator in the RDBMS app.

The get_columns function used MySQL syntax. Both of these queries are now fixed.
