### PR TITLE
[Django babel] shifting django-babel repo to gethue

### DIFF
--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -63,4 +63,4 @@ sqlparse==0.4.1
 tablib==0.13.0
 thrift==0.13.0
 thrift-sasl==0.4.2
-git+git://github.com/agl29/django-babel.git
+git+git://github.com/gethue/django-babel.git


### PR DESCRIPTION
## What changes were proposed in this pull request?

- shifting django-babel repo to gethue
