### PR TITLE
Updates 404 on Django version URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Main Stack
 Hue would not be possible without:
 
    * Python 2.6.5 - 2.7
-   * Django 1.6 (https://docs.djangoproject.com/en/1.6/)
+   * Django 1.6 (https://docs.djangoproject.com/)
    * Knockout.js (http://knockoutjs.com/)
    * jQuery (http://jquery.com/)
    * Bootstrap (http://getbootstrap.com/)


### PR DESCRIPTION
It is just a really minor detail, but the current Django link takes to a 404
Changed the link to point to base Django URL that redirects to current version