### PR TITLE
[core] Avoid failure of loading back the user starred app

### DIFF
--- a/desktop/core/src/desktop/models.py
+++ b/desktop/core/src/desktop/models.py
@@ -1773,7 +1773,7 @@ class ClusterConfig(object):
       user_preference = get_user_preferences(user=self.user, key='default_app')
       if not user_preference:
         raise UserPreferences.DoesNotExist()
-      user_default_app = json.loads(user_preference)
+      user_default_app = json.loads(user_preference['default_app'])
       if apps.get(user_default_app['app']):
         default_interpreter = []
         default_app = apps[user_default_app['app']]


### PR DESCRIPTION
Traceback (most recent call last):
  File "/hue/desktop/core/src/desktop/models.py", line 1792, in get_main_quick_action
    user_default_app = json.loads(user_preference)
  File "/usr/lib/python3.8/json/__init__.py", line 341, in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
  TypeError: the JSON object must be str, bytes or bytearray, not dict
