### PR TITLE
"DoesNotExist: Session matching query does not exist" when using SparkSQL hiveserver2 interface

### DIFF
--- a/apps/beeswax/src/beeswax/server/hive_server2_lib.py
+++ b/apps/beeswax/src/beeswax/server/hive_server2_lib.py
@@ -692,7 +692,7 @@ class HiveServerClient(object):
 
     session = Session.objects.create(
         owner=user,
-        application=self.query_server['server_name'],
+        application='sql' if self.query_server['server_name'] == 'sparksql' else self.query_server['server_name'],
         status_code=res.status.statusCode,
         secret=encoded_status,
         guid=encoded_guid,

--- a/apps/beeswax/src/beeswax/server/hive_server2_lib.py
+++ b/apps/beeswax/src/beeswax/server/hive_server2_lib.py
@@ -226,6 +226,14 @@ class HiveServerTable(Table):
     if self._details is None:
       props = dict([(stat['col_name'], stat['data_type']) for stat in self.properties if stat['col_name'] != 'Table Parameters:'])
       serde = props.get('SerDe Library:', '')
+      if 'ParquetHiveSerDe' in serde:
+        details_format = 'parquet'
+      elif 'LazySimpleSerDe' in serde:
+        details_format = 'text'
+      elif self.is_impala_only:
+        details_format = 'kudu'
+      else:
+        details_format = serde.rsplit('.', 1)[-1]
 
       self._details = {
           'stats': dict([(stat['data_type'], stat['comment']) for stat in self.stats]),
@@ -233,7 +241,7 @@ class HiveServerTable(Table):
             'owner': props.get('Owner:'),
             'create_time': props.get('CreateTime:'),
             'table_type': props.get('Table Type:', 'MANAGED_TABLE'),
-            'format': 'parquet' if 'ParquetHiveSerDe' in serde else ('text' if 'LazySimpleSerDe' in serde else ('kudu' if self.is_impala_only else serde.rsplit('.', 1)[-1])),
+            'format': details_format,
         }
       }
 
@@ -552,7 +560,8 @@ class HiveServerClient(object):
     use_sasl, mechanism, kerberos_principal_short_name, impersonation_enabled, auth_username, auth_password = self.get_security()
     LOG.info(
         '%s: server_host=%s, use_sasl=%s, mechanism=%s, kerberos_principal_short_name=%s, impersonation_enabled=%s, auth_username=%s' % (
-        self.query_server['server_name'], self.query_server['server_host'], use_sasl, mechanism, kerberos_principal_short_name, impersonation_enabled, auth_username)
+        self.query_server['server_name'], self.query_server['server_host'], use_sasl, mechanism, kerberos_principal_short_name,
+        impersonation_enabled, auth_username)
     )
 
     self.use_sasl = use_sasl
@@ -813,7 +822,8 @@ class HiveServerClient(object):
   def get_database(self, database):
     query = 'DESCRIBE DATABASE EXTENDED `%s`' % (database)
 
-    desc_results, desc_schema, operation_handle, session = self.execute_statement(query, max_rows=5000, orientation=TFetchOrientation.FETCH_NEXT)
+    desc_results, desc_schema, operation_handle, session = self.execute_statement(query, max_rows=5000,
+                                                                                  orientation=TFetchOrientation.FETCH_NEXT)
     self._close(operation_handle, session)
 
     if self.query_server.get('dialect') == 'impala':
@@ -910,7 +920,8 @@ class HiveServerClient(object):
         desc_results.results.columns[2].stringVal.values.insert(1, None)
         try:
           part_index = desc_results.results.columns[0].stringVal.values.index('# Partition Information')
-          desc_results.results.columns[0].stringVal.values = desc_results.results.columns[0].stringVal.values[:part_index] # Strip duplicate columns of partitioned tables
+          # Strip duplicate columns of partitioned tables
+          desc_results.results.columns[0].stringVal.values = desc_results.results.columns[0].stringVal.values[:part_index]
           desc_results.results.columns[1].stringVal.values = desc_results.results.columns[1].stringVal.values[:part_index]
           desc_results.results.columns[2].stringVal.values = desc_results.results.columns[2].stringVal.values[:part_index]
 
@@ -1016,7 +1027,8 @@ class HiveServerClient(object):
         session_id=session.id
     )
 
-  # Note: An operation_handle is attached to a session. All operations that require operation_handle cannot recover if the session is closed. Passing the session is not required
+  # Note: An operation_handle is attached to a session. All operations that require operation_handle cannot recover if the session is
+  # closed. Passing the session is not required
   def fetch_data(self, operation_handle, orientation=TFetchOrientation.FETCH_NEXT, max_rows=1000):
     # Fetch until the result is empty dues to a HS2 bug instead of looking at hasMoreRows
     results, schema = self.fetch_result(operation_handle, orientation, max_rows)
@@ -1105,10 +1117,12 @@ class HiveServerClient(object):
   def explain(self, query):
     query_statement = query.get_query_statement(0)
     configuration = self._get_query_configuration(query)
-    return self.execute_query_statement(statement='EXPLAIN %s' % query_statement, configuration=configuration, orientation=TFetchOrientation.FETCH_NEXT)
+    return self.execute_query_statement(statement='EXPLAIN %s' % query_statement, configuration=configuration,
+                                        orientation=TFetchOrientation.FETCH_NEXT)
 
 
-  def get_partitions(self, database, table_name, partition_spec=None, max_parts=None, reverse_sort=True): # TODO execute both requests in same session
+  # TODO execute both requests in same session
+  def get_partitions(self, database, table_name, partition_spec=None, max_parts=None, reverse_sort=True):
     table = self.get_table(database, table_name)
 
     query = 'SHOW PARTITIONS `%s`.`%s`' % (database, table_name)


### PR DESCRIPTION
SparkSQL hiveserver2 interface does not work with Hue 4.7.1 and gives following error:
```
[05/Oct/2020 15:22:03 -0700] access       INFO     10.30.84.249 hadoop - "POST /notebook/api/execute/sql HTTP/1.1" returned in 233ms 200 67
[05/Oct/2020 15:22:03 -0700] decorators   ERROR    Error running execute
Traceback (most recent call last):
  File "/usr/lib/hue/desktop/libs/notebook/src/notebook/decorators.py", line 114, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/hue/desktop/libs/notebook/src/notebook/api.py", line 225, in execute
    response = _execute_notebook(request, notebook, snippet)
  File "/usr/lib/hue/desktop/libs/notebook/src/notebook/api.py", line 153, in _execute_notebook
    response['handle'] = interpreter.execute(notebook, snippet)
  File "/usr/lib/hue/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py", line 98, in decorator
    return func(*args, **kwargs)
  File "/usr/lib/hue/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py", line 296, in execute
    _session = self._get_session_by_id(notebook, snippet['type'])
  File "/usr/lib/hue/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py", line 680, in _get_session_by_id
    return Session.objects.get(**filters)
  File "/usr/lib/hue/build/env/lib/python2.7/site-packages/Django-1.11.29-py2.7.egg/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/lib/hue/build/env/lib/python2.7/site-packages/Django-1.11.29-py2.7.egg/django/db/models/query.py", line 380, in get
    self.model._meta.object_name
DoesNotExist: Session matching query does not exist.
[05/Oct/2020 15:22:03 -0700] dbms         DEBUG    Query Server: {'dialect': 'sparksql', 'has_session_pool': False, 'server_name': 'sparksql', 'transport_mode': 'socket', 'auth_username': 'hue', 'server_host': 'localhost', 'server_port': 10000, 'use_sasl': True, 'auth_password_used': False, 'http_url': u'http://ip-10-5-250-140.ec2.internal:10001/cliservice', 'max_number_of_sessions': 1, 'close_sessions': False, 'principal': None}
[05/Oct/2020 15:22:03 -0700] dbms         DEBUG    Query via ini sparksql
[05/Oct/2020 15:22:03 -0700] base         DEBUG    Selected interpreter sql interface=hiveserver2 compute=None
```

By logging out the type name use for query, I found it is `sql` rather than `sparksql` since it is from snippet name. So adding this change to be able to get the session from query server.
https://github.com/cloudera/hue/blob/1e7c68313b88b310cd4c7dc296b7b4748551fea8/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py#L670

https://github.com/cloudera/hue/blob/1e7c68313b88b310cd4c7dc296b7b4748551fea8/desktop/conf.dist/hue.ini#L943

It is kind of similar to https://github.com/cloudera/hue/pull/1126 while that PR is for mapping `llap` to `beeswax` but the error messages are the same.

It should be safe to just override the snippet type since this is the only place I found related and it is using else for sparksql https://github.com/cloudera/hue/blob/1e7c68313b88b310cd4c7dc296b7b4748551fea8/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py#L776-L777
And if I am thinking it correctly, `sparksql` is the name used by query server https://github.com/cloudera/hue/blob/8e18eba6e01d52ecdb494f5d375ebecfb19d892a/apps/beeswax/src/beeswax/server/dbms.py#L194-L201 