### PR TITLE
Fix Oozie workflow widget id colliding bug

### DIFF
--- a/apps/oozie/src/oozie/models2.py
+++ b/apps/oozie/src/oozie/models2.py
@@ -587,7 +587,7 @@ def _update_adj_list(adj_list):
     elif adj_list[node]['node_type'] == 'end':
       adj_list[node]['uuid'] = '33430f0f-ebfa-c3ec-f237-3e77efa03d0a'
     else:
-      adj_list[node]['uuid'] = node[-4:] + str(uuid.uuid4())[4:]
+      adj_list[node]['uuid'] = node + str(uuid.uuid4())[len(node):]
 
     uuids[id] = adj_list[node]['uuid']
     id += 1

--- a/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflow_graph.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflow_graph.mako
@@ -84,13 +84,14 @@ ${ dashboard.import_layout() }
             if (data.actions) {
               % if layout_json != '':
                 ko.utils.arrayForEach(data.actions, function (action) {
-                  var _w, actionId = action.id.substr(action.id.length - 4);
+                  var _w, actionId = action.id.substr(action.id.lastIndexOf('@'));
                   if (actionId === '@End') {
                     _w = viewModel.getWidgetById('33430f0f-ebfa-c3ec-f237-3e77efa03d0a');
                   }
                   else {
-                    if ($("[id^=wdg_" + actionId.toLowerCase() + "]").length > 0) {
-                      _w = viewModel.getWidgetById($("[id^=wdg_" + actionId.toLowerCase() + "]").attr("id").substr(4));
+                    var actionName = actionId.toLowerCase().substr(1)
+                    if ($("[id^=wdg_" + actionName + "]").length > 0) {
+                      _w = viewModel.getWidgetById($("[id^=wdg_" + actionName + "]").attr("id").substr(4));
                     }
                     else {
                       _w = viewModel.getWidgetById('33430f0f-ebfa-c3ec-f237-3e77efa03d0a');
@@ -162,4 +163,6 @@ ${ dashboard.import_layout() }
       %endif
     });
   })();
+
+//# sourceURL=list_oozie_workflow_graph.js
 </script>

--- a/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflow_graph.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflow_graph.mako
@@ -163,6 +163,4 @@ ${ dashboard.import_layout() }
       %endif
     });
   })();
-
-//# sourceURL=list_oozie_workflow_graph.js
 </script>


### PR DESCRIPTION
Currently, Oozie graph widgets are using the last 4 characters of the action name appending with UUID to generate the widget id. At rendering time, after the AJAX call from refreshView() is made, the JS code is using the last 4 characters of the action name, returned from the AJAX call, to find the matching widgets to update its status (process, completion, etc.)

This causes trouble when multiple action names have the same last 4 digits. I've fixed it by constructing the widget ID more appropriately by appending the full action name + the UUID. I've tried to retain the semantics of the UUID as much as possible (the final ID will have the same length as the UUID) to fix the bug. After this fix, Oozie workflow should be rendered and updated correctly.

More importantly, without this change, the users won't be able to drill down to the logs of the affected actions, due to the fact that the JS will always pick the first match in the list of matched widgets, see here: https://github.com/cloudera/hue/blob/master/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflow_graph.mako#L93

I've added 
```
//# sourceURL=list_oozie_workflow_graph.js
```
to aid debugging in Chrome for this feature in general at the end of the JS code. Without this, you can't select the script in Chrome and pause a debugger. I can remove it as requested.