### PR TITLE
[editor] '?' moved in top-right dropdown menu as "Help"

### DIFF
--- a/desktop/libs/notebook/src/notebook/templates/editor2.mako
+++ b/desktop/libs/notebook/src/notebook/templates/editor2.mako
@@ -115,6 +115,11 @@
             <svg class="hi hi-fw hi-bigger"><use xlink:href="#hi-documents"></use></svg> <span data-bind="text: editorMode() ? '${ _ko('Queries') }' : '${ _ko('Notebooks') }'"></span>
           </a>
         </li>
+        <li>
+          <a href="javascript:void(0)" title="${ _('Show Editor Help') }" data-toggle="modal" data-target="#editorHelpModal">
+            <i class="fa fa-fw fa-question"></i>  ${ _('Help') }
+          </a>
+        </li>
         <li class="divider"></li>
         <!-- ko if: $root.canSave -->
         <!-- ko if: sharingEnabled -->
@@ -922,9 +927,6 @@
         <!-- ko template: { name: 'editor-longer-operation' } --><!-- /ko -->
         <div class="editor-top-right-actions">
           <!-- ko template: { name: 'snippet-header-database-selection' } --><!-- /ko -->
-          <button title="${ _('Show editor help') }" data-toggle="modal" data-target="#editorHelpModal">
-            <i class="fa fa-question"></i>
-          </button>
           <button title="${ _('Expand editor') }" data-bind="toggle: $root.topExpanded">
             <i class="fa" data-bind="css: { 'fa-expand': !$root.topExpanded(), 'fa-compress': $root.topExpanded() }"></i>
           </button>


### PR DESCRIPTION
## What changes were proposed in this pull request?

'?' moved above in the top-right dropdown menu below 'Queries' and renamed as 'Help' in the editor.

## How was this patch tested?

- Patch was manually tested
- UI Changes screenshot below
<img width="364" alt="Screenshot 2021-01-29 at 3 57 02 PM" src="https://user-images.githubusercontent.com/42064744/106263677-b3e28180-624a-11eb-9a43-e0827511641a.png">
<img width="276" alt="Screenshot 2021-01-29 at 3 59 13 PM" src="https://user-images.githubusercontent.com/42064744/106263852-f310d280-624a-11eb-9135-5c7439bdbac2.png">

- On hover, it shows "Show Editor Help".
