### PR TITLE
X-Frame-Options value can be set in hue.ini config.

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -84,9 +84,6 @@
   # Execute this script to produce the SSL password. This will be used when `ssl_password` is not set.
   ## ssl_password_script=
 
-  # Django sets X-Frame-Options HTTP header to this value. Default is 'SAMEORIGIN'.
-  ## django_x_frame_options=DENY
-
   # List of allowed and disallowed ciphers in cipher list format.
   # See http://www.openssl.org/docs/apps/ciphers.html for more information on
   # cipher list format. This list is from
@@ -120,6 +117,9 @@
 
   # The copyright message for the specified Leaflet maps Tile Layer
   ## leaflet_tile_layer_attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+
+  # Django sets X-Frame-Options HTTP header to this value. Use 'DENY' to deny framing completely 
+  ## django_x_frame_options=SAMEORIGIN
 
   # Enable X-Forwarded-Host header if the load balancer requires it.
   ## use_x_forwarded_host=false

--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -84,6 +84,9 @@
   # Execute this script to produce the SSL password. This will be used when `ssl_password` is not set.
   ## ssl_password_script=
 
+  # Django sets X-Frame-Options HTTP header to this value. Default is 'SAMEORIGIN'.
+  ## django_x_frame_options=DENY
+
   # List of allowed and disallowed ciphers in cipher list format.
   # See http://www.openssl.org/docs/apps/ciphers.html for more information on
   # cipher list format. This list is from

--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -118,8 +118,8 @@
   # The copyright message for the specified Leaflet maps Tile Layer
   ## leaflet_tile_layer_attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
 
-  # Django sets X-Frame-Options HTTP header to this value. Use 'DENY' to deny framing completely 
-  ## django_x_frame_options=SAMEORIGIN
+  # X-Frame-Options HTTP header value. Use 'DENY' to deny framing completely 
+  ## http_x_frame_options=SAMEORIGIN
 
   # Enable X-Forwarded-Host header if the load balancer requires it.
   ## use_x_forwarded_host=false

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -122,8 +122,8 @@
   # The copyright message for the specified Leaflet maps Tile Layer
   ## leaflet_tile_layer_attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
 
-  # Django sets X-Frame-Options HTTP header to this value. Use 'DENY' to deny framing completely
-  ## django_x_frame_options=SAMEORIGIN
+  # X-Frame-Options HTTP header value. Use 'DENY' to deny framing completely                   
+  ## http_x_frame_options=SAMEORIGIN
 
   # Enable X-Forwarded-Host header if the load balancer requires it.
   ## use_x_forwarded_host=false

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -122,6 +122,9 @@
   # The copyright message for the specified Leaflet maps Tile Layer
   ## leaflet_tile_layer_attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
 
+  # Django sets X-Frame-Options HTTP header to this value. Use 'DENY' to deny framing completely
+  ## django_x_frame_options=SAMEORIGIN
+
   # Enable X-Forwarded-Host header if the load balancer requires it.
   ## use_x_forwarded_host=false
 

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -91,6 +91,12 @@ HTTP_ALLOWED_METHODS = Config(
   private=True,
   default=['OPTIONS', 'GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT'])
 
+X_FRAME_OPTIONS = Config(
+  key="django_x_frame_options",
+  help=_("X-Frame-Options HTTP header value."),
+  type=str,
+  default="SAMEORIGIN")
+
 SSL_CERTIFICATE = Config(
   key="ssl_certificate",
   help=_("Filename of SSL Certificate"),

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -92,7 +92,7 @@ HTTP_ALLOWED_METHODS = Config(
   default=['OPTIONS', 'GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT'])
 
 X_FRAME_OPTIONS = Config(
-  key="django_x_frame_options",
+  key="http_x_frame_options",
   help=_("X-Frame-Options HTTP header value."),
   type=str,
   default="SAMEORIGIN")

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -273,6 +273,8 @@ TEMPLATE_DEBUG = DEBUG
 # Configure allowed hosts
 ALLOWED_HOSTS = desktop.conf.ALLOWED_HOSTS.get()
 
+X_FRAME_OPTIONS = desktop.conf.X_FRAME_OPTIONS.get()
+
 # Configure hue admins
 ADMINS = []
 for admin in desktop.conf.DJANGO_ADMINS.get():


### PR DESCRIPTION
This is a simple patch to configure Django clickjacking middleware with an X-Frame-Options header from hue.ini

This is not really useful, because Hue escapes any frame I tried to use it in. Still, having it is better than not.