### PR TITLE
[ci] Adding autoclose stale PRs/Issues

### DIFF
--- a/.github/workflows/autoclose-stale.yml
+++ b/.github/workflows/autoclose-stale.yml
@@ -1,0 +1,17 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          exempt-milestones:
+          exempt-issue-labels: 'roadmap'
+          exempt-pr-labels: 'roadmap'
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          days-before-stale: 30
+          days-before-close: 5


### PR DESCRIPTION
WIP

Need to add some labels to prevent blind closure of everything and the legit issues, e.g. 'roadmap' for example or 'triaged'

Will see for getting (lighter) workflow from https://github.com/kubernetes/kubernetes/issues