### PR TITLE
[editor] Only display executed statement in query history

### DIFF
--- a/desktop/libs/notebook/src/notebook/api.py
+++ b/desktop/libs/notebook/src/notebook/api.py
@@ -571,7 +571,17 @@ def _historify(notebook, user):
 
 def _get_statement(notebook):
   if notebook['snippets'] and len(notebook['snippets']) > 0:
-    return Notebook.statement_with_variables(notebook['snippets'][0])
+    snippet = notebook['snippets'][0]
+    try:
+      if snippet.get('executor', {}).get('executables', []):  # With Connectors/Editor 2
+        executable = snippet['executor']['executables'][0]
+        if executable.get('handle'):
+          return executable['handle']['statement']
+        else:
+          return executable['parsedStatement']['statement']
+      return Notebook.statement_with_variables(snippet)
+    except KeyError as e:
+      LOG.warning('Could not get statement from query history: %s' % e)
   return ''
 
 @require_GET


### PR DESCRIPTION
Instead of all statements.
Note: opening up the query properly loads all the statements already.

To clean-up when simplifying the API with Editor 2.