### PR TITLE
Use CLASSPATH value for creating JavaGateway and load JDBC driver class

### DIFF
--- a/desktop/libs/librdbms/src/librdbms/jdbc.py
+++ b/desktop/libs/librdbms/src/librdbms/jdbc.py
@@ -17,7 +17,7 @@
 
 import logging
 import sys
-
+import os
 
 LOG = logging.getLogger(__name__)
 
@@ -51,7 +51,7 @@ class Jdbc():
     if 'py4j' not in sys.modules:
       raise Exception('Required py4j module is not imported.')
 
-    self.gateway = JavaGateway()
+    self.gateway = JavaGateway.launch_gateway(classpath=os.environ['CLASSPATH'])
 
     self.jdbc_driver = driver_name
     self.db_url = url
@@ -62,6 +62,7 @@ class Jdbc():
 
   def connect(self):
     if self.conn is None:
+      self.gateway.jvm.Class.forName(self.jdbc_driver)
       self.conn = self.gateway.jvm.java.sql.DriverManager.getConnection(self.db_url, self.username, self.password)
 
   def cursor(self):


### PR DESCRIPTION
Using [this documentation](http://gethue.com/custom-sql-query-editors/) I failed to connect Hue to my [JDBC-compatible tool](https://github.com/mozafari/verdict). When I investigated the source code I found that the CLASSPATH variable and the JDBC driver class name are not used anywhere in the code. So, my JDBC driver class is not loaded at all.
This PR fixes that and makes sure that the JDBC driver class is loaded.