### PR TITLE
Adding HTTPS options for WebHDFS

### DIFF
--- a/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py
+++ b/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py
@@ -35,7 +35,7 @@ from hadoop.fs import normpath as fs_normpath, SEEK_SET, SEEK_CUR, SEEK_END
 from hadoop.fs.hadoopfs import Hdfs
 from hadoop.fs.exceptions import WebHdfsException
 from hadoop.fs.webhdfs_types import WebHdfsStat, WebHdfsContentSummary
-from hadoop.hdfs_site import get_nn_sentry_prefixes, get_umask_mode, get_supergroup
+from hadoop.hdfs_site import get_nn_sentry_prefixes, get_umask_mode, get_supergroup, get_webhdfs_ssl
 
 
 import hadoop.conf
@@ -1006,8 +1006,8 @@ def _get_service_url(hdfs_config):
   fs_defaultfs = hdfs_config.FS_DEFAULTFS.get()
   netloc = Hdfs.urlsplit(fs_defaultfs)[1]
   host = netloc.split(':')[0]
-  port = hadoop.conf.DEFAULT_NN_HTTP_PORT
-  return "http://%s:%s/webhdfs/v1" % (host, port)
+  #port = hadoop.conf.DEFAULT_NN_HTTP_PORT
+  return "{0}://{1}:{2}/webhdfs/v1".format(get_webhdfs_ssl()["protocol"], host, get_webhdfs_ssl()["port"])
 
 
 def test_fs_configuration(fs_config):

--- a/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py
+++ b/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py
@@ -1006,7 +1006,6 @@ def _get_service_url(hdfs_config):
   fs_defaultfs = hdfs_config.FS_DEFAULTFS.get()
   netloc = Hdfs.urlsplit(fs_defaultfs)[1]
   host = netloc.split(':')[0]
-  #port = hadoop.conf.DEFAULT_NN_HTTP_PORT
   return "{0}://{1}:{2}/webhdfs/v1".format(get_webhdfs_ssl()["protocol"], host, get_webhdfs_ssl()["port"])
 
 

--- a/desktop/libs/hadoop/src/hadoop/hdfs_site.py
+++ b/desktop/libs/hadoop/src/hadoop/hdfs_site.py
@@ -56,7 +56,7 @@ def get_webhdfs_ssl():
   settings = {"protocol": "http", "port": hadoop.conf.DEFAULT_NN_HTTP_PORT}
   if get_conf().get(_CNF_HTTP_POLICY, 'http') == "HTTPS_ONLY":
     settings["protocol"] = 'https'
-    settings["port"] = get_conf().get(_CNF_WEBHDFS_HTTPS_PORT , hadoop.conf.DEFAULT_NN_HTTP_PORT)
+    settings["port"] = get_conf().get(_CNF_WEBHDFS_HTTPS_PORT, hadoop.conf.DEFAULT_NN_HTTP_PORT)
   return settings
 
 def get_nn_sentry_prefixes():

--- a/desktop/libs/hadoop/src/hadoop/hdfs_site.py
+++ b/desktop/libs/hadoop/src/hadoop/hdfs_site.py
@@ -21,7 +21,7 @@ import os.path
 
 import conf
 import confparse
-
+import hadoop.conf
 
 LOG = logging.getLogger(__name__)
 
@@ -31,7 +31,8 @@ _CNF_NN_PERMISSIONS_UMASK_MODE = 'fs.permissions.umask-mode'
 _CNF_NN_SENTRY_PREFIXES = 'sentry.authorization-provider.hdfs-path-prefixes' # Deprecated
 _CNF_NN_SENTRY_PATH_PREFIXES = 'sentry.hdfs.integration.path.prefixes'
 _CNF_NN_PERMISSIONS_SUPERGROUP = 'dfs.permissions.superusergroup'
-
+_CNF_HTTP_POLICY = 'dfs.http.policy'
+_CNF_WEBHDFS_HTTPS_PORT = 'dfs.https.port'
 
 def reset():
   global _HDFS_SITE_DICT
@@ -51,6 +52,12 @@ def get_umask_mode():
 
   return int(umask, 8)
 
+def get_webhdfs_ssl():
+  settings = {"protocol": "http", "port": hadoop.conf.DEFAULT_NN_HTTP_PORT}
+  if get_conf().get(_CNF_HTTP_POLICY, 'http') == "HTTPS_ONLY":
+    settings["protocol"] = 'https'
+    settings["port"] = get_conf().get(_CNF_WEBHDFS_HTTPS_PORT , hadoop.conf.DEFAULT_NN_HTTP_PORT)
+  return settings
 
 def get_nn_sentry_prefixes():
   prefixes = set()

--- a/desktop/libs/hadoop/src/hadoop/hdfs_site.py
+++ b/desktop/libs/hadoop/src/hadoop/hdfs_site.py
@@ -21,7 +21,7 @@ import os.path
 
 import conf
 import confparse
-import hadoop.conf
+from hadoop.conf import DEFAULT_NN_HTTP_PORT
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
Currently, Hue is hard coded to http for webhdfs (return "http://%s:%s/webhdfs/v1" % (host, port)).  This PR makes it dynamically pull SSL from hdfs-site settings with the ability to override the port from hue.ini

Note -> i just moved the port into the hdfs-site.py so i need to test that and make sure it works since previously i was injecting it in webhdfs.py (this seemed cleaner though it does seem to break the convention of no hue.ini settings in hdfs-site.py).