### PR TITLE
Add a dask-sql connector type

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -1043,6 +1043,13 @@
     # ## Presto Session properties when HTTPS is not enabled.
     # # options='{"url": "presto://username:password@localhost:8080/tpch/default","connect_args":"{\"session_props\": {\"query_max_run_time\": \"1m\"}}"}'
 
+    # [[[dask-sql]]]
+    # name=Dask-SQL
+    # interface=sqlalchemy
+    # ## Specific options for connecting to the dask-sql server.
+    # ## Please note, that dask-sql uses the presto protocol.
+    # # options='{"url": "presto://localhost:8080/catalog/default"}'
+
     # [[[clickhouse]]]
     #   name=ClickHouse
     #   interface=jdbc

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -1027,6 +1027,13 @@
     # ## Presto Session properties when HTTPS is not enabled.
     # # options='{"url": "presto://username:password@localhost:8080/tpch/default","connect_args":"{\"session_props\": {\"query_max_run_time\": \"1m\"}}"}'
 
+    # [[[dask-sql]]]
+    # name=Dask-SQL
+    # interface=sqlalchemy
+    # ## Specific options for connecting to the dask-sql server.
+    # ## Please note, that dask-sql uses the presto protocol.
+    # # options='{"url": "presto://localhost:8080/catalog/default"}'
+
     # [[[clickhouse]]]
     #   name=ClickHouse
     #   interface=jdbc

--- a/desktop/core/src/desktop/lib/connectors/types.py
+++ b/desktop/core/src/desktop/lib/connectors/types.py
@@ -369,6 +369,34 @@ CONNECTOR_TYPES = [
     }
   },
   {
+    'nice_name': "dask-sql",
+    'dialect': 'presto',
+    'interface': 'sqlalchemy',
+    'settings': [
+      {'name': 'url', 'value': 'presto://host:8080/catalog/default'},
+      {'name': 'has_ssh', 'value': False},
+      {'name': 'ssh_server_host', 'value': '127.0.0.1'},
+      {'name': 'has_impersonation', 'value': False},
+    ],
+    'category': 'editor',
+    'description': '',
+    'properties': {
+      'is_sql': True,
+      'sql_identifier_quote': '"',
+      'sql_identifier_comment_single': '--',
+      'has_catalog': True,
+      'has_database': True,
+      'has_table': True,
+      'has_live_queries': False,
+      'has_optimizer_risks': False,
+      'has_optimizer_values': True,
+      'has_auto_limit': False,
+      'has_reference_language': False,
+      'has_reference_functions': False,
+      'trim_statement_semicolon': True,
+    }
+  },
+  {
     'nice_name': "Elasticsearch SQL",
     'dialect': 'elasticsearch',
     'interface': 'sqlalchemy',

--- a/desktop/core/src/desktop/lib/connectors/types.py
+++ b/desktop/core/src/desktop/lib/connectors/types.py
@@ -369,7 +369,7 @@ CONNECTOR_TYPES = [
     }
   },
   {
-    'nice_name': 'dask-sql',
+    'nice_name': 'Dask-sql',
     'dialect': 'presto',
     'interface': 'sqlalchemy',
     'settings': [

--- a/desktop/core/src/desktop/lib/connectors/types.py
+++ b/desktop/core/src/desktop/lib/connectors/types.py
@@ -369,7 +369,7 @@ CONNECTOR_TYPES = [
     }
   },
   {
-    'nice_name': "dask-sql",
+    'nice_name': 'dask-sql',
     'dialect': 'presto',
     'interface': 'sqlalchemy',
     'settings': [


### PR DESCRIPTION
First approach to solve #1480 (in parts).

This PR adds a first draft for a dask-sql type, basically copying the presto one, except for the risks - I guess I want `has_optimizer_risks` turned off - but I am not 100% sure I understand it correctly: dask-sql has (so far), no real risk model and no optimization hints, it exposes.

I would be very happy for comments :-)