### PR TITLE
HUE-8888 [gethue] Add last modified date from git info

### DIFF
--- a/docs/gethue/config.toml
+++ b/docs/gethue/config.toml
@@ -5,6 +5,7 @@ theme = "stack-hue-theme"
 pygmentsStyle = "monokailight"
 disqusShortname = "gethue"
 DefaultContentLanguage = "en"
+enableGitInfo = true
 
 [languages]
   [languages.en]

--- a/docs/gethue/themes/stack-hue-theme/layouts/_default/single.html
+++ b/docs/gethue/themes/stack-hue-theme/layouts/_default/single.html
@@ -12,7 +12,9 @@
                     <article>
                         <div class="article__title text-center">
                             <h1 class="h2">{{ .Title }}</h1>
-                            <span>{{ .Date.Format "02 January 2006" }} in</span>
+                            {{ $pub := .Date.Format "02 January 2006" }}
+                            {{ $last := .Lastmod.Format "02 January 2006" }}
+                            <span>Published on {{ $pub }} in</span>
                             <span>
                                 {{ $categories := .Params.categories }}
                                 {{ range $index, $element := $categories }}
@@ -24,6 +26,10 @@
                             </span>
                             {{ $read := .ReadingTime }}
                             - <span>{{ .ReadingTime }} minute{{ if gt $read 1 }}s{{ end }} read</span>
+
+                            {{ if and (ne $pub $last) (.Lastmod.After .Date) }}
+                            <span> - Last modified on {{ $last }}</span>
+                            {{ end }}
                             {{ if .IsTranslated }}
                             - <span>Read in
                                 {{ range .Translations }}


### PR DESCRIPTION
Showing it just in case it's different and newer than the publish date. With this we now also have access to the [.GitInfo object](https://gohugo.io/variables/git/)