### PR TITLE
[HUE-7919] oozie error 'NoneType' object has no attribute 'is_superuser'

### DIFF
--- a/apps/oozie/src/oozie/models2.py
+++ b/apps/oozie/src/oozie/models2.py
@@ -3502,12 +3502,12 @@ class Coordinator(Job):
     if self.data['properties']['document']:
       document = Document2.objects.get_by_uuid(user=self.document.owner, uuid=self.data['properties']['document'])
       wf_doc = WorkflowBuilder().create_workflow(document=document, user=self.document.owner, managed=True)
-      wf = Workflow(data=wf_doc.data)
+      wf = Workflow(data=wf_doc.data,user=self.document.owner)
       wf_doc.delete()
       return wf
     else:
       wf_doc = Document2.objects.get_by_uuid(user=self.document.owner, uuid=self.data['properties']['workflow'])
-      return Workflow(document=wf_doc)
+      return Workflow(document=wf_doc,user=self.document.owner)
 
   def get_absolute_url(self):
     return reverse('oozie:edit_coordinator') + '?coordinator=%s' % self.id


### PR DESCRIPTION
Here are my reappearance steps:
1. create a shell or spark workflow ,(type as Pig/Sqoop/Dist/Shell/MapReduce/Java/Spark , also met issues)
2. create a schedule of this workflow.
3. submit schedule
would get HUE-7919 problem.

In Class Coordinator of hue/apps/oozie/src/oozie/models2.py , 
```
@property
def workflow(self)
```
initialize a Workflow without 'user' parameter, then the workflow.user=None, when passing to check can_read/write_or_exception(), would  raise  'NoneType' object has no attribute 'is_superuser'

--
ps: i'm not sure its exactly correct 