### PR TITLE
added backticks to handle database name that use reserved keyword.

### DIFF
--- a/desktop/libs/librdbms/src/librdbms/server/mysql_lib.py
+++ b/desktop/libs/librdbms/src/librdbms/server/mysql_lib.py
@@ -80,7 +80,7 @@ class MySQLClient(BaseRDMSClient):
       raise RuntimeError(_("Database '%s' is not allowed. Please use database '%s'.") % (database, self._conn_params['db']))
     else:
       cursor = self.connection.cursor()
-      cursor.execute("USE %s" % database)
+      cursor.execute("USE `%s`" % database)
       self.connection.commit()
 
 


### PR DESCRIPTION
Need to add the backticks in the code, because adding it in hue.ini will create another problem.
https://issues.cloudera.org/browse/HUE-3087