### PR TITLE
[editor] Do not auto load sample when creating a brand new editor

### DIFF
--- a/desktop/core/src/desktop/js/apps/notebook2/editorViewModel.js
+++ b/desktop/core/src/desktop/js/apps/notebook2/editorViewModel.js
@@ -318,7 +318,7 @@ class EditorViewModel {
     huePubSub.publish('recalculate.name.description.width');
   }
 
-  async newNotebook(connectorId, callback, queryTab) {
+  async newNotebook(connectorId, callback, queryTab, blank) {
     if (!connectorId) {
       connectorId = getLastKnownConfig().default_sql_interpreter;
     }
@@ -341,7 +341,8 @@ class EditorViewModel {
       $.post('/notebook/api/create_notebook', {
         type: connectorId,
         directory_uuid: hueUtils.getParameter('directory_uuid'),
-        gist: this.isNotificationManager() ? undefined : hueUtils.getParameter('gist')
+        gist: this.isNotificationManager() ? undefined : hueUtils.getParameter('gist'),
+        blank: typeof blank !== 'undefined'
       })
         .then(data => {
           this.loadNotebook(data.notebook);

--- a/desktop/libs/notebook/src/notebook/api.py
+++ b/desktop/libs/notebook/src/notebook/api.py
@@ -64,6 +64,7 @@ def create_notebook(request):
   editor_type = request.POST.get('type', 'notebook')
   gist_id = request.POST.get('gist')
   directory_uuid = request.POST.get('directory_uuid')
+  is_blank = request.POST.get('blank', 'false') == 'true'
 
   if gist_id:
     gist_doc = _get_gist_document(uuid=gist_id)
@@ -79,7 +80,7 @@ def create_notebook(request):
   else:
     editor = Notebook()
 
-    if EXAMPLES.AUTO_OPEN.get():
+    if EXAMPLES.AUTO_OPEN.get() and not is_blank:
       document = _get_dialect_example(dialect=editor_type)
       if document:
         editor = Notebook(document=document)

--- a/desktop/libs/notebook/src/notebook/templates/editor_components2.mako
+++ b/desktop/libs/notebook/src/notebook/templates/editor_components2.mako
@@ -268,7 +268,7 @@
         <ul class="dropdown-menu pull-right">
           <li>
             <!-- ko if: editorMode -->
-            <a href="javascript:void(0)" data-bind="click: function() { hueUtils.removeURLParameter('editor'); newNotebook($root.editorType(), null, selectedNotebook() ? $root.selectedNotebook().snippets()[0].currentQueryTab() : null); }, attr: { 'title': '${ _('New ') }' +  editorTitle() + '${ _(' Query') }' }">
+            <a href="javascript:void(0)" data-bind="click: function() { hueUtils.removeURLParameter('editor'); newNotebook($root.editorType(), null, selectedNotebook() ? $root.selectedNotebook().snippets()[0].currentQueryTab() : null, 'blank'); }, attr: { 'title': '${ _('New ') }' +  editorTitle() + '${ _(' Query') }' }">
               <i class="fa fa-fw fa-file-o"></i> ${ _('New') }
             </a>
             <!-- /ko -->


### PR DESCRIPTION
All the links (e.g. from menu) will auto load the samples, but we should
still allow a blank editor.

This is only affecting when auto load samples is true (i.e. on
demo.gethue.com).

Did not see a simpler way to do. Could have gone the other way around
and changed the URLs of the editor with the new parameters in
get_config() but this feels shorter and less intrusive.
