### PR TITLE
Fix to allow build w/ OpenSSL >= 1.0.2a

### DIFF
--- a/desktop/core/ext-py/pyopenssl/OpenSSL/crypto/crl.c
+++ b/desktop/core/ext-py/pyopenssl/OpenSSL/crypto/crl.c
@@ -3,7 +3,7 @@
 #include "crypto.h"
 
 
-static X509_REVOKED * X509_REVOKED_dup(X509_REVOKED *orig) {
+X509_REVOKED * X509_REVOKED_dup(X509_REVOKED *orig) {
     X509_REVOKED *dupe = NULL;
 
     dupe = X509_REVOKED_new();


### PR DESCRIPTION
This fix allows pyopenssl == 0.13 build against OpenSSL library headers >= 1.0.2a.

More information can be found [here](https://github.com/cloudera/hue/issues/205).

Let me know if you have any questions!

Chris Stephens
Netflix, Inc