### PR TITLE
HUE-9708 [Django Upgrade] RemovedInDjango21Warning: The logout() view…

### DIFF
--- a/desktop/core/src/desktop/auth/views.py
+++ b/desktop/core/src/desktop/auth/views.py
@@ -260,7 +260,7 @@ def dt_logout(request, next_page=None):
   if len([backend for backend in backends if hasattr(backend, 'logout')]) == len(backends):
     LOG.warn("Failed to log out from all backends for user: %s" % (username))
 
-  response = django.contrib.auth.views.logout(request, next_page)
+  response = django.contrib.auth.views.LogoutView.as_view(next_page=next_page)(request)
   response.delete_cookie(LOAD_BALANCER_COOKIE)
   return response
 


### PR DESCRIPTION
… is superseded by the class-based LogoutView()