### PR TITLE
fix non-english oozie workflow name mangling problem

### DIFF
--- a/apps/oozie/src/oozie/models2.py
+++ b/apps/oozie/src/oozie/models2.py
@@ -75,16 +75,18 @@ class Job(object):
 
   @property
   def validated_name(self):
+    xml_entities = {
+            '"': '&quot;',
+            '\'': '&apos;',
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+    }
     good_name = []
 
     for c in self.name[:40]:
-      if not good_name:
-        if not re.match('[a-zA-Z_\{\$\}]', c):
-          c = '_'
-      else:
-        if not re.match('[\-_a-zA-Z0-9\{\$\}]', c):
-          c = '_'
-      good_name.append(c)
+        c = xml_entities.get(c, c)
+        good_name.append(c)
 
     return ''.join(good_name)
 


### PR DESCRIPTION
When Oozie workflow submitted in Hue and the workflow name contains non-english characters, Hue replaced all non-english characters to underscores which seriously affected later displays.

XML standards demands proper escaping of only 5 special characters in attribute string, so there is no need to be so strict.
