### PR TITLE
[ttypes.py | python2] statement can't be encoded with 'utf-8'. oprotwriteString is enough.

### DIFF
--- a/apps/beeswax/gen-py/TCLIService/ttypes.py
+++ b/apps/beeswax/gen-py/TCLIService/ttypes.py
@@ -3964,7 +3964,7 @@ class TExecuteStatementReq(object):
             oprot.writeFieldEnd()
         if self.statement is not None:
             oprot.writeFieldBegin('statement', TType.STRING, 2)
-            oprot.writeString(self.statement.encode('utf-8') if sys.version_info[0] == 2 else self.statement)
+            oprot.writeString(self.statement)
             oprot.writeFieldEnd()
         if self.confOverlay is not None:
             oprot.writeFieldBegin('confOverlay', TType.MAP, 3)


### PR DESCRIPTION
**Problems**
During integration test (`build/env/bin/hue test all`),
`statement.encode('utf-8')` create many errors and failures(on python2).

related to 4 errors and 19 failures.
- 5 failures related to metastore.tests.TestMetastoreWithHadoop
- 14 failures related to beeswax.tests.TestBeeswaxWithHadoop
- 4 errors related to beeswax.tests.TestBeeswaxWithHadoop

These can be resolved by changing to 'oprot.writeString(self.statement)'

examples)
```
root: ERROR: Thrift saw exception (this may be expected).
Traceback (most recent call last):
  File "/home/deploy/hadoopeng/hue/desktop/core/src/desktop/lib/thrift_util.py", line 485, in wrapper
    ret = res(*args, **kwargs)
  File "/home/deploy/hadoopeng/hue/apps/beeswax/gen-py/TCLIService/TCLIService.py", line 324, in ExecuteStatement
    self.send_ExecuteStatement(req)
  File "/home/deploy/hadoopeng/hue/apps/beeswax/gen-py/TCLIService/TCLIService.py", line 331, in send_ExecuteStatement
    args.write(self._oprot)
  File "/home/deploy/hadoopeng/hue/apps/beeswax/gen-py/TCLIService/TCLIService.py", line 2009, in write
    self.req.write(oprot)
  File "/home/deploy/hadoopeng/hue/apps/beeswax/gen-py/TCLIService/ttypes.py", line 3967, in write
    oprot.writeString(self.statement.encode('utf-8') if sys.version_info[0] == 2 else self.statement)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 67: ordinal not in range(128)
```