### PR TITLE
Avoid make failure when default python is python3

### DIFF
--- a/Makefile.vars
+++ b/Makefile.vars
@@ -69,7 +69,7 @@ STATIC_DIR := $(BLD_DIR)/static
 # installation should always use the ENV_PYTHON.
 ##############################
 ENV_PYTHON := $(BLD_DIR_ENV)/bin/$(notdir $(SYS_PYTHON))
-ENV_PYTHON_VERSION = $(shell $(ENV_PYTHON) -c 'import sys; print "python%d.%d"% sys.version_info[:2]')
+ENV_PYTHON_VERSION = $(shell $(ENV_PYTHON) -c 'import sys; print ("python%d.%d"% sys.version_info[:2])')
 
 
 ##############################
@@ -83,7 +83,7 @@ ENV_EASY_INSTALL := $(ENV_PYTHON) $(BLD_DIR_BIN)/easy_install
 ##############################
 # This version is substituted through to the tarballs and packages.
 ##############################
-DESKTOP_VERSION := $(shell python <(cat $(ROOT)/VERSION; echo print VERSION))
+DESKTOP_VERSION := $(shell python <(cat $(ROOT)/VERSION; echo print '(VERSION)'))
 MAVEN_VERSION = $(DESKTOP_VERSION)-SNAPSHOT
 
 ##############################


### PR DESCRIPTION
I added python 2/3 compatible changes to Makefile.vars, because some code is executed before configuring SYS_PYTHON and causes failures when python 3 is the default "python". I added parenthesis for calls to print so that the code works equally well under python 2 and 3.