### PR TITLE
[Django 3.0] ImportError: cannot import name 'six' from 'django.utils…

### DIFF
--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -10,7 +10,7 @@ configobj==5.0.6
 cryptography==3.3.2
 django-auth-ldap==1.3.0
 Django==2.2.17
-django-axes==4.5.4
+django-axes==5.13.0
 django_babel==0.6.2
 django-celery-beat==1.4.0
 django_celery_results==1.0.4
@@ -19,7 +19,7 @@ django-crequest==2018.5.11
 django-debug-panel==0.8.3
 django-debug-toolbar==1.9.1
 django-extensions==1.8.0
-django-ipware==2.1.0
+django-ipware==3.0.2
 django-nose==1.4.7
 django_opentracing==1.1.0
 django_prometheus==1.0.15


### PR DESCRIPTION
…' due to line 13 in axes==4.5.4

## What changes were proposed in this pull request?

Django-axes upgraded from 4.5.4 to 5.13.0. and django-axes 5.13.0 depends on django-ipware<4 and >=3.
## How was this patch tested?

https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis
https://pypi.org/project/django-axes/
