### PR TITLE
Fix PST time difference offset in help message

### DIFF
--- a/apps/oozie/src/oozie/locale/de/LC_MESSAGES/django.po
+++ b/apps/oozie/src/oozie/locale/de/LC_MESSAGES/django.po
@@ -3375,8 +3375,8 @@ msgstr "Planung"
 #: src/oozie/templates/editor/create_coordinator_dataset.mako:31
 #: src/oozie/templates/editor/edit_bundle.mako:113
 #: src/oozie/templates/editor/edit_coordinator.mako:126
-msgid "UTC time only. (e.g. if you want 10pm PST (UTC+8) set it 8 hours later to 6am the next day."
-msgstr "Nur UTC-Zeit. (z. B. wenn Sie 22.00 Uhr PST (UTC+8) um acht Stunden auf 6:00 am nächsten Tag verstellen möchten."
+msgid "UTC time only. (e.g. if you want 10pm PST (UTC-8) set it 8 hours later to 6am the next day."
+msgstr "Nur UTC-Zeit. (z. B. wenn Sie 22.00 Uhr PST (UTC-8) um acht Stunden auf 6:00 am nächsten Tag verstellen möchten."
 
 #: src/oozie/templates/editor/create_coordinator.mako:211
 #: src/oozie/templates/editor/edit_bundle.mako:472

--- a/apps/oozie/src/oozie/locale/en/LC_MESSAGES/django.po
+++ b/apps/oozie/src/oozie/locale/en/LC_MESSAGES/django.po
@@ -2434,7 +2434,7 @@ msgstr ""
 #: src/oozie/templates/editor/edit_bundle.mako:115
 #: src/oozie/templates/editor/edit_coordinator.mako:135
 msgid ""
-"UTC time only. (e.g. if you want 10pm PST (UTC+8) set it 8 hours later to"
+"UTC time only. (e.g. if you want 10pm PST (UTC-8) set it 8 hours later to"
 " 6am the next day."
 msgstr ""
 

--- a/apps/oozie/src/oozie/locale/en_US.pot
+++ b/apps/oozie/src/oozie/locale/en_US.pot
@@ -2434,7 +2434,7 @@ msgstr ""
 #: src/oozie/templates/editor/edit_bundle.mako:115
 #: src/oozie/templates/editor/edit_coordinator.mako:135
 msgid ""
-"UTC time only. (e.g. if you want 10pm PST (UTC+8) set it 8 hours later to"
+"UTC time only. (e.g. if you want 10pm PST (UTC-8) set it 8 hours later to"
 " 6am the next day."
 msgstr ""
 

--- a/apps/oozie/src/oozie/locale/es/LC_MESSAGES/django.po
+++ b/apps/oozie/src/oozie/locale/es/LC_MESSAGES/django.po
@@ -3375,7 +3375,7 @@ msgstr "Programa"
 #: src/oozie/templates/editor/create_coordinator_dataset.mako:31
 #: src/oozie/templates/editor/edit_bundle.mako:113
 #: src/oozie/templates/editor/edit_coordinator.mako:126
-msgid "UTC time only. (e.g. if you want 10pm PST (UTC+8) set it 8 hours later to 6am the next day."
+msgid "UTC time only. (e.g. if you want 10pm PST (UTC-8) set it 8 hours later to 6am the next day."
 msgstr "Solo hora UTC, (p. ej., si desea establecer las 22:00 en la hora estándar del Pacífico (UTC +8), configúrelo 8 horas después de las 6:00 del día siguiente."
 
 #: src/oozie/templates/editor/create_coordinator.mako:211

--- a/apps/oozie/src/oozie/locale/fr/LC_MESSAGES/django.po
+++ b/apps/oozie/src/oozie/locale/fr/LC_MESSAGES/django.po
@@ -3375,8 +3375,8 @@ msgstr "Planifier"
 #: src/oozie/templates/editor/create_coordinator_dataset.mako:31
 #: src/oozie/templates/editor/edit_bundle.mako:113
 #: src/oozie/templates/editor/edit_coordinator.mako:126
-msgid "UTC time only. (e.g. if you want 10pm PST (UTC+8) set it 8 hours later to 6am the next day."
-msgstr "Heure UTC uniquement. Par exemple, si vous voulez indiquer 22:00 heure d'hiver du Pacifique (UTC+8), ajouter 8 heures après 6:00, le jour suivant."
+msgid "UTC time only. (e.g. if you want 10pm PST (UTC-8) set it 8 hours later to 6am the next day."
+msgstr "Heure UTC uniquement. Par exemple, si vous voulez indiquer 22:00 heure d'hiver du Pacifique (UTC-8), ajouter 8 heures après 6:00, le jour suivant."
 
 #: src/oozie/templates/editor/create_coordinator.mako:211
 #: src/oozie/templates/editor/edit_bundle.mako:472

--- a/apps/oozie/src/oozie/locale/ja/LC_MESSAGES/django.po
+++ b/apps/oozie/src/oozie/locale/ja/LC_MESSAGES/django.po
@@ -3374,8 +3374,8 @@ msgstr "スケジュール"
 #: src/oozie/templates/editor/create_coordinator_dataset.mako:31
 #: src/oozie/templates/editor/edit_bundle.mako:113
 #: src/oozie/templates/editor/edit_coordinator.mako:126
-msgid "UTC time only. (e.g. if you want 10pm PST (UTC+8) set it 8 hours later to 6am the next day."
-msgstr "UTC 時間のみ。例えば、PST（UTC+8）の午後 10 時に設定する場合は、8 時間後、つまり、次の日の午前 6 時に 設定します。"
+msgid "UTC time only. (e.g. if you want 10pm PST (UTC-8) set it 8 hours later to 6am the next day."
+msgstr "UTC 時間のみ。例えば、PST（UTC-8）の午後 10 時に設定する場合は、8 時間後、つまり、次の日の午前 6 時に 設定します。"
 
 #: src/oozie/templates/editor/create_coordinator.mako:211
 #: src/oozie/templates/editor/edit_bundle.mako:472

--- a/apps/oozie/src/oozie/locale/ko/LC_MESSAGES/django.po
+++ b/apps/oozie/src/oozie/locale/ko/LC_MESSAGES/django.po
@@ -3375,8 +3375,8 @@ msgstr "예약"
 #: src/oozie/templates/editor/create_coordinator_dataset.mako:31
 #: src/oozie/templates/editor/edit_bundle.mako:113
 #: src/oozie/templates/editor/edit_coordinator.mako:126
-msgid "UTC time only. (e.g. if you want 10pm PST (UTC+8) set it 8 hours later to 6am the next day."
-msgstr "UTC 시간만 해당됩니다. 예를 들어 PST(UTC+8) 오후 10시인 경우 8시간을 더하여 다음 날 오전 6시로 설정합니다."
+msgid "UTC time only. (e.g. if you want 10pm PST (UTC-8) set it 8 hours later to 6am the next day."
+msgstr "UTC 시간만 해당됩니다. 예를 들어 PST(UTC-8) 오후 10시인 경우 8시간을 더하여 다음 날 오전 6시로 설정합니다."
 
 #: src/oozie/templates/editor/create_coordinator.mako:211
 #: src/oozie/templates/editor/edit_bundle.mako:472

--- a/apps/oozie/src/oozie/locale/pt/LC_MESSAGES/django.po
+++ b/apps/oozie/src/oozie/locale/pt/LC_MESSAGES/django.po
@@ -3375,8 +3375,8 @@ msgstr "Programar"
 #: src/oozie/templates/editor/create_coordinator_dataset.mako:31
 #: src/oozie/templates/editor/edit_bundle.mako:113
 #: src/oozie/templates/editor/edit_coordinator.mako:126
-msgid "UTC time only. (e.g. if you want 10pm PST (UTC+8) set it 8 hours later to 6am the next day."
-msgstr "Hora UTC apenas (por exemplo, se quiser 22:00 PST (UTC+8), defina-a 8 horas depois para 06:00 do dia seguinte."
+msgid "UTC time only. (e.g. if you want 10pm PST (UTC-8) set it 8 hours later to 6am the next day."
+msgstr "Hora UTC apenas (por exemplo, se quiser 22:00 PST (UTC-8), defina-a 8 horas depois para 06:00 do dia seguinte."
 
 #: src/oozie/templates/editor/create_coordinator.mako:211
 #: src/oozie/templates/editor/edit_bundle.mako:472

--- a/apps/oozie/src/oozie/locale/pt_BR/LC_MESSAGES/django.po
+++ b/apps/oozie/src/oozie/locale/pt_BR/LC_MESSAGES/django.po
@@ -3375,8 +3375,8 @@ msgstr "Programar"
 #: src/oozie/templates/editor/create_coordinator_dataset.mako:31
 #: src/oozie/templates/editor/edit_bundle.mako:113
 #: src/oozie/templates/editor/edit_coordinator.mako:126
-msgid "UTC time only. (e.g. if you want 10pm PST (UTC+8) set it 8 hours later to 6am the next day."
-msgstr "Hora UTC apenas (por exemplo, se você quiser 22h PST (UTC+8), defina-a 8 horas depois para 6h do dia seguinte."
+msgid "UTC time only. (e.g. if you want 10pm PST (UTC-8) set it 8 hours later to 6am the next day."
+msgstr "Hora UTC apenas (por exemplo, se você quiser 22h PST (UTC-8), defina-a 8 horas depois para 6h do dia seguinte."
 
 #: src/oozie/templates/editor/create_coordinator.mako:211
 #: src/oozie/templates/editor/edit_bundle.mako:472

--- a/apps/oozie/src/oozie/locale/zh_CN/LC_MESSAGES/django.po
+++ b/apps/oozie/src/oozie/locale/zh_CN/LC_MESSAGES/django.po
@@ -3375,8 +3375,8 @@ msgstr "计划"
 #: src/oozie/templates/editor/create_coordinator_dataset.mako:31
 #: src/oozie/templates/editor/edit_bundle.mako:113
 #: src/oozie/templates/editor/edit_coordinator.mako:126
-msgid "UTC time only. (e.g. if you want 10pm PST (UTC+8) set it 8 hours later to 6am the next day."
-msgstr "仅限 UTC 时间。（例如，如果您需要 10pm PST (UTC+8)，则将其设置为比次日 6 am 晚 8 个小时。"
+msgid "UTC time only. (e.g. if you want 10pm PST (UTC-8) set it 8 hours later to 6am the next day."
+msgstr "仅限 UTC 时间。（例如，如果您需要 10pm PST (UTC-8)，则将其设置为比次日 6 am 晚 8 个小时。"
 
 #: src/oozie/templates/editor/create_coordinator.mako:211
 #: src/oozie/templates/editor/edit_bundle.mako:472

--- a/apps/oozie/src/oozie/templates/editor/create_coordinator.mako
+++ b/apps/oozie/src/oozie/templates/editor/create_coordinator.mako
@@ -88,7 +88,7 @@ ${ layout.menubar(section='coordinators') }
             <div class="fieldWrapper">
               <div class="row-fluid">
                 <div class="alert alert-warning">
-                  ${ _('UTC time only. (e.g. if you want 10pm PST (UTC+8) set it 8 hours later to 6am the next day.') }
+                  ${ _('UTC time only. (e.g. if you want 10pm PST (UTC-8) set it 8 hours later to 6am the next day.') }
                 </div>
               </div>
             </div>

--- a/apps/oozie/src/oozie/templates/editor/create_coordinator_dataset.mako
+++ b/apps/oozie/src/oozie/templates/editor/create_coordinator_dataset.mako
@@ -28,7 +28,7 @@
   ${ utils.render_field_no_popover(dataset_form['description']) }
   <div class="row-fluid">
     <div class="alert alert-warning">
-      ${ _('UTC time only. (e.g. if you want 10pm PST (UTC+8) set it 8 hours later to 6am the next day.') }
+      ${ _('UTC time only. (e.g. if you want 10pm PST (UTC-8) set it 8 hours later to 6am the next day.') }
     </div>
   </div>
   ${ utils.render_field_no_popover(dataset_form['start']) }

--- a/apps/oozie/src/oozie/templates/editor/edit_bundle.mako
+++ b/apps/oozie/src/oozie/templates/editor/edit_bundle.mako
@@ -110,7 +110,7 @@ ${ layout.menubar(section='bundles') }
                   </div>
                   <div class="span6">
                     <div class="alert alert-warning">
-                      ${ _('UTC time only. (e.g. if you want 10pm PST (UTC+8) set it 8 hours later to 6am the next day.') }
+                      ${ _('UTC time only. (e.g. if you want 10pm PST (UTC-8) set it 8 hours later to 6am the next day.') }
                     </div>
                   </div>
                 </div>

--- a/apps/oozie/src/oozie/templates/editor/edit_coordinator.mako
+++ b/apps/oozie/src/oozie/templates/editor/edit_coordinator.mako
@@ -123,7 +123,7 @@ ${ layout.menubar(section='coordinators') }
             <div class="fieldWrapper">
               <div class="row-fluid">
                 <div class="alert alert-warning">
-                  ${ _('UTC time only. (e.g. if you want 10pm PST (UTC+8) set it 8 hours later to 6am the next day.') }
+                  ${ _('UTC time only. (e.g. if you want 10pm PST (UTC-8) set it 8 hours later to 6am the next day.') }
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Sorry if this is intended, but I think usually PST is expressed as `UTC-8`, not `UTC+8`...

This message will be shown in `new/` pages of Oozie Coordinator and Bundle :point_down: 

![pr](https://cloud.githubusercontent.com/assets/139241/14732652/bc05abd8-0897-11e6-838e-6e50ef8575dc.png)

