### PR TITLE
Uncover ability to set the oozie.use.system.libpath variable on the Workflow Settings view

### DIFF
--- a/apps/oozie/src/oozie/templates/editor2/workflow_editor.mako
+++ b/apps/oozie/src/oozie/templates/editor2/workflow_editor.mako
@@ -302,7 +302,6 @@ ${ workflow.render() }
   <div class="modal-body">
       <h4>${ _('Variables') }</h4>
       <ul data-bind="foreach: $root.workflow.properties.parameters" class="unstyled">
-        <!-- ko if: name() != 'oozie.use.system.libpath' -->
         <li>
           <input type="text" data-bind="value: name" placeholder="${ _('Name, e.g. market') }"/>
           <input type="text" data-bind="value: value" placeholder="${ _('Value, e.g. US') }"/>
@@ -310,7 +309,6 @@ ${ workflow.render() }
             <i class="fa fa-minus"></i>
           </a>
         </li>
-        <!-- /ko -->
       </ul>
       <a class="pointer" data-bind="click: function(){ $root.workflow.properties.parameters.push(ko.mapping.fromJS({'name': '', 'value': ''})); }">
         <i class="fa fa-plus"></i> ${ _('Add parameter') }


### PR DESCRIPTION
We need a way to exclude ozzie's shared libs for jobs written in Spark that is incompatible with the one distributed along with oozie. There is a setting for doing this: 'oozie.use.system.libpath' but Hue hides it immediately when found on Workflow Settings view. This change prevents hiding and shows the setting back.