### PR TITLE
The csrf_token was missing from the openid login template

### DIFF
--- a/desktop/libs/libopenid/src/libopenid/templates/openid-login.html
+++ b/desktop/libs/libopenid/src/libopenid/templates/openid-login.html
@@ -115,6 +115,7 @@
   <div class="row">
     <div class="login-content">
       <form method="POST" action="{{ action }}" class="well">
+        {% csrf_token %}
         <img id="logo" src="/static/desktop/art/hue-login-logo.png" data-orig="/static/desktop/art/hue-login-logo.png"
              data-hover="/static/desktop/art/hue-login-logo-skew.png"/>
 


### PR DESCRIPTION
Quick fix, for missing csrf token from the openid plugin