### PR TITLE
[oozie] untriggered oozie coordinators break hue

### DIFF
--- a/desktop/libs/liboozie/src/liboozie/types.py
+++ b/desktop/libs/liboozie/src/liboozie/types.py
@@ -274,6 +274,9 @@ class BundleAction(Action):
 
   def get_progress(self):
     """How much more time before the next action."""
+    if self.lastAction is None:
+      return 0
+      
     next = mktime(parse_timestamp(self.lastAction))
     start = mktime(parse_timestamp(self.startTime))
     end = mktime(parse_timestamp(self.endTime))


### PR DESCRIPTION
# How to reproduce

1. create some workflows in some coordinators inside a bundle.
2. mark the coordinators for a startTime of sometime in the future.
3. submit the jobs to oozie.
4. go to hue -> bundles
5. click on the bundle you just submitted.

Expected result:

you see the bundle with all of its coordinators.

Actual result:

you get this situation: https://community.cloudera.com/t5/Web-UI-Hue-Beeswax/HTTP-500-error-launching-Oozie-bundle/td-p/26967

# my theory

I'm not 100% familiar with the hue codebase but based on that stacktrace above (and my identical ones) it looks like to calculate progress it expects to either have a currently running action or one that has happened already. Since a coordinator in prep mode wont have either, you get a None for lastAction.

Solved it locally (CDH5.4.1) by just setting progress to 0, since it makes a lot of sense to me that we have no progress in this case.

Thoughts?