### PR TITLE
fix progress bar and logs icon in oozie wf when run

### DIFF
--- a/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflow_graph.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflow_graph.mako
@@ -87,7 +87,7 @@ ${ dashboard.import_layout() }
                     _w = viewModel.getWidgetById('33430f0f-ebfa-c3ec-f237-3e77efa03d0a');
                   }
                   else {
-                    var actionName = actionId.toLowerCase().substr(actionId.lastIndexOf('-') + 1)
+                    var actionName = actionId.toLowerCase().substr(actionId.lastIndexOf('@') + 1)
                     if ($("[id^=wdg_][id*=" + actionName + "]").length > 0) {
                       _w = viewModel.getWidgetById($("[id^=wdg_][id*=" + actionName + "]").attr("id").substr(4));
                     }


### PR DESCRIPTION
The change that was brought in with HUE-9110 is causing Oozie not to show the logs and the progress bar is moved to the bottom.  Just by replacing the '-' with '@' addresses the issue.

![image](https://user-images.githubusercontent.com/6750690/106799914-a9dacd00-6614-11eb-8b9c-8f66db7b68fc.png)

A text patch was provided to a customer with this fix and it worked on their env and I have tested the same on a local 7.2.x cluster as well.