### PR TITLE
HUE-8321 [oidc] Remove filter query from filter_users_by_claims

### DIFF
--- a/desktop/core/src/desktop/auth/backend.py
+++ b/desktop/core/src/desktop/auth/backend.py
@@ -638,13 +638,6 @@ class OIDCBackend(OIDCAuthenticationBackend):
     username = claims.get('preferred_username')
     if not username:
       return self.UserModel.objects.none()
-    # If username contains '_', each time a oidc user will always be treated
-    # as a new user WHICH should be created and call function create_user
-    # that results in a "Duplicate entry '****' for key 'username'"
-    # Django mode filter doc:
-    # https://docs.djangoproject.com/en/1.11/topics/db/queries/#escaping-percent-signs-and-underscores-in-like-statements
-    # iexact is equals to SQL 'like', replace % and _ for wildcards
-    # username = username.replace('%', '').replace('_', '')
     return self.UserModel.objects.filter(username__iexact=username)
 
   def save_refresh_tokens(self, refresh_token):

--- a/desktop/core/src/desktop/auth/backend.py
+++ b/desktop/core/src/desktop/auth/backend.py
@@ -638,8 +638,13 @@ class OIDCBackend(OIDCAuthenticationBackend):
     username = claims.get('preferred_username')
     if not username:
       return self.UserModel.objects.none()
+    # If username contains '_', each time a oidc user will always be treated
+    # as a new user WHICH should be created and call function create_user
+    # that results in a "Duplicate entry '****' for key 'username'"
+    # Django mode filter doc:
+    # https://docs.djangoproject.com/en/1.11/topics/db/queries/#escaping-percent-signs-and-underscores-in-like-statements
     # iexact is equals to SQL 'like', replace % and _ for wildcards
-    username = username.replace('%', '').replace('_', '')
+    # username = username.replace('%', '').replace('_', '')
     return self.UserModel.objects.filter(username__iexact=username)
 
   def save_refresh_tokens(self, refresh_token):


### PR DESCRIPTION

Now the code "username = username.replace('%', '').replace('_', '')" in function filter_users_by_claims(self, claims): has a bug.

If user has a username like "test_with_under_score", then when openid to login into HUE,
every time HUE will recognize the user as a new user, 
which will end in an exception of "Duplicate entry '****' for key 'username'".



# If username contains '_', each time a oidc user will always be treated
# as a new user WHICH should be created and call function create_user
# that results in a "Duplicate entry '****' for key 'username'"
# Django mode filter doc:
# https://docs.djangoproject.com/en/1.11/topics/db/queries/#escaping-percent-signs-and underscores-in-like-statements

The field lookups that equate to LIKE SQL statements (iexact, contains, icontains, startswith, istartswith, endswith and iendswith) will automatically escape the two special characters used in LIKE statements – the percent sign and the underscore. (In a LIKE statement, the percent sign signifies a multiple-character wildcard and the underscore signifies a single-character wildcard.)


I've already tested in hue embedded django console line:
![image](https://user-images.githubusercontent.com/10403433/42373247-ef40a500-8146-11e8-9b14-9d194faba794.png)


And also with hue & keycloak as below:
![image](https://user-images.githubusercontent.com/10403433/42373347-3884d682-8147-11e8-83ac-d3b5388f0a71.png)

![image](https://user-images.githubusercontent.com/10403433/42373352-3d81d0fe-8147-11e8-844d-a6c47e62ba6c.png)

![image](https://user-images.githubusercontent.com/10403433/42373371-488f58ae-8147-11e8-9cca-c5065dfb2738.png)
