### PR TITLE
HUE-9493 [libsaml] allow accepted_time_diff configure for pysaml

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -1937,6 +1937,9 @@
   # Signed certificate to send along with encrypted metadata.
   ## cert_file=
 
+  # If your computer and another computer that you are communicating with are not in synch regarding the computer clock, then here you can state how big a difference you are prepared to accept.
+  ## accepted_time_diff=
+
   # Path to a file containing the password private key.
   ## key_file_password=/path/key
 

--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -1937,8 +1937,8 @@
   # Signed certificate to send along with encrypted metadata.
   ## cert_file=
 
-  # If your computer and another computer that you are communicating with are not in synch regarding the computer clock, then here you can state how big a difference you are prepared to accept.
-  ## accepted_time_diff=
+  # If your computer and another computer that you are communicating with are not in synch regarding the computer clock, then here you can state how big a difference you are prepared to accept in milliseconds.
+  ## accepted_time_diff=0
 
   # Path to a file containing the password private key.
   ## key_file_password=/path/key

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -1925,6 +1925,9 @@
   # Signed certificate to send along with encrypted metadata.
   ## cert_file=
 
+  # If your computer and another computer that you are communicating with are not in synch regarding the computer clock, then here you can state how big a difference you are prepared to accept in milliseconds.
+  ## accepted_time_diff=0
+
   # Path to a file containing the password private key.
   ## key_file_password=/path/key
 

--- a/desktop/libs/libsaml/src/libsaml/conf.py
+++ b/desktop/libs/libsaml/src/libsaml/conf.py
@@ -140,7 +140,7 @@ ACCEPTED_TIME_DIFF = Config(
   default=0,
   type=int,
   help=_t("If your computer and another computer that you are communicating with are not in synch regarding the computer clock,"
-  "then here you can state how big a difference you are prepared to accept.")
+  "then here you can state how big a difference you are prepared to accept in milliseconds.")
 )
 USER_ATTRIBUTE_MAPPING = Config(
   key="user_attribute_mapping",

--- a/desktop/libs/libsaml/src/libsaml/conf.py
+++ b/desktop/libs/libsaml/src/libsaml/conf.py
@@ -133,6 +133,12 @@ CERT_FILE = Config(
   type=str,
   help=_t("This is the public part of the service private/public key pair. cert_file must be a PEM formatted certificate chain file."))
 
+ACCEPTED_TIME_DIFF = Config(
+  key="accepted_time_diff",
+  default=0,
+  type=int,
+  help=_t("If your computer and another computer that you are communicating with are not in synch regarding the computer clock, then here you can state how big a difference you are prepared to accept.")
+)
 USER_ATTRIBUTE_MAPPING = Config(
   key="user_attribute_mapping",
   default={'uid': ('username', )},

--- a/desktop/libs/libsaml/src/libsaml/conf.py
+++ b/desktop/libs/libsaml/src/libsaml/conf.py
@@ -70,7 +70,8 @@ ENTITY_ID = Config(
   key="entity_id",
   default="<base_url>/saml2/metadata/",
   type=str,
-  help=_t("Entity ID for Hue acting as service provider. Can also accept a pattern where '<base_url>' will be replaced with server URL base."))
+  help=_t("Entity ID for Hue acting as service provider."
+  "Can also accept a pattern where '<base_url>' will be replaced with server URL base."))
 
 CREATE_USERS_ON_LOGIN = Config(
   key="create_users_on_login",
@@ -80,7 +81,7 @@ CREATE_USERS_ON_LOGIN = Config(
 
 ATTRIBUTE_MAP_DIR = Config(
   key="attribute_map_dir",
-  default=os.path.abspath( os.path.join(BASEDIR, '..', '..', 'attribute-maps') ),
+  default=os.path.abspath(os.path.join(BASEDIR, '..', '..', 'attribute-maps')),
   type=str,
   private=True,
   help=_t("Attribute map directory contains files that map SAML attributes to pysaml2 attributes."))
@@ -106,7 +107,7 @@ OPTIONAL_ATTRIBUTES = Config(
 
 METADATA_FILE = Config(
   key="metadata_file",
-  default=os.path.abspath( os.path.join(BASEDIR, '..', '..', 'examples', 'idp.xml') ),
+  default=os.path.abspath(os.path.join(BASEDIR, '..', '..', 'examples', 'idp.xml')),
   type=str,
   help=_t("IdP metadata in the form of a file. This is generally an XML file containing metadata that the Identity Provider generates."))
 
@@ -114,7 +115,8 @@ KEY_FILE = Config(
   key="key_file",
   default="",
   type=str,
-  help=_t("key_file is the name of a PEM formatted file that contains the private key of the Hue service. This is presently used both to encrypt/sign assertions and as client key in a HTTPS session."))
+  help=_t("key_file is the name of a PEM formatted file that contains the private key of the Hue service."
+  "This is presently used both to encrypt/sign assertions and as client key in a HTTPS session."))
 
 KEY_FILE_PASSWORD = Config(
   key="key_file_password",
@@ -137,11 +139,12 @@ ACCEPTED_TIME_DIFF = Config(
   key="accepted_time_diff",
   default=0,
   type=int,
-  help=_t("If your computer and another computer that you are communicating with are not in synch regarding the computer clock, then here you can state how big a difference you are prepared to accept.")
+  help=_t("If your computer and another computer that you are communicating with are not in synch regarding the computer clock,"
+  "then here you can state how big a difference you are prepared to accept.")
 )
 USER_ATTRIBUTE_MAPPING = Config(
   key="user_attribute_mapping",
-  default={'uid': ('username', )},
+  default={'uid': ('username',)},
   type=dict_list_map,
   help=_t("A mapping from attributes in the response from the IdP to django user attributes."))
 

--- a/desktop/libs/libsaml/src/libsaml/saml_settings.py
+++ b/desktop/libs/libsaml/src/libsaml/saml_settings.py
@@ -35,7 +35,7 @@ def config_settings_loader(request):
   if base_url is None:
     base_url = "%(protocol)s%(host)s" % {
       'protocol': 'https://' if (request.is_secure() or request.META.get('HTTP_X_FORWARDED_PROTO') == 'https') else 'http://',
-      'host':  request.get_host(),
+      'host': request.get_host(),
     }
 
   entity_id = libsaml.conf.ENTITY_ID.get().replace('<base_url>', base_url)
@@ -53,7 +53,7 @@ def config_settings_loader(request):
 
     # this block states what services we provide
     'service': {
-      'sp' : {
+      'sp': {
         'name': 'hue',
         'name_id_format': libsaml.conf.NAME_ID_FORMAT.get(),
         'endpoints': {
@@ -87,7 +87,7 @@ def config_settings_loader(request):
 
     # where the remote metadata is stored
     'metadata': {
-      'local': [ libsaml.conf.METADATA_FILE.get() ],
+      'local': [libsaml.conf.METADATA_FILE.get()],
     },
 
     # set to 1 to output debugging information

--- a/desktop/libs/libsaml/src/libsaml/saml_settings.py
+++ b/desktop/libs/libsaml/src/libsaml/saml_settings.py
@@ -103,6 +103,7 @@ def config_settings_loader(request):
       'key_file': libsaml.conf.KEY_FILE.get(),  # private part
       'key_file_passphrase': libsaml.conf.get_key_file_password(),
       'cert_file': libsaml.conf.CERT_FILE.get(),  # public part
+      'accepted_time_diff': libsaml.conf.ACCEPTED_TIME_DIFF.get(),
     }],
   })
 


### PR DESCRIPTION
**What changes were proposed in this pull request?**
HUE-9493 [libsaml] allow accepted_time_diff configure for pysaml

**How was this patch tested?**
Tested manually in hue server the time difference is there, the Config change works well and no error or exception.
