### PR TITLE
Fixed a bug where autocompletion would break on subqueries

### DIFF
--- a/desktop/core/src/desktop/static/desktop/js/sqlAutocompleter3.js
+++ b/desktop/core/src/desktop/static/desktop/js/sqlAutocompleter3.js
@@ -1676,7 +1676,7 @@ var AutocompleteResults = (function () {
     // For Hive it could be either:
     // SELECT col.struct FROM db.tbl -or- SELECT col.struct FROM tbl
     if (self.snippet.type() === 'impala' || self.snippet.type() === 'hive') {
-      if (identifierChain.length > 1 && !identifierChain.subQuery) {
+      if (identifierChain.length > 1 && $.grep(identifierChain, function (e) { return e.subQuery; }).length == 0) {
         self.apiHelper.loadDatabases({
           sourceType: self.snippet.type(),
           timeout: AUTOCOMPLETE_TIMEOUT,


### PR DESCRIPTION
If you type this into the hive query editor: 

    select x.* from (select * from (select 1) y) x where x.`_c0` = "asd"

You will get a strange repeated insertion of the token in between the quotes (`asd`) every time you hit any key. This fixes it.