### PR TITLE
HUE-9398 [core] Add attribute_map_dir saml configuration.

### DIFF
--- a/desktop/core/src/desktop/auth/views.py
+++ b/desktop/core/src/desktop/auth/views.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 
 from future import standard_library
 standard_library.install_aliases()
@@ -48,6 +49,7 @@ from desktop.conf import OAUTH, ENABLE_ORGANIZATIONS
 from desktop.lib.django_util import render, login_notrequired, JsonResponse
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.log.access import access_log, access_warn, last_access_map
+from desktop.views import samlgroup_check
 from desktop.settings import LOAD_BALANCER_COOKIE
 
 
@@ -196,6 +198,8 @@ def dt_login(request, from_modal=False):
 
   if not from_modal:
     request.session.set_test_cookie()
+
+  request.session['samlgroup_permitted_flag'] = samlgroup_check(request)
 
   renderable_path = 'login.mako'
   if from_modal:

--- a/desktop/libs/libsaml/src/libsaml/backend.py
+++ b/desktop/libs/libsaml/src/libsaml/backend.py
@@ -20,6 +20,7 @@ See desktop/auth/backend.py
 
 from __future__ import absolute_import
 
+import json
 import logging
 
 from django.contrib.auth import logout as auth_logout
@@ -63,8 +64,7 @@ class SAML2Backend(_Saml2Backend):
     """Hook to allow custom authorization policies based on user belonging to a list of SAML groups."""
     LOG.debug('is_authorized() attributes = %s' % attributes)
     LOG.debug('is_authorized() attribute_mapping = %s' % attribute_mapping)
-    return not conf.REQUIRED_GROUPS.get() or set(conf.REQUIRED_GROUPS.get()).issubset(set(attributes[conf.REQUIRED_GROUPS_ATTRIBUTE.get()]))
-
+    return True
 
   def get_user(self, user_id):
     if isinstance(user_id, str):
@@ -97,6 +97,10 @@ class SAML2Backend(_Saml2Backend):
       user.username = force_username_case(user.username)
       profile = get_profile(user)
       profile.creation_method = UserProfile.CreationMethod.EXTERNAL.name
+      json_data = json.loads(profile.json_data)
+      if attributes:
+        json_data['saml_attributes'] = attributes
+        profile.json_data = json.dumps(json_data)
       profile.save()
       user.is_superuser = is_super
       user = rewrite_user(user)

--- a/desktop/libs/libsaml/src/libsaml/tests.py
+++ b/desktop/libs/libsaml/src/libsaml/tests.py
@@ -18,17 +18,14 @@
 
 import sys
 
-from nose.plugins.skip import SkipTest
 from nose.tools import assert_equal, assert_true, assert_false
 
-from libsaml.conf import xmlsec, REQUIRED_GROUPS, REQUIRED_GROUPS_ATTRIBUTE
-
+from libsaml.conf import xmlsec
 
 if sys.version_info[0] > 2:
   from unittest.mock import patch, Mock
 else:
   from mock import patch, Mock
-
 
 def test_xmlsec_dynamic_default_no_which():
 
@@ -38,109 +35,3 @@ def test_xmlsec_dynamic_default_no_which():
     )
 
     assert_equal('/usr/local/bin/xmlsec1', xmlsec())
-
-
-class TestLibSaml():
-
-  def setUp(self):
-    try:
-      from djangosaml2 import views as djangosaml2_views
-      from libsaml import views as libsaml_views
-    except ImportError:
-      raise SkipTest('djangosaml2 or libsaml modules not found')
-
-  def test_is_authorized_groups(self):
-    from libsaml.backend import SAML2Backend
-
-    # Single group
-    attributes = {'groups': ['analyst']}
-    attribute_mapping = {}
-
-    resets = [
-      REQUIRED_GROUPS.set_for_testing(['analyst']),
-      REQUIRED_GROUPS_ATTRIBUTE.set_for_testing('groups'),
-    ]
-
-    try:
-      assert_true(SAML2Backend().is_authorized(attributes, attribute_mapping))
-    finally:
-      for reset in resets:
-        reset()
-
-    attributes = {'groups': ['analyst', 'finance']}
-    attribute_mapping = {}
-
-    resets = [
-      REQUIRED_GROUPS.set_for_testing(['analyst']),
-      REQUIRED_GROUPS_ATTRIBUTE.set_for_testing('groups'),
-    ]
-
-    try:
-      assert_true(SAML2Backend().is_authorized(attributes, attribute_mapping))
-    finally:
-      for reset in resets:
-        reset()
-
-
-    # Multi groups
-    attributes = {'groups': ['analyst', 'sales', 'engineering']}
-    attribute_mapping = {}
-
-    resets = [
-      REQUIRED_GROUPS.set_for_testing(['analyst', 'sales']),
-      REQUIRED_GROUPS_ATTRIBUTE.set_for_testing('groups'),
-    ]
-
-    try:
-      assert_true(SAML2Backend().is_authorized(attributes, attribute_mapping))
-    finally:
-      for reset in resets:
-        reset()
-
-
-  def test_is_non_authorized_groups(self):
-    from libsaml.backend import SAML2Backend
-
-    # Single group
-    attributes = {'groups': ['intern']}
-    attribute_mapping = {}
-
-    resets = [
-      REQUIRED_GROUPS.set_for_testing(['sales']),
-      REQUIRED_GROUPS_ATTRIBUTE.set_for_testing('groups'),
-    ]
-
-    try:
-      assert_false(SAML2Backend().is_authorized(attributes, attribute_mapping))
-    finally:
-      for reset in resets:
-        reset()
-
-    attributes = {'groups': ['intern', 'finance']}
-    attribute_mapping = {}
-
-    resets = [
-      REQUIRED_GROUPS.set_for_testing(['sales']),
-      REQUIRED_GROUPS_ATTRIBUTE.set_for_testing('groups'),
-    ]
-
-    try:
-      assert_false(SAML2Backend().is_authorized(attributes, attribute_mapping))
-    finally:
-      for reset in resets:
-        reset()
-
-    # Multi groups
-    attributes = {'groups': ['intern', 'sales']}
-    attribute_mapping = {}
-
-    resets = [
-      REQUIRED_GROUPS.set_for_testing(['sales', 'engineering']),
-      REQUIRED_GROUPS_ATTRIBUTE.set_for_testing('groups'),
-    ]
-
-    try:
-      assert_false(SAML2Backend().is_authorized(attributes, attribute_mapping))
-    finally:
-      for reset in resets:
-        reset()

--- a/tools/container/hue/hueconf/saml_attributes/cldr.py
+++ b/tools/container/hue/hueconf/saml_attributes/cldr.py
@@ -1,0 +1,17 @@
+MAP = {
+  "identifier": "urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified",
+  "fro": {
+    'uid': 'uid',
+    'https://cdp.cloudera.com/SAML/Attributes/groups': 'groups',
+    'urn:oid:2.5.4.4': 'last_name',
+    'urn:oid:2.5.4.42': 'first_name',
+    'urn:oid:0.9.2342.19200300.100.1.3': 'email'
+  },
+  "to": {
+    'uid': 'uid',
+    'groups': 'https://cdp.cloudera.com/SAML/Attributes/groups',
+    'last_name': 'urn:oid:2.5.4.4',
+    'first_name': 'urn:oid:2.5.4.42',
+    'email': 'urn:oid:0.9.2342.19200300.100.1.3'
+  }
+}


### PR DESCRIPTION
"attribute_map_dir": "attribute-maps" Points to a directory that has the attribute maps in Python modules.
