### PR TITLE
Catch missing 'snippets' field in document2 data in hive_server2_lib

### DIFF
--- a/apps/beeswax/src/beeswax/server/hive_server2_lib.py
+++ b/apps/beeswax/src/beeswax/server/hive_server2_lib.py
@@ -654,7 +654,12 @@ class HiveServerClient:
 
         # Only check last 40 documents for performance
         for doc in docs[:40]:
-          snippet_data = json.loads(doc.data)['snippets'][0]
+          try:
+            snippet_data = json.loads(doc.data)['snippets'][0]
+          except (KeyError, IndexError):
+            # data might not contain a 'snippets' field or it might be empty
+            LOG.warn('No snippets in Document2 object of type query-hive')
+            continue
           session_guid = snippet_data.get('result', {}).get('handle', {}).get('session_guid')
           status = snippet_data.get('status')
 


### PR DESCRIPTION
We had occasional cases of document2 objects of type 'query-hive' in the DB missing a 'snippets' field and throwing an exception in hive_server2_lib.
With this change, the exception is caught and the document is ignored.