### PR TITLE
HUE-9538 [core] user home directories are not created for Newly Logged in User

### DIFF
--- a/desktop/core/src/desktop/auth/views.py
+++ b/desktop/core/src/desktop/auth/views.py
@@ -46,6 +46,7 @@ from desktop.auth import forms as auth_forms
 from desktop.auth.backend import OIDCBackend
 from desktop.auth.forms import ImpersonationAuthenticationForm, OrganizationUserCreationForm, OrganizationAuthenticationForm
 from desktop.conf import OAUTH, ENABLE_ORGANIZATIONS
+from desktop.lib import fsmanager
 from desktop.lib.django_util import render, login_notrequired, JsonResponse
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.log.access import access_log, access_warn, last_access_map
@@ -146,7 +147,8 @@ def dt_login(request, from_modal=False):
 
         if request.session.test_cookie_worked():
           request.session.delete_test_cookie()
-
+        if request.fs is None:
+          request.fs = fsmanager.get_filesystem(request.fs_ref)
         try:
           ensure_home_directory(request.fs, user)
         except (IOError, WebHdfsException) as e:
@@ -184,6 +186,8 @@ def dt_login(request, from_modal=False):
         'KnoxSpnegoDjangoBackend' in backend_names or 'SpnegoDjangoBackend' in backend_names or 'OIDCBackend' in backend_names or
         'SAML2Backend' in backend_names
       ) and request.user.is_authenticated():
+      if request.fs is None:
+          request.fs = fsmanager.get_filesystem(request.fs_ref)
       try:
         ensure_home_directory(request.fs, request.user)
       except (IOError, WebHdfsException) as e:

--- a/desktop/core/src/desktop/auth/views.py
+++ b/desktop/core/src/desktop/auth/views.py
@@ -66,7 +66,7 @@ LOG = logging.getLogger(__name__)
 def get_current_users():
   """Return dictionary of User objects and
   a dictionary of the user's IP address and last access time"""
-  current_users = { }
+  current_users = {}
   for session in Session.objects.all():
     try:
       uid = session.get_decoded().get(django.contrib.auth.SESSION_KEY)
@@ -182,12 +182,12 @@ def dt_login(request, from_modal=False):
     first_user_form = None
     auth_form = AuthenticationForm()
     # SAML/OIDC user is already authenticated in djangosaml2.views.login
-    if hasattr(request,'fs') and (
+    if hasattr(request, 'fs') and (
         'KnoxSpnegoDjangoBackend' in backend_names or 'SpnegoDjangoBackend' in backend_names or 'OIDCBackend' in backend_names or
         'SAML2Backend' in backend_names
       ) and request.user.is_authenticated():
       if request.fs is None:
-          request.fs = fsmanager.get_filesystem(request.fs_ref)
+        request.fs = fsmanager.get_filesystem(request.fs_ref)
       try:
         ensure_home_directory(request.fs, request.user)
       except (IOError, WebHdfsException) as e:
@@ -238,7 +238,7 @@ def dt_logout(request, next_page=None):
   # Close Impala session on logout
   session_app = "impala"
   if request.user.has_hue_permission(action='access', app=session_app):
-    session = {"type": session_app, "sourceMethod":" dt_logout"}
+    session = {"type": session_app, "sourceMethod": " dt_logout"}
     try:
       get_api(request, session).close_session(session)
     except PopupException as e:
@@ -312,7 +312,7 @@ def oauth_authenticated(request):
 
   resp, content = client.request(OAUTH.ACCESS_TOKEN_URL.get(), "GET")
   if resp['status'] != '200':
-      raise Exception(_("Invalid response from OAuth provider: %s") % resp)
+    raise Exception(_("Invalid response from OAuth provider: %s") % resp)
 
   access_token = dict(cgi.parse_qsl(content))
 


### PR DESCRIPTION
**What changes were proposed in this pull request?**
HUE-9538 [core] user home directories are not created for Newly Logged in User

**How was this patch tested?**

Tested manually in master branch, if once code change is pushed, user home directory will be created for newly logged in user i LDAP

```
[30/Oct/2020 04:21:34 -0700] backend      DEBUG    Creating Django user user106
[30/Oct/2020 04:21:34 -0700] backend      DEBUG    Populating Django user user106
[30/Oct/2020 04:21:35 -0700] resource     DEBUG    GET http://asnaikCdp01.example.com:9870/webhdfs/v1 returned in 0ms
[30/Oct/2020 04:21:35 -0700] resource     DEBUG    PUT None http://asnaikCdp01.example.com:9870/webhdfs/v1//user/user106?permission=0755&op=MKDIRS&user.name=hue&doas=hdfs  returned in 8ms 200 16 {"boolean":true}
```

