### PR TITLE
[slack] Link-unfurl event

### DIFF
--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -741,7 +741,6 @@ SLACK = ConfigSection(
     SLACK_CLIENT_ID=Config(
         key='slack_client_id',
         type=str,
-        private=True,
         dynamic_default=get_slack_client_id,
       ),
     SLACK_CLIENT_SECRET=Config(

--- a/desktop/core/src/desktop/lib/botserver/views_tests.py
+++ b/desktop/core/src/desktop/lib/botserver/views_tests.py
@@ -14,54 +14,37 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+ 
 import json
 import logging
 import unittest
 import sys
-
+ 
+from nose.plugins.skip import SkipTest
 from nose.tools import assert_equal, assert_true
+ 
 from django.test import TestCase, Client
 from desktop.lib.botserver.views import *
 from desktop import conf
-
+ 
 if sys.version_info[0] > 2:
   from unittest.mock import patch
 else:
   from mock import patch
-
+ 
 LOG = logging.getLogger(__name__)
-
-if conf.SLACK.IS_ENABLED.get():
-  class TestBotServer(unittest.TestCase):
-    def test_get_bot_id(self):
-      with patch('desktop.lib.botserver.views.slack_client.api_call') as api_call:
-        api_call.return_value = {
-          'members': [
-            {
-              'name': 'hue_bot',
-              'deleted': False,
-              'id': 'U01K99VEDR9'
-            }
-          ]
-        }
-        assert_equal(get_bot_id('hue_bot'), 'U01K99VEDR9')
-
-        api_call.return_value = {
-          'members': [
-            {
-              'name': 'hue_bot',
-              'deleted': True,
-              'id': 'U01K99VEDR9'
-            }
-          ]
-        }
-        assert_equal(get_bot_id('hue_bot'), None)
-
-    def test_say_hi_user(self):
-      with patch('desktop.lib.botserver.views.slack_client.api_call') as api_call:
-        api_call.return_value = {
-          "ok": True
-        }
-        response = say_hi_user("channel", "user_id")
-        assert_true(response['ok'])
+ 
+class TestBotServer(unittest.TestCase):
+ 
+  @classmethod
+  def setUpClass(cls):
+    if not conf.SLACK.IS_ENABLED.get():
+      raise SkipTest
+ 
+  def test_say_hi_user(self):
+    with patch('desktop.lib.botserver.views.slack_client.api_call') as api_call:
+      api_call.return_value = {
+        "ok": True
+      }
+      response = say_hi_user("channel", "user_id")
+      assert_true(response['ok'])


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Removed `private=True` from SLACK_CLIENT_ID.
- Removed get_bot_id() since to check its own message we no longer need bot id.
- Added SkipTest
- Started to work on link-unfurl event


