### PR TITLE
Fix notebook user's searching not displaying

### DIFF
--- a/desktop/core/src/desktop/templates/document_browser.mako
+++ b/desktop/core/src/desktop/templates/document_browser.mako
@@ -83,7 +83,7 @@ from desktop.views import _ko
           ${ _('There was an error loading the document.')}
         </div>
         <div style="margin-top: 20px" data-bind="visible: fileEntry.canModify() && ! hasErrors() && ! loading()">
-          <div class="input-append">
+          <div class="input-append" style="font-size: inherit">
              <div id="menu"></div>
               <input id="userSearchAutocomp" placeholder="${_('Type a username or a group name')}" type="text" data-bind="autocomplete: { source: shareAutocompleteUserSource.bind($data), itemTemplate: 'user-search-autocomp-item', noMatchTemplate: 'user-search-autocomp-no-match', valueObservable: searchInput, showSpinner: true, classPrefix: 'hue-', onEnter: onShareAutocompleteUserEnter.bind($data), appendTo: $('#menu') }, clearable: { value: searchInput, textInput: searchInput }" class="ui-autocomplete-input" autocomplete="off" style="width: 420px">
             <div class="btn-group" style="overflow:visible">


### PR DESCRIPTION
Fix an annoying UI bug where the search result of the user search function in notebook sharing is not displayed correctly. You can reproduce this bug in v4.4 in http://demo.gethue.com. 

Attached are the screenshots before and after this simple fix.

# Before
![Before](https://i.ibb.co/RY0spP4/Screen-Shot-2019-05-02-at-6-04-54-PM.png "Before")

# After
![After](https://i.ibb.co/r0Q0XR6/Screen-Shot-2019-05-02-at-6-06-24-PM.png "After")