### PR TITLE
Various improvements to the query editor web component

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,7 +1,0 @@
-{
-  "extends": "stylelint-config-standard",
-  "rules": {
-    "max-empty-lines": 4,
-    "no-descending-specificity": null
-  }
-}

--- a/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/AceEditor.scss
+++ b/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/AceEditor.scss
@@ -1,0 +1,355 @@
+@import '../../../../components/styles/colors.scss';
+@import '../../../../components/styles/mixins.scss';
+
+.ace-editor-component {
+  height: 100%;
+  text-align: left;
+  color: $fluid-black;
+
+  .ace-editor {
+    height: 100%;
+  }
+
+  .hue-ace-syntax-error {
+    position: absolute;
+    border-bottom: 1px dotted $hue-error-color;
+    border-radius: 0 !important;
+  }
+
+  .hue-ace-syntax-warning {
+    position: absolute;
+    border-bottom: 1px dotted $hue-warning-color;
+    border-radius: 0 !important;
+  }
+
+  .ace-hue {
+    .ace_gutter-cell {
+      border-right: 1px solid transparent;
+
+      &.ace-active-gutter-decoration {
+        background-color: $hue-primary-color-light;
+        border-right: 1px solid $hue-primary-color-dark;
+      }
+
+      &.ace-executing-gutter-decoration {
+        background-color: $hue-primary-color-light;
+        border-right: 1px solid $hue-primary-color-dark;
+
+        @include animation(execute-pulse 2s infinite ease-in-out);
+
+        @include keyframes(execute-pulse) {
+          0% {
+            background-color: rgba(0, 140, 255, 0.1);
+          }
+
+          50% {
+            background-color: rgba(0, 140, 255, 0.4);
+            color: $fluid-gray-700;
+          }
+
+          100% {
+            background-color: rgba(0, 140, 255, 0.1);
+          }
+        }
+      }
+
+      &.ace-failed-gutter-decoration {
+        background-color: $fluid-red-050;
+        border-right: 1px solid $fluid-red-700;
+      }
+
+      &.ace-completed-gutter-decoration {
+        background-color: $fluid-green-050;
+        border-right: 1px solid $fluid-green-400;
+      }
+
+      &.ace_error {
+        background-color: $fluid-red-050;
+        border-right: 1px solid $fluid-red-700;
+        border-left: none;
+      }
+    }
+
+    .hue-ace-location {
+      position: absolute;
+      background-color: $hue-primary-color-light;
+      border: 1px solid $hue-primary-color-light;
+      border-radius: 1px;
+      margin-left: -1px;
+      margin-top: -1px;
+    }
+
+    .ace_marker-layer {
+      .ace-failed-marker {
+        position: absolute;
+        width: 100% !important;
+        margin-left: -3px;
+      }
+
+      .ace-failed-marker,
+      .ace_error-line {
+        background-color: $fluid-red-050 !important;
+        opacity: 0.5;
+        z-index: 6;
+      }
+    }
+  }
+
+  .ace-hue-dark {
+    .ace_gutter-cell {
+      border-right: 1px solid transparent;
+
+      &.ace-active-gutter-decoration {
+        background-color: $fluid-slate-700;
+        color: $fluid-slate-100;
+        border-right: 1px solid $fluid-slate-600;
+      }
+
+      &.ace_error {
+        background-color: $fluid-red-050;
+        border-right: 1px solid $fluid-red-700;
+        border-left: none;
+      }
+    }
+
+    .hue-ace-location {
+      position: absolute;
+      background-color: $fluid-slate-700;
+      border: 1px solid $fluid-slate-700;
+      border-radius: 1px;
+      margin-left: -1px;
+      margin-top: -1px;
+    }
+
+    .ace_marker-layer {
+      .ace-failed-marker {
+        position: absolute;
+        width: 100% !important;
+        margin-left: -3px;
+      }
+
+      .ace-failed-marker,
+      .ace_error-line {
+        background-color: $fluid-red-050 !important;
+        opacity: 0.5;
+        z-index: 6;
+      }
+    }
+  }
+
+  .hue-ace-autocompleter {
+    @include display-flex;
+
+    position: fixed;
+    z-index: 999;
+    max-height: 250px;
+    align-items: flex-start;
+  }
+
+  .autocompleter-suggestions,
+  .autocompleter-details {
+    @include display-flex;
+    @include flex(0 0 300px);
+    @include flex-direction(column);
+    @include box-shadow(2px, 0, 8px, rgba(0, 0, 0, 0.18));
+
+    width: 300px;
+    max-height: 250px;
+    overflow: hidden;
+    border: 1px solid $fluid-gray-300;
+    border-radius: 2px;
+    background-color: $fluid-white;
+  }
+
+  .autocompleter-suggestions {
+    z-index: 1002;
+  }
+
+  .autocompleter-details {
+    z-index: 1001;
+    margin-left: 5px;
+  }
+
+  .autocompleter-header {
+    @include flex(0 0 20px);
+
+    position: relative;
+    padding: 5px;
+    background-color: $fluid-gray-040;
+    line-height: 20px;
+    font-size: 14px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .autocompleter-header-popularity {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    width: 19px;
+    height: 19px;
+  }
+
+  .autocompleter-spinner {
+    position: relative;
+    float: right;
+    width: 15px;
+    margin-top: 1px;
+  }
+
+  .autocompleter-categories {
+    display: inline-block;
+    float: left;
+  }
+
+  .autocompleter-categories > div {
+    display: inline-block;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+    padding: 0 5px;
+  }
+
+  .autocompleter-categories > div.active {
+    display: inline-block;
+    border-bottom: 2px solid $fluid-blue-400;
+    cursor: default;
+  }
+
+  .autocompleter-entries {
+    max-height: 225px;
+    position: relative;
+    overflow-y: auto;
+  }
+
+  .autocompleter-suggestion {
+    height: 19px;
+    clear: both;
+    background-color: $fluid-white;
+    padding: 3px;
+    cursor: pointer;
+    position: relative;
+    font: 12px normal Roboto Mono, Menlo, Monaco, Consolas, "Courier New", monospace;
+    direction: ltr;
+    line-height: 18px;
+  }
+
+  .autocompleter-suggestion:hover {
+    background-color: $fluid-gray-200;
+  }
+
+  .autocompleter-suggestion.selected {
+    background-color: $fluid-gray-300;
+  }
+
+  .autocompleter-suggestion-value {
+    width: 85%;
+    margin-left: 3px;
+    margin-right: 6px;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .autocompleter-suggestion-value b {
+    font-weight: bolder;
+  }
+
+  .autocompleter-suggestion-meta {
+    position: absolute;
+    background-color: inherit;
+    z-index: 1;
+    right: 0;
+    top: 3px;
+    padding-right: 3px;
+    color: $fluid-gray-700;
+    max-width: 65px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow-x: hidden;
+  }
+
+  .autocompleter-dot {
+    display: inline-block;
+    margin-top: 5px;
+    width: 8px;
+    height: 8px;
+    border-radius: 4px;
+  }
+
+  .autocompleter-details-contents {
+    max-height: 225px;
+    position: relative;
+    overflow-y: auto;
+  }
+
+  .autocompleter-details-contents-inner {
+    padding: 7px;
+  }
+
+  .autocompleter-details-contents .details-attribute,
+  .autocompleter-details-contents .details-popularity {
+    color: $fluid-gray-700;
+    display: inline-block;
+  }
+
+  .autocompleter-details-contents .details-popularity .progress {
+    display: inline-block;
+    border-radius: 2px;
+    height: 10px;
+    width: 80px;
+  }
+
+  .autocompleter-details-contents .details-popularity .progress .bar {
+    background-color: $fluid-blue-400;
+  }
+
+  .autocompleter-details-contents .details-comment,
+  .autocompleter-details-contents .details-description {
+    font-size: 14px;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    color: $fluid-gray-700;
+  }
+
+  .autocompleter-details-contents .details-header {
+    font-size: 14px;
+    font-weight: bold;
+    margin: 2px 0;
+  }
+
+  .autocompleter-details-contents .details-no-comment {
+    margin-top: 5px;
+    margin-bottom: 5px;
+    font-size: 13px;
+    color: $fluid-gray-700;
+    font-style: italic;
+  }
+
+  .autocompleter-details-contents .details-comment * {
+    font-size: 13px !important;
+    line-height: 14px !important;
+    white-space: pre;
+  }
+
+  .autocompleter-details-contents .details-code {
+    background-color: $fluid-gray-040;
+    padding: 3px;
+    color: $fluid-gray-700;
+    font: 12px normal Roboto Mono, Menlo, Monaco, Consolas, "Courier New", monospace;
+    direction: ltr;
+  }
+
+  .fn-details {
+    max-width: 600px;
+    white-space: normal;
+    overflow-y: auto;
+    height: 100%;
+    padding: 8px;
+  }
+
+  .fn-sig {
+    white-space: pre;
+    font-family: monospace;
+  }
+}

--- a/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/AceEditor.vue
+++ b/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/AceEditor.vue
@@ -442,11 +442,11 @@
             : '12px'
         ),
         enableSnippets: true,
-        showGutter: false,
-        showLineNumbers: false,
+        showGutter: true,
+        showLineNumbers: true,
         showPrintMargin: false,
         scrollPastEnd: 0.1,
-        minLines: 1,
+        minLines: 3,
         maxLines: 25,
         tabSize: 2,
         useSoftTabs: true,
@@ -583,12 +583,6 @@
   }
 </script>
 
-<style lang="scss" scoped>
-  .ace-editor-component {
-    height: 100%;
-
-    .ace-editor {
-      height: 100%;
-    }
-  }
+<style lang="scss">
+  @import './AceEditor.scss';
 </style>

--- a/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/AceEditor.vue
+++ b/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/AceEditor.vue
@@ -19,7 +19,13 @@
 <template>
   <div class="ace-editor-component">
     <div :id="id" ref="editorElement" class="ace-editor" />
-    <ace-autocomplete v-if="editor" :editor="editor" :editor-id="id" :executor="executor" />
+    <ace-autocomplete
+      v-if="editor"
+      :autocomplete-parser="autocompleteParser"
+      :editor="editor"
+      :editor-id="id"
+      :executor="executor"
+    />
   </div>
 </template>
 
@@ -36,7 +42,7 @@
   import { formatSql } from 'apps/notebook2/apiUtils';
   import Executor from 'apps/notebook2/execution/executor';
   import SubscriptionTracker from 'components/utils/SubscriptionTracker';
-  import { IdentifierChainEntry, ParsedLocation } from 'parse/types';
+  import { AutocompleteParser, IdentifierChainEntry, ParsedLocation } from 'parse/types';
   import { EditorInterpreter } from 'types/config';
   import { hueWindow } from 'types/types';
   import huePubSub from 'utils/huePubSub';
@@ -67,6 +73,8 @@
     executor!: Executor;
     @Prop({ required: false, default: () => ({}) })
     aceOptions?: Ace.Options;
+    @Prop({ required: false })
+    autocompleteParser?: AutocompleteParser;
 
     subTracker = new SubscriptionTracker();
     editor: Ace.Editor | null = null;

--- a/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/QueryEditorWebComponent.ts
+++ b/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/QueryEditorWebComponent.ts
@@ -1,8 +1,26 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// 'License'); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import axios from 'axios';
 import AceEditor from './AceEditor.vue';
 import { wrap } from 'vue/webComponentWrapper';
+import style from '!!css-loader!sass-loader!./AceEditor.scss';
 
 wrap('query-editor', AceEditor, {
+  shadowCss: style,
   connectedCallback() {
     const element = <HTMLElement>this;
     const hueBaseUrl = element.getAttribute('hue-base-url');

--- a/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/autocomplete/AceAutocomplete.vue
+++ b/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/autocomplete/AceAutocomplete.vue
@@ -81,6 +81,7 @@
 <script lang="ts">
   import { Ace } from 'ext/ace';
   import ace from 'ext/aceHelper';
+  import { AutocompleteParser } from 'parse/types';
   import Vue from 'vue';
   import Component from 'vue-class-component';
   import { Prop } from 'vue-property-decorator';
@@ -128,6 +129,9 @@
     editor!: Ace.Editor;
     @Prop({ required: false, default: false })
     temporaryOnly?: boolean;
+
+    @Prop({ required: false })
+    autocompleteParser?: AutocompleteParser;
 
     startLayout: DOMRect | null = null;
     startPixelRatio = window.devicePixelRatio;
@@ -198,7 +202,8 @@
         editorId: this.editorId,
         executor: this.executor,
         editor: this.editor,
-        temporaryOnly: this.temporaryOnly
+        temporaryOnly: this.temporaryOnly,
+        autocompleteParser: this.autocompleteParser
       });
 
       this.subTracker.addDisposable(this.autocompleter);

--- a/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/autocomplete/AceAutocomplete.vue
+++ b/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/autocomplete/AceAutocomplete.vue
@@ -607,5 +607,3 @@
     }
   }
 </script>
-
-<style lang="scss" scoped></style>

--- a/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/autocomplete/CatalogEntryDetailsPanel.vue
+++ b/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/autocomplete/CatalogEntryDetailsPanel.vue
@@ -129,5 +129,3 @@
     }
   }
 </script>
-
-<style lang="scss" scoped></style>

--- a/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/autocomplete/MatchedText.vue
+++ b/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/autocomplete/MatchedText.vue
@@ -62,5 +62,3 @@
     }
   }
 </script>
-
-<style lang="scss" scoped></style>

--- a/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/autocomplete/OptionDetailsPanel.vue
+++ b/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/autocomplete/OptionDetailsPanel.vue
@@ -53,5 +53,3 @@
     }
   }
 </script>
-
-<style lang="scss" scoped></style>

--- a/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/autocomplete/UdfDetailsPanel.vue
+++ b/desktop/core/src/desktop/js/apps/notebook2/components/aceEditor/autocomplete/UdfDetailsPanel.vue
@@ -52,5 +52,3 @@
     }
   }
 </script>
-
-<style lang="scss" scoped></style>

--- a/desktop/core/src/desktop/js/components/er-diagram/comps/literal-entity.scss
+++ b/desktop/core/src/desktop/js/components/er-diagram/comps/literal-entity.scss
@@ -20,11 +20,9 @@
   border: 1px solid #d6d8db;
   border-radius: 5px;
   padding: 5px;
-  background-color: #FFF;
-
+  background-color: #fff;
   position: relative;
-
-  box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.05) inset, 0px 0px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05) inset, 0 0 8px rgba(0, 0, 0, 0.15);
 
   .literal-value {
     text-align: center;

--- a/desktop/core/src/desktop/js/components/er-diagram/comps/table-entity.scss
+++ b/desktop/core/src/desktop/js/components/er-diagram/comps/table-entity.scss
@@ -17,7 +17,7 @@
 */
 
 $border-color: #d6d8db;
-$bg-color: #FFF;
+$bg-color: #fff;
 
 .ellipsis-on-overflow {
   white-space: nowrap;
@@ -29,16 +29,13 @@ $bg-color: #FFF;
   border: 1px solid $border-color;
   border-radius: 5px;
   padding: 5px;
-
-  box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.05) inset, 0px 0px 8px rgba(0, 0, 0, 0.15);
-
-  background-color: #EFEFEF;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05) inset, 0 0 8px rgba(0, 0, 0, 0.15);
+  background-color: #efefef;
 
   .db-name {
     color: rgb(5, 5, 5);
     font-size: 0.8em;
     text-align: center;
-
     margin-bottom: -5px;
 
     @extend .ellipsis-on-overflow;
@@ -58,23 +55,25 @@ $bg-color: #FFF;
   .columns-container {
     padding: 0 10px;
 
-    .column-entity, .grouped-columns {
+    .column-entity,
+    .grouped-columns {
       padding: 5px;
       text-align: center;
       background-color: $bg-color;
-
       border: 1px solid $border-color;
       border-radius: 5px;
       margin: 5px 0;
-
       position: relative;
 
       @extend .ellipsis-on-overflow;
     }
 
     .grouped-columns {
-      box-shadow: -2px -2px 0 rgba($bg-color, 0.95), -3px -3px 0 rgba($border-color, 0.95),
-                  -5px -5px 0 rgba($bg-color, 0.7), -6px -6px 0 rgba($border-color, 0.7);
+      box-shadow:
+        -2px -2px 0 rgba($bg-color, 0.95),
+        -3px -3px 0 rgba($border-color, 0.95),
+        -5px -5px 0 rgba($bg-color, 0.7),
+        -6px -6px 0 rgba($border-color, 0.7);
       margin-left: 7px;
       margin-top: 10px;
     }

--- a/desktop/core/src/desktop/js/components/er-diagram/er-diagram.scss
+++ b/desktop/core/src/desktop/js/components/er-diagram/er-diagram.scss
@@ -17,14 +17,14 @@
 */
 
 // Colors
-$bg-color: #FFF;
-$dot-color: #BBB;
+$bg-color: #fff;
+$dot-color: #bbb;
 
 // Dimensions
 $dot-size: 1px;
 $dot-space: 10px;
 
-expand-icon{
+.expand-icon {
   font-size: 13px;
   font-weight: bold;
 
@@ -37,16 +37,14 @@ expand-icon{
   color: #0a78a3;
   border: 1px solid #d6d8db;
   border-radius: 5px;
-
   position: relative;
-
   font-family: Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
   line-height: 20px;
   font-size: 14px;
-
   background:
     linear-gradient(90deg, $bg-color ($dot-space - $dot-size), transparent 1%) center,
-    linear-gradient($bg-color ($dot-space - $dot-size), transparent 1%) center, $dot-color;
+    linear-gradient($bg-color ($dot-space - $dot-size), transparent 1%) center,
+    $dot-color;
   background-size: $dot-space $dot-space;
 
   .buttons-panel {
@@ -71,35 +69,33 @@ expand-icon{
   .erd-container {
     white-space: nowrap;
     min-height: 500px;
-
     position: relative;
 
     .entity-group {
       display: inline-block;
       width: 200px;
       padding: 15px 30px;
-
       white-space: normal;
-
       vertical-align: top;
 
       .entity-container {
         padding: 10px 0;
 
-        .left-point, .right-point {
+        .left-point,
+        .right-point {
           position: absolute;
-          width: 0px;
-          height: 0px;
+          width: 0;
+          height: 0;
           top: 1em;
         }
 
         .left-point {
           left: -1px;
         }
+
         .right-point {
           right: -1px;
         }
-
       }
     }
   }
@@ -107,12 +103,9 @@ expand-icon{
   .erd-relations {
     position: absolute;
     overflow: visible;
-
     top: 0;
     left: 0;
-
     opacity: 0.5;
-
     pointer-events: none;
 
     .relation-path {

--- a/desktop/core/src/desktop/js/components/styles/mixins.scss
+++ b/desktop/core/src/desktop/js/components/styles/mixins.scss
@@ -57,15 +57,17 @@ $hue-panel-border-radius: 3px;
 }
 
 @mixin ease-transition($arg) {
-  @include transition($arg 0.2s ease)
+  @include transition($arg 0.2s ease);
 }
 
 @mixin box-shadow($top, $left, $blur, $color, $inset: false) {
   @if $inset {
-    -webkit-box-shadow:inset $top $left $blur $color;
-    -moz-box-shadow:inset $top $left $blur $color;
-    box-shadow:inset $top $left $blur $color;
-  } @else {
+    -webkit-box-shadow: inset $top $left $blur $color;
+    -moz-box-shadow: inset $top $left $blur $color;
+    box-shadow: inset $top $left $blur $color;
+  }
+
+  @else {
     -webkit-box-shadow: $top $left $blur $color;
     -moz-box-shadow: $top $left $blur $color;
     box-shadow: $top $left $blur $color;
@@ -116,15 +118,19 @@ $hue-panel-border-radius: 3px;
   @-webkit-keyframes #{$animation-name} {
     @content;
   }
+
   @-moz-keyframes #{$animation-name} {
     @content;
   }
+
   @-ms-keyframes #{$animation-name} {
     @content;
   }
+
   @-o-keyframes #{$animation-name} {
     @content;
   }
+
   @keyframes #{$animation-name} {
     @content;
   }
@@ -210,8 +216,8 @@ $hue-panel-border-radius: 3px;
 }
 
 @mixin hue-flex-layout($direction: row) {
-  display: flex;
   @include flex-direction($direction);
+  @include display-flex;
 
   column-gap: 10px;
   row-gap: 10px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20970,6 +20970,45 @@
         "stylelint-config-recommended": "^3.0.0"
       }
     },
+    "stylelint-scss": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.18.0.tgz",
+      "integrity": "sha512-LD7+hv/6/ApNGt7+nR/50ft7cezKP2HM5rI8avIdGaUWre3xlHfV4jKO/DRZhscfuN+Ewy9FMhcTq0CcS0C/SA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "dependencies": {
+        "cssesc": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+          "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+          "dev": true
+        },
+        "postcss-selector-parser": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
+          "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "postcss-value-parser": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+          "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
+          "dev": true
+        }
+      }
+    },
     "sugarss": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,15 @@
   },
   "stylelint": {
     "extends": "stylelint-config-standard",
+    "plugins": [
+      "stylelint-scss"
+    ],
     "rules": {
+      "max-empty-lines": 4,
       "number-leading-zero": null,
-      "no-descending-specificity": null
+      "no-descending-specificity": null,
+      "at-rule-no-unknown": null,
+      "scss/at-rule-no-unknown": true
     }
   },
   "dependencies": {
@@ -131,6 +137,7 @@
     "style-loader": "^1.1.3",
     "stylelint": "13.6.0",
     "stylelint-config-standard": "20.0.0",
+    "stylelint-scss": "3.18.0",
     "ts-loader": "7.0.5",
     "typescript": "3.9.5",
     "vue-jest": "^3.0.6",
@@ -152,8 +159,8 @@
     "dev-workers": "webpack --config webpack.config.workers.js --watch -d",
     "less": "./node_modules/.bin/grunt less",
     "less-dev": "./node_modules/.bin/grunt watch",
-    "less-lint": "stylelint \"desktop/core/src/desktop/static/desktop/less/**/*.less\"",
-    "less-lint-fix": "npm run less-lint -- --fix",
+    "style-lint": "stylelint \"desktop/core/src/desktop/static/desktop/less/**/*.less\" \"desktop/core/src/desktop/js/**/*.scss\"" ,
+    "style-lint-fix": "npm run style-lint -- --fix",
     "lint": "eslint desktop/core/src/desktop/js tools/sql-docs tools/jison",
     "lint-debug": "npm run lint -- --debug",
     "lint-fix": "npm run lint -- --fix",


### PR DESCRIPTION
Styles are now included in the shadow CSS of the web component. A temporary property to supply the parser to use from the outside was also added.

Currently in Hue the parser is fetched using the sqlParserRepository via dynamic imports. It's not trivial and dev friendly to force a dynamic import setup for users of the web comp. so a better solution is to supply a strategy for getting the parsers. That way we can pass the sqlParserRepository from the outside in the Hue code which would allow users of the web component to choose any approach they want. I'll improve this separately.