### PR TITLE
fix(aws): s3datetime_to_timestamp parse timestamp with Z(minio.io)

### DIFF
--- a/desktop/libs/aws/src/aws/s3/__init__.py
+++ b/desktop/libs/aws/src/aws/s3/__init__.py
@@ -137,5 +137,5 @@ def s3datetime_to_timestamp(datetime):
     assert datetime[-4:] == ' GMT', 'Time [%s] is not in GMT.' % datetime
   except ValueError:
     stripped = time.strptime(datetime[:-5], '%Y-%m-%dT%H:%M:%S')
-    assert datetime[-5:] == '.000Z', 'Time [%s] is not in GMT.' % datetime
+    assert datetime[-1:] == 'Z' and datetime[-5:-4] == '.', 'Time [%s] is not in GMT.' % datetime
   return int(calendar.timegm(stripped))

--- a/desktop/libs/aws/src/aws/s3/s3_test.py
+++ b/desktop/libs/aws/src/aws/s3/s3_test.py
@@ -64,12 +64,11 @@ def test_is_root():
 def test_s3datetime_to_timestamp():
   f = s3.s3datetime_to_timestamp
   eq_(1424983327, f('Thu, 26 Feb 2015 20:42:07 GMT'))
-  eq_(1424983327, f('2015-02-26T20:42:07.000Z'))
+  eq_(1424983327, f('2015-02-26T20:42:07.040Z'))
 
   assert_raises(ValueError, f, '2/26/2015 20:42:07')
 
   assert_raises(AssertionError, f, 'Thu, 26 Feb 2015 20:42:07 PDT')
-  assert_raises(AssertionError, f, '2015-02-26T20:42:07.040Z')
 
 
 def test_get_default_region():

--- a/desktop/libs/aws/src/aws/s3/s3_test.py
+++ b/desktop/libs/aws/src/aws/s3/s3_test.py
@@ -64,6 +64,7 @@ def test_is_root():
 def test_s3datetime_to_timestamp():
   f = s3.s3datetime_to_timestamp
   eq_(1424983327, f('Thu, 26 Feb 2015 20:42:07 GMT'))
+  eq_(1424983327, f('2015-02-26T20:42:07.000Z'))
   eq_(1424983327, f('2015-02-26T20:42:07.040Z'))
 
   assert_raises(ValueError, f, '2/26/2015 20:42:07')


### PR DESCRIPTION
Hi!

Fix parse time like: `2020-03-27T19:15:42.462Z`..
This is [minio](http://minio.io/) timestamp format.

Error trace:

```
hue_1       |   File "/usr/share/hue/desktop/libs/aws/src/aws/s3/s3fs.py", line 321, in listdir_stats
hue_1       |     res.append(self._stats_key(item, self.fs))
hue_1       |   File "/usr/share/hue/desktop/libs/aws/src/aws/s3/s3fs.py", line 207, in _stats_key
hue_1       |     return S3Stat.from_key(key, is_dir=is_directory_name, fs=fs)
hue_1       |   File "/usr/share/hue/desktop/libs/aws/src/aws/s3/s3stat.py", line 90, in from_key
hue_1       |     mtime = s3datetime_to_timestamp(s3_date) if s3_date else None
hue_1       |   File "/usr/share/hue/desktop/libs/aws/src/aws/s3/__init__.py", line 140, in s3datetime_to_timestamp
hue_1       |     assert datetime[-5:] == '.000Z', 'Time [%s] is not in GMT.' % datetime
hue_1       | AssertionError: Time [2020-03-27T19:15:42.462Z] is not in GMT.
```