### PR TITLE
ISSUES-381 fix rules for stderror in spark_shell

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/spark_shell.py
+++ b/desktop/libs/notebook/src/notebook/connectors/spark_shell.py
@@ -263,7 +263,7 @@ class SparkApi(Api):
     elif content['status'] == 'error':
       tb = content.get('traceback', None)
 
-      if tb is None:
+      if tb is None or not tb:
         msg = content.get('ename', 'unknown error')
 
         evalue = content.get('evalue')


### PR DESCRIPTION
This is fix for this [issue](https://github.com/cloudera/hue/issues/381).
If you trying to run your scala snippet, you can't see syntax error or error in your SQL request in web UI 
The problem is in [spark_shell.py](https://github.com/cloudera/hue/blob/74040cb987b290ddb8dcf2f2da7e26fba0c4cb25/desktop/libs/notebook/src/notebook/connectors/spark_shell.py#L266)
where I found wrong comparison operator for 'traceback' variable.
If you have exception where 'traceback' variable is not equal None, but it is 'traceback': [] then this line if tb is None: is not work and you can see QueryError with empty message (because on line [273](https://github.com/cloudera/hue/blob/74040cb987b290ddb8dcf2f2da7e26fba0c4cb25/desktop/libs/notebook/src/notebook/connectors/spark_shell.py#L273) you can see join with empty string). Simple fix from `if tb is None:` to `if tb is None or not tb:`