### PR TITLE
Notebook will not recheck status when received status "waiting"

### DIFF
--- a/desktop/libs/notebook/src/notebook/static/notebook/js/notebook.ko.js
+++ b/desktop/libs/notebook/src/notebook/static/notebook/js/notebook.ko.js
@@ -1282,7 +1282,7 @@ var EditorViewModel = (function() {
           if (data.status == 0) {
             self.status(data.query_status.status);
 
-            if (self.status() == 'running' || self.status() == 'starting') {
+            if (self.status() == 'running' || self.status() == 'starting' || self.status() == 'waiting' ) {
               self.result.endTime(new Date());
               if (! notebook.unloaded()) { self.checkStatusTimeout = setTimeout(self.checkStatus, 1000); };
             }

--- a/desktop/libs/notebook/src/notebook/static/notebook/js/notebook.ko.js
+++ b/desktop/libs/notebook/src/notebook/static/notebook/js/notebook.ko.js
@@ -1282,7 +1282,7 @@ var EditorViewModel = (function() {
           if (data.status == 0) {
             self.status(data.query_status.status);
 
-            if (self.status() == 'running' || self.status() == 'starting' || self.status() == 'waiting' ) {
+            if (self.status() == 'running' || self.status() == 'starting' || self.status() == 'waiting') {
               self.result.endTime(new Date());
               if (! notebook.unloaded()) { self.checkStatusTimeout = setTimeout(self.checkStatus, 1000); };
             }


### PR DESCRIPTION
From the commit  LIVY-213 in the Livy Rest server see: [https://github.com/cloudera/livy/commit/b4642b193956b287bb1c1b32bafe4c5a15e71eac](https://github.com/cloudera/livy/commit/b4642b193956b287bb1c1b32bafe4c5a15e71eac)

They have added a new status "waiting" for jobs that have been submitted but are waiting to be executed this pull requests fixes a minor bug that the notebook would not recheck the status in the same way as it does for "starting" and "running" if it receives the status waiting

tested against
Hue commit bbe6acb (25.01.2016)
Livy commit [https://github.com/cloudera/livy/commit/69462b9315cb652a5d19aa4d5104b210d06fb10f](https://github.com/cloudera/livy/commit/69462b9315cb652a5d19aa4d5104b210d06fb10f) (25.01.2016)
Spark 2.1.0
Hadoop 2.7.3
