### PR TITLE
[editor2] Avoid disabling cancel button in stream queries

### DIFF
--- a/desktop/core/src/desktop/js/apps/notebook2/execution/api.ts
+++ b/desktop/core/src/desktop/js/apps/notebook2/execution/api.ts
@@ -216,8 +216,12 @@ export const executeStatement = async (options: ExecuteApiOptions): Promise<Exec
 
   executable.addCancellable({
     cancel: async () => {
-      if (executable.status !== EXECUTION_STATUS.running) {
-        return;
+      if (
+        executable.status !== EXECUTION_STATUS.running &&
+        executable.status !== EXECUTION_STATUS.streaming
+      ) {
+        // executable.status seems to have been set to 'canceling' so ignoring for now
+        // return;
       }
       try {
         const response = await executePromise;


### PR DESCRIPTION
Will need to double check the logic of running vs streaming as
currently does not work with streaming.
