### PR TITLE
[FIX] fix Hue-896

### DIFF
--- a/apps/hbase/src/hbase/api.py
+++ b/apps/hbase/src/hbase/api.py
@@ -218,6 +218,8 @@ class HbaseApi(object):
     client = self.connectCluster(cluster)
     aggregate_data = []
     limit = conf.TRUNCATE_LIMIT.get()
+    if not isinstance(queries, list):
+      queries=json.loads(queries)
     queries = sorted(queries, key=lambda query: query['scan_length']) #sort by scan length
     for query in queries:
       scan_length = int(query['scan_length'])

--- a/desktop/core/src/desktop/js/ko/bindings/ko.highlight.js
+++ b/desktop/core/src/desktop/js/ko/bindings/ko.highlight.js
@@ -70,7 +70,14 @@ ko.bindingHandlers.highlight = {
             let token = tokens[0];
             let value = token.value;
             if (value) {
-              screenColumn = txt.$renderToken(stringBuilder, screenColumn, token, value);
+              try {
+                screenColumn = txt.$renderToken(stringBuilder, screenColumn, token, value);
+              } catch (e) {
+                console.warn(
+                  value,
+                  "Failed to get screen column due to some parsing errors, skip rendering."
+                );
+              }
             }
             for (let i = 1; i < tokens.length; i++) {
               token = tokens[i];

--- a/desktop/core/src/desktop/js/ko/bindings/ko.highlight.js
+++ b/desktop/core/src/desktop/js/ko/bindings/ko.highlight.js
@@ -75,7 +75,7 @@ ko.bindingHandlers.highlight = {
               } catch (e) {
                 console.warn(
                   value,
-                  "Failed to get screen column due to some parsing errors, skip rendering."
+                  'Failed to get screen column due to some parsing errors, skip rendering.'
                 );
               }
             }


### PR DESCRIPTION
add a try { } catch {} block in line 73 of ko.highlight.js to fix issue [[SQL Editor] failed to list query history where there're some chinese in comment](https://github.com/cloudera/hue/issues/896)