### PR TITLE
Fixed GET /sessions url in pyspark example

### DIFF
--- a/apps/spark/java/README.rst
+++ b/apps/spark/java/README.rst
@@ -199,7 +199,7 @@ Once the session has completed starting up, it transitions to the idle state:
 
 .. code:: python
 
-    >>> session_url = host + r.headers['location']
+    >>> session_url = host + '/sessions' + r.headers['location']
     >>> r = requests.get(session_url, headers=headers)
     >>> r.json()
     {u'state': u'idle', u'id': 0, u’kind’: u’spark’}


### PR DESCRIPTION
The pyspark example does not work because of the incorrect sessions url.