### PR TITLE
HUE-5170 [oozie] fails with spark action 0.2 schema

### DIFF
--- a/apps/oozie/src/oozie/templates/editor2/gen/workflow-spark.xml.mako
+++ b/apps/oozie/src/oozie/templates/editor2/gen/workflow-spark.xml.mako
@@ -18,7 +18,7 @@
 <%namespace name="common" file="workflow-common.xml.mako" />
 
     <action name="${ node['name'] }"${ common.credentials(node['properties']['credentials']) }${ common.retry_max(node['properties']['retry_max']) }${ common.retry_interval(node['properties']['retry_interval']) }>
-        <spark xmlns="uri:oozie:spark-action:0.2">
+        <spark xmlns="uri:oozie:spark-action:0.1">
             <job-tracker>${'${'}jobTracker}</job-tracker>
             <name-node>${'${'}nameNode}</name-node>
 


### PR DESCRIPTION
oozie workflow fails to submit and execute spark action due to spark-action-0.2 schema not found. Should use spark-aciton-0.1 instead.