### PR TITLE
[flink] adding Flink to right assist Function panel

### DIFF
--- a/desktop/core/src/desktop/js/ko/components/assist/ko.rightAssistPanel.js
+++ b/desktop/core/src/desktop/js/ko/components/assist/ko.rightAssistPanel.js
@@ -123,7 +123,8 @@ class RightAssistPanel {
         this.connector() &&
         (this.connector().dialect === 'hive' ||
           this.connector().dialect === 'impala' ||
-          this.connector().dialect === 'pig')
+          this.connector().dialect === 'pig' ||
+          this.connector().dialect === 'flink')
     );
     this.langRefTabAvailable = ko.pureComputed(
       () =>

--- a/desktop/core/src/desktop/js/sql/reference/flink/udfReference.ts
+++ b/desktop/core/src/desktop/js/sql/reference/flink/udfReference.ts
@@ -252,7 +252,7 @@ const DATE_FUNCTIONS: UdfCategoryFunctions = {
   }
 };
 
-const AUXILIARY_FUNCTIONS: UdfCategoryFunctions = {
+const WINDOW_FUNCTIONS: UdfCategoryFunctions = {
   hop: {
     name: 'hop',
     returnTypes: ['T'],
@@ -476,6 +476,6 @@ export const UDF_CATEGORIES: UdfCategory[] = [
   { name: I18n('Aggregate'), isAggregate: true, functions: AGGREGATE_FUNCTIONS },
   { name: I18n('Analytic'), isAnalytic: true, functions: ANALYTIC_FUNCTIONS },
   { name: I18n('Date'), functions: DATE_FUNCTIONS },
-  { name: I18n('Misc'), functions: AUXILIARY_FUNCTIONS },
+  { name: I18n('Window Functions'), functions: WINDOW_FUNCTIONS },
   { name: I18n('String'), functions: STRING_FUNCTIONS }
 ];

--- a/desktop/core/src/desktop/js/sql/reference/flink/udfReference.ts
+++ b/desktop/core/src/desktop/js/sql/reference/flink/udfReference.ts
@@ -252,7 +252,7 @@ const DATE_FUNCTIONS: UdfCategoryFunctions = {
   }
 };
 
-const WINDOW_FUNCTIONS: UdfCategoryFunctions = {
+const GROUP_WINDOW_FUNCTIONS: UdfCategoryFunctions = {
   hop: {
     name: 'hop',
     returnTypes: ['T'],
@@ -476,6 +476,6 @@ export const UDF_CATEGORIES: UdfCategory[] = [
   { name: I18n('Aggregate'), isAggregate: true, functions: AGGREGATE_FUNCTIONS },
   { name: I18n('Analytic'), isAnalytic: true, functions: ANALYTIC_FUNCTIONS },
   { name: I18n('Date'), functions: DATE_FUNCTIONS },
-  { name: I18n('Window Functions'), functions: WINDOW_FUNCTIONS },
+  { name: I18n('Group Windows Functions'), functions: GROUP_WINDOW_FUNCTIONS },
   { name: I18n('String'), functions: STRING_FUNCTIONS }
 ];

--- a/desktop/core/src/desktop/js/sql/reference/flink/udfReference.ts
+++ b/desktop/core/src/desktop/js/sql/reference/flink/udfReference.ts
@@ -476,6 +476,6 @@ export const UDF_CATEGORIES: UdfCategory[] = [
   { name: I18n('Aggregate'), isAggregate: true, functions: AGGREGATE_FUNCTIONS },
   { name: I18n('Analytic'), isAnalytic: true, functions: ANALYTIC_FUNCTIONS },
   { name: I18n('Date'), functions: DATE_FUNCTIONS },
-  { name: I18n('Group Windows Functions'), functions: GROUP_WINDOW_FUNCTIONS },
+  { name: I18n('Group Window Functions'), functions: GROUP_WINDOW_FUNCTIONS },
   { name: I18n('String'), functions: STRING_FUNCTIONS }
 ];


### PR DESCRIPTION
## What changes were proposed in this pull request?

- #GH-1629 - [flink] adding Flink to right assist Function panel

## How was this patch tested?

- Tested manually in local, The Right assist panel has to show flink and associated group window functions
<img width="1506" alt="Screenshot 2021-02-09 at 10 46 18 AM" src="https://user-images.githubusercontent.com/18462803/107319090-1433b780-6ac4-11eb-9189-10b1de0fa2cb.png">

