### PR TITLE
[core] Setting to turn off CORS

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -236,6 +236,9 @@
   # Timeout in seconds for REST calls.
   ## rest_conn_timeout=120
 
+  # To set to true when using a decoupled UI.
+  ## cors_enabled=false
+
   # A json file containing a list of log redaction rules for cleaning sensitive data
   # from log files. It is defined as:
   #

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -240,6 +240,9 @@
   # Timeout in seconds for REST calls.
   ## rest_conn_timeout=120
 
+  # To set to true when using a decoupled UI.
+  ## cors_enabled=false
+
   # A json file containing a list of log redaction rules for cleaning sensitive data
   # from log files. It is defined as:
   #

--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -14,6 +14,7 @@ django-axes==4.5.4
 django_babel==0.6.2
 django-celery-beat==1.4.0
 django_celery_results==1.0.4
+django-cors-headers==3.7.0
 django-crequest==2018.5.11
 django-debug-panel==0.8.3
 django-debug-toolbar==1.9.1

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -553,6 +553,14 @@ REST_CONN_TIMEOUT = Config(
   type=int,
   help=_('Timeout in seconds for REST calls.'))
 
+CORS_ENABLED = Config(
+  key="cors_enabled",
+  help=_("To set to true when using a decoupled UI."),
+  type=coerce_bool,
+  default=False
+)
+
+
 VCS = UnspecifiedConfigSection(
   "vcs",
   help="One entry for each Version Control",

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -355,6 +355,11 @@ SERVER_EMAIL = desktop.conf.DJANGO_SERVER_EMAIL.get()
 EMAIL_BACKEND = desktop.conf.DJANGO_EMAIL_BACKEND.get()
 EMAIL_SUBJECT_PREFIX = 'Hue %s - ' % desktop.conf.CLUSTER_ID.get()
 
+# Permissive CORS
+if desktop.conf.CORS_ENABLED.get():
+  INSTALLED_APPS.append('corsheaders')
+  MIDDLEWARE.append('corsheaders.middleware.CorsMiddleware')
+  CORS_ALLOW_ALL_ORIGINS = True
 
 # Configure database
 if os.getenv('DESKTOP_DB_CONFIG'):


### PR DESCRIPTION
First:

  ./build/env/bin/pip install django-cors-headers==3.7.0

Then in ini:

  [desktop]
  # To set to true when using a decoupled UI.
  cors_enabled=true
