### PR TITLE
Replace 'None' with 'NULL' in table sample

### DIFF
--- a/apps/metastore/src/metastore/templates/sample.mako
+++ b/apps/metastore/src/metastore/templates/sample.mako
@@ -37,7 +37,13 @@ from django.utils.translation import ugettext as _
       % for i, row in enumerate(sample):
       <tr>
         % for item in row:
-        <td>${ smart_unicode(item, errors='ignore') }</td>
+        <td>
+          % if item is None:
+            NULL
+          % else:
+            ${ escape(smart_unicode(item, errors='ignore')).replace(' ', '&nbsp;') | n,unicode }
+          % endif
+        </td>
         % endfor
       </tr>
       % endfor


### PR DESCRIPTION
There was an inconsistency between the table samples shown in the metastore app to the ones accessible from the left sidebar of the hive/impala apps. Nulls in the data were coming through as "None" rather than NULL, so this patch fixes that (copied code block from describe_table.mako). 

(p.s. do I need to create a JIRA too?)