### PR TITLE
Fix Job Browser show duplicate jobs

### DIFF
--- a/apps/jobbrowser/src/jobbrowser/templates/jobs.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/jobs.mako
@@ -207,15 +207,22 @@ ${ components.menubar(hiveserver2_impersonation_enabled) }
               }
             });
             if (foundRow == null) {
-              try {
-                jobTable.fnAddData(getJobRow(job));
-                if ($("#noJobs").is(":visible")) {
-                  $("#noJobs").hide();
-                  $(".datatables").show();
+              var jobsData = jobTable.fnGetData();
+              var foundJob = jobsData.filter(function(jobData) {
+                return $(jobData[1]).text().trim() == job.shortId;
+              }).length > 0;
+
+              if(!foundJob) {
+                try {
+                  jobTable.fnAddData(getJobRow(job));
+                  if ($("#noJobs").is(":visible")) {
+                    $("#noJobs").hide();
+                    $(".datatables").show();
+                  }
+                  $("a[data-row-selector='true']").jHueRowSelector();
+                } catch (error) {
+                  $(document).trigger("error", error);
                 }
-                $("a[data-row-selector='true']").jHueRowSelector();
-              } catch (error) {
-                $(document).trigger("error", error);
               }
             } else {
               updateJobRow(job, foundRow);


### PR DESCRIPTION
Job Browser keep adding duplicate job to the job table.
This happen when number of jobs exceed the first page.

The reason is because when we update jobTable, we check if job is already in the table using data from jobTable.fnGetNodes() which only return visited rows not every row in the table.

I add the logic to check if job already exist using data from jobTable.fnGetData() before we append new jobs to the table.