### PR TITLE
Autocomplete for ABFS

### DIFF
--- a/desktop/core/src/desktop/js/ko/components/assist/assistStorageEntry.js
+++ b/desktop/core/src/desktop/js/ko/components/assist/assistStorageEntry.js
@@ -145,6 +145,7 @@ class AssistStorageEntry {
         self.entries(
           filteredFiles.map(file => {
             return new AssistStorageEntry({
+              originalType: self.originalType,
               type: self.type,
               definition: file,
               parent: self
@@ -262,6 +263,7 @@ class AssistStorageEntry {
             filteredFiles.map(
               file =>
                 new AssistStorageEntry({
+                  originalType: self.originalType,
                   type: self.type,
                   definition: file,
                   parent: self

--- a/desktop/core/src/desktop/js/ko/components/contextPopover/storageContext.js
+++ b/desktop/core/src/desktop/js/ko/components/contextPopover/storageContext.js
@@ -49,6 +49,7 @@ class StorageContext {
       do {
         result.unshift({
           name: currentEntry.definition.name,
+          originalType: currentEntry.originalType,
           isActive: currentEntry === self.storageEntry(),
           storageEntry: currentEntry,
           makeActive: function() {

--- a/desktop/core/src/desktop/js/sql/autocompleteResults.js
+++ b/desktop/core/src/desktop/js/sql/autocompleteResults.js
@@ -1309,6 +1309,14 @@ class AutocompleteResults {
             details: null
           },
           {
+            value: 'abfs://',
+            meta: META_I18n.keyword,
+            category: CATEGORIES.KEYWORD,
+            weightAdjust: 0,
+            popular: ko.observable(false),
+            details: null
+          },
+          {
             value: '/',
             meta: META_I18n.dir,
             category: CATEGORIES.HDFS,
@@ -1326,6 +1334,9 @@ class AutocompleteResults {
       } else if (/^adl:\/\//i.test(path)) {
         fetchFunction = 'fetchAdlsPath';
         path = path.substring(5);
+      } else if (/^abfs:\/\//i.test(path)) {
+        fetchFunction = 'fetchAbfsPath';
+        path = path.substring(6);
       } else if (/^hdfs:\/\//i.test(path)) {
         path = path.substring(6);
       }


### PR DESCRIPTION
This commit allows ABFS to show up as an autocomplete result.
It also fixes the issue where autocomplete would not include the filesystem root.