### PR TITLE
HUE-7186 bugfix for variables cannot be commented in editor

### DIFF
--- a/desktop/libs/notebook/src/notebook/static/notebook/js/notebook.ko.js
+++ b/desktop/libs/notebook/src/notebook/static/notebook/js/notebook.ko.js
@@ -657,7 +657,7 @@ var EditorViewModel = (function() {
         matches = self.getPigParameters();
       } else {
         var re = /(?:^|\W)\${(\w*\=?[\w\s]*)}/g;
-        while (match = re.exec(self.statement_raw())) {
+        while (match = re.exec(self.statement_raw().replace(/(--.*$|\/\*[\s\S]*?\*\/)/gm, ' '))) {
           if (match[1].indexOf('=') > -1) {
               var splittedName = match[1].split('=');
               matches[splittedName[0]] = matches[splittedName[0]] || splittedName[1];


### PR DESCRIPTION
When we comment a line with variable value, the _variables_ still have this variable
```sql
SELECT * FROM table 
-- WHERE col=${col}
```