### PR TITLE
setting cluster information uri to /cluster/info

### DIFF
--- a/desktop/libs/hadoop/src/hadoop/yarn/resource_manager_api.py
+++ b/desktop/libs/hadoop/src/hadoop/yarn/resource_manager_api.py
@@ -83,7 +83,7 @@ class ResourceManagerApi(object):
     return self._security_enabled
 
   def cluster(self, **kwargs):
-    return self._execute(self._root.get, 'cluster', params=kwargs, headers={'Accept': _JSON_CONTENT_TYPE})
+    return self._execute(self._root.get, 'cluster/info', params=kwargs, headers={'Accept': _JSON_CONTENT_TYPE})
 
   def apps(self, **kwargs):
     return self._execute(self._root.get, 'cluster/apps', params=kwargs, headers={'Accept': _JSON_CONTENT_TYPE})


### PR DESCRIPTION
The `cluster` uri in the `cluster()` method from `desktop/libs/hadoop/src/hadoop/yarn/resource_manager_api.py` redirects to `cluster/info` for information about cluster. In this fix we set uri to 'cluster/info' to avoid redirect failing on standby resourcemanager.