### PR TITLE
[useradmin] Fix last activity update for jobbrowser/api/jobs requests

### DIFF
--- a/apps/useradmin/src/useradmin/middleware.py
+++ b/apps/useradmin/src/useradmin/middleware.py
@@ -91,7 +91,7 @@ class LastActivityMiddleware(object):
       logout = True
 
     # Save last activity for user except when polling
-    if not (request.path.strip('/') == 'jobbrowser/jobs' and request.POST.get('format') == 'json') and not (request.path == '/desktop/debug/is_idle'):
+    if not (request.path.strip('/') == 'jobbrowser/api/jobs') and not (request.path.strip('/') == 'jobbrowser/jobs' and request.POST.get('format') == 'json') and not (request.path == '/desktop/debug/is_idle'):
       try:
         profile.last_activity = datetime.now()
         profile.save()


### PR DESCRIPTION
When idle_session_timeout used and jobbrowser app is enabled, jobbrowser/api/jobs schedule requests does not allow the user session to expire.