### PR TITLE
HUE-2707 Allow sample on partitioned tables in strict mode.

### DIFF
--- a/apps/beeswax/src/beeswax/server/dbms.py
+++ b/apps/beeswax/src/beeswax/server/dbms.py
@@ -185,7 +185,11 @@ class HiveServer2Dbms(object):
     """No samples if it's a view (HUE-526)"""
     if not table.is_view:
       limit = min(100, BROWSE_PARTITIONED_TABLE_LIMIT.get())
-      hql = "SELECT * FROM %s.%s LIMIT %s" % (database, table.name, limit)
+      partition_query = ""
+      if table.partition_keys:
+        partitions = self.get_partitions(database, table, 1)
+        partition_query = 'WHERE ' + ' AND '.join(["%s='%s'" % (table.partition_keys[idx].name, key) for idx, key in enumerate(partitions[0].values)])
+      hql = "SELECT * FROM `%s.%s` %s LIMIT %s" % (database, table.name, partition_query, limit)
       query = hql_query(hql)
       handle = self.execute_and_wait(query, timeout_sec=5.0)
 


### PR DESCRIPTION
Submitting a pull request as requested in ticket HUE-2707 for allowing the showing of samples in partitioned tables.

Reworked the patch to include in Romain's code improvement suggestions.