### PR TITLE
[docker] Thrift sasl Python module needed for plain SASL sessions

### DIFF
--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -53,8 +53,8 @@ requests>=2.20.0
 requests-kerberos==0.12.0
 rsa==3.4.2
 sasl==0.2.1  # Move to https://pypi.org/project/sasl3/ ?
-six==1.12.0
 SQLAlchemy==1.3.8
 sqlparse==0.4.1
 tablib==0.13.0
 thrift==0.13.0
+thrift-sasl==0.4.2


### PR DESCRIPTION
Hardcoded six version is too old, better to just auto pull it.
