### PR TITLE
Removed Ctrl-E keybinding (editor.create.new) on macOS

### DIFF
--- a/desktop/core/src/desktop/static/desktop/js/ko.hue-bindings.js
+++ b/desktop/core/src/desktop/static/desktop/js/ko.hue-bindings.js
@@ -3076,7 +3076,7 @@
 
       editor.commands.addCommand({
         name: "new",
-        bindKey: {win: "Ctrl-e", mac: "Command-e|Ctrl-e"},
+        bindKey: {win: "Ctrl-e", mac: "Command-e"},
         exec: function () {
           huePubSub.publish('editor.create.new');
         }


### PR DESCRIPTION
Ctrl-E is meant to move the cursor to the end of the line on macOS. 