### PR TITLE
[slack] Refactor link-unfurl and update UTs

### DIFF
--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -17,12 +17,16 @@
 
 import logging
 import json
+from urllib.parse import urlsplit
 from pprint import pprint
 
 from desktop import conf
-from django.http import HttpResponse
+from desktop.conf import ENABLE_GIST_PREVIEW
 from desktop.lib.django_util import login_notrequired, JsonResponse
 from desktop.lib.exceptions_renderable import PopupException
+from desktop.models import Document2, _get_gist_document
+
+from django.http import HttpResponse
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_exempt
 
@@ -36,6 +40,7 @@ if conf.SLACK.IS_ENABLED.get():
   from slack_sdk import WebClient
   slack_client = WebClient(token=SLACK_BOT_USER_TOKEN)
 
+
 @login_notrequired
 @csrf_exempt
 def slack_events(request):
@@ -45,7 +50,7 @@ def slack_events(request):
     if slack_message['token'] != SLACK_VERIFICATION_TOKEN:
       return HttpResponse(status=403)
 
-      # challenge verification
+    # challenge verification
     if slack_message['type'] == 'url_verification':
       response_dict = {"challenge": slack_message['challenge']}
       return JsonResponse(response_dict, status=200)
@@ -53,32 +58,152 @@ def slack_events(request):
     if 'event' in slack_message:
       event_message = slack_message['event']
       parse_events(event_message)
-  except ValueError as e:
-    raise PopupException(_("Response content is not valid JSON"), detail=e)
-  
+  except ValueError as err:
+    raise PopupException(_("Response content is not valid JSON"), detail=err)
+
   return HttpResponse(status=200)
 
 
-def parse_events(event_message):
-  user_id = event_message.get('user')
-  text = event_message.get('text')
-  channel = event_message.get('channel')
+def parse_events(event):
+  """
+  Parses the event according to its 'type'.
 
-  # ignore bot's own message since that will cause an infinite loop of messages if we respond
-  if event_message.get('bot_id'):
+  """
+  channel_id = event.get('channel')
+  if event.get('type') == 'message':
+    handle_on_message(channel_id, event.get('bot_id'), event.get('text'), event.get('user'))
+
+  if event.get('type') == 'link_shared':
+    handle_on_link_shared(channel_id, event.get('message_ts'), event.get('links'))
+
+
+def handle_on_message(channel_id, bot_id, text, user_id):
+  # ignore bot's own message since that will cause an infinite loop of messages if we respond.
+  if bot_id:
     return HttpResponse(status=200)
   
-  if slack_client is not None:
-    if 'hello hue' in text.lower():
-      response = say_hi_user(channel, user_id)
+  if slack_client:
+    if text and 'hello hue' in text.lower():
+      response = say_hi_user(channel_id, user_id)
+
+      if not response['ok']:
+        raise PopupException(_("Error posting message"), detail=response["error"])
+
+
+def handle_on_link_shared(channel_id, message_ts, links):
+  for item in links:
+    path = urlsplit(item['url'])[2]
+    queryid_or_uuid = urlsplit(item['url'])[3]  # if /hue/editor/ then query_id else if /hue/gist then uuid
+
+    if path == '/hue/editor':
+      query_id = queryid_or_uuid.split('=')[1]
+      doc2 = Document2.objects.get(id=query_id)
+      doc2_data = json.loads(doc2.data)
+
+      statement = doc2_data['snippets'][0]['statement_raw']
+      dialect = doc2_data['dialect'].capitalize()
+      database = doc2_data['snippets'][0]['database'].capitalize()
+      
+      payload = make_query_history_payload(item['url'], statement, dialect, database)
+      response = slack_client.chat_unfurl(channel=channel_id, ts=message_ts, unfurls=payload)
       if response['ok']:
-        return HttpResponse(status=200)
-      else:
-        raise PopupException(response["error"])
+        raise PopupException(_("Cannot unfurl query history link"), detail=response["error"])
 
-  
-def say_hi_user(channel, user_id):
-  """Bot sends Hi<username> message in a specific channel"""
+    if path == '/hue/gist' and ENABLE_GIST_PREVIEW.get():
+      gist_uuid = queryid_or_uuid.split('=')[1]
+      gist_doc = _get_gist_document(uuid=gist_uuid)
+      gist_doc_data = json.loads(gist_doc.data)
 
+      statement = gist_doc_data['statement_raw']
+      created_by = gist_doc.owner.get_full_name() or gist_doc.owner.username
+      dialect = gist_doc.extra.capitalize()
+      
+      payload = make_gist_payload(item['url'], statement, dialect, created_by)
+      response = slack_client.chat_unfurl(channel=channel_id, ts=message_ts, unfurls=payload)
+      if not response['ok']:
+        raise PopupException(_("Cannot unfurl gist link"), detail=response["error"])
+
+def say_hi_user(channel_id, user_id):
+  """
+  Sends Hi<user_id> message in a specific channel.
+
+  """
   bot_message = 'Hi <@{}> :wave:'.format(user_id)
-  return slack_client.api_call(api_method='chat.postMessage', json={'channel': channel, 'text': bot_message})
+  return slack_client.api_call(api_method='chat.postMessage', json={'channel': channel_id, 'text': bot_message})
+
+
+def make_gist_payload(url, statement, dialect, created_by):
+  gist_payload = {
+    url: {
+      "color": "#025BA6",
+      "blocks": [
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "\n*<{}|Hue - SQL Gist>*".format(url)
+          }
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": statement if len(statement) < 150 else (statement[:150] + '...')
+          }
+        },
+        {
+          "type": "section",
+          "fields": [
+            {
+              "type": "mrkdwn",
+              "text": "*Dialect:*\n{}".format(dialect)
+            },
+            {
+              "type": "mrkdwn",
+              "text": "*Created By:*\n{}".format(created_by)
+            }
+          ]
+        }
+      ]
+    }
+  }
+  return gist_payload
+
+
+def make_query_history_payload(url, statement, dialect, database):
+  payload = {
+    url: {
+      "color": "#025BA6",
+      "blocks": [
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "\n*<{}|Hue - SQL Editor>*".format(url)
+          }
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": statement if len(statement) < 150 else (statement[:150] + '...')
+          }
+        },
+        {
+          "type": "section",
+          "fields": [
+            {
+              "type": "mrkdwn",
+              "text": "*Dialect:*\n{}".format(dialect)
+            },
+            {
+              "type": "mrkdwn",
+              "text": "*Database:*\n{}".format(database)
+            }
+          ]
+        }
+      ]
+    }
+  }
+  return payload
+

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -110,7 +110,7 @@ def handle_on_link_shared(channel_id, message_ts, links):
     payload = _make_unfurl_payload(item['url'], statement, dialect, created_by)
     response = slack_client.chat_unfurl(channel=channel_id, ts=message_ts, unfurls=payload)
     if not response['ok']:
-        raise PopupException(_("Cannot unfurl link"), detail=response["error"])
+      raise PopupException(_("Cannot unfurl link"), detail=response["error"])
 
 def _make_unfurl_payload(url, statement, dialect, created_by):
   payload = {

--- a/desktop/core/src/desktop/lib/botserver/views_tests.py
+++ b/desktop/core/src/desktop/lib/botserver/views_tests.py
@@ -78,8 +78,8 @@ class TestBotServer(unittest.TestCase):
         
             client = make_logged_in_client(username="test", groupname="default", recreate=True, is_superuser=False)
             user = User.objects.get(username="test")
-            channel_id = "channel_id"
-            message_ts = "123.1"
+            channel_id = "channel"
+            message_ts = "12.1"
 
             # qhistory link
             links = [{"url": "https://demo.gethue.com/hue/editor?editor=123456"}]
@@ -104,5 +104,5 @@ class TestBotServer(unittest.TestCase):
             assert_true(chat_unfurl.called)
 
             # Cannot unfurl link
-            assert_raises(PopupException, handle_on_link_shared, "channel_id", "123.1", [{"url": "https://demo.gethue.com/hue/editor/?type=4"}])
-            assert_raises(PopupException, handle_on_link_shared, "channel_id", "123.1", [{"url": "http://demo.gethue.com/hue/gist?uuids/=xyz"}])
+            assert_raises(PopupException, handle_on_link_shared, "channel", "12.1", [{"url": "https://demo.gethue.com/hue/editor/?type=4"}])
+            assert_raises(PopupException, handle_on_link_shared, "channel", "12.1", [{"url": "http://demo.gethue.com/hue/gist?uuids/=xyz"}])

--- a/desktop/core/src/desktop/lib/botserver/views_tests.py
+++ b/desktop/core/src/desktop/lib/botserver/views_tests.py
@@ -91,7 +91,9 @@ class TestBotServer(unittest.TestCase):
               }]
             }
             document2_objects_get.return_value = Mock(data=json.dumps(doc_data), owner=user)
+
             handle_on_link_shared(channel_id, message_ts, links)
+            
             mock_unfurl_payload.assert_called_with(links[0]["url"], "SELECT 5000", "Mysql", "test")
             assert_true(chat_unfurl.called)
 
@@ -99,7 +101,9 @@ class TestBotServer(unittest.TestCase):
             doc_data = {"statement_raw": "SELECT 98765"}
             _get_gist_document.return_value = Mock(data=json.dumps(doc_data), owner=user, extra='mysql')
             links = [{"url": "http://demo.gethue.com/hue/gist?uuid=random"}]
+
             handle_on_link_shared(channel_id, message_ts, links)
+            
             mock_unfurl_payload.assert_called_with(links[0]["url"], "SELECT 98765", "Mysql", "test")
             assert_true(chat_unfurl.called)
 

--- a/desktop/core/src/desktop/lib/botserver/views_tests.py
+++ b/desktop/core/src/desktop/lib/botserver/views_tests.py
@@ -73,11 +73,11 @@ class TestBotServer(unittest.TestCase):
   def test_handle_on_link_shared(self):
     with patch('desktop.lib.botserver.views.slack_client.chat_unfurl') as chat_unfurl:
       with patch('desktop.lib.botserver.views._make_unfurl_payload') as mock_unfurl_payload:
-
+        
         client = make_logged_in_client(username="test", groupname="default", recreate=True, is_superuser=False)
         user = User.objects.get(username="test")
         channel_id = "channel_id"
-        message_ts = "12345.123"
+        message_ts = "123.1"
 
         # qhistory link
         links = [{"url": "https://demo.gethue.com/hue/editor?editor=123456"}]
@@ -88,20 +88,26 @@ class TestBotServer(unittest.TestCase):
             "statement_raw": "SELECT 5000",
           }]
         }
-
-        Document2.objects.create(id=123456, data=json.dumps(doc_data), owner=user)
-        handle_on_link_shared(channel_id, message_ts, links)
+        doc = Document2.objects.create(id=123456, data=json.dumps(doc_data), owner=user)
+        try:
+          handle_on_link_shared(channel_id, message_ts, links)
+        finally:
+          doc.delete()
         mock_unfurl_payload.assert_called_with(links[0]["url"], "SELECT 5000", "Mysql", "test")
         assert_true(chat_unfurl.called)
 
         # gist link
         doc_data = {"statement_raw": "SELECT 98765"}
-        gist_doc = Document2.objects.create(id=101010, data=json.dumps(doc_data), owner=user, extra='mysql', type='gist')
-        links = [{"url": "http://demo.gethue.com/hue/gist?uuid="+str(gist_doc.uuid)}]
-        handle_on_link_shared(channel_id, message_ts, links)
+        links = []
+        try:
+          gist_doc = Document2.objects.create(id=101010, data=json.dumps(doc_data), owner=user, extra='mysql', type='gist')
+          links = [{"url": "http://demo.gethue.com/hue/gist?uuid="+str(gist_doc.uuid)}]
+          handle_on_link_shared(channel_id, message_ts, links)
+        finally:
+          gist_doc.delete()
         mock_unfurl_payload.assert_called_with(links[0]["url"], "SELECT 98765", "Mysql", "test")
         assert_true(chat_unfurl.called)
 
         # Cannot unfurl link
-        assert_raises(PopupException, handle_on_link_shared, "channel_id", "12345.123", [{"url": "https://demo.gethue.com/hue/editor/?type=4"}])
-        assert_raises(PopupException, handle_on_link_shared, "channel_id", "12345.123", [{"url": "http://demo.gethue.com/hue/gist?uuids/=something"}])
+        assert_raises(PopupException, handle_on_link_shared, "channel_id", "123.1", [{"url": "https://demo.gethue.com/hue/editor/?type=4"}])
+        assert_raises(PopupException, handle_on_link_shared, "channel_id", "123.1", [{"url": "http://demo.gethue.com/hue/gist?uuids/=xyz"}])

--- a/desktop/core/src/desktop/lib/botserver/views_tests.py
+++ b/desktop/core/src/desktop/lib/botserver/views_tests.py
@@ -20,7 +20,7 @@ import logging
 import unittest
 import sys
 
-from nose.tools import assert_equal, assert_true
+from nose.tools import assert_equal, assert_true, assert_false
 from nose.plugins.skip import SkipTest
 from django.test import TestCase, Client
 from desktop.lib.botserver.views import *
@@ -48,3 +48,19 @@ class TestBotServer(unittest.TestCase):
       response = say_hi_user("channel", "user_id")
       api_call.assert_called_with(api_method='chat.postMessage', json={'channel': 'channel', 'text': 'Hi <@user_id> :wave:'})
       assert_true(response['ok'])
+  
+  def test_handle_on_message(self):
+    with patch('desktop.lib.botserver.views.say_hi_user') as say_hi_user:
+      
+      response = handle_on_message("channel", "bot_id", "text", "user_id")
+      assert_equal(response.status_code, 200)
+      assert_false(say_hi_user.called)
+      
+      handle_on_message("channel", None, None, "user_id")
+      assert_false(say_hi_user.called)
+
+      handle_on_message("channel", None, "text", "user_id")
+      assert_false(say_hi_user.called)
+
+      handle_on_message("channel", None, "hello hue test", "user_id")
+      assert_true(say_hi_user.called)


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Added gist unfurling
- Refactored views.py with link_unfurl section
- Updated on_handle_message UT
<img width="903" alt="Screenshot 2021-02-26 at 8 47 58 PM" src="https://user-images.githubusercontent.com/42064744/109318535-eac0ad00-7873-11eb-964b-e71450f63ad8.png">

To-dos:
- Add on_handle_link_shared UT -- Done
- document does not exist or no access along with query sharing permissions
- [Blow-up issue](https://github.com/cloudera/hue/pull/1824#discussion_r583096054)


Follow-up of PR #1824 