### PR TITLE
HUE-5128 [sqoop] Allows job creation and updates

### DIFF
--- a/apps/sqoop/src/sqoop/client/config.py
+++ b/apps/sqoop/src/sqoop/client/config.py
@@ -66,11 +66,10 @@ class Input(object):
       'type': self.type,
       'name': self.name,
       'sensitive': self.sensitive,
+      'size': self.size,
     }
     if self.value:
       d['value'] = self.value
-    if self.size != -1:
-      d['size'] = self.size
     if self.values:
       d['values'] = ','.join(self.values)
     return d


### PR DESCRIPTION
Tested within an HDP 2.5 environment, with Sqoop 1.99.6 built from source. 

After some combination of changes and errors (I started with 1.99.5 release, then tried the CDH release, then maybe tried MapR release...), I eventually was able to search this stacktrace piece
```
NullPointerException 
    at "org.apache.sqoop.json.util.ConfigInputSerialization.restoreConfig(ConfigInputSerialization.java:160)"
```

[Which lead me here](http://www.cnblogs.com/fillPv/p/5458677.html), (in Chinese, but mostly translatable) which says something about Hue not correctly POST-ing or PUT-ing to the Sqoop endpoint. 

This change seems to fix the issue, as I am able to create, update, and run jobs successfully via Hue.  

---

I am unsure of the implications of this change otherwise. 

The `size` field itself doesn't really make sense outside of a database context to me.  

> `size`   The length of this input field
[Sqoop Docs](https://sqoop.apache.org/docs/1.99.6/RESTAPI.html)

An alternative suggestion would be `len(name)`, I guess