### PR TITLE
Fixed manual reload for side panel on Hue

### DIFF
--- a/desktop/core/src/desktop/js/ko/components/assist/ko.assistStoragePanel.js
+++ b/desktop/core/src/desktop/js/ko/components/assist/ko.assistStoragePanel.js
@@ -194,7 +194,7 @@ class AssistStoragePanel {
 
     huePubSub.subscribe('assist.storage.refresh', () => {
       apiHelper.clearStorageCache(this.activeSource());
-      self.reload();
+      this.reload();
     });
 
     huePubSub.subscribe('assist.storage.go.home', () => {


### PR DESCRIPTION
Currently there is a problem when refreshing the assist panel. The problem begins by first clicking the files category on the assist panel and then going to one of the filesystems (HDFS, S3, ADLS). If the manual refresh button is pushed, it causes an error. This is just a minor change that fixes that problem.