### PR TITLE
added builtin str for compatiblity with python2 and python3

### DIFF
--- a/apps/filebrowser/src/filebrowser/views_test.py
+++ b/apps/filebrowser/src/filebrowser/views_test.py
@@ -22,6 +22,7 @@ standard_library.install_aliases()
 from builtins import zip
 from builtins import range
 from builtins import object
+from builtins import str
 import json
 import logging
 import os


### PR DESCRIPTION
related #1171 

added `builtin str`, especially for https://github.com/cloudera/hue/blob/d3cc8ff366620b90670121eea0bad013cfd74dc1/apps/filebrowser/src/filebrowser/views_test.py#L1286


I tested test cases with OK in the file. `apps/filebrowser/src/filebrowser/views_test.py `
``` sh
./build/env/bin/hue test specific filebrowser.views_test:TestFileBrowserWithHadoop
```