### PR TITLE
HUE-9508 [querybrowser] Hue does not work with Hive/Impala enforced to TLS 1.2 

### DIFF
--- a/desktop/core/src/desktop/lib/thrift_/TSSLSocketWithWildcardSAN.py
+++ b/desktop/core/src/desktop/lib/thrift_/TSSLSocketWithWildcardSAN.py
@@ -41,7 +41,7 @@ class TSSLSocketWithWildcardSAN(TSSLSocket.TSSLSocket):
       validate=True,
       ca_certs=None,
       unix_socket=None,
-      keyfile=None, certfile=None,ssl_version=None
+      keyfile=None, certfile=None, ssl_version=None
       ):
     TSSLSocket.TSSLSocket.__init__(self, host, port, validate, ca_certs, keyfile, certfile, unix_socket, ssl_version=ssl_version)
 

--- a/desktop/core/src/desktop/lib/thrift_/TSSLSocketWithWildcardSAN.py
+++ b/desktop/core/src/desktop/lib/thrift_/TSSLSocketWithWildcardSAN.py
@@ -42,7 +42,7 @@ class TSSLSocketWithWildcardSAN(TSSLSocket.TSSLSocket):
       unix_socket=None,
       keyfile=None, certfile=None,ssl_version=None
       ):
-    TSSLSocket.TSSLSocket.__init__(self, host, port, validate, ca_certs, keyfile, certfile, unix_socket,ssl_version=ssl_version)
+    TSSLSocket.TSSLSocket.__init__(self, host, port, validate, ca_certs, keyfile, certfile, unix_socket, ssl_version=ssl_version)
 
   def _validate_cert(self):
     cert = self.handle.getpeercert()

--- a/desktop/core/src/desktop/lib/thrift_/TSSLSocketWithWildcardSAN.py
+++ b/desktop/core/src/desktop/lib/thrift_/TSSLSocketWithWildcardSAN.py
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file comes from the Apache2 licenced file source code file https://github.com/apache/incubator-impala/blob/45ff0f9e674f54b35afb2b5eced0d6ec346890d6/shell/TSSLSocketWithWildcardSAN.py
+# This file comes from the Apache2 licenced file source code file
+# https://github.com/apache/incubator-impala/blob/45ff0f9e674f54b35afb2b5eced0d6ec346890d6/shell/TSSLSocketWithWildcardSAN.py
 
 from builtins import map
 import re

--- a/desktop/core/src/desktop/lib/thrift_/TSSLSocketWithWildcardSAN.py
+++ b/desktop/core/src/desktop/lib/thrift_/TSSLSocketWithWildcardSAN.py
@@ -40,9 +40,9 @@ class TSSLSocketWithWildcardSAN(TSSLSocket.TSSLSocket):
       validate=True,
       ca_certs=None,
       unix_socket=None,
-      keyfile=None, certfile=None
+      keyfile=None, certfile=None,ssl_version=None
       ):
-    TSSLSocket.TSSLSocket.__init__(self, host, port, validate, ca_certs, keyfile, certfile, unix_socket)
+    TSSLSocket.TSSLSocket.__init__(self, host, port, validate, ca_certs, keyfile, certfile, unix_socket,ssl_version=ssl_version)
 
   def _validate_cert(self):
     cert = self.handle.getpeercert()

--- a/desktop/core/src/desktop/lib/thrift_util.py
+++ b/desktop/core/src/desktop/lib/thrift_util.py
@@ -632,26 +632,26 @@ def thrift2json(tft):
       JSON protocol only supports key types that are base types.
   I believe this ought to be true for sets, as well.
   """
-  if isinstance(tft,type(None)):
+  if isinstance(tft, type(None)):
     return None
-  if isinstance(tft,(float,int,complex,basestring)):
+  if isinstance(tft, (float,int,complex,basestring)):
     return tft
-  if isinstance(tft,dict):
+  if isinstance(tft, dict):
     d = {}
     for key, val in tft.items():
       d[key] = thrift2json(val)
     return d
-  if isinstance(tft,list):
+  if isinstance(tft, list):
     return [thrift2json(x) for x in tft]
   if isinstance(tft, set):
-    return dict( (x, True) for x in tft )
+    return dict((x, True) for x in tft)
 
   json = {}
   d = {}
-  if hasattr(tft,"__dict__"):
+  if hasattr(tft, "__dict__"):
     d = tft.__dict__
   else:
-    if hasattr(tft,"__slots__"):
+    if hasattr(tft, "__slots__"):
       d = tft.__slots__
     else:
       return {}
@@ -819,7 +819,7 @@ def fixup_enums(obj, name_class_map, suffix="AsString"):
   """
   for n in list(name_class_map.keys()):
     c = name_class_map[n]
-    setattr(obj, n + suffix, c._VALUES_TO_NAMES[getattr(obj,n)])
+    setattr(obj, n + suffix, c._VALUES_TO_NAMES[getattr(obj, n)])
   return obj
 
 def is_thrift_struct(o):

--- a/desktop/core/src/desktop/lib/thrift_util.py
+++ b/desktop/core/src/desktop/lib/thrift_util.py
@@ -64,25 +64,25 @@ MAX_RECURSION_DEPTH = 50
 
 
 class LifoQueue(queue.Queue):
-    '''
-    Variant of Queue that retrieves most recently added entries first.
+  '''
+  Variant of Queue that retrieves most recently added entries first.
 
-    This LIFO Queue is included in python2.7 (or 2.6) and later,
-    but it's a simple subclass, so we "backport" it here.
-    '''
+  This LIFO Queue is included in python2.7 (or 2.6) and later,
+  but it's a simple subclass, so we "backport" it here.
+  '''
 
-    def _init(self, maxsize):
-        self.queue = []
-        self.maxsize = maxsize
+  def _init(self, maxsize):
+      self.queue = []
+      self.maxsize = maxsize
 
-    def _qsize(self, len=len):
-        return len(self.queue)
+  def _qsize(self, len=len):
+      return len(self.queue)
 
-    def _put(self, item):
-        self.queue.append(item)
+  def _put(self, item):
+      self.queue.append(item)
 
-    def _get(self):
-        return self.queue.pop()
+  def _get(self):
+      return self.queue.pop()
 
 
 class ConnectionConfig(object):
@@ -150,8 +150,9 @@ class ConnectionConfig(object):
     self.coordinator_host = coordinator_host
 
   def __str__(self):
-    return ', '.join(map(str, [self.klass, self.host, self.port, self.service_name, self.use_sasl, self.kerberos_principal, self.timeout_seconds,
-                               self.mechanism, self.username, self.use_ssl, self.ca_certs, self.keyfile, self.certfile, self.validate, self.transport,
+    return ', '.join(map(str, [self.klass, self.host, self.port, self.service_name, self.use_sasl, self.kerberos_principal,
+                               self.timeout_seconds, self.mechanism, self.username, self.use_ssl, self.ca_certs, self.keyfile,
+                               self.certfile, self.validate, self.transport,
                                self.multiple, self.transport_mode, self.http_url, self.coordinator_host]))
 
   def update_coordinator_host(self, coordinator_host):
@@ -259,7 +260,8 @@ class ConnectionPooler(object):
           raise socket.timeout(
             ("Timed out after %.2f seconds waiting to retrieve a %s client from the pool.") % (has_waited_for, conf.service_name))
         else:
-          message = "Waited %d seconds for a Thrift client to %s:%d %s" % (has_waited_for, conf.host, conf.port, conf.get_coordinator_host())
+          message = "Waited %d seconds for a Thrift client to %s:%d %s" % (has_waited_for,
+                                                                           conf.host, conf.port, conf.get_coordinator_host())
           log_if_slow_call(duration=has_waited_for, message=message)
 
     return connection
@@ -314,7 +316,8 @@ def connect_to_thrift(conf):
           PROTOCOL_SSLv23 = PROTOCOL_TLS
         except ImportError:
           PROTOCOL_SSLv23 = PROTOCOL_TLS = 2
-      mode = TSSLSocketWithWildcardSAN(conf.host, conf.port, validate=conf.validate, ca_certs=conf.ca_certs, keyfile=conf.keyfile, certfile=conf.certfile,ssl_version=PROTOCOL_SSLv23)
+      mode = TSSLSocketWithWildcardSAN(conf.host, conf.port, validate=conf.validate, ca_certs=conf.ca_certs,
+                                       keyfile=conf.keyfile, certfile=conf.certfile, ssl_version=PROTOCOL_SSLv23)
     else:
       mode = TSocket(conf.host, conf.port)
 
@@ -634,7 +637,7 @@ def thrift2json(tft):
   """
   if isinstance(tft, type(None)):
     return None
-  if isinstance(tft, (float,int,complex,basestring)):
+  if isinstance(tft, (float, int, complex, basestring)):
     return tft
   if isinstance(tft, dict):
     d = {}

--- a/desktop/core/src/desktop/lib/thrift_util.py
+++ b/desktop/core/src/desktop/lib/thrift_util.py
@@ -305,7 +305,16 @@ def connect_to_thrift(conf):
     mode.set_verify(conf.validate)
   else:
     if conf.use_ssl:
-      mode = TSSLSocketWithWildcardSAN(conf.host, conf.port, validate=conf.validate, ca_certs=conf.ca_certs, keyfile=conf.keyfile, certfile=conf.certfile)
+      try:
+         from ssl import PROTOCOL_TLS
+         PROTOCOL_SSLv23 = PROTOCOL_TLS
+      except ImportError:
+        try:
+          from ssl import PROTOCOL_SSLv23 as PROTOCOL_TLS
+          PROTOCOL_SSLv23 = PROTOCOL_TLS
+        except ImportError:
+          PROTOCOL_SSLv23 = PROTOCOL_TLS = 2
+      mode = TSSLSocketWithWildcardSAN(conf.host, conf.port, validate=conf.validate, ca_certs=conf.ca_certs, keyfile=conf.keyfile, certfile=conf.certfile,ssl_version=PROTOCOL_SSLv23)
     else:
       mode = TSocket(conf.host, conf.port)
 

--- a/desktop/core/src/desktop/lib/thrift_util.py
+++ b/desktop/core/src/desktop/lib/thrift_util.py
@@ -72,17 +72,17 @@ class LifoQueue(queue.Queue):
   '''
 
   def _init(self, maxsize):
-      self.queue = []
-      self.maxsize = maxsize
+    self.queue = []
+    self.maxsize = maxsize
 
   def _qsize(self, len=len):
-      return len(self.queue)
+    return len(self.queue)
 
   def _put(self, item):
-      self.queue.append(item)
+    self.queue.append(item)
 
   def _get(self):
-      return self.queue.pop()
+    return self.queue.pop()
 
 
 class ConnectionConfig(object):
@@ -308,8 +308,8 @@ def connect_to_thrift(conf):
   else:
     if conf.use_ssl:
       try:
-         from ssl import PROTOCOL_TLS
-         PROTOCOL_SSLv23 = PROTOCOL_TLS
+        from ssl import PROTOCOL_TLS
+        PROTOCOL_SSLv23 = PROTOCOL_TLS
       except ImportError:
         try:
           from ssl import PROTOCOL_SSLv23 as PROTOCOL_TLS


### PR DESCRIPTION
What changes were proposed in this pull request?
HUE-9508 [querybrowser] Hue does not work with Hive/Impala enforced to TLS 1.2 

How was this patch tested?
Tested manually in for Imapla and Hive for TLSv1.2 and TLSv1.0