### PR TITLE
an error in refreshing home page project document numbers

### DIFF
--- a/desktop/core/src/desktop/static/desktop/js/home.vm.js
+++ b/desktop/core/src/desktop/static/desktop/js/home.vm.js
@@ -142,8 +142,10 @@ function HomeViewModel(json_tags, json_docs) {
             }
           });
           if (_removeDocFromTag) {
-            tag.docs().splice(tag.docs().indexOf(doc.id), 1);
-            tag.docs.valueHasMutated();
+            if(tag.docs().indexOf(doc.id)!=-1) {
+              tag.docs().splice(tag.docs().indexOf(doc.id), 1);
+              tag.docs.valueHasMutated();
+            }
           }
         });
       }


### PR DESCRIPTION
When I change a project document to a new project in home page.The other project's document numbers are also been changed.So I correct it.