### PR TITLE
Rdbms result escape xml

### DIFF
--- a/apps/rdbms/src/rdbms/templates/execute.mako
+++ b/apps/rdbms/src/rdbms/templates/execute.mako
@@ -832,6 +832,11 @@ ${ commonshare() | n,unicode }
     $.jHueNotify.info("${_('Query saved successfully!')}")
   });
 
+  // Initial htmlEscape
+  String.prototype.htmlEscape = function() {
+    return $('<div/>').text(this.toString()).html();
+  };
+
   var dataTable = null;
   function cleanResultsTable() {
     if (dataTable) {
@@ -848,6 +853,7 @@ ${ commonshare() | n,unicode }
     $("#executeQuery").button("loading");
   }
 
+
   function addResults(viewModel, dataTable, index, pageSize) {
     $.each(viewModel.rows.slice(index, index + pageSize), function (row_index, row) {
       var ordered_row = [];
@@ -856,7 +862,7 @@ ${ commonshare() | n,unicode }
           ordered_row.push(index + row_index + 1);
         }
         else {
-          ordered_row.push(row[col]);
+          ordered_row.push(row[col]).toString().htmlEscape();
         }
       });
       dataTable.fnAddData(ordered_row);

--- a/apps/rdbms/src/rdbms/templates/execute.mako
+++ b/apps/rdbms/src/rdbms/templates/execute.mako
@@ -853,7 +853,6 @@ ${ commonshare() | n,unicode }
     $("#executeQuery").button("loading");
   }
 
-
   function addResults(viewModel, dataTable, index, pageSize) {
     $.each(viewModel.rows.slice(index, index + pageSize), function (row_index, row) {
       var ordered_row = [];


### PR DESCRIPTION
if RDBMS result has XML column, the XML data will not display in HTML.

add `toString().htmlEscape()` to escape the result.
![1](https://cloud.githubusercontent.com/assets/1259324/15421312/207d4b20-1ea5-11e6-9fce-be4cbb86322f.png)

