### PR TITLE
HUE-8752: [editor] Variable substitution does not use the default val…

### DIFF
--- a/desktop/core/src/desktop/js/apps/notebook/snippet.js
+++ b/desktop/core/src/desktop/js/apps/notebook/snippet.js
@@ -949,9 +949,11 @@ class Snippet {
             const pad =
               variable.type() == 'datetime-local' && variable.value().length == 16 ? ':00' : ''; // Chrome drops the seconds from the timestamp when it's at 0 second.
             const value = variable.value();
+            const isValuePresent = //If value is string there is a need to check whether it is empty
+              typeof value === 'string' ? value : value !== undefined && value !== null;
             return (
               p1 +
-              (value !== undefined && value !== null
+              (isValuePresent
                 ? value + pad
                 : variable.meta.placeholder && variable.meta.placeholder())
             );


### PR DESCRIPTION
…ue when empty

[Link](https://issues.cloudera.org/browse/HUE-8752) to jira
This fix does not break the boolean variables in editor and fixes usage of default value when empty