### PR TITLE
Add file separator for accessing yarn-site.xml.

### DIFF
--- a/apps/spark/java/livy-yarn/src/main/scala/com/cloudera/hue/livy/yarn/Client.scala
+++ b/apps/spark/java/livy-yarn/src/main/scala/com/cloudera/hue/livy/yarn/Client.scala
@@ -18,7 +18,7 @@
 
 package com.cloudera.hue.livy.yarn
 
-import java.io.{InputStream, BufferedReader, InputStreamReader}
+import java.io.{File, InputStream, BufferedReader, InputStreamReader}
 
 import com.cloudera.hue.livy.yarn.Client._
 import com.cloudera.hue.livy.{Utils, LineBufferedProcess, LivyConf, Logging}
@@ -52,7 +52,7 @@ class Client(livyConf: LivyConf) extends Logging {
 
   private[this] val yarnConf = new YarnConfiguration()
   private[this] val yarnClient = YarnClient.createYarnClient()
-  val path = new Path(sys.env("HADOOP_CONF_DIR") + YarnConfiguration.YARN_SITE_CONFIGURATION_FILE)
+  val path = new Path(sys.env("HADOOP_CONF_DIR") + File.separator + YarnConfiguration.YARN_SITE_CONFIGURATION_FILE)
   yarnConf.addResource(path)
   val rm_address = yarnConf.get(YarnConfiguration.RM_ADDRESS)
   info(s"Resource Manager address: $rm_address")


### PR DESCRIPTION
Currently the code assumes HADOOP_CONF_DIR always ends up with a trailing '/'. So it just appends yarn-site.xml to the path. In case the / is missing, it won't be able locate the yarn-site.xml file. That will cause it not able to find the yarn endpoints to get job status thus things start to fail.

In other places, code always adds a file separator ('/' in this case) so the files can be found. Doing the same here.