### PR TITLE
fixing extra bracket and missing paren in ext-py/parquet/bitstring.py

### DIFF
--- a/desktop/core/ext-py/parquet-python/parquet/bitstring.py
+++ b/desktop/core/ext-py/parquet-python/parquet/bitstring.py
@@ -1,7 +1,4 @@
-
 SINGLE_BIT_MASK =  [1 << x for x in range(7, -1, -1)]
-
-]
 
 class BitString(object):
 
@@ -10,7 +7,6 @@ class BitString(object):
 		self.offset = offset if offset is not None else 0
 		self.length = length if length is not None else 8 * len(data) - self.offset 
 
-
 	def __getitem__(self, key):
 		try:
 			start = key.start
@@ -18,5 +14,6 @@ class BitString(object):
 		except AttributeError:
 			if key < 0 or key >= length:
 				raise IndexError()
-			byte_index, bit_offset = divmod(self.offset + key), 8)
+			byte_index, bit_offset = (divmod(self.offset + key), 8)
 			return self.bytes[byte_index] & SINGLE_BIT_MASK[bit_offset]
+


### PR DESCRIPTION
It looks like this file has an extra ] and a missing (.  

This file doesn't compile under Python 2.7:

```
$ python desktop/core/ext-py/parquet-python/parquet/bitstring.py
  File "desktop/core/ext-py/parquet-python/parquet/bitstring.py", line 4
    ]
    ^
SyntaxError: invalid syntax
$ python desktop/core/ext-py/parquet-python/parquet/bitstring.py
  File "desktop/core/ext-py/parquet-python/parquet/bitstring.py", line 19
    byte_index, bit_offset = divmod(self.offset + key), 8)
                                                         ^
SyntaxError: invalid syntax
```

Interestingly, the ] bracket was deleted [upstream](https://github.com/jcrobak/parquet-python/commit/a11b59454e9e0f01338814225a97ea30b085c6fc), but the ( paren wasn't added?

I've started a pull request upstream.
