### PR TITLE
[issue-1163] set request.fs to create home directory for first login user

### DIFF
--- a/desktop/core/src/desktop/middleware.py
+++ b/desktop/core/src/desktop/middleware.py
@@ -130,11 +130,9 @@ class ClusterMiddleware(object):
     if "fs" in view_kwargs:
       del view_kwargs["fs"]
 
-    request.fs = None
+    request.fs = fsmanager.get_filesystem(request.fs_ref)
 
     if request.user.is_authenticated():
-      request.fs = fsmanager.get_filesystem(request.fs_ref)
-
       if request.fs is not None:
         request.fs.setuser(request.user.username)
 


### PR DESCRIPTION
related to #1163 

This change resolves broken 4 test cases.
```
FAIL: desktop.auth.views_test.TestMultipleBackendLogin.test_fallback_to_db
FAIL: desktop.auth.views_test.TestLoginWithHadoop.test_login_old
FAIL: desktop.auth.views_test.TestLoginWithHadoop.test_login
FAIL: desktop.auth.views_test.TestLdapLogin.test_login
```