### PR TITLE
GH-1390 [parser] Fix window is not defined bug when parser used on node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gethue",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "description": "Hue is an Open source SQL Query Editor for Databases/Warehouses",
   "keywords": [
     "Query Editor",

--- a/webpack.config.npm.js
+++ b/webpack.config.npm.js
@@ -99,7 +99,9 @@ const parserConf = Object.assign({}, defaultConfig, {
     path: `${DIST_DIR}/parsers`,
     library: '[name]',
     libraryExport: "default",
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    umdNamedDefine: true,
+    globalObject: `(typeof self !== 'undefined' ? self : this)`
   },
 });
 


### PR DESCRIPTION
This is a Webpack 4 bug and more about it can be found @ https://medium.com/@JakeXiao/window-is-undefined-in-umd-library-output-for-webpack4-858af1b881df