### PR TITLE
[hdfs] Do not use object store home as home when not HDFS

### DIFF
--- a/desktop/core/src/desktop/auth/backend.py
+++ b/desktop/core/src/desktop/auth/backend.py
@@ -166,8 +166,8 @@ class DefaultUserAugmentor(object):
   def get_groups(self):
     return self._get_profile().get_groups()
 
-  def get_home_directory(self):
-    return REMOTE_STORAGE_HOME.get() if hasattr(REMOTE_STORAGE_HOME, 'get') and REMOTE_STORAGE_HOME.get() \
+  def get_home_directory(self, force_home=False):
+    return REMOTE_STORAGE_HOME.get() if hasattr(REMOTE_STORAGE_HOME, 'get') and REMOTE_STORAGE_HOME.get() and not force_home \
         else self._get_profile().home_directory
 
   def has_hue_permission(self, action, app):

--- a/desktop/core/src/desktop/models.py
+++ b/desktop/core/src/desktop/models.py
@@ -1925,7 +1925,8 @@ class ClusterConfig(object):
     remote_home_storage = REMOTE_STORAGE_HOME.get() if hasattr(REMOTE_STORAGE_HOME, 'get') and REMOTE_STORAGE_HOME.get() else None
 
     for hdfs_connector in hdfs_connectors:
-      home_path = remote_home_storage if remote_home_storage else self.user.get_home_directory().encode('utf-8')
+      force_home = remote_home_storage and not remote_home_storage.startswith('/')
+      home_path = self.user.get_home_directory(force_home=force_home).encode('utf-8')
       interpreters.append({
         'type': 'hdfs',
         'displayName': hdfs_connector,


### PR DESCRIPTION
Otherwise clicking on the HDFS icon will land on S3 for example.
