### PR TITLE
Query Results-Vertical Scrollbar Fix

### DIFF
--- a/desktop/libs/notebook/src/notebook/templates/editor_components.mako
+++ b/desktop/libs/notebook/src/notebook/templates/editor_components.mako
@@ -686,7 +686,7 @@ ${ sqlSyntaxDropdown.sqlSyntaxDropdown() }
         <!-- /ko -->
       </ul>
 
-      <div class="tab-content" style="border: none; overflow-x: hidden">
+      <div class="tab-content" style="border: none; overflow-x: hidden" data-bind="style: {'max-height': !$root.isResultFullScreenMode() ? '400px' : '800px' }">
         <div class="tab-pane" style="min-height:80px;" id="queryHistory" data-bind="css: {'active': currentQueryTab() == 'queryHistory'}, style: { 'height' : $parent.historyInitialHeight() > 0 ? Math.max($parent.historyInitialHeight(), 40) + 'px' : '' }">
           <!-- ko if: $parent.loadingHistory -->
           <div class="margin-top-10 margin-left-10">


### PR DESCRIPTION
So currently, there isn't anything that contains the result container so it overflows.  this code limits it to 400px when not in full screen and 800px when in full screen so that the scrollbar shows up.  It also works much better with browser zoom.

Notes:  the best way to do this is to have the window sizes calc'd in the view model so that I don't need to hard code this.  If they were there, we could just reference them, currently the $(window).resize() event is distributed all over the codebase.

![Screen Shot 2019-12-08 at 9 51 24 AM](https://user-images.githubusercontent.com/6674285/70398294-c6f31c00-19ce-11ea-970e-6e04b8ac56df.png)
