### PR TITLE
Correct check for undefined variable

### DIFF
--- a/apps/search/src/search/static/search/js/search.ko.js
+++ b/apps/search/src/search/static/search/js/search.ko.js
@@ -1470,7 +1470,7 @@ var SearchViewModel = function (collection_json, query_json, initial_json) {
             try {
               data = JSON.bigdataParse(data);
 
-              if (typeof callback != undefined && callback != null) {
+              if (typeof callback === "function") {
                 callback(data);
               }
 


### PR DESCRIPTION
The code was comparing the result of `typeof` with a variable named `undefined`. As typeof returns a string it should compare to `'undefined'`.

What we really want is to check if `callback` is a function, so I changed the nature of the `if` condition.