### PR TITLE
Assure make does not fail because the wrong version of python is used…

### DIFF
--- a/Makefile.vars
+++ b/Makefile.vars
@@ -69,7 +69,7 @@ STATIC_DIR := $(BLD_DIR)/static
 # installation should always use the ENV_PYTHON.
 ##############################
 ENV_PYTHON := $(BLD_DIR_ENV)/bin/$(notdir $(SYS_PYTHON))
-ENV_PYTHON_VERSION = $(shell $(ENV_PYTHON) -c 'import sys; print "python%d.%d"% sys.version_info[:2]')
+ENV_PYTHON_VERSION = $(shell $(ENV_PYTHON) -c 'import sys; print ("python%d.%d"% sys.version_info[:2]);')
 
 
 ##############################
@@ -83,7 +83,7 @@ ENV_EASY_INSTALL := $(ENV_PYTHON) $(BLD_DIR_BIN)/easy_install
 ##############################
 # This version is substituted through to the tarballs and packages.
 ##############################
-DESKTOP_VERSION := $(shell python <(cat $(ROOT)/VERSION; echo print VERSION))
+DESKTOP_VERSION := $(shell python <(cat $(ROOT)/VERSION; echo print (VERSION)))
 MAVEN_VERSION = $(DESKTOP_VERSION)-SNAPSHOT
 
 ##############################


### PR DESCRIPTION
… to configure

In this early stage the Makefile.vars file is executed without knowing exactly which version "python" refers to. This causes failures if your default "python" is python 3, even printing the version, etc. I have changed all the python calls to be 2/3 compatible (for instance adding parentheses to the arguments to the print call, that works equally well in python 2 and 3).