### PR TITLE
Fix for systems that do not have ABFS Configuration 

### DIFF
--- a/desktop/libs/azure/src/azure/abfs/abfsstats.py
+++ b/desktop/libs/azure/src/azure/abfs/abfsstats.py
@@ -61,12 +61,12 @@ class ABFSStat(object):
     return False
   
   @classmethod
-  def for_root(cls):
-    return cls(True, 0, 0, 0, 'abfs://')
+  def for_root(cls,path):
+    return cls(True, 0, 0, 0, path)
   
   @classmethod
-  def for_filesystems(cls,headers,resp):
-    return cls(True, headers['date'], resp['lastModified'], 0, 'abfs://' + resp['name'])
+  def for_filesystems(cls,headers,resp, scheme):
+    return cls(True, headers['date'], resp['lastModified'], 0, scheme + resp['name'])
 
   @classmethod
   def for_directory(cls,headers,resp, path):


### PR DESCRIPTION
It fixes the issue where users that do not have the configuration for ABFS cannot run Hue.
It also adds changes that may be used in later commits.
