### PR TITLE
GH-1807 [Django Upgrade] LDAP auth error: authenticate() missing 1 required positional argument: 'request'

### DIFF
--- a/desktop/core/src/desktop/auth/backend.py
+++ b/desktop/core/src/desktop/auth/backend.py
@@ -579,7 +579,10 @@ class LdapBackend(object):
     try:
       allowed_group = self.check_ldap_access_groups(server, username)
       if allowed_group:
-        user = self._backend.authenticate(username=username, password=password)
+        if sys.version_info[0] > 2:
+          user = self._backend.authenticate(request, username=username, password=password)
+        else:
+          user = self._backend.authenticate(username=username, password=password)
       else:
         LOG.warn("%s not in an allowed login group" % username)
         return None

--- a/desktop/core/src/desktop/auth/backend_tests.py
+++ b/desktop/core/src/desktop/auth/backend_tests.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+from nose.tools import assert_equal
+
+from desktop.auth.backend import LdapBackend, rewrite_user
+from desktop.lib.django_test_util import make_logged_in_client
+from useradmin.models import User
+
+if sys.version_info[0] > 2:
+  from unittest.mock import patch, Mock
+else:
+  from mock import patch, Mock
+
+class TestLdapBackend():
+    
+  def setUp(self):
+    self.client = make_logged_in_client(username="test", groupname="default", recreate=True, is_superuser=False)
+    self.user = rewrite_user(User.objects.get(username="test"))
+
+  def test_authenticate(self):
+    with patch('desktop.auth.backend.LdapBackend.check_ldap_access_groups') as check_ldap_access_groups:
+      check_ldap_access_groups.return_value = True
+
+      user = LdapBackend().authenticate(request=Mock(), username=Mock(), password=Mock(), server=Mock())
+
+      assert_equal(user, None)


### PR DESCRIPTION
## What changes were proposed in this pull request?
 - GH-1807 - [Django Upgrade] LDAP auth error: authenticate() missing 1 required positional argument: 'request'
- `request` argument is added