### PR TITLE
Add csrf_token to Pig app template

### DIFF
--- a/apps/pig/src/pig/templates/app.mako
+++ b/apps/pig/src/pig/templates/app.mako
@@ -192,6 +192,7 @@ ${ commonheader(None, "pig", user) | n,unicode }
             <div id="queryColumn" class="span9">
               <a id="navigatorShow" href="#" title="${_('Show the assist')}" style="position:absolute;z-index: 10000; margin-top:10px;display:none;right:30px" rel="tooltip" data-placement="left"><i class="fa fa-compass"></i></a>
               <form id="queryForm">
+                ${ csrf_token(request) | n,unicode }
                 <textarea id="scriptEditor" data-bind="text:currentScript().script"></textarea>
               </form>
             </div>
@@ -346,6 +347,7 @@ ${ commonheader(None, "pig", user) | n,unicode }
             <h3><span data-bind="text: currentScript().name"></span></h3>
           </div>
           <form class="form-inline" style="padding-left: 10px">
+            ${ csrf_token(request) | n,unicode }
             <label>
               ${ _('Script name') } &nbsp;
               <input type="text" id="scriptName" class="input-xlarge" data-bind="value: currentScript().name, valueUpdate:'afterkeydown'" />


### PR DESCRIPTION
Currently, forms in Pig app do not carry csrf_token. If a user loses the cookie, using Pig becomes impossible because of error 403. We encounter this constantly and the enclosed patch fixes it.