### PR TITLE
Use BytesIO for Thrift over http

### DIFF
--- a/desktop/core/src/desktop/lib/thrift_/http_client.py
+++ b/desktop/core/src/desktop/lib/thrift_/http_client.py
@@ -27,9 +27,9 @@ from desktop.lib.rest.http_client import HttpClient
 from desktop.lib.rest.resource import Resource
 
 if sys.version_info[0] > 2:
-  from io import StringIO as string_io
+  from io import BytesIO as buffer_writer
 else:
-  from cStringIO import StringIO as string_io
+  from cStringIO import StringIO as buffer_writer
 
 LOG = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ class THttpClient(TTransportBase):
     self._client = HttpClient(self._base_url, logger=LOG)
     self._data = None
     self._headers = None
-    self._wbuf = string_io()
+    self._wbuf = buffer_writer()
 
   def open(self):
     pass
@@ -87,7 +87,7 @@ class THttpClient(TTransportBase):
 
   def flush(self):
     data = self._wbuf.getvalue()
-    self._wbuf = string_io()
+    self._wbuf = buffer_writer()
 
     # POST
     self._root = Resource(self._client)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR addresses the issue described in HUE-1698 https://github.com/cloudera/hue/issues/1698

Namely an error seen whilst using thrift over HTTP 
`TypeError: string argument expected, got 'bytes'`

This error is only seen whilst using python 3.x and no issues seen in python 2.7.

Due to StringIO differences in py2 -> py3  we must use BytesIO module.
We reason that this is acceptable since the Thrift HTTP client also uses BytesIO in their THttpClient https://github.com/Thriftpy/thriftpy2/blob/master/thriftpy2/http.py#L195


## How was this patch tested?

- This PR was built as a docker image and tested on our k8s environment. We  carried out fingerprinting of  sample datasets and compared against the latest-py2 docker image 
