### PR TITLE
[flink] #1685 - The DB assist panel lists wrong list of columns for flink table's

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/flink_sql.py
+++ b/desktop/libs/notebook/src/notebook/connectors/flink_sql.py
@@ -294,12 +294,11 @@ class FlinkSqlApi(Api):
 
     resp = self.db.execute_statement(session_id=session_id, statement='USE %(database)s' % {'database': database})
     resp = self.db.execute_statement(session_id=session_id, statement='DESCRIBE %(table)s' % {'table': table})
-
-    columns = resp['results'][0]['columns']
+    columns = resp['results'][0]['data']
 
     return [{
-        'name': col['name'],
-        'type': col['type'],  # Types to unify
+        'name': col[0],
+        'type': col[1],  # Types to unify
         'comment': '',
       }
       for col in columns


### PR DESCRIPTION
**What changes were proposed in this pull request?**

#1685 - The DB assist panel lists wrong list of columns for flink table's .

**How was this patch tested?**

- Tested manually, the DB assist panel should show correct data on autocomplete.

<img width="1582" alt="Screenshot 2021-01-24 at 10 47 18 PM" src="https://user-images.githubusercontent.com/18462803/105637948-1f68cf80-5e96-11eb-86e4-911824cc52fa.png">
