### PR TITLE
[Mako] Opening table browser error need Mako upgradation

### DIFF
--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -23,7 +23,6 @@ django-ipware==3.0.2
 django-nose==1.4.7
 django_opentracing==1.1.0
 django_prometheus==1.0.15
-djangomako==1.2.1
 django-webpack-loader==0.5.0
 eventlet==0.24.1
 future==0.18.2
@@ -36,7 +35,7 @@ kazoo==2.8.0
 kerberos==1.3.0
 lockfile==0.12.2
 lxml==4.6.2
-Mako==1.0.7
+Mako==1.1.4
 Markdown==3.1
 mysqlclient==1.4.6
 nose==1.3.7


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Mako upgraded to the latest version (1.1.4). And djangomako package removed as it is not giving an error (ModuleNotFoundError: No module named 'djangomako') like before.

- after Mako up-gradation table_browser opens perfectly.