### PR TITLE
Test to repro multiple Gist directories

### DIFF
--- a/desktop/core/src/desktop/api2_tests.py
+++ b/desktop/core/src/desktop/api2_tests.py
@@ -726,6 +726,9 @@ class TestDocumentGist(object):
 
     assert_true(home_dir.children.filter(name='Gist').exists())
 
+    gist_dir2 = Directory.objects.create(name='Gist', owner=self.user, parent_directory=home_dir)
+    assert_raises(Directory.MultipleObjectsReturned, Document2.objects.get_gist_directory, self.user)
+
 
   def test_get_unfurl(self):
     # Unfurling on

--- a/desktop/core/src/desktop/api2_tests.py
+++ b/desktop/core/src/desktop/api2_tests.py
@@ -719,6 +719,7 @@ class TestDocumentGist(object):
 
     assert_equal(1, Directory.objects.filter(name=Document2.GIST_DIR, type='directory').count())
     assert_true(Directory.objects.filter(name=Document2.GIST_DIR, type='directory', uuid=gist_parent_uuid).exists())
+    assert_equal(gist_dir1.uuid, Directory.objects.get(name=Document2.GIST_DIR, type='directory', parent_directory=home_dir).uuid)
 
 
   def test_get(self):

--- a/desktop/core/src/desktop/api2_tests.py
+++ b/desktop/core/src/desktop/api2_tests.py
@@ -699,8 +699,8 @@ class TestDocumentGist(object):
         json.loads(Document2.objects.get(type='gist', uuid=gist2['uuid']).data)['statement_raw']
     )
 
-  def test_handle_multiple_gist_dir(self):
-    # Create multiple gist directories and then make a new gist
+
+  def test_multiple_gist_dirs_on_gist_create(self):
     home_dir = Directory.objects.get_home_directory(self.user)
 
     gist_dir1 = Directory.objects.create(name=Document2.GIST_DIR, owner=self.user, parent_directory=home_dir)
@@ -709,21 +709,14 @@ class TestDocumentGist(object):
     assert_equal(2, Directory.objects.filter(name=Document2.GIST_DIR, type='directory').count())
 
     response = self._create_gist(
-        statement='SELECT 12345',
-        doc_type='hive-query',
-        name='test_gist_create',
+      statement='SELECT 12345',
+      doc_type='hive-query',
+      name='test_gist_create',
     )
-    gist = json.loads(response.content)
 
-    # Gist directories merged into one
     assert_equal(1, Directory.objects.filter(name=Document2.GIST_DIR, type='directory').count())
+    assert_equal(Document2.GIST_DIR, Document2.objects.get(type='gist', name='test_gist_create').parent_directory.name)
 
-    assert_true(Document2.objects.get(type='gist', name='test_gist_create'))
-    assert_true(Document2.objects.get(type='gist', uuid=gist['uuid']))
-    assert_equal(
-        'SELECT 12345',
-        json.loads(Document2.objects.get(type='gist', uuid=gist['uuid']).data)['statement_raw']
-    )
 
   def test_get(self):
     response = self._create_gist(

--- a/desktop/core/src/desktop/api2_tests.py
+++ b/desktop/core/src/desktop/api2_tests.py
@@ -708,15 +708,17 @@ class TestDocumentGist(object):
 
     assert_equal(2, Directory.objects.filter(name=Document2.GIST_DIR, type='directory').count())
 
+    # get_gist_directory merges all duplicate gist directories into one
     response = self._create_gist(
       statement='SELECT 12345',
       doc_type='hive-query',
       name='test_gist_create',
     )
-    gist_parent_dir = Document2.objects.get(type='gist', name='test_gist_create').parent_directory
+    gist_uuid = json.loads(response.content)['uuid']
+    gist_parent_uuid = Document2.objects.get(uuid=gist_uuid).parent_directory.uuid
 
     assert_equal(1, Directory.objects.filter(name=Document2.GIST_DIR, type='directory').count())
-    assert_true(Directory.objects.filter(name=Document2.GIST_DIR, type='directory', uuid=gist_parent_dir.uuid).exists())
+    assert_true(Directory.objects.filter(name=Document2.GIST_DIR, type='directory', uuid=gist_parent_uuid).exists())
 
 
   def test_get(self):

--- a/desktop/core/src/desktop/api2_tests.py
+++ b/desktop/core/src/desktop/api2_tests.py
@@ -713,9 +713,10 @@ class TestDocumentGist(object):
       doc_type='hive-query',
       name='test_gist_create',
     )
+    gist_parent_dir = Document2.objects.get(type='gist', name='test_gist_create').parent_directory
 
     assert_equal(1, Directory.objects.filter(name=Document2.GIST_DIR, type='directory').count())
-    assert_equal(Document2.GIST_DIR, Document2.objects.get(type='gist', name='test_gist_create').parent_directory.name)
+    assert_true(Directory.objects.filter(name=Document2.GIST_DIR, type='directory', uuid=gist_parent_dir.uuid).exists())
 
 
   def test_get(self):

--- a/desktop/core/src/desktop/api2_tests.py
+++ b/desktop/core/src/desktop/api2_tests.py
@@ -699,29 +699,31 @@ class TestDocumentGist(object):
         json.loads(Document2.objects.get(type='gist', uuid=gist2['uuid']).data)['statement_raw']
     )
 
+  def test_handle_multiple_gist_dir(self):
     # Create multiple gist directories and then make a new gist
     home_dir = Directory.objects.get_home_directory(self.user)
-    gist_dir2 = Directory.objects.create(name='Gist', owner=self.user, parent_directory=home_dir)
 
-    assert_equal(2, Directory.objects.filter(name='Gist', type='directory').count())
+    gist_dir1 = Directory.objects.create(name=Document2.GIST_DIR, owner=self.user, parent_directory=home_dir)
+    gist_dir2 = Directory.objects.create(name=Document2.GIST_DIR, owner=self.user, parent_directory=home_dir)
 
-    response3 = self._create_gist(
-        statement='SELECT 3',
+    assert_equal(2, Directory.objects.filter(name=Document2.GIST_DIR, type='directory').count())
+
+    response = self._create_gist(
+        statement='SELECT 12345',
         doc_type='hive-query',
-        name='test_gist_create3',
+        name='test_gist_create',
     )
-    gist3 = json.loads(response3.content)
+    gist = json.loads(response.content)
 
     # Gist directories merged into one
-    assert_equal(1, Directory.objects.filter(name='Gist', type='directory').count())
+    assert_equal(1, Directory.objects.filter(name=Document2.GIST_DIR, type='directory').count())
 
-    assert_true(Document2.objects.filter(type='gist', name='test_gist_create3'))
-    assert_true(Document2.objects.filter(type='gist', uuid=gist3['uuid']))
+    assert_true(Document2.objects.get(type='gist', name='test_gist_create'))
+    assert_true(Document2.objects.get(type='gist', uuid=gist['uuid']))
     assert_equal(
-        'SELECT 3',
-        json.loads(Document2.objects.get(type='gist', uuid=gist3['uuid']).data)['statement_raw']
+        'SELECT 12345',
+        json.loads(Document2.objects.get(type='gist', uuid=gist['uuid']).data)['statement_raw']
     )
-
 
   def test_get(self):
     response = self._create_gist(

--- a/desktop/core/src/desktop/api2_tests.py
+++ b/desktop/core/src/desktop/api2_tests.py
@@ -705,8 +705,15 @@ class TestDocumentGist(object):
 
     gist_dir1 = Directory.objects.create(name=Document2.GIST_DIR, owner=self.user, parent_directory=home_dir)
     gist_dir2 = Directory.objects.create(name=Document2.GIST_DIR, owner=self.user, parent_directory=home_dir)
+    gist_child = Document2.objects.create(
+      name='test_gist_child',
+      data=json.dumps({'statement': 'SELECT 123'}),
+      owner=self.user,
+      type='gist',
+      parent_directory=gist_dir2,
+    )
 
-    assert_equal(2, Directory.objects.filter(name=Document2.GIST_DIR, type='directory').count())
+    assert_equal(2, Directory.objects.filter(name=Document2.GIST_DIR, type='directory', owner=self.user).count())
 
     # get_gist_directory merges all duplicate gist directories into one
     response = self._create_gist(
@@ -715,11 +722,12 @@ class TestDocumentGist(object):
       name='test_gist_create',
     )
     gist_uuid = json.loads(response.content)['uuid']
-    gist_parent_uuid = Document2.objects.get(uuid=gist_uuid).parent_directory.uuid
+    gist_home = Document2.objects.get(uuid=gist_uuid).parent_directory
 
-    assert_equal(1, Directory.objects.filter(name=Document2.GIST_DIR, type='directory').count())
-    assert_true(Directory.objects.filter(name=Document2.GIST_DIR, type='directory', uuid=gist_parent_uuid).exists())
-    assert_equal(gist_dir1.uuid, Directory.objects.get(name=Document2.GIST_DIR, type='directory', parent_directory=home_dir).uuid)
+    assert_equal(1, Directory.objects.filter(name=Document2.GIST_DIR, type='directory', owner=self.user).count())
+    assert_true(Directory.objects.filter(name=Document2.GIST_DIR, type='directory', uuid=gist_home.uuid).exists())
+    assert_equal(gist_dir1.uuid, gist_home.uuid)
+    assert_equal(Document2.objects.get(name='test_gist_child', type='gist', owner=self.user).parent_directory, gist_home)
 
 
   def test_get(self):

--- a/desktop/core/src/desktop/models.py
+++ b/desktop/core/src/desktop/models.py
@@ -1068,22 +1068,22 @@ class Document2Manager(models.Manager, Document2QueryMixin):
 
   def get_gist_directory(self, user):
     home_dir = self.get_home_directory(user)
-    try:
 
+    try:
       gist_dir, created = Directory.objects.get_or_create(name=Document2.GIST_DIR, owner=user, parent_directory=home_dir)
       if created:
         LOG.info('Successfully created gist directory for user: %s' % user.username)
-      return gist_dir
+        
     except Directory.MultipleObjectsReturned:
       LOG.error('Multiple Gist directories detected. Merging all into one.')
 
       gist_dirs = list(self.filter(owner=user, parent_directory=home_dir, name=Document2.GIST_DIR, type='directory').order_by('-last_modified'))
-      parent_home_dir = gist_dirs.pop()
+      gist_dir = gist_dirs.pop()
       for dir in gist_dirs:
-        dir.children.exclude(name='.Trash').update(parent_directory=parent_home_dir)
+        dir.children.exclude(name='.Trash').update(parent_directory=gist_dir)
         dir.delete()
 
-      return parent_home_dir
+    return gist_dir
 
   def get_by_path(self, user, path):
     """

--- a/desktop/core/src/desktop/models.py
+++ b/desktop/core/src/desktop/models.py
@@ -1079,9 +1079,8 @@ class Document2Manager(models.Manager, Document2QueryMixin):
       all_gist_dirs = self.filter(owner=user, parent_directory=home_dir, name=Document2.GIST_DIR, type='directory').order_by('-last_modified')
       gist_dir = all_gist_dirs.last()
       gist_dirs_dup = all_gist_dirs.exclude(uuid=gist_dir.uuid)
-
       for dir in gist_dirs_dup:
-        dir.children.exclude(name='.Trash').update(parent_directory=gist_dir)
+        dir.children.update(parent_directory=gist_dir)
 
       gist_dirs_dup.delete()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Updated the `test_gist_directory_creation` UT to reproduce the Multiple Gist Directories Exception( `Directory.MultipleObjectsReturned` )
