### PR TITLE
HUE-9564 [oozie] Oozie Jobs Submitted via Filebrowser Execute Options  Doesn't Show Logs Button in workflow

### DIFF
--- a/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflow_graph.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflow_graph.mako
@@ -88,8 +88,8 @@ ${ dashboard.import_layout() }
                   }
                   else {
                     var actionName = actionId.toLowerCase().substr(actionId.lastIndexOf('-') + 1)
-                    if ($("[id^=wdg_" + actionName + "]").length > 0) {
-                      _w = viewModel.getWidgetById($("[id^=wdg_" + actionName + "]").attr("id").substr(4));
+                    if ($("[id^=wdg_][id*=" + actionName + "]").length > 0) {
+                      _w = viewModel.getWidgetById($("[id^=wdg_][id*=" + actionName + "]").attr("id").substr(4));
                     }
                     else {
                       _w = viewModel.getWidgetById('33430f0f-ebfa-c3ec-f237-3e77efa03d0a');


### PR DESCRIPTION
**What changes were proposed in this pull request?**
HUE-9564 [oozie] Oozie Jobs Submitted via Filebrowser Execute Options  Doesn't Show Logs Button in workflow

**How was this patch tested?**

Tested the Scenarios 
- Workflow Triggered via Scheduler 
- Workflow Triggered via wF-manager
- Workflow Triggered via Filebrowser.

The Fix Works Fine.