### PR TITLE
HUE #1799 - Fix for lib xxd binary file view in File Browser, when using Python 3 runtime.

### DIFF
--- a/apps/filebrowser/src/filebrowser/lib/xxd.py
+++ b/apps/filebrowser/src/filebrowser/lib/xxd.py
@@ -66,8 +66,13 @@ def xxd(shift, data, bytes_per_line, bytes_per_sentence):
   current = 0
   for current in range(0, len(data), bytes_per_line):
     line = data[current:current+bytes_per_line]
+    # Convert bytes object back to string object if the
+    # data is a bytes object
+    if isinstance(data, (bytes, bytearray)):
+      line = "".join( chr(x) for x in bytearray(line))
+
     line_printable = mask_not_alphanumeric(line)[1]
-    line_ordinals = list(map(ord, line))
+    line_ordinals = list(map(ord, str(line)))
     offsets = list(range(0, len(line_ordinals), bytes_per_sentence))
     line_ordinal_words = [ line_ordinals[x:x+bytes_per_sentence] for x in offsets ]
 

--- a/apps/filebrowser/src/filebrowser/lib/xxd.py
+++ b/apps/filebrowser/src/filebrowser/lib/xxd.py
@@ -26,83 +26,95 @@ import sys
 
 import re
 
-def make_re(mask):
-  """Makes a regex from an iterable of characters."""
-  as_string = "".join(mask)
-  r = '[^' + re.escape(as_string) + ']'
-  return re.compile(r)
 
-# All the printable characters, without tabs and newlines, but including spaces.
-NON_FANCY_PRINTABLE = make_re(set(string.printable).difference(string.whitespace).union(" "))
+def make_re(mask):
+    """Makes a regex from an iterable of characters."""
+    as_string = "".join(mask)
+    r = '[^' + re.escape(as_string) + ']'
+    return re.compile(r)
+
+
+# All the printable characters, without tabs and newlines,
+# but including spaces.
+NON_FANCY_PRINTABLE = make_re(
+    set(string.printable).difference(string.whitespace).union(" "))
 PRINTABLE = make_re(string.printable)
 
+
 def mask_not_printable(contents, mask_re=PRINTABLE):
-  """
-  Replaces non-printable characters with "."
-  Returns (number_of_replacements, masked_string).
-  """
-  out, cnt = mask_re.subn('.', contents)
-  return cnt, out
+    """
+    Replaces non-printable characters with "."
+    Returns (number_of_replacements, masked_string).
+    """
+    out, cnt = mask_re.subn('.', contents)
+    return cnt, out
+
 
 def mask_not_alphanumeric(data):
-  """
-  Same as above, except also masks out tab and newline.
-  """
-  return mask_not_printable(data, NON_FANCY_PRINTABLE)
+    """
+    Same as above, except also masks out tab and newline.
+    """
+    return mask_not_printable(data, NON_FANCY_PRINTABLE)
+
 
 def xxd(shift, data, bytes_per_line, bytes_per_sentence):
-  """
-  A generator of (offset, [[byte ordinal]], printable) strings,
-  to support something similar to the xxd command.  Essentially,
-  this splits up a string into chunks.
+    """
+    A generator of (offset, [[byte ordinal]], printable) strings,
+    to support something similar to the xxd command.  Essentially,
+    this splits up a string into chunks.
 
-  In the output below, there are 8 sentences, each of 2 bytes.  The
-  offset is 0, and the printable representation is on the right.
+    In the output below, there are 8 sentences, each of 2 bytes.  The
+    offset is 0, and the printable representation is on the right.
 
-  0000000: 565b 373a 4fd1 ff78 4aa6 023d e4bb 2f92  V[7:O..xJ..=../.
+    0000000: 565b 373a 4fd1 ff78 4aa6 023d e4bb 2f92  V[7:O..xJ..=../.
 
-  @param shift: Shifts the returned offsets by this amount.
-  """
-  current = 0
-  for current in range(0, len(data), bytes_per_line):
-    line = data[current:current+bytes_per_line]
-    # Convert bytes object back to string object if the
-    # data is a bytes object
-    if isinstance(data, (bytes, bytearray)):
-      line = "".join( chr(x) for x in bytearray(line))
+    @param shift: Shifts the returned offsets by this amount.
+    """
+    current = 0
+    for current in range(0, len(data), bytes_per_line):
+        line = data[current:current+bytes_per_line]
+        # Convert bytes object back to string object if the
+        # data is a bytes object
+        if isinstance(data, (bytes, bytearray)):
+            line = "".join(chr(x) for x in bytearray(line))
 
-    line_printable = mask_not_alphanumeric(line)[1]
-    line_ordinals = list(map(ord, str(line)))
-    offsets = list(range(0, len(line_ordinals), bytes_per_sentence))
-    line_ordinal_words = [ line_ordinals[x:x+bytes_per_sentence] for x in offsets ]
+        line_printable = mask_not_alphanumeric(line)[1]
+        line_ordinals = list(map(ord, str(line)))
+        offsets = list(range(0, len(line_ordinals), bytes_per_sentence))
+        line_ordinal_words = [
+            line_ordinals[x:x+bytes_per_sentence] for x in offsets]
 
-    yield (shift + current, line_ordinal_words, line_printable)
+        yield (shift + current, line_ordinal_words, line_printable)
+
 
 def main(input, output):
-  """
-  Prints out input just as xxd would do it.
-  """
-  offset = 0
-  bytes_per_line = 16
-  bytes_per_sentence = 2
+    """
+    Prints out input just as xxd would do it.
+    """
+    offset = 0
+    bytes_per_line = 16
+    bytes_per_sentence = 2
 
-  # Must be multiple of bytes_per_line
-  input_chunk = bytes_per_line * 10
+    while True:
+        data = input.read(bytes_per_line)
+        if data == '':
+            return
 
-  while True:
-    data = input.read(bytes_per_line)
-    if data == '':
-      return
+        for off, ordinals, printable in xxd(offset, data,
+                                            bytes_per_line,
+                                            bytes_per_sentence):
+            def ashex(ord):
+                return "%02x" % ord
+            hex = " ".join(
+                ["".join(map(ashex, sentence)) for sentence in ordinals])
+            # 2 characters per byte, 1 extra for spacing,
+            # and 1 extra at the end.
+            hex = hex.ljust(bytes_per_line*2 + int(
+                math.floor(bytes_per_line / bytes_per_sentence)) - 1)
+            output.write("%07x: %s  %s\n" % (off, hex, printable))
 
-    for off, ordinals, printable in xxd(offset, data, bytes_per_line, bytes_per_sentence):
-      def ashex(ord):
-        return "%02x" % ord
-      hex = " ".join([ "".join(map(ashex, sentence)) for sentence in ordinals])
-      # 2 characters per byte, 1 extra for spacing, and 1 extra at the end.
-      hex = hex.ljust(bytes_per_line*2 + int(math.floor(bytes_per_line / bytes_per_sentence)) - 1)
-      output.write("%07x: %s  %s\n" % (off, hex, printable))
+        offset += len(data)
 
-    offset += len(data)
 
 if __name__ == "__main__":
-  main(sys.stdin, sys.stdout)
+    main(sys.stdin, sys.stdout)

--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -1407,8 +1407,8 @@ def extract_archive_using_batch_job(request):
 
     if upload_path and archive_name:
       try:
-        upload_path = urllib.unquote(upload_path)
-        archive_name = urllib.unquote(archive_name)
+        upload_path = urllib_unquote(upload_path)
+        archive_name = urllib_unquote(archive_name)
         response = extract_archive_in_hdfs(request, upload_path, archive_name)
       except Exception as e:
         response['message'] = _('Exception occurred while extracting archive: %s' % e)
@@ -1430,9 +1430,9 @@ def compress_files_using_batch_job(request):
 
     if upload_path and file_names and archive_name:
       try:
-        upload_path = urllib.unquote(upload_path)
-        archive_name = urllib.unquote(archive_name)
-        file_names = [urllib.unquote(name) for name in file_names]
+        upload_path = urllib_unquote(upload_path)
+        archive_name = urllib_unquote(archive_name)
+        file_names = [urllib_unquote(name) for name in file_names]
         response = compress_files_in_hdfs(request, file_names, upload_path, archive_name)
       except Exception as e:
         response['message'] = _('Exception occurred while compressing files: %s' % e)


### PR DESCRIPTION
### What changes were proposed in this pull request?

- For issue #1799, fixes the xxd implementation in the File Browser for Python 3 runtime environments when trying to view binary files.  The fix makes a byte conversion on binary data in the case of a byte or bytearray object.

### How was this patch tested?

- Manual testing including attempts to open binary data files in the File Browser, including compressed files like .gz or .zip, binary image files like .png and .jpg, and avro binary data files.
