### PR TITLE
Add HTML rendering support in filebrowser app

### DIFF
--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -88,7 +88,7 @@ BYTES_PER_SENTENCE = 2
 # The maximum size the file editor will allow you to edit
 MAX_FILEEDITOR_SIZE = 256 * 1024
 
-INLINE_DISPLAY_MIMETYPE = re.compile('video/|image/|audio/|application/pdf|application/msword|application/excel|'
+INLINE_DISPLAY_MIMETYPE = re.compile('video/|image/|audio/|application/pdf|application/msword|application/excel|text/html'
                                      'application/vnd\.ms|'
                                      'application/vnd\.openxmlformats')
 


### PR DESCRIPTION
Adds support in FileBrowser application for HTML rendering directly in the UI, as suggested by @romainr.

Note, I did not know how to test this change I've tried to run Hue locally and through Docker but failed.

Addresses issue https://github.com/cloudera/hue/issues/915

Thank you for taking the time to look at this :)