### PR TITLE
a bug with coordinator application URI in a bundle job

### DIFF
--- a/apps/oozie/src/oozie/templates/editor2/gen/bundle.xml.mako
+++ b/apps/oozie/src/oozie/templates/editor2/gen/bundle.xml.mako
@@ -41,7 +41,7 @@
 
   % for bundled in bundle.data['coordinators']:
   <coordinator name="${ mapping['coord_%s' % loop.index].name }-${ loop.index }">
-     <app-path>${'${'}nameNode}${ mapping['coord_%s_dir' % loop.index ] }</app-path>
+     <app-path>${ mapping['coord_%s_dir' % loop.index ] }</app-path>
      <configuration>
        <property>
           <name>wf_application_path</name>

--- a/apps/oozie/src/oozie/views/editor2.py
+++ b/apps/oozie/src/oozie/views/editor2.py
@@ -762,7 +762,7 @@ def _submit_bundle(request, bundle, properties):
 
       coordinator = Coordinator(document=coord)
       coord_dir = Submission(request.user, coordinator, request.fs, request.jt, properties).deploy()
-      deployment_mapping['coord_%s_dir' % i] = coord_dir
+      deployment_mapping['coord_%s_dir' % i] = request.fs.get_hdfs_path(coord_dir)
       deployment_mapping['coord_%s' % i] = coord
 
     properties.update(deployment_mapping)

--- a/desktop/core/src/desktop/static/desktop/ext/js/topo/nul.topo.js
+++ b/desktop/core/src/desktop/static/desktop/ext/js/topo/nul.topo.js
@@ -1,1 +1,0 @@
-var NUL_TOPO = {"type":"Topology","objects":{"nul":{"type":"GeometryCollection","geometries":[{"type":"Polygon","properties":{"name":null},"id":"-99","arcs":[[0]]}]}},"arcs":[[[0,9999],[9999,0],[0,-9999],[-9999,0],[0,9999]]],"transform":{"scale":[9.053905432543252e-10,9.053905432543252e-10],"translate":[-0.000004544999911,-0.000004496999935]}}


### PR DESCRIPTION
Normally this wouldn't happen, but when i set my nameNode as "hdfs://defaultCluster/", notice the ending '/', the coordinator application URI in bundle xml would be "hdfs://defaultCluster//user/hue/oozie/....". 