### PR TITLE
add ’Executors Memory‘

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/spark_shell.py
+++ b/desktop/libs/notebook/src/notebook/connectors/spark_shell.py
@@ -50,6 +50,7 @@ class SparkApi(Api):
     {'name': 'driverMemory', 'nice_name': _('Driver Memory'), 'default': '1', 'type': 'jvm', 'is_yarn': False},
 
     {'name': 'driverCores', 'nice_name': _('Driver Cores'), 'default': '1', 'type': 'number', 'is_yarn': True},
+	{'name': 'executorMemory', 'nice_name': _('Executors Memory'), 'default': '1', 'type': 'jvm', 'is_yarn': True},
     {'name': 'executorCores', 'nice_name': _('Executor Cores'), 'default': '1', 'type': 'number', 'is_yarn': True},
     {'name': 'queue', 'nice_name': _('Queue'), 'default': '1', 'type': 'string', 'is_yarn': True},
     {'name': 'archives', 'nice_name': _('Archives'), 'default': '', 'type': 'csv-hdfs-files', 'is_yarn': True},


### PR DESCRIPTION
miss Executors Memory when choosing a property during recreate session, so add it.