### PR TITLE
Reading Oozie Share Lib path from Oozie configuration

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -789,7 +789,9 @@
 
   # Location on HDFS where the workflows/coordinator are deployed when submitted.
   ## remote_deployement_dir=/user/hue/oozie/deployments
-
+  
+  # Location of Oozie Share Lib.
+  ## share_lib_path=/user/oozie/share/lib
 
 ###########################################################################
 # Settings to configure the Oozie app

--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -789,7 +789,6 @@
 
   # Location on HDFS where the workflows/coordinator are deployed when submitted.
   ## remote_deployement_dir=/user/hue/oozie/deployments
-  
 
 ###########################################################################
 # Settings to configure the Oozie app

--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -790,8 +790,6 @@
   # Location on HDFS where the workflows/coordinator are deployed when submitted.
   ## remote_deployement_dir=/user/hue/oozie/deployments
   
-  # Location of Oozie Share Lib.
-  ## share_lib_path=/user/oozie/share/lib
 
 ###########################################################################
 # Settings to configure the Oozie app

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -796,7 +796,9 @@
 
   # Location on HDFS where the workflows/coordinator are deployed when submitted.
   ## remote_deployement_dir=/user/hue/oozie/deployments
-
+  
+  # Location of Oozie Share Lib.
+  ## share_lib_path=/user/oozie/share/lib
 
 ###########################################################################
 # Settings to configure the Oozie app

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -797,8 +797,6 @@
   # Location on HDFS where the workflows/coordinator are deployed when submitted.
   ## remote_deployement_dir=/user/hue/oozie/deployments
   
-  # Location of Oozie Share Lib.
-  ## share_lib_path=/user/oozie/share/lib
 
 ###########################################################################
 # Settings to configure the Oozie app

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -796,7 +796,6 @@
 
   # Location on HDFS where the workflows/coordinator are deployed when submitted.
   ## remote_deployement_dir=/user/hue/oozie/deployments
-  
 
 ###########################################################################
 # Settings to configure the Oozie app

--- a/desktop/libs/liboozie/src/liboozie/conf.py
+++ b/desktop/libs/liboozie/src/liboozie/conf.py
@@ -90,7 +90,8 @@ def config_validator(user):
       def get_fully_qualifying_key(self): return self.value
 
     for cluster in get_all_hdfs().values():
-      res.extend(validate_path(ConfigMock('/user/oozie/share/lib'), is_dir=True, fs=cluster,
+      res.extend(validate_path(ConfigMock(SHARE_LIB_PATH.get()), is_dir=True, fs=cluster,
                                message=_('Oozie Share Lib not installed in default location.')))
+
 
   return res

--- a/desktop/libs/liboozie/src/liboozie/conf.py
+++ b/desktop/libs/liboozie/src/liboozie/conf.py
@@ -49,6 +49,11 @@ SSL_CERT_CA_VERIFY=Config(
   default=True,
   type=coerce_bool)
 
+SHARE_LIB_PATH = Config(
+  key='share_lib_path',
+  help=_t('Oozie Share Lib path.'),
+  default='/user/oozie/share/lib',
+  type=str)
 
 def get_oozie_status(user):
   from liboozie.oozie_api import get_oozie


### PR DESCRIPTION
So many people has their own share lib folder that they cannot add their own sharelib path to Hue and Hue tries to use the default path. I have added a key in the configuration for sharelib path that Hue can read that path instead of changing the code manually.