### PR TITLE
Fix markdown rendering (Issue #1116)

### DIFF
--- a/desktop/libs/notebook/src/notebook/templates/editor_components.mako
+++ b/desktop/libs/notebook/src/notebook/templates/editor_components.mako
@@ -1536,12 +1536,12 @@ ${ sqlSyntaxDropdown.sqlSyntaxDropdown() }
       }"></div>
     </div>
     <div class="span6">
-      <div data-bind="html: renderMarkdown, attr: {'id': 'liveMD' + id()}"></div>
+      <div data-bind="html: renderMarkdown(), attr: {'id': 'liveMD' + id()}"></div>
     </div>
   </div>
   <!-- /ko -->
   <!-- ko if: $root.isPresentationMode() -->
-  <div data-bind="html: renderMarkdown"></div>
+  <div data-bind="html: renderMarkdown()"></div>
   <!-- /ko -->
 </script>
 


### PR DESCRIPTION
The snippet 'Markdown' was not rendering in notebook because of missing parenthesis. Just added the parenthesis and it's working.
See Issue #1116 
