### PR TITLE
Add scalatra-metrics support to livy

### DIFF
--- a/apps/spark/java/livy-server/pom.xml
+++ b/apps/spark/java/livy-server/pom.xml
@@ -53,6 +53,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.scalatra</groupId>
+            <artifactId>scalatra-metrics_${scala.binary.version}</artifactId>
+            <version>2.4.0.M3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.typesafe.akka</groupId>
+                    <artifactId>akka-actor_${scala.binary.version}</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-assembly_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>

--- a/apps/spark/java/livy-server/src/main/scala/com/cloudera/hue/livy/server/Main.scala
+++ b/apps/spark/java/livy-server/src/main/scala/com/cloudera/hue/livy/server/Main.scala
@@ -25,6 +25,8 @@ import com.cloudera.hue.livy._
 import com.cloudera.hue.livy.server.batch._
 import com.cloudera.hue.livy.server.interactive._
 import org.scalatra._
+import org.scalatra.metrics.MetricsBootstrap
+import org.scalatra.metrics.MetricsSupportExtensions._
 import org.scalatra.servlet.ScalatraListener
 import org.slf4j.LoggerFactory
 
@@ -121,7 +123,10 @@ object Main {
   }
 }
 
-class ScalatraBootstrap extends LifeCycle with Logging {
+class ScalatraBootstrap
+  extends LifeCycle
+  with Logging
+  with MetricsBootstrap {
 
   var sessionManager: SessionManager[InteractiveSession] = null
   var batchManager: SessionManager[BatchSession] = null
@@ -145,6 +150,7 @@ class ScalatraBootstrap extends LifeCycle with Logging {
 
       context.mount(new InteractiveSessionServlet(sessionManager), "/sessions/*")
       context.mount(new BatchSessionServlet(batchManager), "/batches/*")
+      context.mountMetricsAdminServlet("/")
     } catch {
       case e: Throwable =>
         println(f"Exception thrown when initializing server: $e")


### PR DESCRIPTION
 Mount MetricsAdminServlet under "/" which gives 4 new contexts: /healthcheck, /metrics, /ping, and /threads

 The admin servlet also gives a small html page with links to the above.  Additional metrics and checks can be added easily in the future.