### PR TITLE
add originalIdentifierChain is undefined  check logic

### DIFF
--- a/desktop/core/src/desktop/static/desktop/js/autocomplete/sql.js
+++ b/desktop/core/src/desktop/static/desktop/js/autocomplete/sql.js
@@ -5257,6 +5257,9 @@ parser.identifyPartials = function (beforeCursor, afterCursor) {
 };
 
 parser.expandLateralViews = function (lateralViews, originalIdentifierChain, columnSuggestion) {
+  if (!originalIdentifierChain) {
+    return undefined;
+  }
   var identifierChain = originalIdentifierChain.concat(); // Clone in case it's re-used
   var firstIdentifier = identifierChain[0];
   if (typeof lateralViews !== 'undefined') {

--- a/desktop/core/src/desktop/static/desktop/js/autocomplete/sql_support.js
+++ b/desktop/core/src/desktop/static/desktop/js/autocomplete/sql_support.js
@@ -561,6 +561,9 @@ parser.identifyPartials = function (beforeCursor, afterCursor) {
 };
 
 parser.expandLateralViews = function (lateralViews, originalIdentifierChain, columnSuggestion) {
+  if (!originalIdentifierChain) {
+    return undefined;
+  }
   var identifierChain = originalIdentifierChain.concat(); // Clone in case it's re-used
   var firstIdentifier = identifierChain[0];
   if (typeof lateralViews !== 'undefined') {


### PR DESCRIPTION
# Problem
- sympton
  - Hue hive query editor insert cumulative characters occasionally.
  - After add undefined check logic to expandLateralViews method, it seems resolved.
  - [error video(youtube)](https://youtu.be/Ml944gpSSmA)
    - I just typing '1', '2', '3', '4', '5', 'a', 'b', 'c', 'd'

- query(simplify for confidence)
```
            SELECT
                a.a1 AS a1,
                a.a2 AS a2,
                (b.b1 / CAST(a.a3 AS float)) AS a3
            FROM
                (
                  SELECT
                    a2,
                    a1,
                    a3,
                    a4,
                    a5
                  FROM
                    a
                  WHERE
                    a.created_date = '20170305'
                  {sampling_condition}
                ) AS a
                LEFT OUTER JOIN(
                    select
                        a2,
                        b2,
                        b1
                    from
                        b
                    WHERE
                        b.created_date = '20170305'
                ) AS b ON a.a2 = b.a2
                        AND a.a4 = b.b2
```

- chrome console error
```
Uncaught TypeError: Cannot read property 'concat' of undefined
    at Object.parser.expandLateralViews (http://hue.server.url/static/desktop/js/autocomplete/sql.1b6e11d18890.js:5215:48)
    at commitLocations (http://hue.server.url/static/desktop/js/autocomplete/sql.1b6e11d18890.js:5031:43)
    at Parser.parser.parseSql (http://hue.server.url/static/desktop/js/autocomplete/sql.1b6e11d18890.js:5992:3)
    at SqlAutocompleter3.autocomplete (http://hue.server.url/static/desktop/js/sqlAutocompleter3.b60fc1940167.js:1718:27)
    at http://hue.server.url/notebook/editor?type=hive:7855:32
    at http://hue.server.url/static/desktop/js/hue.utils.b6c4b34de5d0.js:385:9
    at Array.forEach (native)
    at Object.publish (http://hue.server.url/static/desktop/js/hue.utils.b6c4b34de5d0.js:384:21)
    at Array.g (http://hue.server.url/static/desktop/js/ace/ext-language_tools.13b34f9ae3c0.js:1:34820)
    at o.r._signal (http://hue.server.url/static/desktop/js/ace/ace.158b200f7c10.js:1:50096)
```

#  What changed
- as-is
```
parser.expandLateralViews = function (lateralViews, originalIdentifierChain, columnSuggestion) {
  var identifierChain = originalIdentifierChain.concat(); // Clone in case it's re-used
  var firstIdentifier = identifierChain[0];
```

- to-be
```
parser.expandLateralViews = function (lateralViews, originalIdentifierChain, columnSuggestion) {
  if (!originalIdentifierChain) {
    return undefined;
  }
  var identifierChain = originalIdentifierChain.concat(); // Clone in case it's re-used
  var firstIdentifier = identifierChain[0];
```