### PR TITLE
[jb] Kill any running "jobs" in job browser errors

### DIFF
--- a/apps/jobbrowser/src/jobbrowser/api2.py
+++ b/apps/jobbrowser/src/jobbrowser/api2.py
@@ -119,7 +119,7 @@ def action(request, interface=None, action=None):
 
   response['operation'] = operation
   response.update(
-      get_api(request.user, interface, cluster=cluster).action(app_ids, operation, request)
+      get_api(request.user, interface, cluster=cluster).action(app_ids, operation)
   )
 
   return JsonResponse(response)

--- a/apps/jobbrowser/src/jobbrowser/apis/hive_query_api.py
+++ b/apps/jobbrowser/src/jobbrowser/apis/hive_query_api.py
@@ -22,14 +22,12 @@ from logging import exception
 from datetime import datetime
 from django.utils.translation import ugettext as _
 
+from beeswax.models import QueryHistory
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.python_util import current_ms_from_utc
 from desktop.lib.rest.http_client import HttpClient
 from desktop.lib.rest.resource import Resource
-
-from notebook.models import _get_notebook_api, make_notebook
-
-from beeswax.models import QueryHistory
+from notebook.models import _get_notebook_api, make_notebook, MockRequest
 
 from jobbrowser.apis.base_api import Api
 from jobbrowser.conf import QUERY_STORE
@@ -115,7 +113,7 @@ class HiveQueryApi(Api):
 
     return app
 
-  def action(self, query_ids, action, request=None):
+  def action(self, query_ids, action):
     message = {'actions': {}, 'status': 0}
 
     if action.get('action') == 'kill':
@@ -123,6 +121,7 @@ class HiveQueryApi(Api):
         action_details = {}
 
         try:
+          request = MockRequest(user=self.user)
           self.kill_query(query_id, request)
           action_details['status'] = 0
           action_details['message'] = _('kill action performed')


### PR DESCRIPTION
The signature was bad and breaking all the APIs.
request object can actually be half mocked.
