### PR TITLE
Use .xlsx write-only optimization in export_csvxls.py

### DIFF
--- a/desktop/core/src/desktop/lib/export_csvxls.py
+++ b/desktop/core/src/desktop/lib/export_csvxls.py
@@ -64,8 +64,8 @@ class XlsWrapper():
 def xls_dataset(headers, data, encoding=None):
   output = StringIO.StringIO()
 
-  workbook = openpyxl.Workbook(write_only=False)
-  worksheet = workbook.active
+  workbook = openpyxl.Workbook(write_only=True)
+  worksheet = workbook.create_sheet()
 
   if headers:
     worksheet.append(format(headers, encoding))


### PR DESCRIPTION
Making the openpyxl Workbook write-only greatly decreases memory usage during generation of the .xlsx file.
See also https://openpyxl.readthedocs.org/en/2.3.3/optimized.html#write-only-mode