### PR TITLE
[fix] fix bug -- table browser can not add description

### DIFF
--- a/desktop/core/src/desktop/js/api/apiHelper.js
+++ b/desktop/core/src/desktop/js/api/apiHelper.js
@@ -1528,7 +1528,7 @@ class ApiHelper {
           data.new_table_name = options.properties.name;
         }
       }
-    } else if (options.path > 2) {
+    } else if (options.path.length > 2) {
       url = '/metastore/table/' + options.path[0] + '/' + options.path[1] + '/alter_column';
       data.column = options.path.slice(2).join('.');
       if (options.properties) {


### PR DESCRIPTION
Fix bug  related to table browser module:  Unable  adding hive table column description  in table browser mode.Occurring render unexpected form data.


![screenshot-1](https://user-images.githubusercontent.com/17582823/62618380-a47cc380-b946-11e9-9ff2-36102337e392.png)
![图片](https://user-images.githubusercontent.com/17582823/62618428-c37b5580-b946-11e9-81cc-de98b3e0a406.png)


