### PR TITLE
[desktop] Fix code not compatible with py3 (#1239)

### DIFF
--- a/desktop/core/src/desktop/auth/backend.py
+++ b/desktop/core/src/desktop/auth/backend.py
@@ -795,7 +795,7 @@ class OIDCBackend(OIDCAuthenticationBackend):
 
     if verified_id:
       self.save_refresh_tokens(refresh_token)
-      user =  self.get_or_create_user(access_token, id_token, verified_id)
+      user = self.get_or_create_user(access_token, id_token, verified_id)
       user = rewrite_user(user)
       return user
 

--- a/desktop/core/src/desktop/auth/backend.py
+++ b/desktop/core/src/desktop/auth/backend.py
@@ -556,7 +556,7 @@ class LdapBackend(object):
     try:
       allowed_group = self.check_ldap_access_groups(server, username)
       if allowed_group:
-        user = self._backend.authenticate(username, password)
+        user = self._backend.authenticate(username=username, password=password)
       else:
         LOG.warn("%s not in an allowed login group" % username)
         return None

--- a/desktop/core/src/desktop/lib/wsgiserver.py
+++ b/desktop/core/src/desktop/lib/wsgiserver.py
@@ -641,7 +641,7 @@ class HTTPRequest(object):
       if x.args[0] not in socket_errors_to_ignore:
         raise
 
-  def start_response(self, status, headers, exc_info = None):
+  def start_response(self, status, headers, exc_info=None):
     """WSGI callable to begin the HTTP response."""
     # "The application may call start_response more than once,
     # if and only if the exc_info argument is provided."

--- a/desktop/core/src/desktop/lib/wsgiserver.py
+++ b/desktop/core/src/desktop/lib/wsgiserver.py
@@ -1715,7 +1715,7 @@ class CherryPyWSGIServer(object):
         ctx.use_privatekey_file(self.ssl_private_key)
         ctx.use_certificate_file(self.ssl_certificate)
         if self.ssl_certificate_chain:
-        ctx.use_certificate_chain_file(self.ssl_certificate_chain)
+          ctx.use_certificate_chain_file(self.ssl_certificate_chain)
       except Exception as ex:
         logging.exception('SSL key and certificate could not be found or have a problem')
         raise ex


### PR DESCRIPTION
List of changes:
- in backend.py: the kwargs not properly stated lead to the password being
  passed as username, causing LDAP authentication to fail. Not sure why this
  present iself in py3, but adding username= and password= fixes.
- wsgiserver.py: a misindentation after an if causes a syntax error.