### PR TITLE
[frontend] Make un-expand menu full width clickable

### DIFF
--- a/desktop/core/src/desktop/js/components/sidebar/Sidebar.vue
+++ b/desktop/core/src/desktop/js/components/sidebar/Sidebar.vue
@@ -75,7 +75,6 @@
           :active-item-name="activeItemName"
         />
         <div class="sidebar-footer-bottom-row">
-          <div class="sidebar-footer-version-number"><!-- TODO: Add Version --></div>
           <BaseNavigationItem
             :css-classes="'sidebar-footer-collapse-btn'"
             :item="{


### PR DESCRIPTION
## What changes were proposed in this pull request?

- The un-expand menu action is full-width clickable now.

## How was this patch tested?

- Tested manually