### PR TITLE
Default regex tightened to address open URL redirection issue

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -134,7 +134,7 @@
   # Comma-separated list of regular expressions, which match the redirect URL.
   # For example, to restrict to your local domain and FQDN, the following value can be used:
   # ^\/.*$,^http:\/\/www.mydomain.com\/.*$
-  ## redirect_whitelist=^\/.*$
+  ## redirect_whitelist=^(\/[a-zA-Z0-9]+.*|\/)$
 
   # Comma separated list of apps to not load at server startup.
   # e.g.: pig,zookeeper

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -138,7 +138,7 @@
   # Comma-separated list of regular expressions, which match the redirect URL.
   # For example, to restrict to your local domain and FQDN, the following value can be used:
   # ^\/.*$,^http:\/\/www.mydomain.com\/.*$
-  ## redirect_whitelist=^\/.*$
+  ## redirect_whitelist=^(\/[a-zA-Z0-9]+.*|\/)$
 
   # Comma separated list of apps to not load at server startup.
   # e.g.: pig,zookeeper

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -295,7 +295,7 @@ REDIRECT_WHITELIST = Config(
          "For example, to restrict to your local domain and FQDN, the following value can be used:"
          "  ^\/.*$,^http:\/\/www.mydomain.com\/.*$"),
   type=list_of_compiled_res(skip_empty=True),
-  default='^\/.*$')
+  default='^(\/[a-zA-Z0-9]+.*|\/)$')
 
 USE_X_FORWARDED_HOST = Config(
   key="use_x_forwarded_host",


### PR DESCRIPTION
It is possible to bypass the existing whitelist to redirect to a URL of an attacker's choosing using a schemaless URL. e.g. //github.com. This is because the current default regex whitelist checks only to ensure that the first character of the location header in the redirect request is a '/'. This has been assigned CVE-2015-8094, although no details have been released on it.

The changed regex is tightened to allow for '/' alone, but if more characters are found in the string, then the second character must be alphanumeric. No further restrictions are in place. 

I'd like to encourage testing of this to ensure that the fix works as expected. 