### PR TITLE
HUE-9165 [tool] Supported kerberos config when use hue on docker

### DIFF
--- a/tools/docker/hue/Dockerfile
+++ b/tools/docker/hue/Dockerfile
@@ -3,6 +3,7 @@
 FROM ubuntu:18.04
 LABEL description="Hue SQL Assistant - gethue.com"
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && apt-get install -y \
   build-essential \
   libkrb5-dev \
@@ -32,6 +33,8 @@ RUN apt-get update -y && apt-get install -y \
   # openssl \ # Breaks build
   xmlsec1 \
   libxmlsec1-openssl \
+  krb5-config \
+  krb5-user \
   && rm -rf /var/lib/apt/lists/*
 
 ADD . /hue
@@ -62,7 +65,9 @@ RUN ./build/env/bin/pip install \
   flower \
   pyhive \
   gevent \
-  threadloop # Needed for Jaeger
+  # Needed for Jaeger
+  threadloop \
+  thrift-sasl==0.2.1
 
 COPY tools/docker/hue/conf desktop/conf
 COPY tools/docker/hue/startup.sh .


### PR DESCRIPTION
In our company product environment, kerberos is a necessary authentication mechanism. So kerberos related dependencies(such as krb5-config) need to be add in Dockerfile