### PR TITLE
HUE-9485 [frontend] Remove side margins of Tab for better alignment

### DIFF
--- a/desktop/core/src/desktop/js/components/Tabs.vue
+++ b/desktop/core/src/desktop/js/components/Tabs.vue
@@ -78,7 +78,7 @@
     ul {
       border-bottom: 1px solid $hue-border-color;
       list-style: none;
-      margin: 20px 12px;
+      margin: 0;
 
       li {
         display: inline-block;
@@ -101,7 +101,7 @@
     }
     .hue-tab-container {
       position: relative;
-      margin: 12px;
+      margin: 12px 0;
       background-color: $fluid-white;
     }
   }


### PR DESCRIPTION
Because of the margin, the alignment wasn't looking proper on using this component. Hence this patch.