### PR TITLE
HUE-9552 [fb] Folder Fails to Load when the foldername contains #

### DIFF
--- a/desktop/core/src/desktop/js/utils/hueUtils.js
+++ b/desktop/core/src/desktop/js/utils/hueUtils.js
@@ -168,7 +168,8 @@ export const changeURL = (newURL, params) => {
     url += (url.indexOf('?') === -1 ? '?' : '&') + extraSearch;
   }
   if (hashSplit.length > 1) {
-    url += '#' + hashSplit[1];
+    //the foldername may contain # , so create substring ignoring first #
+    url += '#' + newURL.substring(newURL.indexOf('#') + 1);
   } else if (window.location.hash) {
     url += window.location.hash;
   }


### PR DESCRIPTION
**What changes were proposed in this pull request?**
HUE-9552 [fb] Folder Fails to Load when the foldername contains #

**How was this patch tested?**
Tested Manually by Creating an Folder with # and testing out the fix of the issue
<img width="1381" alt="Screenshot 2020-11-06 at 10 25 48 AM" src="https://user-images.githubusercontent.com/18462803/98327818-78a12f80-201a-11eb-9f23-c038f1ae3018.png">

