### PR TITLE
bugfix: the deactivate login error's form doesn't have 'username'. (related to #1164)

### DIFF
--- a/desktop/core/src/desktop/auth/views_test.py
+++ b/desktop/core/src/desktop/auth/views_test.py
@@ -136,12 +136,15 @@ class TestLoginWithHadoop(PseudoHdfsTestBase):
     user.save()
 
     # Deactivate user
+    old_settings = settings.ADMINS
+    settings.ADMINS = []
     response = self.c.post('/hue/accounts/login/', {
         'username': self.test_username,
         'password': "test-hue-foo2",
       }, follow=True)
     assert_equal(200, response.status_code, "Expected ok status.")
     assert_true("Account deactivated. Please contact an administrator." in response.content, response.content)
+    settings.ADMINS = old_settings
 
     # Activate user
     user = User.objects.get(username=self.test_username)

--- a/desktop/core/src/desktop/templates/login.mako
+++ b/desktop/core/src/desktop/templates/login.mako
@@ -107,7 +107,7 @@ ${ commonheader(_("Welcome to Hue"), "login", user, request, "50px", True, True)
         % if 'AllowAllBackend' in backend_names or backend_names == ['OAuthBackend']:
           hide
         % endif
-        % if form['password'].errors or (login_errors and ('username' in form and not form['username'].errors) and not form['password'].errors):
+        % if form['password'].errors or (login_errors and not form['username'].errors and not form['password'].errors):
           error
         % endif
       ">
@@ -135,7 +135,7 @@ ${ commonheader(_("Welcome to Hue"), "login", user, request, "50px", True, True)
     </div>
     % endif
 
-    % if login_errors and ('username' in form and not form['username'].errors) and not form['password'].errors:
+    % if login_errors and not form['username'].errors and not form['password'].errors:
       % if form.errors:
         % for error in form.errors:
          ${ form.errors[error] | unicode,n }

--- a/desktop/core/src/desktop/templates/login.mako
+++ b/desktop/core/src/desktop/templates/login.mako
@@ -107,7 +107,7 @@ ${ commonheader(_("Welcome to Hue"), "login", user, request, "50px", True, True)
         % if 'AllowAllBackend' in backend_names or backend_names == ['OAuthBackend']:
           hide
         % endif
-        % if form['password'].errors or (login_errors and not form['username'].errors and not form['password'].errors):
+        % if form['password'].errors or (login_errors and 'username' in form.fields and not form['username'].errors and not form['password'].errors):
           error
         % endif
       ">
@@ -135,7 +135,7 @@ ${ commonheader(_("Welcome to Hue"), "login", user, request, "50px", True, True)
     </div>
     % endif
 
-    % if login_errors and not form['username'].errors and not form['password'].errors:
+    % if login_errors and 'username' in form.fields and not form['username'].errors and not form['password'].errors:
       % if form.errors:
         % for error in form.errors:
          ${ form.errors[error] | unicode,n }


### PR DESCRIPTION
related to #1164 