### PR TITLE
[HUE-7810] Fix Oozie Dashboard ignores ACL permissions

### DIFF
--- a/apps/oozie/src/oozie/views/dashboard.py
+++ b/apps/oozie/src/oozie/views/dashboard.py
@@ -1187,7 +1187,7 @@ def check_job_edition_permission(oozie_job, user):
 
 
 def has_job_edition_permission(oozie_job, user):
-  return user.is_superuser or oozie_job.user == user.username or (oozie_job.group and user.groups.filter(name=oozie_job.group).exists())
+  return user.is_superuser or oozie_job.user == user.username or (oozie_job.group and user.groups.filter(name=oozie_job.group).exists()) or (user.username in oozie_job.acl.split(','))
 
 
 def has_dashboard_jobs_access(user):

--- a/apps/oozie/src/oozie/views/dashboard.py
+++ b/apps/oozie/src/oozie/views/dashboard.py
@@ -1187,7 +1187,7 @@ def check_job_edition_permission(oozie_job, user):
 
 
 def has_job_edition_permission(oozie_job, user):
-  return user.is_superuser or oozie_job.user == user.username or (oozie_job.group and user.groups.filter(name=oozie_job.group).exists()) or (user.username in oozie_job.acl.split(','))
+  return user.is_superuser or oozie_job.user == user.username or (oozie_job.group and user.groups.filter(name=oozie_job.group).exists()) or (oozie_job.acl and user.username in oozie_job.acl.split(','))
 
 
 def has_dashboard_jobs_access(user):


### PR DESCRIPTION
Fixes Issue https://github.com/cloudera/hue/issues/637 (JIRA Link: https://issues.cloudera.org/browse/HUE-7810)
Adds ACL permissions validation to allow users to manage Oozie jobs if granted using `oozie.job.acl` parameter