### PR TITLE
HUE-8020 - Increase username length on auth form

### DIFF
--- a/desktop/core/src/desktop/auth/forms.py
+++ b/desktop/core/src/desktop/auth/forms.py
@@ -72,7 +72,7 @@ class AuthenticationForm(DjangoAuthenticationForm):
     'inactive': _t("Account deactivated. Please contact an administrator."),
   }
 
-  username = CharField(label=_t("Username"), widget=TextInput(attrs={'maxlength': 30, 'placeholder': _t("Username"), 'autocomplete': 'off', 'autofocus': 'autofocus'}))
+  username = CharField(label=_t("Username"), widget=TextInput(attrs={'maxlength': 150, 'placeholder': _t("Username"), 'autocomplete': 'off', 'autofocus': 'autofocus'}))
   password = CharField(label=_t("Password"), widget=PasswordInput(attrs={'placeholder': _t("Password"), 'autocomplete': 'off'}))
 
   def authenticate(self):


### PR DESCRIPTION
~~For our use case, 30 characters is too short and is not allowing some users
to access Hue (it seems that is also the case of the original reporter
on the linked issue).~~

~~I've added a new configuration value which allows tweak this length and,
by default, it maintains the previous behavior (30 characters per
username). I'm not sure if having this as a parametrizable configuration
is the way to go or if you prefer to just increase the max length of
this field.~~

The max length for a username on Django 1.11 is 150 (was increased from
30): https://docs.djangoproject.com/en/1.11/ref/contrib/auth/#django.contrib.auth.models.User.username

I've checked the size of the username field on `auth_user` and the field
is a `varchar(150)`, so it should be safe to increase.