### PR TITLE
[hive] Fix wrong use of positional argument in describe table

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py
+++ b/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py
@@ -921,12 +921,12 @@ DROP TABLE IF EXISTS `%(table)s`;
 
 
   def describe_column(self, notebook, snippet, database=None, table=None, column=None):
-    db = self._get_db(snippet, self.interpreter)
+    db = self._get_db(snippet, interpreter=self.interpreter)
     return db.get_table_columns_stats(database, table, column)
 
 
   def describe_table(self, notebook, snippet, database=None, table=None):
-    db = self._get_db(snippet, self.interpreter)
+    db = self._get_db(snippet, interpreter=self.interpreter)
     tb = db.get_table(database, table)
 
     return {


### PR DESCRIPTION
To avoid:

[16/Jan/2021 13:40:45 -0800] decorators   ERROR    Error running describe
Traceback (most recent call last):
  File "/usr/share/hue/desktop/libs/notebook/src/notebook/decorators.py", line 114, in wrapper
    return f(*args, **kwargs)
  File "/usr/share/hue/desktop/libs/notebook/src/notebook/api.py", line 1035, in describe
    describe = get_api(request, snippet).describe(notebook, snippet, database, table, column=column)
  File "/usr/share/hue/desktop/libs/notebook/src/notebook/connectors/base.py", line 627, in describe
    describe_table = self.describe_table(notebook, snippet, database, table)
  File "/usr/share/hue/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py", line 929, in describe_table
    db = self._get_db(snippet, self.interpreter)
  File "/usr/share/hue/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py", line 798, in _get_db
    return dbms.get(self.user, query_server=get_query_server_config(name=name, connector=interpreter))
  File "/usr/share/hue/apps/beeswax/src/beeswax/server/dbms.py", line 239, in get_query_server_config
    'server_host': SPARK_SERVER_HOST.get(),
AttributeError: 'Config' object has no attribute 'get'
[16/Jan/2021 13:40:45 -0800] dbms         DEBUG    Query via ini sparksql
[16/Jan/2021 13:40:45 -0800] base         DEBUG    Selected interpreter 6 interface=hiveserver2 compute=None
