### PR TITLE
[dasksql] Adding NYC taxi data query example

### DIFF
--- a/apps/beeswax/data/queries.json
+++ b/apps/beeswax/data/queries.json
@@ -281,5 +281,25 @@
       "file_resources": [],
       "settings": []
     }
+  },
+  {
+    "name": "New York Taxi dataset Analysis",
+    "desc": "Regular SELECTs with custom Python UDF and create Machine Learning Model",
+    "dialects": ["dasksql"],
+    "type": "2",
+    "auto_load_only": false,
+    "data": {
+      "query": {
+        "query": "\nSELECT\n    FLOOR(trip_distance / 5) * 5 AS \"distance\",\n    AVG(tip_amount) AS \"given tip\",\n    AVG(predict_price(total_amount, trip_distance, passenger_count)) AS \"predicted tip\"\nFROM \"nyc-taxi\"\nWHERE\n    trip_distance > 0 AND trip_distance < 50\nGROUP BY\n    FLOOR(trip_distance / 5) * 5\n;\n",
+        "type": 0,
+        "email_notify": false,
+        "is_parameterized": false,
+        "database": ""
+      },
+      "functions": [],
+      "VERSION": "0.4.1",
+      "file_resources": [],
+      "settings": []
+    }
   }
 ]


### PR DESCRIPTION
Will then auto show up on https://demo.gethue.com/hue/editor/?type=10 and be available in the install samples admin section of Hue.

Note: seems like the `CREATE MODEL` is not available in dasksql latest image, e.g.

```
CREATE MODEL fare_estimator WITH (
    model_class = 'sklearn.ensemble.GradientBoostingClassifier',
    wrap_predict = True,
    target_column = 'fare_amount'
) AS (
    SELECT trip_distance, fare_amount
    FROM "nyc-taxi"
    LIMIT 100
)```

```
'message': 'Can not parse the given SQL: Incorrect syntax near the keyword \'CREATE\' at line 1, column 1.\nWas expecting one of:\n "CREATE"...
```