### PR TITLE
HUE-6066 - Add EXTERNAL_TABLE to the list of DEFAULT_TABLE_TYPES

### DIFF
--- a/apps/beeswax/src/beeswax/server/hive_server2_lib.py
+++ b/apps/beeswax/src/beeswax/server/hive_server2_lib.py
@@ -476,6 +476,7 @@ class HiveServerClient:
   DEFAULT_TABLE_TYPES = [
     'TABLE',
     'VIEW',
+    'EXTERNAL_TABLE',
   ]
 
   def __init__(self, query_server, user):


### PR DESCRIPTION
 Add EXTERNAL_TABLE to the list of DEFAULT_TABLE_TYPES in hive_server2_lib so Hue will show external tables in database meta info