### PR TITLE
[slack] Remove private=True from SLACK_CLIENT_ID.

### DIFF
--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -741,7 +741,6 @@ SLACK = ConfigSection(
     SLACK_CLIENT_ID=Config(
         key='slack_client_id',
         type=str,
-        private=True,
         dynamic_default=get_slack_client_id,
       ),
     SLACK_CLIENT_SECRET=Config(


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Remove private=True from SLACK_CLIENT_ID.

