### PR TITLE
Update Python.h check in Makefile.vars, for Mac OS X 10.11+

### DIFF
--- a/Makefile.vars
+++ b/Makefile.vars
@@ -36,7 +36,7 @@ ifneq ($(wildcard $(ROOT)/Makefile.buildvars),)
   include $(ROOT)/Makefile.buildvars
 endif
 
-PYTHON_H ?= $(shell ls /usr/include/python2.7/Python.h 2>/dev/null || ls /usr/include/python2.6/Python.h 2>/dev/null)
+PYTHON_H ?= $(shell ls /usr/include/python2.7/Python.h 2>/dev/null || ls /usr/include/python2.6/Python.h 2>/dev/null || ls /System/Library/Frameworks/Python.framework/Versions/2.6/include/python2.6/Python.h 2>/dev/null || ls /System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7/Python.h 2>/dev/null)
 ifndef SKIP_PYTHONDEV_CHECK
   ifeq ($(PYTHON_H),)
     $(error "Error: must have python development packages for 2.6 or 2.7. Could not find Python.h. Please install python2.6-devel or python2.7-devel")


### PR DESCRIPTION
``make apps`` was failing with this error
    Makefile.vars:42: *** "Error: must have python development packages for 2.6 or 2.7. Could not find Python.h. Please install python2.6-devel or python2.7-devel".  Stop.

