### PR TITLE
Correct the SparkSQL hiveserver2 fix in PR-1287

### DIFF
--- a/apps/beeswax/src/beeswax/server/hive_server2_lib.py
+++ b/apps/beeswax/src/beeswax/server/hive_server2_lib.py
@@ -701,7 +701,7 @@ class HiveServerClient(object):
 
     session = Session.objects.create(
         owner=user,
-        application='sql' if self.query_server['server_name'] == 'sparksql' else self.query_server['server_name'],
+        application=self.query_server['server_name'],
         status_code=res.status.statusCode,
         secret=encoded_status,
         guid=encoded_guid,

--- a/desktop/libs/notebook/src/notebook/connectors/base.py
+++ b/desktop/libs/notebook/src/notebook/connectors/base.py
@@ -348,6 +348,7 @@ class Notebook(object):
 
 
 def get_interpreter(connector_type, user=None):
+  connector_type = 'sql' if connector_type == 'sparksql' else connector_type
   interpreter = [
     interpreter for interpreter in get_ordered_interpreters(user) if connector_type == interpreter['type']
   ]

--- a/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py
+++ b/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py
@@ -676,10 +676,12 @@ DROP TABLE IF EXISTS `%(table)s`;
 
 
   def _get_session(self, notebook, type='hive'):
+    type = 'sparksql' if type == 'sql' else type
     session = next((session for session in notebook['sessions'] if session['type'] == type), None)
     return session
 
   def _get_session_by_id(self, notebook, type='hive'):
+    type = 'sparksql' if type == 'sql' else type
     session = self._get_session(notebook, type)
     if session:
       session_id = session.get('id')


### PR DESCRIPTION
I recently tried backport the PR https://github.com/cloudera/hue/pull/1287 but found there is actually a test issue (maybe the workspace is not clean at that moment). Since that PR is already merged, I open this PR for further discussion.

In previous fix, the session type is now matching but the issue persist, I made some change to log info for debugging.
code:
```
  def _get_session(self, notebook, type='hive'):
    LOG.info("sessions: ")
    LOG.info(notebook['sessions'])
    session = next((session for session in notebook['sessions'] if session['type'] == type), None)
    return session

  def _get_session_by_id(self, notebook, type='hive'):
    session = self._get_session(notebook, type)
    LOG.info("session: ")
    LOG.info(session)
    if session:
      session_id = session.get('id')
      if session_id:
        filters = {'id': session_id, 'application': 'beeswax' if type == 'hive' or type == 'llap' else type}
        if not is_admin(self.user):
          filters['owner'] = self.user
        LOG.info("filter: ")
        LOG.info(filters)
        LOG.info("SQL sessions: ")
        rss = Session.objects.filter(application='sql')
        for rs in rss:
            LOG.info(rs.id)
        LOG.info(Session.objects.filter(application='sql'))
        LOG.info("SparkSQL sessions: ")
        LOG.info(Session.objects.filter(application='sparksql'))
        return Session.objects.get(**filters)
```
log:
```
[10/Nov/2020 13:55:40 -0800] decorators   ERROR    Error running execute
Traceback (most recent call last):
  File "/usr/lib/hue/desktop/libs/notebook/src/notebook/decorators.py", line 114, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/hue/desktop/libs/notebook/src/notebook/api.py", line 227, in execute
    response = _execute_notebook(request, notebook, snippet)
  File "/usr/lib/hue/desktop/libs/notebook/src/notebook/api.py", line 152, in _execute_notebook
    response['handle'] = interpreter.execute(notebook, snippet)
  File "/usr/lib/hue/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py", line 98, in decorator
    return func(*args, **kwargs)
  File "/usr/lib/hue/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py", line 296, in execute
    _session = self._get_session_by_id(notebook, snippet['type'])
  File "/usr/lib/hue/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py", line 703, in _get_session_by_id
    return Session.objects.get(**filters)
  File "/usr/lib/hue/build/env/lib/python2.7/site-packages/Django-1.11.29-py2.7.egg/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/lib/hue/build/env/lib/python2.7/site-packages/Django-1.11.29-py2.7.egg/django/db/models/query.py", line 380, in get
    self.model._meta.object_name
DoesNotExist: Session matching query does not exist.
[10/Nov/2020 13:55:40 -0800] hiveserver2  INFO     <QuerySet []>
[10/Nov/2020 13:55:40 -0800] hiveserver2  INFO     SparkSQL sessions: 
[10/Nov/2020 13:55:40 -0800] hiveserver2  INFO     <QuerySet [<Session: hadoop 2020-11-10 11:36:26>, <Session: hadoop 2020-11-10 11:36:27>]>
[10/Nov/2020 13:55:40 -0800] hiveserver2  INFO     4
[10/Nov/2020 13:55:40 -0800] hiveserver2  INFO     3
[10/Nov/2020 13:55:40 -0800] hiveserver2  INFO     SQL sessions: 
[10/Nov/2020 13:55:40 -0800] hiveserver2  INFO     {'application': u'sql', 'id': 2}
[10/Nov/2020 13:55:40 -0800] hiveserver2  INFO     filter: 
[10/Nov/2020 13:55:40 -0800] hiveserver2  INFO     {u'dialect': u'sql', u'reuse_session': False, u'session_id': u'00436feb98d88bd1:b37ff9aa2b980e9c', u'properties': [{u'multiple': True, u'defaultValue': [], u'value': [], u'nice_name': u'Files', u'key': u'files', u'help_text': u'Add one or more files, jars, or archives to the list of resources.', u'type': u'hdfs-files'}, {u'multiple': True, u'defaultValue': [], u'value': [], u'nice_name': u'Functions', u'key': u'functions', u'help_text': u'Add one or more registered UDFs (requires function name and fully-qualified class name).', u'type': u'functions'}, {u'multiple': True, u'defaultValue': [], u'value': [], u'nice_name': u'Settings', u'key': u'settings', u'help_text': u'Hive and Hadoop configuration properties.', u'type': u'settings', u'options': [u'hive.map.aggr', u'hive.exec.compress.output', u'hive.exec.parallel', u'hive.execution.engine', u'mapreduce.job.queuename']}], u'configuration': {u'hive.map.aggr': u'true', u'hive.execution.engine': u'tez', u'mapreduce.job.queuename': u'default', u'hive.exec.parallel': u'false', u'hive.exec.compress.output': u'false', u'hive.server2.thrift.resultset.default.fetch.size': u'1000'}, u'type': u'sql', u'id': 2}
[10/Nov/2020 13:55:40 -0800] hiveserver2  INFO     session: 
[10/Nov/2020 13:55:40 -0800] hiveserver2  INFO     [{u'dialect': u'sql', u'reuse_session': False, u'session_id': u'00436feb98d88bd1:b37ff9aa2b980e9c', u'properties': [{u'multiple': True, u'defaultValue': [], u'value': [], u'nice_name': u'Files', u'key': u'files', u'help_text': u'Add one or more files, jars, or archives to the list of resources.', u'type': u'hdfs-files'}, {u'multiple': True, u'defaultValue': [], u'value': [], u'nice_name': u'Functions', u'key': u'functions', u'help_text': u'Add one or more registered UDFs (requires function name and fully-qualified class name).', u'type': u'functions'}, {u'multiple': True, u'defaultValue': [], u'value': [], u'nice_name': u'Settings', u'key': u'settings', u'help_text': u'Hive and Hadoop configuration properties.', u'type': u'settings', u'options': [u'hive.map.aggr', u'hive.exec.compress.output', u'hive.exec.parallel', u'hive.execution.engine', u'mapreduce.job.queuename']}], u'configuration': {u'hive.map.aggr': u'true', u'hive.execution.engine': u'tez', u'mapreduce.job.queuename': u'default', u'hive.exec.parallel': u'false', u'hive.exec.compress.output': u'false', u'hive.server2.thrift.resultset.default.fetch.size': u'1000'}, u'type': u'sql', u'id': 2}]
[10/Nov/2020 13:55:40 -0800] hiveserver2  INFO     sessions: 
[10/Nov/2020 13:55:40 -0800] hiveserver2  INFO     [{u'dialect': u'sql', u'reuse_session': False, u'session_id': u'00436feb98d88bd1:b37ff9aa2b980e9c', u'properties': [{u'multiple': True, u'defaultValue': [], u'value': [], u'nice_name': u'Files', u'key': u'files', u'help_text': u'Add one or more files, jars, or archives to the list of resources.', u'type': u'hdfs-files'}, {u'multiple': True, u'defaultValue': [], u'value': [], u'nice_name': u'Functions', u'key': u'functions', u'help_text': u'Add one or more registered UDFs (requires function name and fully-qualified class name).', u'type': u'functions'}, {u'multiple': True, u'defaultValue': [], u'value': [], u'nice_name': u'Settings', u'key': u'settings', u'help_text': u'Hive and Hadoop configuration properties.', u'type': u'settings', u'options': [u'hive.map.aggr', u'hive.exec.compress.output', u'hive.exec.parallel', u'hive.execution.engine', u'mapreduce.job.queuename']}], u'configuration': {u'hive.map.aggr': u'true', u'hive.execution.engine': u'tez', u'mapreduce.job.queuename': u'default', u'hive.exec.parallel': u'false', u'hive.exec.compress.output': u'false', u'hive.server2.thrift.resultset.default.fetch.size': u'1000'}, u'type': u'sql', u'id': 2}]
[10/Nov/2020 13:55:40 -0800] hiveserver2  INFO     sessions: 
[10/Nov/2020 13:55:40 -0800] dbms         DEBUG    Query Server: {'dialect': 'sparksql', 'has_session_pool': False, 'server_name': 'sparksql', 'transport_mode': 'socket', 'auth_username': 'hue', 'server_host': 'localhost', 'server_port': 10000, 'use_sasl': True, 'auth_password_used': False, 'http_url': u'http://ip-10-102-131-194.ec2.internal:10001/cliservice', 'max_number_of_sessions': 1, 'close_sessions': False, 'principal': None}
[10/Nov/2020 13:55:40 -0800] dbms         DEBUG    Query via ini sparksql
```

We can see the type is matching but the id is different. I cannot really find how this id is determined and used in notebook and  session model. So I propose to make change in `_get_session ` and `_get_session_by_id` which will be straightforward. And I found another bug after applying this change. When you right click the table for "Open in Browser" and click "Refresh" in up right, it will pop up error `Snippet type sparksql is not configured.`. I believe the cause for it is by clicking this UI, Hue is submitting another query with session type as snippet. So I made the corresponding change in `get_interpreter ` to work around the issue.

Just wondering if you have any better idea about fixing this @romainr . Also, if there any reason for changing the sparksql snippet type to `sql` at the first place in this commit https://github.com/cloudera/hue/commit/d439df8c11c4d988d549213143029cb497c87629. It would be better if we can fix this inconsistency permanently 