### PR TITLE
[k8s] Add password_script to database configuration

### DIFF
--- a/tools/kubernetes/helm/hue/templates/configmap-hue.yaml
+++ b/tools/kubernetes/helm/hue/templates/configmap-hue.yaml
@@ -11,7 +11,11 @@ data:
     host={{ .Values.hue.database.host }}
     port={{ .Values.hue.database.port }}
     user={{ .Values.hue.database.user }}
+{{- if .Values.hue.database.password_script }}
+    password_script={{ .Values.hue.database.password_script }}
+{{- else }}
     password={{ .Values.hue.database.password }}
+{{- end }}
     name={{ .Values.hue.database.name }}
 
     [aws]

--- a/tools/kubernetes/helm/hue/values.yaml
+++ b/tools/kubernetes/helm/hue/values.yaml
@@ -12,6 +12,7 @@ hue:
     port: 5432
     user: "hue"
     password: "hue"
+    #password_script=echo ${DATABASE_PASSWORD}
     name: "hue"
     storageName: "microk8s-hostpath"
   interpreters: |


### PR DESCRIPTION
This makes it possible to avoid storing passwords in `values.yml` and using `echo ${SOME_VAR}` as a script to obtain the password via environment variables.