### PR TITLE
Consistent filtering of dir children in gist creation test

### DIFF
--- a/desktop/core/src/desktop/api2_tests.py
+++ b/desktop/core/src/desktop/api2_tests.py
@@ -750,11 +750,11 @@ class TestDocumentGist(object):
   def test_gist_directory_creation(self):
     home_dir = Directory.objects.get_home_directory(self.user)
 
-    assert_false(home_dir.children.filter(name='Gist').exists())
+    assert_false(home_dir.children.filter(name=Document2.GIST_DIR, owner=self.user).exists())
 
     Document2.objects.get_gist_directory(self.user)
 
-    assert_true(home_dir.children.filter(name='Gist').exists())
+    assert_true(home_dir.children.filter(name=Document2.GIST_DIR, owner=self.user).exists())
 
 
   def test_get_unfurl(self):


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Made name to `Document2.GIST_DIR` to be consistent
- Added `owner` in filter
## How was this patch tested?

- Ran unit test and it passed
