### PR TITLE
Huebot django app integrate with Hue Server

### DIFF
--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -816,6 +816,14 @@
    ## collection_interval=30000
 
 
+  # Configuration options for Slack
+  # ------------------------------------------------------------------------
+  [[slack]]
+
+   # Enable slack bot server URLs "/slack/"
+   ## enable_slack_integration=True
+
+
   # Configuration options for the request Tracing
   # ------------------------------------------------------------------------
   [[tracing]]

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -703,6 +703,17 @@ METRICS = ConfigSection(
   )
 )
 
+SLACK = ConfigSection(
+  key='slack',
+  help=_("""Configuration options for slack """),
+  members=dict(
+    ENABLE_SLACK_INTEGRATION=Config(
+      key='enable_slack_integration',
+      help=_('Enable slack bot server URLs "/slack/"'),
+      default=True,
+      type=coerce_bool),
+  )
+)
 
 ANALYTICS = ConfigSection(
   key='analytics',

--- a/desktop/core/src/desktop/lib/botserver/__init__.py
+++ b/desktop/core/src/desktop/lib/botserver/__init__.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/desktop/core/src/desktop/lib/botserver/admin.py
+++ b/desktop/core/src/desktop/lib/botserver/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/desktop/core/src/desktop/lib/botserver/admin.py
+++ b/desktop/core/src/desktop/lib/botserver/admin.py
@@ -1,3 +1,20 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from django.contrib import admin
 
 # Register your models here.

--- a/desktop/core/src/desktop/lib/botserver/admin.py
+++ b/desktop/core/src/desktop/lib/botserver/admin.py
@@ -17,4 +17,3 @@
 
 from django.contrib import admin
 
-# Register your models here.

--- a/desktop/core/src/desktop/lib/botserver/apps.py
+++ b/desktop/core/src/desktop/lib/botserver/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class BotserverConfig(AppConfig):
+    name = 'botserver'

--- a/desktop/core/src/desktop/lib/botserver/apps.py
+++ b/desktop/core/src/desktop/lib/botserver/apps.py
@@ -1,3 +1,20 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from django.apps import AppConfig
 
 

--- a/desktop/core/src/desktop/lib/botserver/apps.py
+++ b/desktop/core/src/desktop/lib/botserver/apps.py
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.apps import AppConfig
+# from django.apps import AppConfig
 
 
-class BotserverConfig(AppConfig):
-  name = 'botserver'
+# class BotserverConfig(AppConfig):
+#   name = 'botserver'

--- a/desktop/core/src/desktop/lib/botserver/apps.py
+++ b/desktop/core/src/desktop/lib/botserver/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class BotserverConfig(AppConfig):
-    name = 'botserver'
+  name = 'botserver'

--- a/desktop/core/src/desktop/lib/botserver/migrations/__init__.py
+++ b/desktop/core/src/desktop/lib/botserver/migrations/__init__.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/desktop/core/src/desktop/lib/botserver/models.py
+++ b/desktop/core/src/desktop/lib/botserver/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/desktop/core/src/desktop/lib/botserver/models.py
+++ b/desktop/core/src/desktop/lib/botserver/models.py
@@ -1,3 +1,20 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from django.db import models
 
 # Create your models here.

--- a/desktop/core/src/desktop/lib/botserver/models.py
+++ b/desktop/core/src/desktop/lib/botserver/models.py
@@ -17,4 +17,3 @@
 
 from django.db import models
 
-# Create your models here.

--- a/desktop/core/src/desktop/lib/botserver/tests.py
+++ b/desktop/core/src/desktop/lib/botserver/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/desktop/core/src/desktop/lib/botserver/tests.py
+++ b/desktop/core/src/desktop/lib/botserver/tests.py
@@ -1,3 +1,20 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from django.test import TestCase
 
 # Create your tests here.

--- a/desktop/core/src/desktop/lib/botserver/tests.py
+++ b/desktop/core/src/desktop/lib/botserver/tests.py
@@ -17,4 +17,3 @@
 
 from django.test import TestCase
 
-# Create your tests here.

--- a/desktop/core/src/desktop/lib/botserver/urls.py
+++ b/desktop/core/src/desktop/lib/botserver/urls.py
@@ -1,3 +1,20 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from django.conf.urls import url
 from . import views
 

--- a/desktop/core/src/desktop/lib/botserver/urls.py
+++ b/desktop/core/src/desktop/lib/botserver/urls.py
@@ -1,0 +1,6 @@
+from django.conf.urls import url
+from . import views
+
+urlpatterns = [
+  url(r'^events/', views.home, name = 'home')
+]

--- a/desktop/core/src/desktop/lib/botserver/urls.py
+++ b/desktop/core/src/desktop/lib/botserver/urls.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 from django.conf.urls import url
-from . import views
+from desktop.lib.botserver import views
 
 urlpatterns = [
   url(r'^events/', views.home, name='home')

--- a/desktop/core/src/desktop/lib/botserver/urls.py
+++ b/desktop/core/src/desktop/lib/botserver/urls.py
@@ -2,5 +2,5 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-  url(r'^events/', views.home, name = 'home')
+  url(r'^events/', views.home, name='home')
 ]

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -1,0 +1,7 @@
+from django.shortcuts import render
+from django.http import HttpResponse
+
+# Create your views here.
+
+def home(request):
+  return HttpResponse("Hello World")

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -17,8 +17,9 @@
 
 from django.shortcuts import render
 from django.http import HttpResponse
+from desktop.lib.django_util import login_notrequired
 
-# Create your views here.
 
+@login_notrequired
 def home(request):
   return HttpResponse("Hello World")

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -1,3 +1,20 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from django.shortcuts import render
 from django.http import HttpResponse
 

--- a/desktop/core/src/desktop/urls.py
+++ b/desktop/core/src/desktop/urls.py
@@ -275,6 +275,7 @@ if is_oidc_configured():
     url(r'^oidc/', include('mozilla_django_oidc.urls')),
   ]
 
+# Slack botserver URLs
 if SLACK.ENABLE_SLACK_INTEGRATION.get():
   urlpatterns += [
     url(r'^slack/', include('desktop.lib.botserver.urls')),

--- a/desktop/core/src/desktop/urls.py
+++ b/desktop/core/src/desktop/urls.py
@@ -46,7 +46,7 @@ from desktop import views as desktop_views
 from desktop import api as desktop_api
 from desktop import api2 as desktop_api2
 from desktop.auth import views as desktop_auth_views
-from desktop.conf import METRICS, USE_NEW_EDITOR, ENABLE_DJANGO_DEBUG_TOOL, ANALYTICS, has_connectors, ENABLE_PROMETHEUS
+from desktop.conf import METRICS, USE_NEW_EDITOR, ENABLE_DJANGO_DEBUG_TOOL, ANALYTICS, has_connectors, ENABLE_PROMETHEUS, SLACK
 from desktop.configuration import api as desktop_configuration_api
 from desktop.lib.vcs import api as desktop_lib_vcs_api
 from desktop.settings import is_oidc_configured
@@ -275,6 +275,7 @@ if is_oidc_configured():
     url(r'^oidc/', include('mozilla_django_oidc.urls')),
   ]
 
-urlpatterns += [
+if SLACK.ENABLE_SLACK_INTEGRATION.get():
+  urlpatterns += [
     url(r'^slack/', include('desktop.lib.botserver.urls')),
   ]

--- a/desktop/core/src/desktop/urls.py
+++ b/desktop/core/src/desktop/urls.py
@@ -274,3 +274,7 @@ if is_oidc_configured():
   urlpatterns += [
     url(r'^oidc/', include('mozilla_django_oidc.urls')),
   ]
+
+urlpatterns += [
+    url(r'^slack/', include('desktop.lib.botserver.urls')),
+  ]


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Bot server integration with existing Hue server currently serving /slack/events.

