### PR TITLE
Update ServiceMonitor Label

### DIFF
--- a/tools/kubernetes/helm/hue/templates/servicemonitor-hue.yaml
+++ b/tools/kubernetes/helm/hue/templates/servicemonitor-hue.yaml
@@ -15,5 +15,5 @@ spec:
     - default
   selector:
     matchLabels:
-      app: hue
+      pod: hue
 {{- end -}}


### PR DESCRIPTION
When deploying Hue on K8's i observed that enabling monitoring with prometheus works fine, That is service discovery works fine.
But the Target labels gets dropped because of the possible wrong selector in place. 
All services have the labels pod:hue. Having app:hue results in targetlabes getting dropped. 

Without the targetlabel , having this monitoring is not that useful because we can't write any alerting.
[service-hue](https://github.com/cloudera/hue/blob/master/tools/kubernetes/helm/hue/templates/service-hue.yaml#L6) also follows up with a label called pod: hue. 
Unsure why app: hue is mentioned here but definitely  when using this , Target labels get dropped. 

I also see that a change done on  [Sep 17, 2019](https://github.com/cloudera/hue/commit/8f055acbc890339745e8bec3715e183af21d5269#diff-2afc08b4582def0d6b421b21ce5e568f28ac87ba5eac0788261b781e9e061f4c) might be the cause of this and update on service-mointor.yaml was missed here.