### PR TITLE
oozie.coord.actions.default.length and latest coordinator displayed actions

### DIFF
--- a/apps/oozie/src/oozie/views/dashboard.py
+++ b/apps/oozie/src/oozie/views/dashboard.py
@@ -740,7 +740,10 @@ def massaged_coordinator_actions_for_json(coordinator, oozie_bundle):
       'missingDependencies': action.missingDependencies
     }
 
-    actions.insert(0, massaged_action)
+    actions.append(massaged_action)
+
+  # sorting for oozie old versions backward compatibility
+  actions.sort(key=lambda k: k['number'],reverse=True)
 
   return actions
 

--- a/desktop/libs/liboozie/src/liboozie/oozie_api.py
+++ b/desktop/libs/liboozie/src/liboozie/oozie_api.py
@@ -160,6 +160,7 @@ class OozieApi(object):
   def get_coordinator(self, jobid):
     params = self._get_params()
     params.update({'len': -1})
+    params.update({'order': 'desc'})
     resp = self._root.get('job/%s' % (jobid,), params)
     return Coordinator(self, resp)
 


### PR DESCRIPTION
Oozie configuration can have 'oozie.coord.actions.default.length' parameter which overloads oozie 'len' param, and Hue may not display latest coordinator actions if they are exceeding this value. Since https://issues.apache.org/jira/browse/OOZIE-1754 oozie can sort coordinator actions.
We need to request oozie to sort coordinator actions in descending order and display them correctly by dashboard.py.
