### PR TITLE
Force TextFile file_format in table import

### DIFF
--- a/apps/beeswax/src/beeswax/create_table.py
+++ b/apps/beeswax/src/beeswax/create_table.py
@@ -235,7 +235,8 @@ def import_wizard(request, database='default'):
                 'name': table_name,
                 'comment': s1_file_form.cleaned_data['comment'],
                 'row_format': 'Delimited',
-                'field_terminator': delim
+                'field_terminator': delim,
+                'file_format': 'TextFile'
              },
             'columns': [ f.cleaned_data for f in s3_col_formset.forms ],
             'partition_columns': [],


### PR DESCRIPTION
Explicitly use TextFile format when creating a table from a CSV file. Otherwise, hive.default.fileformat is used, which could lead to the resulting table not being accessible.