### PR TITLE
[oozie] locking "save" button during workflow saving

### DIFF
--- a/apps/oozie/src/oozie/templates/editor/edit_workflow.mako
+++ b/apps/oozie/src/oozie/templates/editor/edit_workflow.mako
@@ -686,6 +686,7 @@ function save_workflow(callback) {
     _callbackFn = callback;
   }
   workflow.loading(true);
+  $("#btn-save-wf").button('loading');
   if (kill_view_model.enabled()) {
     if (kill_view_model.isValid()) {
       workflow.save({ success: _callbackFn, error: workflow_save_error });


### PR DESCRIPTION
Double clicking "Save" button on workflow edit page performs two unsynchronized requests to the server. Even on simple one-action workflow it messes data in database and makes workflow unable to be submitted or exported.

Appropriate resets on save button has already beed added in https://github.com/cloudera/hue/commit/d5110c63e086a0624a67ff77fc724761f05da54b