### PR TITLE
[slack] Botserver update with Hue App greeting

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -820,9 +820,14 @@
   # Configuration options for Slack
   # ------------------------------------------------------------------------
   [[slack]]
-
-   # Turns on Slack application API endpoints
-   ## is_enabled=false
+    # Slack credentials
+    ## slack_client_id=
+    ## slack_client_secret=
+    ## slack_verification_token=
+    ## slack_bot_user_token=
+    
+    # Enables Slack application API endpoints
+    ## is_enabled=true
 
 
   # Configuration options for the request Tracing

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -822,9 +822,14 @@
   # Configuration options for Slack
   # ------------------------------------------------------------------------
   [[slack]]
-
-   # Turns on Slack application API endpoints
-   ## is_enabled=false
+    # Slack credentials
+    ## slack_client_id=
+    ## slack_client_secret=
+    ## slack_verification_token=
+    ## slack_bot_user_token=
+    
+    # Enables Slack application API endpoints
+    ## is_enabled=true
 
 
   # Configuration options for the request Tracing

--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -58,6 +58,7 @@ requests>=2.20.0
 requests-kerberos==0.12.0
 rsa==3.4.2
 sasl==0.2.1  # Move to https://pypi.org/project/sasl3/ ?
+slack-sdk==3.2.0
 SQLAlchemy==1.3.8
 sqlparse==0.4.1
 tablib==0.13.0

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -130,6 +130,19 @@ def is_https_enabled():
   """Hue is configured for HTTPS."""
   return bool(SSL_CERTIFICATE.get() and SSL_PRIVATE_KEY.get())
 
+def get_slack_client_id():
+  return os.environ.get('SLACK_CLIENT_ID')
+
+def get_slack_client_secret():
+  return os.environ.get('SLACK_CLIENT_SECRET')
+
+def get_slack_verification_token():
+  return os.environ.get('SLACK_VERIFICATION_TOKEN')
+
+def get_slack_bot_user_token():
+  return os.environ.get('SLACK_BOT_USER_TOKEN')
+
+
 USE_CHERRYPY_SERVER = Config(
   key="use_cherrypy_server",
   help=_("If set to true, CherryPy will be used. Otherwise, Gunicorn will be used as the webserver."),
@@ -717,9 +730,34 @@ SLACK = ConfigSection(
   members=dict(
     IS_ENABLED=Config(
       key='is_enabled',
-      help=_('Turns on Slack application API endpoints'),
+      help=_('Enables Slack application API endpoints'),
+      type=coerce_bool,
       default=False,
-      type=coerce_bool),
+      ),
+    SLACK_CLIENT_ID=Config(
+        key='slack_client_id',
+        type=str,
+        private=True,
+        dynamic_default=get_slack_client_id,
+      ),
+    SLACK_CLIENT_SECRET=Config(
+        key='slack_client_secret',
+        type=str,
+        private=True,
+        dynamic_default=get_slack_client_secret,
+      ),
+    SLACK_VERIFICATION_TOKEN=Config(
+        key='slack_verification_token',
+        type=str,
+        private=True,
+        dynamic_default=get_slack_verification_token,
+      ),
+    SLACK_BOT_USER_TOKEN=Config(
+        key='slack_bot_user_token',
+        type=str,
+        private=True,
+        dynamic_default=get_slack_bot_user_token,
+      ),
   )
 )
 

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -718,7 +718,7 @@ SLACK = ConfigSection(
     IS_ENABLED=Config(
       key='is_enabled',
       help=_('Turns on Slack application API endpoints'),
-      default=True,
+      default=False,
       type=coerce_bool),
   )
 )

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -131,15 +131,19 @@ def is_https_enabled():
   return bool(SSL_CERTIFICATE.get() and SSL_PRIVATE_KEY.get())
 
 def get_slack_client_id():
+  """Returns Slack Client ID if set as environment variable else None"""
   return os.environ.get('SLACK_CLIENT_ID')
 
 def get_slack_client_secret():
+  """Returns Slack Client Secret if set as environment variable else None"""
   return os.environ.get('SLACK_CLIENT_SECRET')
 
 def get_slack_verification_token():
+  """Returns Slack Verification Token if set as environment variable else None"""
   return os.environ.get('SLACK_VERIFICATION_TOKEN')
 
 def get_slack_bot_user_token():
+  """Returns Slack Bot User Token if set as environment variable else None"""
   return os.environ.get('SLACK_BOT_USER_TOKEN')
 
 

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -718,7 +718,7 @@ SLACK = ConfigSection(
     IS_ENABLED=Config(
       key='is_enabled',
       help=_('Turns on Slack application API endpoints'),
-      default=False,
+      default=True,
       type=coerce_bool),
   )
 )

--- a/desktop/core/src/desktop/lib/botserver/urls.py
+++ b/desktop/core/src/desktop/lib/botserver/urls.py
@@ -19,5 +19,5 @@ from django.conf.urls import url
 from desktop.lib.botserver import views
 
 urlpatterns = [
-  url(r'^events/', views.home, name='home')
+  url(r'^events/', views.slack_events, name='slack_events')
 ]

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -83,7 +83,7 @@ def parse_events(event_message):
   
 def say_hi_user(channel, user_id):
   """Bot sends Hi<username> message in a specific channel"""
-  bot_message = f'Hi <@{user_id}> :wave:'
+  bot_message = 'Hi <@{}> :wave:'.format(user_id)
   response = slack_client.api_call(api_method='chat.postMessage', json={'channel': channel, 'text': bot_message})
   return response
 

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -22,6 +22,7 @@ from pprint import pprint
 from django.shortcuts import render
 from django.http import HttpResponse
 from desktop.lib.django_util import login_notrequired, JsonResponse
+from desktop import conf
 from django.views.decorators.csrf import csrf_exempt
 
 from django.conf import settings
@@ -29,8 +30,8 @@ from slack_sdk import WebClient
 
 LOG = logging.getLogger(__name__)
 
-SLACK_VERIFICATION_TOKEN = getattr(settings, 'SLACK_VERIFICATION_TOKEN', None)
-SLACK_BOT_USER_TOKEN = getattr(settings, 'SLACK_BOT_USER_TOKEN', None)
+SLACK_VERIFICATION_TOKEN = conf.SLACK.SLACK_VERIFICATION_TOKEN.get()
+SLACK_BOT_USER_TOKEN = conf.SLACK.SLACK_BOT_USER_TOKEN.get()
 
 
 slack_client = WebClient(token=SLACK_BOT_USER_TOKEN)

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -74,25 +74,27 @@ def parse_events(event_message):
   if BOT_ID == user_id:
     return HttpResponse(status=200)
   
-  if slack_client is not None:
-    if 'hello hue' in text.lower():
-      response = say_hi_user(channel, user_id)
-      if response['ok']:
-        return HttpResponse(status=200)
-      else:
-        raise PopupException(response["error"])
+  if 'hello hue' in text.lower():
+    response = say_hi_user(channel, user_id)
+    if response['ok']:
+      return HttpResponse(status=200)
+    else:
+      raise PopupException(response["error"])
 
   
 def say_hi_user(channel, user_id):
   """Bot sends Hi<username> message in a specific channel"""
+
   bot_message = 'Hi <@{}> :wave:'.format(user_id)
-  response = slack_client.api_call(api_method='chat.postMessage', json={'channel': channel, 'text': bot_message})
-  return response
+  if slack_client is not None:
+    return slack_client.api_call(api_method='chat.postMessage', json={'channel': channel, 'text': bot_message})
 
 def get_bot_id(botusername):
   """Takes in bot username, Returns the bot id"""
-  response = slack_client.api_call('users.list')
-  users = response['members']
-  for user in users:
-    if botusername in user.get('name', '') and not user.get('deleted'):
-      return user.get('id')
+  
+  if slack_client is not None:
+    response = slack_client.api_call('users.list')
+    users = response['members']
+    for user in users:
+      if botusername in user.get('name', '') and not user.get('deleted'):
+        return user.get('id')

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -15,11 +15,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+import json
+
 from django.shortcuts import render
 from django.http import HttpResponse
-from desktop.lib.django_util import login_notrequired
+from desktop.lib.django_util import login_notrequired, JsonResponse
+from django.views.decorators.csrf import csrf_exempt
 
+from django.conf import settings
+from slack_sdk import WebClient
+
+LOG = logging.getLogger(__name__)
+
+SLACK_VERIFICATION_TOKEN = getattr(settings, 'SLACK_VERIFICATION_TOKEN', None)
+SLACK_BOT_USER_TOKEN = getattr(settings, 'SLACK_BOT_USER_TOKEN', None)
+
+
+Client = WebClient(token=SLACK_BOT_USER_TOKEN)
+BOT_ID = Client.api_call('auth.test')['user_id']
 
 @login_notrequired
-def home(request):
-  return HttpResponse("Hello World")
+@csrf_exempt
+def slack_events(request):
+  slack_message = json.loads(request.body.decode('utf-8'))
+
+  if slack_message['token'] != SLACK_VERIFICATION_TOKEN:
+    return HttpResponse(status=403)
+
+  # verification challenge
+  if slack_message['type'] == 'url_verification':
+    response_dict = {"challenge": slack_message.get('challenge')}
+    return JsonResponse(response_dict, status=200)
+  
+
+  # Bot greeting when User says "hello hue"
+  if 'event' in slack_message:
+    event_message = slack_message['event']
+   
+    user_id = event_message.get('user')
+
+    # ignore bot's own message
+    if BOT_ID == user_id:
+      return HttpResponse(status=200) 
+            
+    # process user's message              
+    text = event_message.get('text')                     
+    channel = event_message.get('channel')
+
+    bot_text = 'Hi <@{}> :wave:'.format(user_id)
+    if 'hello hue' in text.lower():
+      Client.api_call(api_method='chat.postMessage', json={'channel': channel,'text': bot_text})
+      return HttpResponse(status=200)
+
+  return HttpResponse(status=200)
+
+
+  

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -71,12 +71,14 @@ def parse_events(event_message):
     say_hi_user(channel, user_id)
   
 def say_hi_user(channel, user_id):
-  # App greets when user says "hello hue"
+  """Bot sends Hi<username> message in a specific channel"""
   bot_message = f'Hi <@{user_id}> :wave:'
-  slack_client.api_call(api_method='chat.postMessage', json={'channel': channel, 'text': bot_message})
-  return HttpResponse(status=200)
+  response = slack_client.api_call(api_method='chat.postMessage', json={'channel': channel, 'text': bot_message})
+  if response["ok"]:
+    return HttpResponse(status=200)
 
 def get_bot_id(botusername):
+  """Takes in bot username, Returns the bot id"""
   response = slack_client.api_call('users.list')
   users = response['members']
   for user in users:

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -51,12 +51,12 @@ def slack_events(request):
 
       # challenge verification
     if slack_message['type'] == 'url_verification':
-        response_dict = {"challenge": slack_message['challenge']}
-        return JsonResponse(response_dict, status=200)
+      response_dict = {"challenge": slack_message['challenge']}
+      return JsonResponse(response_dict, status=200)
     
     if 'event' in slack_message:
-        event_message = slack_message['event']
-        parse_events(event_message)
+      event_message = slack_message['event']
+      parse_events(event_message)
   except Exception as ex:
     raise PopupException(_("Response content is not valid JSON"), detail=ex)
   

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -34,16 +34,8 @@ SLACK_BOT_USER_TOKEN = getattr(settings, 'SLACK_BOT_USER_TOKEN', None)
 
 
 slack_client = WebClient(token=SLACK_BOT_USER_TOKEN)
-appname = "SQL Assistant"
+appname = "hue_bot"
 
-def get_bot_id(botusername):
-  response = slack_client.api_call("users.list")
-  users = response["members"]
-  for user in users:
-    if 'name' in user and botusername in user.get('name') and not user.get('deleted'):
-      return user.get('id')
-
-BOT_ID = get_bot_id(appname)
 
 @login_notrequired
 @csrf_exempt
@@ -68,6 +60,7 @@ def parse_events(event_message):
   user_id = event_message.get('user')
   text = event_message.get('text')
   channel = event_message.get('channel')
+  BOT_ID = get_bot_id(appname)
 
   # ignore bot's own message
   if BOT_ID == user_id:
@@ -81,3 +74,10 @@ def say_hi_user(channel, user_id):
   bot_message = f'Hi <@{user_id}> :wave:'
   slack_client.api_call(api_method='chat.postMessage', json={'channel': channel, 'text': bot_message})
   return HttpResponse(status=200)
+
+def get_bot_id(botusername):
+  response = slack_client.api_call('users.list')
+  users = response['members']
+  for user in users:
+    if 'name' in user and botusername in user.get('name') and not user.get('deleted'):
+      return user.get('id')

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -74,27 +74,26 @@ def parse_events(event_message):
   if BOT_ID == user_id:
     return HttpResponse(status=200)
   
-  if 'hello hue' in text.lower():
-    response = say_hi_user(channel, user_id)
-    if response['ok']:
-      return HttpResponse(status=200)
-    else:
-      raise PopupException(response["error"])
+  if slack_client is not None:
+    if 'hello hue' in text.lower():
+      response = say_hi_user(channel, user_id)
+      if response['ok']:
+        return HttpResponse(status=200)
+      else:
+        raise PopupException(response["error"])
 
   
 def say_hi_user(channel, user_id):
   """Bot sends Hi<username> message in a specific channel"""
 
   bot_message = 'Hi <@{}> :wave:'.format(user_id)
-  if slack_client is not None:
-    return slack_client.api_call(api_method='chat.postMessage', json={'channel': channel, 'text': bot_message})
+  return slack_client.api_call(api_method='chat.postMessage', json={'channel': channel, 'text': bot_message})
 
 def get_bot_id(botusername):
   """Takes in bot username, Returns the bot id"""
   
-  if slack_client is not None:
-    response = slack_client.api_call('users.list')
-    users = response['members']
-    for user in users:
-      if botusername in user.get('name', '') and not user.get('deleted'):
-        return user.get('id')
+  response = slack_client.api_call('users.list')
+  users = response['members']
+  for user in users:
+    if botusername in user.get('name', '') and not user.get('deleted'):
+      return user.get('id')

--- a/desktop/core/src/desktop/lib/botserver/views_tests.py
+++ b/desktop/core/src/desktop/lib/botserver/views_tests.py
@@ -63,7 +63,16 @@ class TestBotServer(unittest.TestCase):
       }
       response = say_hi_user("channel", "user_id")
       assert_equal(response.status_code, 200)
+  
+  def test_slack_events(self):
+    payload =  {"token": "Jhj5dZrVaK7ZwHHjRyZWjbDl",
+    "challenge": "3eZbrw1aBm2rZgRNFdxV2595E9CY3gmdALWMmHkvFXO7tYXAYM8P",
+    "type": "message"}
+    client = Client()
+    response = client.post('/slack/events/', payload)
+    assert_equal(response.status_code, 200)
 
+  
   
 
 

--- a/desktop/core/src/desktop/lib/botserver/views_tests.py
+++ b/desktop/core/src/desktop/lib/botserver/views_tests.py
@@ -21,7 +21,7 @@ import unittest
 import sys
 
 from nose.tools import assert_equal, assert_true
-from django.test import TestCase
+from django.test import TestCase, Client
 from desktop.lib.botserver.views import *
 
 if sys.version_info[0] > 2:
@@ -33,8 +33,8 @@ LOG = logging.getLogger(__name__)
 
 class TestBotServer(unittest.TestCase):
   def test_get_bot_id(self):
-    with patch('desktop.lib.botserver.views.slack_client') as slack_client_mock:
-      slack_client_mock.api_call("users.list").return_value = {
+    with patch('desktop.lib.botserver.views.slack_client.api_call') as api_call:
+      api_call.return_value = {
         'members': [
           {
             'name': 'hue_bot',
@@ -43,8 +43,27 @@ class TestBotServer(unittest.TestCase):
           }
         ]
       }
-      bot_id = get_bot_id('hue_bot')
-      assert_equal(bot_id, 'U01K99VEDR9')
+      assert_equal(get_bot_id('hue_bot'), 'U01K99VEDR9')
+
+      api_call.return_value = {
+        'members': [
+          {
+            'name': 'hue_bot',
+            'deleted': True,
+            'id': 'U01K99VEDR9'
+          }
+        ]
+      }
+      assert_equal(get_bot_id('hue_bot'), None)
+
+  def test_say_hi_user(self):
+    with patch('desktop.lib.botserver.views.slack_client.api_call') as api_call:
+      api_call.return_value = {
+        "ok": True
+      }
+      response = say_hi_user("channel", "user_id")
+      assert_equal(response.status_code, 200)
+
   
 
 

--- a/desktop/core/src/desktop/lib/botserver/views_tests.py
+++ b/desktop/core/src/desktop/lib/botserver/views_tests.py
@@ -62,15 +62,8 @@ class TestBotServer(unittest.TestCase):
         "ok": True
       }
       response = say_hi_user("channel", "user_id")
-      assert_equal(response.status_code, 200)
-  
-  def test_slack_events(self):
-    payload =  {"token": "Jhj5dZrVaK7ZwHHjRyZWjbDl",
-    "challenge": "3eZbrw1aBm2rZgRNFdxV2595E9CY3gmdALWMmHkvFXO7tYXAYM8P",
-    "type": "message"}
-    client = Client()
-    response = client.post('/slack/events/', payload)
-    assert_equal(response.status_code, 200)
+      assert_true(response['ok'])
+      
 
   
   

--- a/desktop/core/src/desktop/lib/botserver/views_tests.py
+++ b/desktop/core/src/desktop/lib/botserver/views_tests.py
@@ -23,6 +23,7 @@ import sys
 from nose.tools import assert_equal, assert_true
 from django.test import TestCase, Client
 from desktop.lib.botserver.views import *
+from desktop import conf
 
 if sys.version_info[0] > 2:
   from unittest.mock import patch
@@ -31,44 +32,36 @@ else:
 
 LOG = logging.getLogger(__name__)
 
-class TestBotServer(unittest.TestCase):
-  def test_get_bot_id(self):
-    with patch('desktop.lib.botserver.views.slack_client.api_call') as api_call:
-      api_call.return_value = {
-        'members': [
-          {
-            'name': 'hue_bot',
-            'deleted': False,
-            'id': 'U01K99VEDR9'
-          }
-        ]
-      }
-      assert_equal(get_bot_id('hue_bot'), 'U01K99VEDR9')
+if conf.SLACK.IS_ENABLED.get():
+  class TestBotServer(unittest.TestCase):
+    def test_get_bot_id(self):
+      with patch('desktop.lib.botserver.views.slack_client.api_call') as api_call:
+        api_call.return_value = {
+          'members': [
+            {
+              'name': 'hue_bot',
+              'deleted': False,
+              'id': 'U01K99VEDR9'
+            }
+          ]
+        }
+        assert_equal(get_bot_id('hue_bot'), 'U01K99VEDR9')
 
-      api_call.return_value = {
-        'members': [
-          {
-            'name': 'hue_bot',
-            'deleted': True,
-            'id': 'U01K99VEDR9'
-          }
-        ]
-      }
-      assert_equal(get_bot_id('hue_bot'), None)
+        api_call.return_value = {
+          'members': [
+            {
+              'name': 'hue_bot',
+              'deleted': True,
+              'id': 'U01K99VEDR9'
+            }
+          ]
+        }
+        assert_equal(get_bot_id('hue_bot'), None)
 
-  def test_say_hi_user(self):
-    with patch('desktop.lib.botserver.views.slack_client.api_call') as api_call:
-      api_call.return_value = {
-        "ok": True
-      }
-      response = say_hi_user("channel", "user_id")
-      assert_true(response['ok'])
-      
-
-  
-  
-
-
-
-
-
+    def test_say_hi_user(self):
+      with patch('desktop.lib.botserver.views.slack_client.api_call') as api_call:
+        api_call.return_value = {
+          "ok": True
+        }
+        response = say_hi_user("channel", "user_id")
+        assert_true(response['ok'])

--- a/desktop/core/src/desktop/lib/botserver/views_tests.py
+++ b/desktop/core/src/desktop/lib/botserver/views_tests.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import unittest
+import sys
+
+from nose.tools import assert_equal, assert_true
+from django.test import TestCase
+from desktop.lib.botserver.views import *
+
+if sys.version_info[0] > 2:
+  from unittest.mock import patch
+else:
+  from mock import patch
+
+LOG = logging.getLogger(__name__)
+
+class TestBotServer(unittest.TestCase):
+  def test_get_bot_id(self):
+    with patch('desktop.lib.botserver.views.slack_client') as slack_client_mock:
+      slack_client_mock.api_call("users.list").return_value = {
+        'members': [
+          {
+            'name': 'hue_bot',
+            'deleted': False,
+            'id': 'U01K99VEDR9'
+          }
+        ]
+      }
+      bot_id = get_bot_id('hue_bot')
+      assert_equal(bot_id, 'U01K99VEDR9')
+  
+
+
+
+
+

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -823,10 +823,8 @@ except ValueError:
 ################################################################
 # SLACK API Configurations
 ################################################################
-# Warning: Do not save your secrets here, instead export them as environment variables and read here
 
-# use your keys 
-SLACK_CLIENT_ID = ''
-SLACK_CLIENT_SECRET = ''
-SLACK_VERIFICATION_TOKEN = os.environ.get('SLACK_VERIFICATION_TOKEN')
-SLACK_BOT_USER_TOKEN = os.environ.get('SLACK_BOT_USER_TOKEN')
+SLACK_CLIENT_ID = desktop.conf.SLACK.SLACK_CLIENT_ID.get()
+SLACK_CLIENT_SECRET = desktop.conf.SLACK.SLACK_CLIENT_SECRET.get()
+SLACK_VERIFICATION_TOKEN = desktop.conf.SLACK.SLACK_VERIFICATION_TOKEN.get()
+SLACK_BOT_USER_TOKEN = desktop.conf.SLACK.SLACK_BOT_USER_TOKEN.get()

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -826,7 +826,7 @@ except ValueError:
 # Warning: Do not save your secrets here, instead export them as environment variables and read here
 
 # use your keys 
-SLACK_CLIENT_ID=''
-SLACK_CLIENT_SECRET=''
-SLACK_VERIFICATION_TOKEN=os.environ.get('SLACK_VERIFICATION_TOKEN')
-SLACK_BOT_USER_TOKEN=os.environ.get('SLACK_BOT_USER_TOKEN')
+SLACK_CLIENT_ID = ''
+SLACK_CLIENT_SECRET = ''
+SLACK_VERIFICATION_TOKEN = os.environ.get('SLACK_VERIFICATION_TOKEN')
+SLACK_BOT_USER_TOKEN = os.environ.get('SLACK_BOT_USER_TOKEN')

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -819,12 +819,3 @@ try:
 except ValueError:
   from desktop.monkey_patches import monkey_patch_md5
   monkey_patch_md5(MODULES_TO_PATCH)
-
-################################################################
-# SLACK API Configurations
-################################################################
-
-SLACK_CLIENT_ID = desktop.conf.SLACK.SLACK_CLIENT_ID.get()
-SLACK_CLIENT_SECRET = desktop.conf.SLACK.SLACK_CLIENT_SECRET.get()
-SLACK_VERIFICATION_TOKEN = desktop.conf.SLACK.SLACK_VERIFICATION_TOKEN.get()
-SLACK_BOT_USER_TOKEN = desktop.conf.SLACK.SLACK_BOT_USER_TOKEN.get()

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -819,3 +819,14 @@ try:
 except ValueError:
   from desktop.monkey_patches import monkey_patch_md5
   monkey_patch_md5(MODULES_TO_PATCH)
+
+################################################################
+# SLACK API Configurations
+################################################################
+# Warning: Do not save your secrets here, instead export them as environment variables and read here
+
+# use your keys 
+SLACK_CLIENT_ID=''
+SLACK_CLIENT_SECRET=''
+SLACK_VERIFICATION_TOKEN=os.environ.get('SLACK_VERIFICATION_TOKEN')
+SLACK_BOT_USER_TOKEN=os.environ.get('SLACK_BOT_USER_TOKEN')

--- a/desktop/libs/metadata/src/metadata/conf.py
+++ b/desktop/libs/metadata/src/metadata/conf.py
@@ -473,7 +473,7 @@ NAVIGATOR = ConfigSection(
       dynamic_default=get_security_default,
       type=coerce_bool
     ),
-     FETCH_SIZE_SEARCH=Config(
+    FETCH_SIZE_SEARCH=Config(
       key="fetch_size_search",
       help=_t("Max number of items to fetch in one call in object search."),
       default=450,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Botserver integrated with existing Hue server and is now serving at /slack/events/ for event from Hue App. The App greets user when user messages "hello hue".

Some points to note:
1. All secret keys need to me exported as environment variables for now.
2. ngrok is used to tunnel the incoming http post request (event) from slack to localhost/slack/events/
3. To use ngrok - 
- Download ngrok
- Run `ngrok http 8000` since hue dev server listens at port 8000
- Update the Request URL in "Enable Events" in the slack api. Append /slack/events/ as that is our endpoint.
4. Free version of ngrok's public URL session expires and also you need to keep terminal open else you have to generate other and update.
5. Config flag is set false by default for slack endpoint and it is enabled in the ini files.
7. Credentials are managed from the ini files [[slack]] section
6. tests are under process
