### PR TITLE
Patch to allow configuration of spark session variables

### DIFF
--- a/apps/spark/src/spark/conf.py
+++ b/apps/spark/src/spark/conf.py
@@ -52,6 +52,59 @@ LIVY_SERVER_SESSION_KIND = Config( # Note: this one is ignored by Livy, this sho
    help=_t("Configure livy to start in local 'process' mode, or 'yarn' workers."),
    default="yarn")
 
+LIVY_DEFAULT_QUEUE = Config(
+  key="livy_default_queue",
+  help=_t("Default Queue for Spark Livy Sessions"),
+  type=str,
+  default="default"
+)
+def get_livy_default_queue():
+  """Get from top level default from desktop"""
+  return LIVY_DEFAULT_QUEUE.get()
+
+LIVY_DRIVER_MEMORY = Config(
+  key="livy_driver_memory",
+  help=_t("Default Driver Memory for Spark Livy Sessions"),
+  type=str,
+  default="2G"
+)
+def get_livy_driver_memory():
+  """Get from top level default from desktop"""
+  return LIVY_DRIVER_MEMORY.get()
+
+LIVY_DRIVER_CORES = Config(
+  key="livy_driver_cores",
+  help=_t("Default Driver Cores for Spark Livy Sessions"),
+  type=int,
+  default=1
+)
+
+def get_livy_driver_cores():
+  """Get from top level default from desktop"""
+  return LIVY_DRIVER_CORES.get()
+
+LIVY_EXECUTOR_MEMORY = Config(
+  key="livy_executor_memory",
+  help=_t("Default Executor Memory for Spark Livy Sessions"),
+  type=str,
+  default="1G"
+)
+
+def get_livy_executor_memory():
+  """Get from top level default from desktop"""
+  return LIVY_EXECUTOR_MEMORY.get()
+
+LIVY_EXECUTOR_CORES = Config(
+  key="livy_executor_cores",
+  help=_t("Default Executor Cores for Spark Livy Sessions"),
+  type=int,
+  default=1
+)
+
+def get_livy_executor_cores():
+  """Get from top level default from desktop"""
+  return LIVY_EXECUTOR_CORES.get()
+
 SECURITY_ENABLED = Config(
   key="security_enabled",
   help=_t("Whether Livy requires client to perform Kerberos authentication."),

--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -849,6 +849,13 @@
   ## order in which the interpreter entries appear. Only the first 5 interpreters will appear on the wheel.
   # interpreters_shown_on_wheel=
 
+  ## Set of parameters to change the default notebook spark session variables
+  # notebook_livy_default_queue=default
+  # notebook_livy_driver_memory=2G
+  # notebook_livy_driver_cores=1
+  # notebook_livy_executor_memory=1G
+  # notebook_livy_executor_cores=1
+
   # One entry for each type of snippet.
   [[interpreters]]
     # Define the name and how to connect and execute the language.
@@ -1280,6 +1287,12 @@
   # Choose whether Hue should validate certificates received from the server.
   ## ssl_cert_ca_verify=true
 
+  ## Override Default Spark Settings (listed are the defaults)
+  # livy_default_queue=default
+  # livy_driver_memory=2G
+  # livy_driver_cores=1
+  # livy_executor_memory=1G
+  # livy_executor_cores=1
 
 ###########################################################################
 # Settings to configure the Oozie app

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -850,6 +850,13 @@
   ## Comma separated list of interpreters that should be shown on the wheel. This list takes precedence over the
   ## order in which the interpreter entries appear. Only the first 5 interpreters will appear on the wheel.
   # interpreters_shown_on_wheel=
+  
+  ## Set of parameters to change the default notebook spark session variables
+  # notebook_livy_default_queue=default
+  # notebook_livy_driver_memory=2G
+  # notebook_livy_driver_cores=1
+  # notebook_livy_executor_memory=1G
+  # notebook_livy_executor_cores=1
 
   # One entry for each type of snippet.
   [[interpreters]]

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -1290,7 +1290,12 @@
   # Choose whether Hue should validate certificates received from the server.
   ## ssl_cert_ca_verify=true
 
-
+  ## Override Default Spark Settings (listed are the defaults)
+  # livy_default_queue=default
+  # livy_driver_memory=2G
+  # livy_driver_cores=1
+  # livy_executor_memory=1G
+  # livy_executor_cores=1
 ###########################################################################
 # Settings to configure the Oozie app
 ###########################################################################

--- a/desktop/libs/notebook/src/notebook/conf.py
+++ b/desktop/libs/notebook/src/notebook/conf.py
@@ -23,7 +23,7 @@ from django.utils.translation import ugettext_lazy as _t
 from desktop import appmanager
 from desktop.conf import is_oozie_enabled, CONNECTORS
 from desktop.lib.conf import Config, UnspecifiedConfigSection, ConfigSection, coerce_json_dict, coerce_bool, coerce_csv
-
+from spark.conf import get_livy_default_queue, get_livy_driver_memory, get_livy_driver_cores, get_livy_executor_memory, get_livy_executor_cores
 
 SHOW_NOTEBOOKS = Config(
     key="show_notebooks",
@@ -207,6 +207,40 @@ ENABLE_QUERY_ANALYSIS = Config(
   default=False
 )
 
+NOTEBOOK_LIVY_DEFAULT_QUEUE = Config(
+  key="notebook_livy_default_queue",
+  help=_t("Default Queue for Spark Livy Sessions"),
+  type=str,
+  dynamic_default=get_livy_default_queue
+)
+
+NOTEBOOK_LIVY_DRIVER_MEMORY = Config(
+  key="notebook_livy_driver_memory",
+  help=_t("Default Driver Memory for Spark Livy Sessions"),
+  type=str,
+  dynamic_default=get_livy_driver_memory
+)
+
+NOTEBOOK_LIVY_DRIVER_CORES = Config(
+  key="notebook_livy_driver_cores",
+  help=_t("Default Driver Cores for Spark Livy Sessions"),
+  type=int,
+  dynamic_default=get_livy_driver_cores
+)
+
+NOTEBOOK_LIVY_EXECUTOR_MEMORY = Config(
+  key="notebook_livy_executor_memory",
+  help=_t("Default Executor Memory for Spark Livy Sessions"),
+  type=str,
+  dynamic_default=get_livy_executor_memory
+)
+
+NOTEBOOK_LIVY_EXECUTOR_CORES = Config(
+  key="notebook_livy_executor_cores",
+  help=_t("Default Executor Cores for Spark Livy Sessions"),
+  type=int,
+  dynamic_default=get_livy_executor_cores
+)
 
 def _default_interpreters(user):
   interpreters = []

--- a/desktop/libs/notebook/src/notebook/connectors/spark_shell.py
+++ b/desktop/libs/notebook/src/notebook/connectors/spark_shell.py
@@ -42,7 +42,8 @@ except ImportError, e:
 
 
 class SparkConfiguration(object):
-
+  from spark.conf import LIVY_DEFAULT_QUEUE, LIVY_DRIVER_MEMORY, LIVY_DRIVER_CORES, LIVY_EXECUTOR_MEMORY, LIVY_EXECUTOR_CORES
+  from notebook.conf import NOTEBOOK_LIVY_DEFAULT_QUEUE, NOTEBOOK_LIVY_DRIVER_MEMORY, NOTEBOOK_LIVY_DRIVER_CORES, NOTEBOOK_LIVY_EXECUTOR_MEMORY, NOTEBOOK_LIVY_EXECUTOR_CORES
   APP_NAME = 'spark'
 
   PROPERTIES = [
@@ -90,8 +91,8 @@ class SparkConfiguration(object):
       "type": "jvm",
       "is_yarn": False,
       "multiple": False,
-      "defaultValue": '1G',
-      "value": '1G',
+      "defaultValue": LIVY_DRIVER_MEMORY.get(),
+      "value": NOTEBOOK_LIVY_DRIVER_MEMORY.get(),
     },
     # YARN-only properties
     {
@@ -101,8 +102,8 @@ class SparkConfiguration(object):
       "type": "number",
       "is_yarn": True,
       "multiple": False,
-      "defaultValue": 1,
-      "value": 1,
+      "defaultValue": LIVY_DRIVER_CORES.get(),
+      "value": NOTEBOOK_LIVY_DRIVER_CORES.get(),
     }, {
       "name": "executorMemory",
       "nice_name": _("Executor Memory"),
@@ -110,8 +111,8 @@ class SparkConfiguration(object):
       "type": "jvm",
       "is_yarn": True,
       "multiple": False,
-      "defaultValue": '1G',
-      "value": '1G',
+      "defaultValue": LIVY_EXECUTOR_MEMORY.get(),
+      "value": NOTEBOOK_LIVY_EXECUTOR_MEMORY.get(),
     }, {
       "name": "executorCores",
       "nice_name": _("Executor Cores"),
@@ -119,8 +120,8 @@ class SparkConfiguration(object):
       "type": "number",
       "is_yarn": True,
       "multiple": False,
-      "defaultValue": 1,
-      "value": 1,
+      "defaultValue": LIVY_EXECUTOR_CORES.get(),
+      "value": NOTEBOOK_LIVY_EXECUTOR_CORES.get(),
     }, {
       "name": "queue",
       "nice_name": _("Queue"),
@@ -128,8 +129,8 @@ class SparkConfiguration(object):
       "type": "string",
       "is_yarn": True,
       "multiple": False,
-      "defaultValue": 'default',
-      "value": 'default',
+      "defaultValue": LIVY_DEFAULT_QUEUE.get(),
+      "value": NOTEBOOK_LIVY_DEFAULT_QUEUE.get(),
     }, {
       "name": "archives",
       "nice_name": _("Archives"),


### PR DESCRIPTION
Consists of changes to 

Spark/Conf.py (Livy) which creates defaults and allows override of all sessions
notebook/conf.py allows for overriding the livy settings just for notebooks
spark-shell.py adds the defaults to the livy call

hue.ini => adding variable sections
pseudoini => adding variable sections