### PR TITLE
HUE-9653 [filebrowser] Issue with fileupload when Large Files are uploaded

### DIFF
--- a/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
+++ b/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
@@ -2116,6 +2116,7 @@ from filebrowser.conf import ENABLE_EXTRACT_UPLOADED_ARCHIVE
               dest: ops.path
             },
             autoDiscover: false,
+            timeout: 300000,
             maxFilesize: 5000000,
             previewsContainer: '#progressStatusContent',
             previewTemplate: '<div class="progress-row">' +

--- a/desktop/core/src/desktop/js/ko/bindings/ko.dropzone.js
+++ b/desktop/core/src/desktop/js/ko/bindings/ko.dropzone.js
@@ -30,6 +30,7 @@ ko.bindingHandlers.dropzone = {
     }
     const options = {
       autoDiscover: false,
+      timeout: 300000,
       maxFilesize: 5000000,
       previewsContainer: '#progressStatusContent',
       previewTemplate:


### PR DESCRIPTION
**What changes were proposed in this pull request?**
HUE-9653 [filebrowser] Issue with fileupload when Large Files are uploaded

**How was this patch tested?**

Tested the Scenarios 
- Drag and drop works well for Long files
- No other impact on any other places

Source of the Fix : https://www.dropzonejs.com/#config-timeout
The Fix Works Fine.