### PR TITLE
Handle multiple gist dirs by merging them into one

### DIFF
--- a/desktop/core/src/desktop/models.py
+++ b/desktop/core/src/desktop/models.py
@@ -1068,10 +1068,21 @@ class Document2Manager(models.Manager, Document2QueryMixin):
 
   def get_gist_directory(self, user):
     home_dir = self.get_home_directory(user)
-    gist_dir, created = Directory.objects.get_or_create(name=Document2.GIST_DIR, owner=user, parent_directory=home_dir)
-    if created:
-      LOG.info('Successfully created gist directory for user: %s' % user.username)
-    return gist_dir
+    try:
+      gist_dir, created = Directory.objects.get_or_create(name=Document2.GIST_DIR, owner=user, parent_directory=home_dir)
+      if created:
+        LOG.info('Successfully created gist directory for user: %s' % user.username)
+      return gist_dir
+    except Directory.MultipleObjectsReturned:
+      LOG.error('Multiple Gist directories detected. Merging all into one.')
+
+      gist_dirs = list(self.filter(owner=user, parent_directory=home_dir, name=Document2.GIST_DIR, type='directory').order_by('-last_modified'))
+      parent_home_dir = gist_dirs.pop()
+      for dir in gist_dirs:
+        dir.children.exclude(name='.Trash').update(parent_directory=parent_home_dir)
+        dir.delete()
+
+      return parent_home_dir
 
   def get_by_path(self, user, path):
     """


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Added a try/except just like in `get_home_directory` to check for `Directory.MultipleObjectsReturned` exception and merge all the gist directories except one.

This patch fixes #1809 and is inspired from https://github.com/cloudera/hue/pull/1835#pullrequestreview-600269880