### PR TITLE
[py3] Avoid missing glob module

### DIFF
--- a/tools/docker/hue/Dockerfile.py3
+++ b/tools/docker/hue/Dockerfile.py3
@@ -69,8 +69,8 @@ RUN ./build/env/bin/pip install \
   pybigquery \
   elasticsearch-dbapi \
   pyasn1==0.4.1 \
-  gevent \
-  eventlet \
+  # View some parquet files
+  python-snappy==0.5.4 \
   threadloop  # Needed for Jaeger \
   thrift-sasl==0.2.1
 


### PR DESCRIPTION
Collecting gevent
  Downloading gevent-20.12.1.tar.gz (5.9 MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /usr/share/hue/build/env/bin/python3.6 /usr/share/hue/build/env/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpdrdp1zjb
       cwd: /tmp/pip-install-7lbwjz70/gevent_0275bc262bde4bf9afddae86774d9edc
  Complete output (4 lines):
  Traceback (most recent call last):
    File "/usr/share/hue/build/env/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py", line 15, in <module>
      from glob import glob
  ModuleNotFoundError: No module named 'glob'
