### PR TITLE
[Oozie] XSS attack vulnerability

### DIFF
--- a/apps/oozie/src/oozie/models.py
+++ b/apps/oozie/src/oozie/models.py
@@ -1755,6 +1755,13 @@ class BundledCoordinator(models.Model):
   def get_parameters(self):
     return json.loads(self.parameters)
 
+  @property
+  def parameters_escapejs(self):
+    return self._escapejs_parameters_list(self.parameters)
+
+  def _escapejs_parameters_list(self, parameters):
+    return json.dumps(json.loads(parameters), cls=JSONEncoderForHTML)
+
 
 class Bundle(Job):
   kick_off_time = models.DateTimeField(default=datetime.today(), verbose_name=_t('Start'),

--- a/apps/oozie/src/oozie/templates/editor/edit_bundle.mako
+++ b/apps/oozie/src/oozie/templates/editor/edit_bundle.mako
@@ -319,7 +319,7 @@ ${ layout.menubar(section='bundles') }
       var ViewModel = function() {
         var self = this;
 
-        self.parameters = ko.observableArray(${ bundle.parameters | n });
+        self.parameters = ko.observableArray(${ bundle.parameters_escapejs | n });
         self.add_parameters = function() {
           self.parameters.push({name: "", value: ""});
         };

--- a/apps/oozie/src/oozie/templates/editor/edit_bundled_coordinator.mako
+++ b/apps/oozie/src/oozie/templates/editor/edit_bundled_coordinator.mako
@@ -42,7 +42,7 @@ $(document).ready(function () {
   var ViewModel = function() {
     var self = this;
 
-    self.edit_bundled_coordinator_parameters = ko.observableArray(${ bundled_coordinator_instance.parameters | n,unicode });
+    self.edit_bundled_coordinator_parameters = ko.observableArray(${ bundled_coordinator_instance.parameters_escapejs | n,unicode });
     self.add_edit_bundled_coordinator_parameters = function() {
       self.edit_bundled_coordinator_parameters.push({name: "", value: ""});
     };


### PR DESCRIPTION
Fixes #129
Hue is vulnerable to [XSS](http://en.wikipedia.org/wiki/Cross-site_scripting) attack. Steps to reproduce:
go to oozie editor -> bundle -> create ->  Advanced settings -> add:
name = 
```javascript
</script><script>alert('xss')</script>
```
![XSS](http://storage6.static.itmages.com/i/14/1204/h_1417721409_8690634_2fc32c1b58.png)

save this bundle. After selecting it you'll get XSS allert.