### PR TITLE
[Dajngo 4.0 Warning] RemovedInDjango40Warning: django.utils.translati…

### DIFF
--- a/apps/about/src/about/templates/admin_wizard.mako
+++ b/apps/about/src/about/templates/admin_wizard.mako
@@ -15,8 +15,9 @@
 ## limitations under the License.
 
 <%!
+import sys
+
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 
 from metadata.conf import OPTIMIZER, has_optimizer
 
@@ -24,6 +25,11 @@ from desktop.auth.backend import is_admin
 from desktop.conf import has_connectors
 from desktop.lib.i18n import smart_unicode
 from desktop.views import commonheader, commonfooter
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="/about_layout.mako" />

--- a/apps/about/src/about/views.py
+++ b/apps/about/src/about/views.py
@@ -17,8 +17,7 @@
 
 from builtins import str
 import logging
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop import appmanager
 from desktop.auth.backend import is_hue_admin
@@ -26,6 +25,11 @@ from desktop.auth.decorators import admin_required
 from desktop.lib.django_util import JsonResponse, render
 from desktop.models import Settings, hue_version
 from desktop.views import collect_usage
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 def admin_wizard(request):

--- a/apps/beeswax/src/beeswax/api.py
+++ b/apps/beeswax/src/beeswax/api.py
@@ -19,10 +19,10 @@ from builtins import zip
 import logging
 import json
 import re
+import sys
 
 from django.urls import reverse
 from django.http import Http404
-from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 
 from thrift.transport.TTransport import TTransportException
@@ -50,6 +50,11 @@ from beeswax.server.dbms import expand_exception, get_query_server_config, Query
     SubQueryTable
 from beeswax.views import authorized_get_design, authorized_get_query_history, make_parameterization_form, \
     safe_get_design, save_design, massage_columns_for_json, _get_query_handle_and_state, parse_out_jobs
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/beeswax/src/beeswax/conf.py
+++ b/apps/beeswax/src/beeswax/conf.py
@@ -20,12 +20,16 @@ from builtins import str
 import logging
 import math
 import os.path
-
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
+import sys
 
 from desktop.conf import default_ssl_cacerts, default_ssl_validate, AUTH_PASSWORD as DEFAULT_AUTH_PASSWORD,\
   AUTH_USERNAME as DEFAULT_AUTH_USERNAME
 from desktop.lib.conf import ConfigSection, Config, coerce_bool, coerce_csv, coerce_password_from_script
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/beeswax/src/beeswax/create_table.py
+++ b/apps/beeswax/src/beeswax/create_table.py
@@ -26,10 +26,10 @@ import json
 import logging
 import math
 import re
+import sys
 
 from django.urls import reverse
 from django.http import QueryDict
-from django.utils.translation import ugettext as _
 
 from aws.s3.s3fs import S3FileSystemException
 from desktop.context_processors import get_app_name
@@ -48,6 +48,11 @@ from beeswax.forms import CreateTableForm, ColumnTypeFormSet,\
 from beeswax.server import dbms
 from beeswax.server.dbms import QueryServerException
 from beeswax.views import execute_directly
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/beeswax/src/beeswax/data_export.py
+++ b/apps/beeswax/src/beeswax/data_export.py
@@ -20,12 +20,16 @@ from builtins import object
 import json
 import logging
 import math
+import sys
 import types
-
-from django.utils.translation import ugettext as _
 
 from desktop.lib import export_csvxls
 from beeswax import common, conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/beeswax/src/beeswax/design.py
+++ b/apps/beeswax/src/beeswax/design.py
@@ -26,16 +26,21 @@ import json
 import logging
 import os
 import re
+import sys
 import urllib.parse
 
 import django.http
 from django import forms
 from django.forms import ValidationError
-from django.utils.translation import ugettext as _
 
 from notebook.sql_utils import split_statements, strip_trailing_semicolon
 from desktop.lib.django_forms import BaseSimpleFormSet, MultiForm
 from hadoop.cluster import get_hdfs
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/beeswax/src/beeswax/forms.py
+++ b/apps/beeswax/src/beeswax/forms.py
@@ -15,9 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from builtins import chr
 from django import forms
-from django.utils.translation import ugettext as _, ugettext_lazy as _t
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.forms import NumberInput
 
@@ -27,6 +28,11 @@ from filebrowser.forms import PathField
 
 from beeswax import common
 from beeswax.models import SavedQuery
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _, gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext as _, ugettext_lazy as _t
 
 
 class QueryForm(MultiForm):

--- a/apps/beeswax/src/beeswax/management/commands/beeswax_install_examples.py
+++ b/apps/beeswax/src/beeswax/management/commands/beeswax_install_examples.py
@@ -20,10 +20,10 @@ import csv
 import logging
 import json
 import os
+import sys
 import pwd
 
 from django.core.management.base import BaseCommand
-from django.utils.translation import ugettext as _
 
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.conf import USE_NEW_EDITOR
@@ -38,6 +38,10 @@ from beeswax.hive_site import has_concurrency_support
 from beeswax.models import SavedQuery, HQL, IMPALA, RDBMS
 from beeswax.server import dbms
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/beeswax/src/beeswax/management/commands/create_table_query_data.py
+++ b/apps/beeswax/src/beeswax/management/commands/create_table_query_data.py
@@ -18,10 +18,9 @@
 from builtins import str
 
 import logging
+import sys
 
 from django.core.management.base import BaseCommand
-from django.utils.translation import ugettext as _
-
 
 from desktop.lib import django_mako
 from beeswax.server import dbms
@@ -30,6 +29,11 @@ from beeswax.server.dbms import get_query_server_config
 from beeswax.design import hql_query
 from beeswax import hive_site
 from useradmin.models import install_sample_user
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/beeswax/src/beeswax/models.py
+++ b/apps/beeswax/src/beeswax/models.py
@@ -26,7 +26,6 @@ import sys
 from django.db import models
 from django.contrib.contenttypes.fields import GenericRelation
 from django.urls import reverse
-from django.utils.translation import ugettext as _, ugettext_lazy as _t
 
 from enum import Enum
 from TCLIService.ttypes import TSessionHandle, THandleIdentifier, TOperationState, TOperationHandle, TOperationType
@@ -38,6 +37,11 @@ from librdbms.server import dbms as librdbms_dbms
 from useradmin.models import User
 
 from beeswax.design import HQLdesign
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _, gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext as _, ugettext_lazy as _t
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/beeswax/src/beeswax/query_history.py
+++ b/apps/beeswax/src/beeswax/query_history.py
@@ -21,10 +21,9 @@ from builtins import str
 import collections
 import logging
 import json
+import sys
 import threading
 import uuid
-
-from django.utils.translation import ugettext as _
 
 from beeswax.design import hql_query
 from beeswax.server import dbms
@@ -35,6 +34,11 @@ from desktop.lib.exceptions_renderable import raise_popup_exception, PopupExcept
 from desktop.lib import django_mako
 
 from useradmin.models import install_sample_user
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/beeswax/src/beeswax/server/dbms.py
+++ b/apps/beeswax/src/beeswax/server/dbms.py
@@ -25,7 +25,6 @@ import json
 
 from django.core.cache import caches
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 from kazoo.client import KazooClient
 
 from desktop.conf import CLUSTER_ID, has_connectors
@@ -57,6 +56,10 @@ if sys.version_info[0] > 2:
 else:
   from django.utils.encoding import force_unicode as force_str
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/beeswax/src/beeswax/server/hive_metastore_server.py
+++ b/apps/beeswax/src/beeswax/server/hive_metastore_server.py
@@ -18,10 +18,10 @@
 from builtins import object
 import logging
 import re
+import sys
 import thrift
 
 from django.utils.encoding import smart_str, force_unicode
-from django.utils.translation import ugettext as _
 
 import hadoop.cluster
 
@@ -35,6 +35,11 @@ from beeswax.conf import SERVER_CONN_TIMEOUT
 from beeswax.server.hive_server2_lib import ResultCompatible
 from beeswax.models import HiveServerQueryHandle, QueryHistory
 from beeswax.server.dbms import Table, DataTable
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/beeswax/src/beeswax/server/hive_server2_lib.py
+++ b/apps/beeswax/src/beeswax/server/hive_server2_lib.py
@@ -23,7 +23,6 @@ import sys
 
 from operator import itemgetter
 
-from django.utils.translation import ugettext as _
 from TCLIService import TCLIService
 from TCLIService.ttypes import TOpenSessionReq, TGetTablesReq, TFetchResultsReq, TStatusCode, TGetResultSetMetadataReq, \
   TGetColumnsReq, TTypeId, TExecuteStatementReq, TGetOperationStatusReq, TFetchOrientation, \
@@ -38,6 +37,11 @@ from beeswax.hive_site import hiveserver2_use_ssl
 from beeswax.conf import CONFIG_WHITELIST, LIST_PARTITIONS_LIMIT
 from beeswax.models import Session, HiveServerQueryHandle, HiveServerQueryHistory
 from beeswax.server.dbms import Table, DataTable, QueryServerException, InvalidSessionQueryServerException
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/beeswax/src/beeswax/templates/beeswax_components.mako
+++ b/apps/beeswax/src/beeswax/templates/beeswax_components.mako
@@ -14,8 +14,13 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
   from desktop.lib.django_util import extract_field_data
-  from django.utils.translation import ugettext as _
+  
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%def name="getEllipsifiedCell(val, placement='bottom', klass='')">

--- a/apps/beeswax/src/beeswax/templates/configuration.mako
+++ b/apps/beeswax/src/beeswax/templates/configuration.mako
@@ -14,8 +14,14 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
+
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="layout.mako" />

--- a/apps/beeswax/src/beeswax/templates/confirm.mako
+++ b/apps/beeswax/src/beeswax/templates/confirm.mako
@@ -15,7 +15,12 @@
 ## limitations under the License.
 
 <%!
-from django.utils.translation import ugettext as _
+import sys
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <form action="{{ url }}" method="POST">>

--- a/apps/beeswax/src/beeswax/templates/create_database.mako
+++ b/apps/beeswax/src/beeswax/templates/create_database.mako
@@ -14,9 +14,15 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
+
 from desktop import conf
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="comps" file="beeswax_components.mako" />

--- a/apps/beeswax/src/beeswax/templates/create_table_manually.mako
+++ b/apps/beeswax/src/beeswax/templates/create_table_manually.mako
@@ -14,9 +14,15 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
+
 from desktop import conf
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="comps" file="beeswax_components.mako" />

--- a/apps/beeswax/src/beeswax/templates/execute.mako
+++ b/apps/beeswax/src/beeswax/templates/execute.mako
@@ -14,13 +14,19 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
+
   from desktop.lib.django_util import extract_field_data
   from desktop.views import commonheader, commonfooter, commonshare, _ko
   from beeswax import conf as beeswax_conf
   from desktop import conf
   from desktop.conf import USE_NEW_EDITOR
-  from django.utils.translation import ugettext as _
   from notebook.conf import ENABLE_QUERY_BUILDER
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="comps" file="beeswax_components.mako" />

--- a/apps/beeswax/src/beeswax/templates/import_wizard_choose_delimiter.mako
+++ b/apps/beeswax/src/beeswax/templates/import_wizard_choose_delimiter.mako
@@ -14,9 +14,15 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
+
 from desktop import conf
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="comps" file="beeswax_components.mako" />

--- a/apps/beeswax/src/beeswax/templates/import_wizard_choose_file.mako
+++ b/apps/beeswax/src/beeswax/templates/import_wizard_choose_file.mako
@@ -14,9 +14,15 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
+
 from desktop import conf
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="comps" file="beeswax_components.mako" />

--- a/apps/beeswax/src/beeswax/templates/import_wizard_define_columns.mako
+++ b/apps/beeswax/src/beeswax/templates/import_wizard_define_columns.mako
@@ -14,9 +14,15 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
+
 from desktop import conf
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="comps" file="beeswax_components.mako" />

--- a/apps/beeswax/src/beeswax/templates/layout.mako
+++ b/apps/beeswax/src/beeswax/templates/layout.mako
@@ -15,7 +15,12 @@
 ## limitations under the License.
 
 <%!
-from django.utils.translation import ugettext as _
+import sys
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 def is_selected(section, matcher):
   if section == matcher:

--- a/apps/beeswax/src/beeswax/templates/list_designs.mako
+++ b/apps/beeswax/src/beeswax/templates/list_designs.mako
@@ -17,14 +17,15 @@
     import sys
     import time
     from django.template.defaultfilters import timesince
-    from django.utils.translation import ugettext as _
 
     from desktop.views import commonheader, commonfooter
 
     if sys.version_info[0] > 2:
       from django.utils.encoding import force_str
+      from django.utils.translation import gettext as _
     else:
       from django.utils.encoding import force_unicode as force_str
+      from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/apps/beeswax/src/beeswax/templates/list_history.mako
+++ b/apps/beeswax/src/beeswax/templates/list_history.mako
@@ -15,11 +15,16 @@
 ## limitations under the License.
 
 <%!
+import sys
 import time
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
 from beeswax import models
 from beeswax.views import collapse_whitespace
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/apps/beeswax/src/beeswax/templates/list_trashed_designs.mako
+++ b/apps/beeswax/src/beeswax/templates/list_trashed_designs.mako
@@ -14,10 +14,15 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+    import sys
     import time
     from django.template.defaultfilters import timesince
     from desktop.views import commonheader, commonfooter
-    from django.utils.translation import ugettext as _
+
+    if sys.version_info[0] > 2:
+      from django.utils.translation import gettext as _
+    else:
+      from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/apps/beeswax/src/beeswax/templates/my_queries.mako
+++ b/apps/beeswax/src/beeswax/templates/my_queries.mako
@@ -14,12 +14,16 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 import time
 from django.template.defaultfilters import timesince
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
 from beeswax import models
 from beeswax.views import collapse_whitespace
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/apps/beeswax/src/beeswax/templates/save_results.mako
+++ b/apps/beeswax/src/beeswax/templates/save_results.mako
@@ -14,10 +14,14 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from desktop.views import commonheader, commonfooter
 from desktop.lib.django_util import extract_field_data
 
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="layout.mako" />

--- a/apps/beeswax/src/beeswax/templates/util.mako
+++ b/apps/beeswax/src/beeswax/templates/util.mako
@@ -14,7 +14,11 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-from django.utils.translation import ugettext as _
+import sys
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 <%def name="render_error(err)">
   <div>

--- a/apps/beeswax/src/beeswax/templates/watch_results.mako
+++ b/apps/beeswax/src/beeswax/templates/watch_results.mako
@@ -14,10 +14,14 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from desktop.lib.i18n import smart_unicode
 from desktop.views import commonheader, commonfooter
 from django.utils.encoding import force_unicode
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="layout.mako" />

--- a/apps/beeswax/src/beeswax/views.py
+++ b/apps/beeswax/src/beeswax/views.py
@@ -29,7 +29,6 @@ from django.db.models import Q
 from django.http import HttpResponse, QueryDict
 from django.shortcuts import redirect
 from django.utils.html import escape
-from django.utils.translation import ugettext as _
 from django.urls import reverse
 
 from desktop.appmanager import get_apps_dict
@@ -56,6 +55,11 @@ from beeswax.server import dbms
 from beeswax.server.dbms import expand_exception, get_query_server_config, QueryServerException
 
 from desktop.auth.backend import is_admin
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/filebrowser/src/filebrowser/conf.py
+++ b/apps/filebrowser/src/filebrowser/conf.py
@@ -15,11 +15,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.utils.translation import ugettext_lazy as _
+import sys
 
 from desktop.conf import ENABLE_DOWNLOAD
 from desktop.lib.conf import Config, coerce_bool
 from desktop.conf import is_oozie_enabled
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _
+else:
+  from django.utils.translation import ugettext_lazy as _
 
 
 MAX_SNAPPY_DECOMPRESSION_SIZE = Config(

--- a/apps/filebrowser/src/filebrowser/forms.py
+++ b/apps/filebrowser/src/filebrowser/forms.py
@@ -26,7 +26,6 @@ import urllib.request, urllib.error
 from django import forms
 from django.forms import FileField, CharField, BooleanField, Textarea
 from django.forms.formsets import formset_factory, BaseFormSet
-from django.utils.translation import ugettext_lazy as _
 
 from aws.s3 import S3A_ROOT, normpath as s3_normpath
 from azure.abfs.__init__ import ABFS_ROOT, normpath as abfs_normpath
@@ -38,8 +37,10 @@ from filebrowser.lib import rwx
 
 if sys.version_info[0] > 2:
   from urllib.parse import unquote as urllib_unquote
+  from django.utils.translation import gettext_lazy as _
 else:
   from urllib import unquote as urllib_unquote
+  from django.utils.translation import ugettext_lazy as _
 
 
 logger = logging.getLogger(__name__)

--- a/apps/filebrowser/src/filebrowser/lib/archives.py
+++ b/apps/filebrowser/src/filebrowser/lib/archives.py
@@ -27,9 +27,13 @@ import tarfile
 import tempfile
 
 from desktop.lib.exceptions_renderable import PopupException
-from django.utils.translation import ugettext as _
 from filebrowser.conf import ARCHIVE_UPLOAD_TEMPDIR
 from zipfile import ZipFile
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 __all__ = ['archive_factory']

--- a/apps/filebrowser/src/filebrowser/templates/display.mako
+++ b/apps/filebrowser/src/filebrowser/templates/display.mako
@@ -21,12 +21,13 @@
   from filebrowser.views import truncate
   from desktop.lib.paths import SAFE_CHARACTERS_URI_COMPONENTS
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
 
   if sys.version_info[0] > 2:
     from urllib.parse import quote as urllib_quote
+    from django.utils.translation import gettext as _
   else:
     from urllib import quote as urllib_quote
+    from django.utils.translation import ugettext as _
 %>
 <%
   path_enc = urllib_quote(path.encode('utf-8'), safe=SAFE_CHARACTERS_URI_COMPONENTS)

--- a/apps/filebrowser/src/filebrowser/templates/edit.mako
+++ b/apps/filebrowser/src/filebrowser/templates/edit.mako
@@ -16,10 +16,16 @@
 
 <%!
   import datetime
+  import sys
+
   from django.template.defaultfilters import urlencode, stringformat, date, filesizeformat, time
   from filebrowser.views import truncate
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%

--- a/apps/filebrowser/src/filebrowser/templates/fb_components.mako
+++ b/apps/filebrowser/src/filebrowser/templates/fb_components.mako
@@ -19,14 +19,15 @@ import sys
 from desktop.lib.paths import SAFE_CHARACTERS_URI_COMPONENTS
 
 from django.template.defaultfilters import urlencode, stringformat, date, filesizeformat, time
-from django.utils.translation import ugettext as _
 
 from aws.conf import get_default_region
 
 if sys.version_info[0] > 2:
   from urllib.parse import quote as urllib_quote
+  from django.utils.translation import gettext as _
 else:
   from urllib import quote as urllib_quote
+  from django.utils.translation import ugettext as _
 %>
 
 <%def name="breadcrumbs(path, breadcrumbs, from_listdir=False)">

--- a/apps/filebrowser/src/filebrowser/templates/fileop.mako
+++ b/apps/filebrowser/src/filebrowser/templates/fileop.mako
@@ -15,10 +15,16 @@
 ## limitations under the License.
 <%!
 import datetime
+import sys
+
 from django import forms
 from django.template.defaultfilters import urlencode, escape, stringformat, date, filesizeformat, time
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 

--- a/apps/filebrowser/src/filebrowser/templates/listdir.mako
+++ b/apps/filebrowser/src/filebrowser/templates/listdir.mako
@@ -15,12 +15,17 @@
 ## limitations under the License.
 
 <%!
+import sys
+
 from django.template.defaultfilters import urlencode
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
 
 from filebrowser.conf import ENABLE_EXTRACT_UPLOADED_ARCHIVE
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
+++ b/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
@@ -16,12 +16,18 @@
 
 <%!
 import datetime
+import sys
+
 from django.template.defaultfilters import urlencode, stringformat, filesizeformat, date, time, escape
 from desktop.lib.django_util import reverse_with_get, extract_field_data
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext as _
 
 from filebrowser.conf import ENABLE_EXTRACT_UPLOADED_ARCHIVE
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="edit" file="editor_components.mako" />

--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -43,7 +43,6 @@ from django.shortcuts import redirect
 from functools import partial
 from django.utils.http import http_date
 from django.utils.html import escape
-from django.utils.translation import ugettext as _
 
 from aws.s3.s3fs import S3FileSystemException, S3ListAllBucketsException
 from desktop import appmanager
@@ -84,6 +83,7 @@ if sys.version_info[0] > 2:
   from builtins import str as new_str
   from avro import datafile, io
   from gzip import decompress as decompress_gzip
+  from django.utils.translation import gettext as _
 else:
   from cStringIO import StringIO as string_io
   from urllib import quote as urllib_quote
@@ -93,6 +93,7 @@ else:
   import parquet
   from avro import datafile, io
   from gzip import GzipFile
+  from django.utils.translation import ugettext as _
 
 
 DEFAULT_CHUNK_SIZE_BYTES = 1024 * 4 # 4KB

--- a/apps/filebrowser/src/filebrowser/views_test.py
+++ b/apps/filebrowser/src/filebrowser/views_test.py
@@ -42,7 +42,6 @@ from aws.s3.s3test_utils import get_test_bucket
 from azure.conf import is_abfs_enabled, is_adls_enabled
 from django.urls import reverse
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext_lazy as _
 from nose.plugins.attrib import attr
 from nose.plugins.skip import SkipTest
 from nose.tools import assert_true, assert_false, assert_equal, assert_not_equal, assert_raises,\
@@ -64,14 +63,13 @@ from filebrowser.views import snappy_installed
 if sys.version_info[0] > 2:
   from urllib.parse import unquote as urllib_unquote, urlparse
   open_file = open
+  from django.utils.translation import gettext_lazy as _
+  from unittest.mock import patch, Mock
 else:
   from urllib import unquote as urllib_unquote
   from urlparse import urlparse
   open_file = file
-
-if sys.version_info[0] > 2:
-  from unittest.mock import patch, Mock
-else:
+  from django.utils.translation import ugettext_lazy as _
   from mock import patch, Mock
 
 

--- a/apps/hbase/src/hbase/api.py
+++ b/apps/hbase/src/hbase/api.py
@@ -21,8 +21,8 @@ import json
 import logging
 import re
 import csv
+import sys
 
-from django.utils.translation import ugettext as _
 from django.utils.encoding import smart_str
 
 from desktop.lib import thrift_util
@@ -32,6 +32,10 @@ from hbase import conf
 from hbase.hbase_site import get_server_principal, get_server_authentication, is_using_thrift_ssl, is_using_thrift_http, get_thrift_transport
 from hbase.server.hbase_lib import get_thrift_type, get_client_type
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/hbase/src/hbase/conf.py
+++ b/apps/hbase/src/hbase/conf.py
@@ -20,12 +20,14 @@ import logging
 import os
 import sys
 
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
-
 from desktop.conf import default_ssl_validate
 from desktop.lib.conf import Config, validate_thrift_transport, coerce_bool
 from hbase.hbase_site import get_thrift_transport
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/hbase/src/hbase/management/commands/hbase_setup.py
+++ b/apps/hbase/src/hbase/management/commands/hbase_setup.py
@@ -17,11 +17,11 @@
 
 import logging
 import os
+import sys
 
 from datetime import datetime, timedelta
 
 from django.core.management.base import BaseCommand
-from django.utils.translation import ugettext as _
 
 from desktop.lib.paths import get_apps_root
 from useradmin.models import install_sample_user, User
@@ -29,6 +29,10 @@ from useradmin.models import install_sample_user, User
 from hbased.ttypes import AlreadyExists
 from hbase.api import HbaseApi
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/hbase/src/hbase/templates/app.mako
+++ b/apps/hbase/src/hbase/templates/app.mako
@@ -15,8 +15,13 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/apps/hbase/src/hbase/views.py
+++ b/apps/hbase/src/hbase/views.py
@@ -24,8 +24,6 @@ import re
 import sys
 import urllib.request, urllib.parse, urllib.error
 
-from django.utils.translation import ugettext as _
-
 from desktop.auth.backend import is_admin
 from desktop.lib.django_util import JsonResponse, render
 
@@ -38,9 +36,11 @@ from hbase.server.hbase_lib import get_thrift_type
 
 if sys.version_info[0] > 2:
   from io import StringIO as string_io
+  from django.utils.translation import gettext as _
 else:
   from cStringIO import StringIO as string_io
   from avro import datafile, io
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/hive/src/hive/conf.py
+++ b/apps/hive/src/hive/conf.py
@@ -20,12 +20,14 @@ import sys
 
 import beeswax.hive_site
 
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
-
 from desktop.conf import has_connectors
 from desktop.lib.exceptions import StructuredThriftTransportException
 from beeswax.settings import NICE_NAME
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/impala/src/impala/api.py
+++ b/apps/impala/src/impala/api.py
@@ -21,8 +21,8 @@ import base64
 import logging
 import json
 import struct
+import sys
 
-from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 
 from beeswax.api import error_handler
@@ -41,6 +41,11 @@ from impala.server import get_api as get_impalad_api, _get_impala_server_url
 from libanalyze import analyze as analyzer, rules
 
 from notebook.models import make_notebook
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/impala/src/impala/conf.py
+++ b/apps/impala/src/impala/conf.py
@@ -20,8 +20,6 @@ import os
 import socket
 import sys
 
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
-
 from desktop.conf import default_ssl_cacerts, default_ssl_validate, AUTH_USERNAME as DEFAULT_AUTH_USERNAME, \
     AUTH_PASSWORD as DEFAULT_AUTH_PASSWORD, has_connectors
 from desktop.lib.conf import ConfigSection, Config, coerce_bool, coerce_csv, coerce_password_from_script
@@ -31,6 +29,10 @@ from desktop.lib.paths import get_desktop_root
 from impala.impala_flags import get_max_result_cache_size, is_impersonation_enabled, is_kerberos_enabled, is_webserver_spnego_enabled
 from impala.settings import NICE_NAME
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/impala/src/impala/dbms.py
+++ b/apps/impala/src/impala/dbms.py
@@ -16,8 +16,7 @@
 # limitations under the License.
 
 import logging
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.conf import CLUSTER_ID, has_connectors
 from desktop.lib.exceptions_renderable import PopupException
@@ -31,6 +30,11 @@ from beeswax.server.dbms import HiveServer2Dbms, QueryServerException, QueryServ
 
 from impala import conf
 from impala.impala_flags import get_hs2_http_port
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/impala/src/impala/server.py
+++ b/apps/impala/src/impala/server.py
@@ -20,8 +20,7 @@ from builtins import object
 import json
 import logging
 import threading
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.rest.http_client import HttpClient
@@ -33,6 +32,10 @@ from ImpalaService import ImpalaHiveServer2Service
 from impala.impala_flags import get_webserver_certificate_file, is_webserver_spnego_enabled, is_kerberos_enabled
 from impala.conf import DAEMON_API_USERNAME, DAEMON_API_PASSWORD, DAEMON_API_AUTH_SCHEME, COORDINATOR_URL
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/jobbrowser/src/jobbrowser/api.py
+++ b/apps/jobbrowser/src/jobbrowser/api.py
@@ -17,10 +17,10 @@
 
 from builtins import object
 import logging
+import sys
 
 from datetime import datetime, timedelta
 from django.core.paginator import Paginator
-from django.utils.translation import ugettext as _
 
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.rest.http_client import RestException
@@ -38,6 +38,10 @@ from jobbrowser.conf import SHARE_JOBS
 from jobbrowser.yarn_models import Application, YarnV2Job, Job as YarnJob, KilledJob as KilledYarnJob, Container, SparkJob
 from desktop.auth.backend import is_admin
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/jobbrowser/src/jobbrowser/api2.py
+++ b/apps/jobbrowser/src/jobbrowser/api2.py
@@ -17,11 +17,11 @@
 
 import json
 import logging
+import sys
 
 from urllib.request import Request, urlopen
 
 from django.http import HttpResponse
-from django.utils.translation import ugettext as _
 
 from desktop.lib.i18n import smart_unicode
 from desktop.lib.django_util import JsonResponse
@@ -31,6 +31,11 @@ from jobbrowser.apis.base_api import get_api
 from jobbrowser.apis.query_store import query_store_proxy, stream_download_bundle
 
 from jobbrowser.conf import DISABLE_KILLING_JOBS, USE_PROXY
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/jobbrowser/src/jobbrowser/apis/base_api.py
+++ b/apps/jobbrowser/src/jobbrowser/apis/base_api.py
@@ -19,12 +19,15 @@ from builtins import object
 import logging
 import posixpath
 import re
-
-from django.utils.translation import ugettext as _
+import sys
 
 from hadoop.fs.hadoopfs import Hdfs
 from desktop.lib.exceptions_renderable import PopupException
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/jobbrowser/src/jobbrowser/apis/beat_api.py
+++ b/apps/jobbrowser/src/jobbrowser/apis/beat_api.py
@@ -16,16 +16,19 @@
 # limitations under the License.
 
 import logging
+import sys
 
 from datetime import datetime
-
-from django.utils.translation import ugettext as _
 
 from dateutil import parser
 from desktop.lib.scheduler.lib.beat import CeleryBeatApi
 
 from jobbrowser.apis.base_api import Api
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/jobbrowser/src/jobbrowser/apis/beeswax_query_api.py
+++ b/apps/jobbrowser/src/jobbrowser/apis/beeswax_query_api.py
@@ -18,15 +18,19 @@ from builtins import filter
 
 import logging
 import re
+import sys
 
 from datetime import datetime
 
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.python_util import current_ms_from_utc
 
-from django.utils.translation import ugettext as _
-
 from jobbrowser.apis.base_api import Api
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/jobbrowser/src/jobbrowser/apis/bundle_api.py
+++ b/apps/jobbrowser/src/jobbrowser/apis/bundle_api.py
@@ -17,8 +17,7 @@
 
 import logging
 import json
-
-from django.utils.translation import ugettext as _
+import sys
 
 from liboozie.oozie_api import get_oozie
 
@@ -26,6 +25,10 @@ from jobbrowser.apis.base_api import Api, MockDjangoRequest
 from jobbrowser.apis.workflow_api import _manage_oozie_job, _filter_oozie_jobs
 from jobbrowser.apis.schedule_api import MockGet
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/jobbrowser/src/jobbrowser/apis/clusters.py
+++ b/apps/jobbrowser/src/jobbrowser/apis/clusters.py
@@ -16,17 +16,21 @@
 # limitations under the License.
 
 import logging
+import sys
 
 from datetime import datetime
 from dateutil import parser
 
 from django.utils import timezone
-from django.utils.translation import ugettext as _
 
 from notebook.connectors.altus import DataWarehouse2Api
 
 from jobbrowser.apis.base_api import Api
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/jobbrowser/src/jobbrowser/apis/data_eng_api.py
+++ b/apps/jobbrowser/src/jobbrowser/apis/data_eng_api.py
@@ -16,15 +16,18 @@
 # limitations under the License.
 
 import logging
+import sys
 
 from datetime import datetime,  timedelta
-
-from django.utils.translation import ugettext as _
 
 from notebook.connectors.altus import DataEngApi, DATE_FORMAT
 
 from jobbrowser.apis.base_api import Api
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/jobbrowser/src/jobbrowser/apis/data_warehouse.py
+++ b/apps/jobbrowser/src/jobbrowser/apis/data_warehouse.py
@@ -16,17 +16,21 @@
 # limitations under the License.
 
 import logging
+import sys
 
 from datetime import datetime
 from dateutil import parser
 
 from django.utils import timezone
-from django.utils.translation import ugettext as _
 
 from notebook.connectors.altus import AnalyticDbApi, DataWarehouse2Api
 
 from jobbrowser.apis.base_api import Api
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/jobbrowser/src/jobbrowser/apis/history.py
+++ b/apps/jobbrowser/src/jobbrowser/apis/history.py
@@ -16,11 +16,10 @@
 # limitations under the License.
 
 import logging
+import sys
 
 from datetime import datetime
 from dateutil import parser
-
-from django.utils.translation import ugettext as _
 
 from desktop.models import Document2
 from notebook.api import _get_statement
@@ -28,6 +27,11 @@ from notebook.models import Notebook
 
 from jobbrowser.apis.base_api import Api
 from jobbrowser.conf import MAX_JOB_FETCH
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/jobbrowser/src/jobbrowser/apis/hive_query_api.py
+++ b/apps/jobbrowser/src/jobbrowser/apis/hive_query_api.py
@@ -18,9 +18,9 @@ from builtins import filter
 
 import logging
 from logging import exception
+import sys
 
 from datetime import datetime
-from django.utils.translation import ugettext as _
 
 from beeswax.models import QueryHistory
 from desktop.lib.exceptions_renderable import PopupException
@@ -33,6 +33,11 @@ from notebook.models import _get_notebook_api, make_notebook, MockRequest
 from jobbrowser.apis.base_api import Api
 from jobbrowser.conf import QUERY_STORE
 from jobbrowser.models import HiveQuery
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/jobbrowser/src/jobbrowser/apis/job_api.py
+++ b/apps/jobbrowser/src/jobbrowser/apis/job_api.py
@@ -17,9 +17,9 @@
 
 import json
 import logging
+import sys
 
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext as _
 from hadoop.yarn import resource_manager_api
 
 from desktop.lib.django_util import JsonResponse
@@ -27,6 +27,11 @@ from desktop.lib.exceptions import MessageException
 from desktop.lib.exceptions_renderable import PopupException
 from jobbrowser.conf import MAX_JOB_FETCH, LOG_OFFSET
 from jobbrowser.views import job_executor_logs, job_single_logs
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/jobbrowser/src/jobbrowser/apis/livy_api.py
+++ b/apps/jobbrowser/src/jobbrowser/apis/livy_api.py
@@ -16,13 +16,16 @@
 # limitations under the License.
 
 import logging
-
-from django.utils.translation import ugettext as _
+import sys
 
 from spark.livy_client import get_api
 
 from jobbrowser.apis.base_api import Api
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/jobbrowser/src/jobbrowser/apis/query_api.py
+++ b/apps/jobbrowser/src/jobbrowser/apis/query_api.py
@@ -20,16 +20,20 @@ from builtins import range
 import itertools
 import logging
 import re
+import sys
 import time
 from datetime import datetime
-
-from django.utils.translation import ugettext as _
 
 from desktop.lib import export_csvxls
 from libanalyze import analyze as analyzer, rules
 from notebook.conf import ENABLE_QUERY_ANALYSIS
 
 from jobbrowser.apis.base_api import Api
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 ANALYZER = rules.TopDownAnalysis() # We need to parse some files so save as global
 LOG = logging.getLogger(__name__)

--- a/apps/jobbrowser/src/jobbrowser/apis/schedule_api.py
+++ b/apps/jobbrowser/src/jobbrowser/apis/schedule_api.py
@@ -18,14 +18,18 @@
 from builtins import object
 import logging
 import json
-
-from django.utils.translation import ugettext as _
+import sys
 
 from liboozie.oozie_api import get_oozie
 from liboozie.utils import format_time
 
 from jobbrowser.apis.base_api import Api, MockDjangoRequest
 from jobbrowser.apis.workflow_api import _manage_oozie_job, _filter_oozie_jobs
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/jobbrowser/src/jobbrowser/apis/schedule_hive.py
+++ b/apps/jobbrowser/src/jobbrowser/apis/schedule_hive.py
@@ -16,16 +16,19 @@
 # limitations under the License.
 
 import logging
+import sys
 
 from datetime import datetime
-
-from django.utils.translation import ugettext as _
 
 from dateutil import parser
 from desktop.lib.scheduler.lib.hive import HiveSchedulerApi
 
 from jobbrowser.apis.base_api import Api
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/jobbrowser/src/jobbrowser/apis/workflow_api.py
+++ b/apps/jobbrowser/src/jobbrowser/apis/workflow_api.py
@@ -17,12 +17,15 @@
 
 import logging
 import json
-
-from django.utils.translation import ugettext as _
+import sys
 
 from jobbrowser.apis.base_api import Api, MockDjangoRequest, _extract_query_params, is_linkable, hdfs_link_js
 from liboozie.oozie_api import get_oozie
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/jobbrowser/src/jobbrowser/conf.py
+++ b/apps/jobbrowser/src/jobbrowser/conf.py
@@ -15,9 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.utils.translation import ugettext_lazy as _
+import sys
 
 from desktop.lib.conf import Config, coerce_bool, ConfigSection
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _
+else:
+  from django.utils.translation import ugettext_lazy as _
 
 
 SHARE_JOBS = Config(

--- a/apps/jobbrowser/src/jobbrowser/models.py
+++ b/apps/jobbrowser/src/jobbrowser/models.py
@@ -23,11 +23,11 @@ import logging
 import math
 import functools
 import re
+import sys
 
 from django.db import connection, models
 from django.urls import reverse
 from django.utils.html import escape
-from django.utils.translation import ugettext as _
 
 from desktop.auth.backend import is_admin
 from desktop.conf import REST_CONN_TIMEOUT
@@ -35,6 +35,11 @@ from desktop.lib import i18n
 from desktop.lib.view_util import format_duration_in_millis, location_to_url
 
 from jobbrowser.conf import DISABLE_KILLING_JOBS
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/jobbrowser/src/jobbrowser/templates/attempt.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/attempt.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 <%namespace name="comps" file="jobbrowser_components.mako" />
 

--- a/apps/jobbrowser/src/jobbrowser/templates/attempt_logs.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/attempt_logs.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 <%namespace name="comps" file="jobbrowser_components.mako" />
 

--- a/apps/jobbrowser/src/jobbrowser/templates/container.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/container.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="comps" file="jobbrowser_components.mako" />

--- a/apps/jobbrowser/src/jobbrowser/templates/job.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/job.mako
@@ -18,13 +18,18 @@
 
 <%!
   import os
+  import sys
   from hadoop.fs.exceptions import WebHdfsException
   from jobbrowser.views import format_counter_name
   from desktop.lib.view_util import location_to_url
   from desktop.views import commonheader, commonfooter
   from django.template.defaultfilters import urlencode
-  from django.utils.translation import ugettext as _
   from six import iteritems
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 <%def name="task_table(dom_id, tasks)">
     <table id="${ dom_id }" class="taskTable table table-condensed">

--- a/apps/jobbrowser/src/jobbrowser/templates/job_attempt_logs.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/job_attempt_logs.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="comps" file="jobbrowser_components.mako" />

--- a/apps/jobbrowser/src/jobbrowser/templates/job_browser.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/job_browser.mako
@@ -14,7 +14,7 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.conf import CUSTOM, IS_K8S_ONLY
 from desktop.views import commonheader, commonfooter, _ko
@@ -26,6 +26,11 @@ from notebook.conf import ENABLE_QUERY_SCHEDULING
 from jobbrowser.conf import DISABLE_KILLING_JOBS, MAX_JOB_FETCH, ENABLE_QUERY_BROWSER, ENABLE_HIVE_QUERY_BROWSER, ENABLE_QUERIES_LIST, ENABLE_HISTORY_V2
 
 from webpack_loader.templatetags.webpack_loader import render_bundle
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%

--- a/apps/jobbrowser/src/jobbrowser/templates/job_not_assigned.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/job_not_assigned.mako
@@ -17,10 +17,14 @@
 <%namespace name="comps" file="jobbrowser_components.mako" />
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
 
   from django.template.defaultfilters import urlencode
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 ${ commonheader(_('Job'), "jobbrowser", user, request) | n,unicode }

--- a/apps/jobbrowser/src/jobbrowser/templates/jobbrowser_components.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/jobbrowser_components.mako
@@ -14,7 +14,11 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-    from django.utils.translation import ugettext as _
+    import sys
+    if sys.version_info[0] > 2:
+        from django.utils.translation import gettext as _
+    else:
+        from django.utils.translation import ugettext as _
 %>
 
 <%def name="task_counters(counters)">

--- a/apps/jobbrowser/src/jobbrowser/templates/jobs.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/jobs.mako
@@ -14,10 +14,14 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%
+  import sys
   from jobbrowser.views import get_state_link
   from django.template.defaultfilters import urlencode
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 <%namespace name="actionbar" file="actionbar.mako" />
 <%namespace name="components" file="jobbrowser_components.mako" />

--- a/apps/jobbrowser/src/jobbrowser/templates/task.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/task.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 <%namespace name="comps" file="jobbrowser_components.mako" />
 

--- a/apps/jobbrowser/src/jobbrowser/templates/tasks.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/tasks.mako
@@ -14,9 +14,13 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%
+  import sys
   from jobbrowser.views import get_state_link
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="comps" file="jobbrowser_components.mako" />

--- a/apps/jobbrowser/src/jobbrowser/templates/tasktracker.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/tasktracker.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="comps" file="jobbrowser_components.mako" />

--- a/apps/jobbrowser/src/jobbrowser/templates/tasktrackers.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/tasktrackers.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="comps" file="jobbrowser_components.mako" />

--- a/apps/jobbrowser/src/jobbrowser/templatetags/unix_ms_to_datetime.py
+++ b/apps/jobbrowser/src/jobbrowser/templatetags/unix_ms_to_datetime.py
@@ -19,8 +19,12 @@ from __future__ import division
 import datetime
 import django
 import math
+import sys
 
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 register = django.template.Library()
 

--- a/apps/jobbrowser/src/jobbrowser/views.py
+++ b/apps/jobbrowser/src/jobbrowser/views.py
@@ -34,7 +34,6 @@ from urllib.parse import quote_plus
 
 from django.http import HttpResponseRedirect
 from django.utils.functional import wraps
-from django.utils.translation import ugettext as _
 from django.urls import reverse
 
 from desktop.auth.backend import is_admin
@@ -51,6 +50,10 @@ from hadoop import cluster
 from hadoop.yarn.clients import get_log_client
 from hadoop.yarn import resource_manager_api as resource_manager_api
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/jobbrowser/src/jobbrowser/yarn_models.py
+++ b/apps/jobbrowser/src/jobbrowser/yarn_models.py
@@ -24,12 +24,11 @@ import logging
 import math
 import os
 import re
+import sys
 import time
 import urllib.parse
 
 from lxml import html
-
-from django.utils.translation import ugettext as _
 
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.rest.http_client import HttpClient
@@ -39,10 +38,12 @@ from desktop.lib.view_util import big_filesizeformat, format_duration_in_millis
 from hadoop import cluster
 from hadoop.yarn.clients import get_log_client
 
-
-
 from jobbrowser.models import format_unixtime_ms
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/jobsub/src/jobsub/conf.py
+++ b/apps/jobsub/src/jobsub/conf.py
@@ -16,10 +16,15 @@
 # limitations under the License.
 
 import os.path
+import sys
 
 from desktop.lib.conf import Config
 from desktop.lib import paths
-from django.utils.translation import ugettext_lazy as _
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _
+else:
+  from django.utils.translation import ugettext_lazy as _
 
 
 LOCAL_DATA_DIR = Config(

--- a/apps/jobsub/src/jobsub/forms.py
+++ b/apps/jobsub/src/jobsub/forms.py
@@ -17,13 +17,17 @@
 
 from builtins import object
 import logging
+import sys
 
 from django import forms
 
 from desktop.lib.django_forms import MultiForm
 from jobsub import models
 
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/jobsub/src/jobsub/models.py
+++ b/apps/jobsub/src/jobsub/models.py
@@ -17,14 +17,18 @@
 
 from builtins import str
 import logging
+import sys
 
 from django.db import models
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
 
 from desktop.lib.parameterization import find_parameters, bind_parameters
 from useradmin.models import User
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _
+else:
+  from django.utils.translation import ugettext_lazy as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/jobsub/src/jobsub/old_migrations/0005_unify_with_oozie.py
+++ b/apps/jobsub/src/jobsub/old_migrations/0005_unify_with_oozie.py
@@ -1,12 +1,18 @@
 # encoding: utf-8
 import datetime
+import sys
+
 from django.contrib.auth.models import User
-from django.utils.translation import ugettext as _
 from south.db import db
 from south.v2 import DataMigration
 from django.db import models
 from oozie.importlib.jobdesigner import convert_jobsub_design
 from oozie.models import Workflow, Kill, Start, End
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 class Migration(DataMigration):

--- a/apps/jobsub/src/jobsub/old_migrations/0006_chg_varchars_to_textfields.py
+++ b/apps/jobsub/src/jobsub/old_migrations/0006_chg_varchars_to_textfields.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
 import datetime
-from django.utils.translation import ugettext as _
+import sys
+
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 class Migration(SchemaMigration):

--- a/apps/jobsub/src/jobsub/templates/designs.mako
+++ b/apps/jobsub/src/jobsub/templates/designs.mako
@@ -15,9 +15,13 @@
 
 <%!
 import cgi
+import sys
 import time
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/apps/jobsub/src/jobsub/templates/not_available.mako
+++ b/apps/jobsub/src/jobsub/templates/not_available.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <link rel="stylesheet" href="${ static('desktop/css/httperrors.css') }">

--- a/apps/jobsub/src/jobsub/views.py
+++ b/apps/jobsub/src/jobsub/views.py
@@ -27,9 +27,8 @@ is a "job submission".  Submissions can be "watched".
 
 from builtins import str
 import logging
+import sys
 import time as py_time
-
-from django.utils.translation import ugettext as _
 
 from desktop import appmanager
 from desktop.lib.django_util import render, render_json
@@ -44,6 +43,11 @@ from oozie.utils import model_to_dict, format_dict_field_values,\
                         sanitize_node_dict
 
 from desktop.auth.backend import is_admin
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 MAX_DESIGNS = 250

--- a/apps/metastore/src/metastore/conf.py
+++ b/apps/metastore/src/metastore/conf.py
@@ -15,9 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.utils.translation import ugettext_lazy as _
+import sys
 
 from desktop.lib.conf import Config
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _
+else:
+  from django.utils.translation import ugettext_lazy as _
 
 
 ENABLE_NEW_CREATE_TABLE = Config(

--- a/apps/metastore/src/metastore/forms.py
+++ b/apps/metastore/src/metastore/forms.py
@@ -15,8 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from django import forms
-from django.utils.translation import ugettext as _, ugettext_lazy as _t
 
 from desktop.lib.django_forms import simple_formset_factory, DependencyAwareForm
 from desktop.lib.django_forms import ChoiceOrOtherField, MultiForm, SubmitButton
@@ -24,6 +25,11 @@ from filebrowser.forms import PathField
 
 from beeswax import common
 from beeswax.models import SavedQuery
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _, gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext as _, ugettext_lazy as _t
 
 
 class DbForm(forms.Form):

--- a/apps/metastore/src/metastore/templates/components.mako
+++ b/apps/metastore/src/metastore/templates/components.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
   from desktop.lib.django_util import extract_field_data
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%def name="menubar(is_embeddable=False)">

--- a/apps/metastore/src/metastore/templates/confirm.mako
+++ b/apps/metastore/src/metastore/templates/confirm.mako
@@ -15,7 +15,11 @@
 ## limitations under the License.
 
 <%!
-from django.utils.translation import ugettext as _
+import sys
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <form action="{{ url }}" method="POST">>

--- a/apps/metastore/src/metastore/templates/metastore.mako
+++ b/apps/metastore/src/metastore/templates/metastore.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from django.utils.html import escape
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 from desktop import conf
 from desktop.conf import USE_NEW_EDITOR

--- a/apps/metastore/src/metastore/templates/popups/load_data.mako
+++ b/apps/metastore/src/metastore/templates/popups/load_data.mako
@@ -14,7 +14,11 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-from django.utils.translation import ugettext as _
+import sys
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="comps" file="../components.mako" />

--- a/apps/metastore/src/metastore/templates/util.mako
+++ b/apps/metastore/src/metastore/templates/util.mako
@@ -14,7 +14,11 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-from django.utils.translation import ugettext as _
+import sys
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 <%def name="render_error(err)">
   <div>

--- a/apps/metastore/src/metastore/views.py
+++ b/apps/metastore/src/metastore/views.py
@@ -20,13 +20,13 @@ standard_library.install_aliases()
 from builtins import str
 import json
 import logging
+import sys
 import urllib.request, urllib.parse, urllib.error
 
 from django.db.models import Q
 from django.urls import reverse
 from django.shortcuts import redirect
 from django.utils.functional import wraps
-from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_http_methods
 
 from desktop.conf import has_connectors
@@ -49,6 +49,11 @@ from metastore.forms import LoadDataForm, DbForm
 from metastore.settings import DJANGO_APPS
 
 from desktop.auth.backend import is_admin
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/oozie/src/oozie/conf.py
+++ b/apps/oozie/src/oozie/conf.py
@@ -16,14 +16,18 @@
 # limitations under the License.
 
 import os.path
-
-from django.utils.translation import ugettext as _, ugettext_lazy as _t
+import sys
 
 from desktop.lib.conf import Config, coerce_bool
 from desktop.lib import paths
 from liboozie.conf import get_oozie_status
 
 from oozie.settings import NICE_NAME
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _, gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext as _, ugettext_lazy as _t
 
 
 DEFINITION_XSLT_DIR = Config(

--- a/apps/oozie/src/oozie/decorators.py
+++ b/apps/oozie/src/oozie/decorators.py
@@ -17,9 +17,9 @@
 
 import json
 import logging
+import sys
 
 from django.utils.functional import wraps
-from django.utils.translation import ugettext as _
 
 from desktop.conf import USE_NEW_EDITOR
 from desktop.lib.exceptions_renderable import PopupException
@@ -28,6 +28,11 @@ from desktop.models import Document, Document2
 from oozie.models import Job, Node, Dataset
 
 from desktop.auth.backend import is_admin
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/oozie/src/oozie/forms.py
+++ b/apps/oozie/src/oozie/forms.py
@@ -18,13 +18,13 @@
 from builtins import object
 import logging
 from datetime import datetime, timedelta
+import sys
 from time import mktime, struct_time
 
 from django import forms
 from django.core.exceptions import ValidationError
 from django.forms.widgets import TextInput
 from functools import partial
-from django.utils.translation import ugettext_lazy as _t
 
 from desktop.lib.django_forms import MultiForm, SplitDateTimeWidget
 from desktop.models import Document
@@ -33,6 +33,11 @@ from oozie.conf import ENABLE_CRON_SCHEDULING
 from oozie.models import Workflow, Node, Java, Mapreduce, Streaming, Coordinator,\
   Dataset, DataInput, DataOutput, Pig, Link, Hive, Sqoop, Ssh, Shell, DistCp, Fs,\
   Email, SubWorkflow, Generic, Bundle, BundledCoordinator
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext_lazy as _t
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/oozie/src/oozie/importlib/bundles.py
+++ b/apps/oozie/src/oozie/importlib/bundles.py
@@ -18,11 +18,15 @@
 import json
 import logging
 from lxml import etree
-
-from django.utils.translation import ugettext as _
+import sys
 
 from oozie.models import Coordinator, BundledCoordinator
 from oozie.utils import oozie_to_django_datetime
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/oozie/src/oozie/importlib/coordinators.py
+++ b/apps/oozie/src/oozie/importlib/coordinators.py
@@ -19,13 +19,18 @@ import json
 import logging
 import os
 from lxml import etree
+import sys
 
 from django.core import serializers
-from django.utils.translation import ugettext as _
 
 from oozie import conf
 from oozie.models import Workflow, Dataset, DataInput, DataOutput
 from oozie.utils import oozie_to_django_datetime, oozie_to_hue_frequency
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/oozie/src/oozie/importlib/workflows.py
+++ b/apps/oozie/src/oozie/importlib/workflows.py
@@ -42,7 +42,6 @@ import sys
 
 from django.core import serializers
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext as _
 
 from desktop.models import Document
 
@@ -50,6 +49,11 @@ from oozie.conf import DEFINITION_XSLT_DIR, DEFINITION_XSLT2_DIR
 from oozie.models import Workflow, Node, Link, Start, End,\
                          Decision, DecisionEnd, Fork, Join,\
                          Kill
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/oozie/src/oozie/management/commands/oozie_setup.py
+++ b/apps/oozie/src/oozie/management/commands/oozie_setup.py
@@ -19,11 +19,11 @@ import json
 import logging
 import os
 from lxml import etree
+import sys
 
 from django.core import management
 from django.core.management.base import BaseCommand
 from django.db import transaction
-from django.utils.translation import ugettext as _
 
 from desktop.conf import USE_NEW_EDITOR
 from desktop.models import Directory, Document, Document2, Document2Permission
@@ -38,6 +38,11 @@ from oozie.models import Workflow, Coordinator, Bundle
 from oozie.importlib.workflows import import_workflow_root
 from oozie.importlib.coordinators import import_coordinator_root
 from oozie.importlib.bundles import import_bundle_root
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/oozie/src/oozie/models.py
+++ b/apps/oozie/src/oozie/models.py
@@ -40,7 +40,6 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.forms.models import inlineformset_factory
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext as _, ugettext_lazy as _t
 import django.utils.timezone as dtz
 
 from desktop.auth.backend import is_admin
@@ -62,9 +61,11 @@ from oozie.timezones import TIMEZONES
 if sys.version_info[0] > 2:
   from io import BytesIO as string_io
   from django.utils.encoding import force_str
+  from django.utils.translation import gettext as _, gettext_lazy as _t
 else:
   from cStringIO import StringIO as string_io
   from django.utils.encoding import force_unicode as force_str
+  from django.utils.translation import ugettext as _, ugettext_lazy as _t
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/oozie/src/oozie/models2.py
+++ b/apps/oozie/src/oozie/models2.py
@@ -35,7 +35,6 @@ from xml.sax.saxutils import escape
 
 from django.urls import reverse
 from django.db.models import Q
-from django.utils.translation import ugettext as _
 
 from desktop.conf import USE_DEFAULT_CONFIGURATION
 from desktop.lib import django_mako
@@ -59,8 +58,10 @@ from oozie.importlib.workflows import generate_v2_graph_nodes, MalformedWfDefExc
 
 if sys.version_info[0] > 2:
   from django.utils.encoding import force_str
+  from django.utils.translation import gettext as _
 else:
   from django.utils.encoding import force_unicode as force_str
+  from django.utils.translation import ugettext as _
 
 WORKFLOW_DEPTH_LIMIT = 24
 LOG = logging.getLogger(__name__)

--- a/apps/oozie/src/oozie/old_migrations/0020_chg_large_varchars_to_textfields.py
+++ b/apps/oozie/src/oozie/old_migrations/0020_chg_large_varchars_to_textfields.py
@@ -1,9 +1,15 @@
 # encoding: utf-8
 import datetime
-from django.utils.translation import ugettext as _
+import sys
+
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 class Migration(SchemaMigration):
 

--- a/apps/oozie/src/oozie/templates/dashboard/list_oozie_bundle.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/list_oozie_bundle.mako
@@ -19,14 +19,15 @@
   import sys
   from desktop.lib.paths import SAFE_CHARACTERS_URI_COMPONENTS
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
 
   from oozie.conf import ENABLE_V2
 
   if sys.version_info[0] > 2:
     from urllib.parse import quote as urllib_quote
+    from django.utils.translation import gettext as _
   else:
     from urllib import quote as urllib_quote
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="../navigation-bar.mako" />

--- a/apps/oozie/src/oozie/templates/dashboard/list_oozie_bundles.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/list_oozie_bundles.mako
@@ -16,9 +16,13 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
   from oozie.conf import ENABLE_OOZIE_BACKEND_FILTERING
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="../navigation-bar.mako" />

--- a/apps/oozie/src/oozie/templates/dashboard/list_oozie_coordinator.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/list_oozie_coordinator.mako
@@ -19,14 +19,15 @@
   import sys
   from desktop.lib.paths import SAFE_CHARACTERS_URI_COMPONENTS
   from desktop.views import commonheader, commonfooter, _ko
-  from django.utils.translation import ugettext as _
   
   from oozie.conf import ENABLE_V2
 
   if sys.version_info[0] > 2:
     from urllib.parse import quote as urllib_quote
+    from django.utils.translation import gettext as _
   else:
     from urllib import quote as urllib_quote
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="../navigation-bar.mako" />

--- a/apps/oozie/src/oozie/templates/dashboard/list_oozie_coordinators.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/list_oozie_coordinators.mako
@@ -16,8 +16,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
   from oozie.conf import ENABLE_OOZIE_BACKEND_FILTERING
 %>
 

--- a/apps/oozie/src/oozie/templates/dashboard/list_oozie_info.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/list_oozie_info.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="../navigation-bar.mako" />

--- a/apps/oozie/src/oozie/templates/dashboard/list_oozie_sla.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/list_oozie_sla.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="../navigation-bar.mako" />

--- a/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflow.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflow.mako
@@ -18,12 +18,14 @@
 <%!
   import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
   from oozie.forms import ParameterForm
   from six import iteritems
 
   if sys.version_info[0] > 2:
     unicode = str
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="../navigation-bar.mako" />

--- a/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflow_action.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflow_action.mako
@@ -16,8 +16,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="../navigation-bar.mako" />

--- a/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflow_graph.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflow_graph.mako
@@ -15,7 +15,11 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 

--- a/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflows.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflows.mako
@@ -16,8 +16,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
   from oozie.conf import ENABLE_OOZIE_BACKEND_FILTERING
 %>
 

--- a/apps/oozie/src/oozie/templates/dashboard/rerun_bundle_popup.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/rerun_bundle_popup.mako
@@ -16,7 +16,11 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="utils" file="../utils.inc.mako" />

--- a/apps/oozie/src/oozie/templates/dashboard/rerun_coord_popup.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/rerun_coord_popup.mako
@@ -16,7 +16,11 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%

--- a/apps/oozie/src/oozie/templates/dashboard/rerun_workflow_popup.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/rerun_workflow_popup.mako
@@ -16,7 +16,11 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%

--- a/apps/oozie/src/oozie/templates/editor/action_utils.mako
+++ b/apps/oozie/src/oozie/templates/editor/action_utils.mako
@@ -15,9 +15,14 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
   from liboozie.oozie_api import get_oozie
   from desktop.views import _ko
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="utils" file="../utils.inc.mako" />

--- a/apps/oozie/src/oozie/templates/editor/control_utils.mako
+++ b/apps/oozie/src/oozie/templates/editor/control_utils.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
   from desktop.views import _ko
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="utils" file="../utils.inc.mako" />

--- a/apps/oozie/src/oozie/templates/editor/coordinator_properties.mako
+++ b/apps/oozie/src/oozie/templates/editor/coordinator_properties.mako
@@ -15,7 +15,11 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="utils" file="../../utils.inc.mako" />

--- a/apps/oozie/src/oozie/templates/editor/coordinator_utils.mako
+++ b/apps/oozie/src/oozie/templates/editor/coordinator_utils.mako
@@ -15,7 +15,11 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
   from liboozie.oozie_api import get_oozie
 %>
 

--- a/apps/oozie/src/oozie/templates/editor/create_bundle.mako
+++ b/apps/oozie/src/oozie/templates/editor/create_bundle.mako
@@ -16,8 +16,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="../navigation-bar.mako" />

--- a/apps/oozie/src/oozie/templates/editor/create_bundled_coordinator.mako
+++ b/apps/oozie/src/oozie/templates/editor/create_bundled_coordinator.mako
@@ -16,7 +16,11 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="properties" file="coordinator_properties.mako" />

--- a/apps/oozie/src/oozie/templates/editor/create_coordinator.mako
+++ b/apps/oozie/src/oozie/templates/editor/create_coordinator.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="../navigation-bar.mako" />

--- a/apps/oozie/src/oozie/templates/editor/create_coordinator_data.mako
+++ b/apps/oozie/src/oozie/templates/editor/create_coordinator_data.mako
@@ -16,8 +16,12 @@
 
 <%!
 import re
+import sys
 
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 from django.utils.safestring import mark_safe
 
 %>

--- a/apps/oozie/src/oozie/templates/editor/create_coordinator_dataset.mako
+++ b/apps/oozie/src/oozie/templates/editor/create_coordinator_dataset.mako
@@ -15,7 +15,11 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
   from oozie.models import DATASET_FREQUENCY
 %>
 

--- a/apps/oozie/src/oozie/templates/editor/create_workflow.mako
+++ b/apps/oozie/src/oozie/templates/editor/create_workflow.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="../navigation-bar.mako" />

--- a/apps/oozie/src/oozie/templates/editor/dataset_utils.mako
+++ b/apps/oozie/src/oozie/templates/editor/dataset_utils.mako
@@ -15,7 +15,11 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 ## How to use:

--- a/apps/oozie/src/oozie/templates/editor/edit_bundle.mako
+++ b/apps/oozie/src/oozie/templates/editor/edit_bundle.mako
@@ -16,8 +16,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="../navigation-bar.mako" />

--- a/apps/oozie/src/oozie/templates/editor/edit_bundled_coordinator.mako
+++ b/apps/oozie/src/oozie/templates/editor/edit_bundled_coordinator.mako
@@ -15,7 +15,11 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="properties" file="coordinator_properties.mako" />

--- a/apps/oozie/src/oozie/templates/editor/edit_coordinator.mako
+++ b/apps/oozie/src/oozie/templates/editor/edit_coordinator.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="../navigation-bar.mako" />

--- a/apps/oozie/src/oozie/templates/editor/edit_coordinator_dataset.mako
+++ b/apps/oozie/src/oozie/templates/editor/edit_coordinator_dataset.mako
@@ -15,7 +15,11 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
   from oozie.models import DATASET_FREQUENCY
 %>
 

--- a/apps/oozie/src/oozie/templates/editor/edit_workflow.mako
+++ b/apps/oozie/src/oozie/templates/editor/edit_workflow.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="../navigation-bar.mako" />

--- a/apps/oozie/src/oozie/templates/editor/gen/workflow-graph-status.xml.mako
+++ b/apps/oozie/src/oozie/templates/editor/gen/workflow-graph-status.xml.mako
@@ -21,10 +21,12 @@
 <%!
   import re
   import sys
-  from django.utils.translation import ugettext as _
 
   if sys.version_info[0] > 2:
     unicode = str
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%def name="get_tab(form, action, control, css_box_class)">

--- a/apps/oozie/src/oozie/templates/editor/import_coordinator.mako
+++ b/apps/oozie/src/oozie/templates/editor/import_coordinator.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="../navigation-bar.mako" />

--- a/apps/oozie/src/oozie/templates/editor/import_workflow.mako
+++ b/apps/oozie/src/oozie/templates/editor/import_workflow.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="../navigation-bar.mako" />

--- a/apps/oozie/src/oozie/templates/editor/job_action_properties.mako
+++ b/apps/oozie/src/oozie/templates/editor/job_action_properties.mako
@@ -15,7 +15,11 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="utils" file="../../utils.inc.mako" />

--- a/apps/oozie/src/oozie/templates/editor/list_bundles.mako
+++ b/apps/oozie/src/oozie/templates/editor/list_bundles.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
   import time as py_time
 %>
 

--- a/apps/oozie/src/oozie/templates/editor/list_coordinators.mako
+++ b/apps/oozie/src/oozie/templates/editor/list_coordinators.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
   import time as py_time
 %>
 <%namespace name="actionbar" file="../actionbar.mako" />

--- a/apps/oozie/src/oozie/templates/editor/list_history.mako
+++ b/apps/oozie/src/oozie/templates/editor/list_history.mako
@@ -16,8 +16,12 @@
 
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
   import time as py_time
 %>
 

--- a/apps/oozie/src/oozie/templates/editor/list_history_record.mako
+++ b/apps/oozie/src/oozie/templates/editor/list_history_record.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="utils" file="../utils.inc.mako" />

--- a/apps/oozie/src/oozie/templates/editor/list_trashed_bundles.mako
+++ b/apps/oozie/src/oozie/templates/editor/list_trashed_bundles.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
   import time as py_time
 %>
 

--- a/apps/oozie/src/oozie/templates/editor/list_trashed_coordinators.mako
+++ b/apps/oozie/src/oozie/templates/editor/list_trashed_coordinators.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
   import time as py_time
 %>
 <%namespace name="actionbar" file="../actionbar.mako" />

--- a/apps/oozie/src/oozie/templates/editor/list_trashed_workflows.mako
+++ b/apps/oozie/src/oozie/templates/editor/list_trashed_workflows.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
   import time as py_time
 %>
 <%namespace name="actionbar" file="../actionbar.mako" />

--- a/apps/oozie/src/oozie/templates/editor/list_workflows.mako
+++ b/apps/oozie/src/oozie/templates/editor/list_workflows.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
   import time as py_time
 %>
 <%namespace name="actionbar" file="../actionbar.mako" />

--- a/apps/oozie/src/oozie/templates/editor/submit_job_popup.mako
+++ b/apps/oozie/src/oozie/templates/editor/submit_job_popup.mako
@@ -15,7 +15,11 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="utils" file="../utils.inc.mako" />

--- a/apps/oozie/src/oozie/templates/editor/workflow_utils.mako
+++ b/apps/oozie/src/oozie/templates/editor/workflow_utils.mako
@@ -15,7 +15,11 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 

--- a/apps/oozie/src/oozie/templates/editor2/bundle_editor.mako
+++ b/apps/oozie/src/oozie/templates/editor2/bundle_editor.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from desktop.views import commonheader, commonfooter, commonshare, _ko
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="dashboard" file="/common_dashboard.mako" />

--- a/apps/oozie/src/oozie/templates/editor2/common_scheduler.inc.mako
+++ b/apps/oozie/src/oozie/templates/editor2/common_scheduler.inc.mako
@@ -15,9 +15,13 @@
 ## limitations under the License.
 
 <%!
+import sys
 from builtins import range
 from desktop.views import _ko
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="utils" file="../utils.inc.mako" />

--- a/apps/oozie/src/oozie/templates/editor2/common_scheduler.mako
+++ b/apps/oozie/src/oozie/templates/editor2/common_scheduler.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from desktop.views import _ko
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="scheduler" file="common_scheduler.inc.mako" />

--- a/apps/oozie/src/oozie/templates/editor2/common_workflow.mako
+++ b/apps/oozie/src/oozie/templates/editor2/common_workflow.mako
@@ -22,7 +22,11 @@
 #
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
   from desktop.views import _ko
 %>
 

--- a/apps/oozie/src/oozie/templates/editor2/coordinator_editor.mako
+++ b/apps/oozie/src/oozie/templates/editor2/coordinator_editor.mako
@@ -14,7 +14,11 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-from django.utils.translation import ugettext as _
+import sys
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 from desktop.views import commonheader, commonfooter, commonshare, _ko
 %>
 

--- a/apps/oozie/src/oozie/templates/editor2/coordinator_utils.mako
+++ b/apps/oozie/src/oozie/templates/editor2/coordinator_utils.mako
@@ -15,7 +15,11 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
   from liboozie.oozie_api import get_oozie
 %>
 

--- a/apps/oozie/src/oozie/templates/editor2/gen/workflow-graph-status.xml.mako
+++ b/apps/oozie/src/oozie/templates/editor2/gen/workflow-graph-status.xml.mako
@@ -20,10 +20,12 @@
 
 <%!
   import sys
-  from django.utils.translation import ugettext as _
 
   if sys.version_info[0] > 2:
     unicode = str
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%def name="get_tab(form, action, control, css_box_class)">

--- a/apps/oozie/src/oozie/templates/editor2/list_editor_bundles.mako
+++ b/apps/oozie/src/oozie/templates/editor2/list_editor_bundles.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter, commonshare, commonimportexport, _ko
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="../actionbar.mako" />

--- a/apps/oozie/src/oozie/templates/editor2/list_editor_coordinators.mako
+++ b/apps/oozie/src/oozie/templates/editor2/list_editor_coordinators.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter, commonshare, commonimportexport, _ko
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 <%namespace name="actionbar" file="../actionbar.mako" />
 <%namespace name="layout" file="../navigation-bar.mako" />

--- a/apps/oozie/src/oozie/templates/editor2/list_editor_workflows.mako
+++ b/apps/oozie/src/oozie/templates/editor2/list_editor_workflows.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter, commonshare, commonimportexport, _ko
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 <%namespace name="actionbar" file="../actionbar.mako" />
 <%namespace name="layout" file="../navigation-bar.mako" />

--- a/apps/oozie/src/oozie/templates/editor2/submit_job_popup.mako
+++ b/apps/oozie/src/oozie/templates/editor2/submit_job_popup.mako
@@ -15,7 +15,11 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="utils" file="../utils.inc.mako" />

--- a/apps/oozie/src/oozie/templates/editor2/workflow_editor.mako
+++ b/apps/oozie/src/oozie/templates/editor2/workflow_editor.mako
@@ -14,12 +14,17 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop import conf
 from desktop.views import commonheader, commonfooter, commonshare, _ko
 
 from oozie.conf import ENABLE_DOCUMENT_ACTION, ENABLE_IMPALA_ACTION, ENABLE_ALTUS_ACTION
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="dashboard" file="/common_dashboard.mako" />

--- a/apps/oozie/src/oozie/templates/navigation-bar.mako
+++ b/apps/oozie/src/oozie/templates/navigation-bar.mako
@@ -15,8 +15,14 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+
   from oozie.conf import ENABLE_V2
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="utils" file="utils.inc.mako" />

--- a/apps/oozie/src/oozie/templates/utils.inc.mako
+++ b/apps/oozie/src/oozie/templates/utils.inc.mako
@@ -29,7 +29,6 @@
   import time
 
   from django.template.defaultfilters import date, time as dtime
-  from django.utils.translation import ugettext as _
 
   from desktop.lib.view_util import format_duration_in_millis
   from hadoop.fs.hadoopfs import Hdfs
@@ -37,6 +36,10 @@
 
   if sys.version_info[0] > 2:
     unicode = str
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
+
 
   LOG = logging.getLogger(__name__)
 %>

--- a/apps/oozie/src/oozie/utils.py
+++ b/apps/oozie/src/oozie/utils.py
@@ -22,15 +22,20 @@ from past.builtins import basestring
 import json
 import logging
 import re
+import sys
 import urllib.parse
 from datetime import datetime
 from dateutil import tz
 from dateutil import parser
 
 from django.utils.formats import localize_input
-from django.utils.translation import ugettext as _
 from desktop.lib.parameterization import find_variables
 from liboozie.oozie_api import get_oozie, DEFAULT_USER
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/oozie/src/oozie/views/api.py
+++ b/apps/oozie/src/oozie/views/api.py
@@ -24,7 +24,6 @@ import re
 import sys
 
 from django.http import Http404
-from django.utils.translation import ugettext as _
 
 from desktop.lib.django_util import JsonResponse
 from desktop.lib.exceptions import StructuredException
@@ -38,6 +37,10 @@ from oozie.models import Workflow, Node, Start, End, Kill,\
 from oozie.decorators import check_job_access_permission, check_job_edition_permission
 from oozie.utils import model_to_dict, format_dict_field_values, format_field_value
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/oozie/src/oozie/views/dashboard.py
+++ b/apps/oozie/src/oozie/views/dashboard.py
@@ -22,13 +22,13 @@ import json
 import logging
 import os
 import re
+import sys
 import time
 import urllib.request, urllib.parse, urllib.error
 
 from django.forms.formsets import formset_factory
 from django.http import HttpResponse
 from django.utils.functional import wraps
-from django.utils.translation import ugettext as _
 from django.urls import reverse
 from django.shortcuts import redirect
 
@@ -58,6 +58,11 @@ from oozie.settings import DJANGO_APPS
 from oozie.utils import convert_to_server_timezone
 
 from desktop.auth.backend import is_admin
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 def get_history():
   if ENABLE_V2.get():

--- a/apps/oozie/src/oozie/views/editor.py
+++ b/apps/oozie/src/oozie/views/editor.py
@@ -19,6 +19,7 @@ from builtins import str
 import json
 import logging
 import shutil
+import sys
 import time
 
 from django.urls import reverse
@@ -30,7 +31,6 @@ from django.shortcuts import redirect
 from django.template.defaultfilters import strip_tags
 from functools import partial
 from django.utils.http import http_date
-from django.utils.translation import ugettext as _, activate as activate_translation
 
 from desktop.lib.django_util import JsonResponse, render, extract_field_data
 from desktop.lib.exceptions_renderable import PopupException
@@ -59,6 +59,11 @@ from oozie.forms import WorkflowForm, CoordinatorForm, DatasetForm,\
                         ImportWorkflowForm, ImportCoordinatorForm
 
 from desktop.auth.backend import is_admin
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _, activate as activate_translation
+else:
+  from django.utils.translation import ugettext as _, activate as activate_translation
 
 LOG = logging.getLogger(__name__)
 

--- a/apps/oozie/src/oozie/views/editor2.py
+++ b/apps/oozie/src/oozie/views/editor2.py
@@ -18,12 +18,12 @@
 from builtins import str
 import json
 import logging
+import sys
 
 from datetime import datetime
 from django.urls import reverse
 from django.forms.formsets import formset_factory
 from django.shortcuts import redirect
-from django.utils.translation import ugettext as _
 
 from desktop.conf import USE_NEW_EDITOR, IS_MULTICLUSTER_ONLY
 from desktop.lib import django_mako
@@ -49,6 +49,11 @@ from oozie.models2 import Node, Workflow, Coordinator, Bundle, NODES, WORKFLOW_N
   _import_workspace, _save_workflow
 from oozie.utils import convert_to_server_timezone
 from oozie.views.editor import edit_workflow as old_edit_workflow, edit_coordinator as old_edit_coordinator, edit_bundle as old_edit_bundle
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/pig/src/pig/api.py
+++ b/apps/pig/src/pig/api.py
@@ -18,10 +18,10 @@
 from builtins import object
 import json
 import logging
+import sys
 import time
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 
 from desktop.lib.i18n import smart_str
 from desktop.lib.view_util import format_duration_in_millis
@@ -30,6 +30,11 @@ from oozie.models import Workflow, Pig
 from oozie.views.api import get_log as get_workflow_logs
 from oozie.views.editor import _submit_workflow
 from desktop.auth.backend import is_admin
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/pig/src/pig/conf.py
+++ b/apps/pig/src/pig/conf.py
@@ -18,12 +18,15 @@
 import os
 import sys
 
-from django.utils.translation import ugettext as _, ugettext_lazy as _t
-
 from desktop.lib.conf import Config
 from liboozie.conf import get_oozie_status
 
 from pig.settings import NICE_NAME
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _, gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext as _, ugettext_lazy as _t
 
 
 LOCAL_SAMPLE_DIR = Config(

--- a/apps/pig/src/pig/management/commands/pig_setup.py
+++ b/apps/pig/src/pig/management/commands/pig_setup.py
@@ -18,11 +18,11 @@
 import json
 import logging
 import os
+import sys
 
 from django.core import management
 from django.core.management.base import BaseCommand
 from django.db import transaction
-from django.utils.translation import ugettext as _
 
 from desktop.conf import USE_NEW_EDITOR
 from desktop.lib import paths
@@ -34,6 +34,11 @@ from notebook.models import make_notebook
 from useradmin.models import get_default_user_group, install_sample_user
 
 from pig.conf import LOCAL_SAMPLE_DIR, REMOTE_SAMPLE_DIR
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/pig/src/pig/models.py
+++ b/apps/pig/src/pig/models.py
@@ -19,11 +19,11 @@ from builtins import str
 from builtins import object
 import json
 import posixpath
+import sys
 
 from django.db import models
 from django.contrib.contenttypes.fields import GenericRelation
 from django.urls import reverse
-from django.utils.translation import ugettext as _, ugettext_lazy as _t
 
 from desktop.auth.backend import is_admin
 from desktop.lib.exceptions_renderable import PopupException
@@ -31,6 +31,10 @@ from desktop.models import Document as Doc, SAMPLE_USER_ID
 from hadoop.fs.hadoopfs import Hdfs
 from useradmin.models import User
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _, gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext as _, ugettext_lazy as _t
 
 class Document(models.Model):
   owner = models.ForeignKey(

--- a/apps/pig/src/pig/templates/app.mako
+++ b/apps/pig/src/pig/templates/app.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter, commonshare
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/apps/pig/src/pig/views.py
+++ b/apps/pig/src/pig/views.py
@@ -20,10 +20,10 @@ standard_library.install_aliases()
 from builtins import str
 import json
 import logging
+import sys
 import urllib.request, urllib.parse, urllib.error
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie
 
 from desktop.lib.django_util import JsonResponse, render
@@ -39,6 +39,11 @@ from pig import api
 from pig.management.commands import pig_setup
 from pig.models import get_workflow_output, hdfs_link, PigScript,\
   create_or_update_script, get_scripts
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/rdbms/src/rdbms/api.py
+++ b/apps/rdbms/src/rdbms/api.py
@@ -20,9 +20,9 @@ import datetime
 import decimal
 import json
 import logging
+import sys
 
 from django.http import Http404
-from django.utils.translation import ugettext as _
 from django.utils.html import escape
 
 from desktop.lib.django_util import JsonResponse
@@ -38,6 +38,11 @@ from beeswax.views import authorized_get_query_history, safe_get_design
 
 from rdbms.forms import SQLForm
 from rdbms.views import save_design
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/rdbms/src/rdbms/forms.py
+++ b/apps/rdbms/src/rdbms/forms.py
@@ -15,9 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 from django import forms
-from django.utils.translation import ugettext_lazy as _t
-
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext_lazy as _t
 
 class SQLForm(forms.Form):
   query = forms.CharField(label=_t("Query Editor"),

--- a/apps/rdbms/src/rdbms/templates/common.mako
+++ b/apps/rdbms/src/rdbms/templates/common.mako
@@ -13,7 +13,13 @@
 ## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
-<%! from django.utils.translation import ugettext as _ %>
+<%!
+import sys
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _ 
+%>
 
 <%def name="navbar()">
   <div class="navbar hue-title-bar">

--- a/apps/rdbms/src/rdbms/templates/error.mako
+++ b/apps/rdbms/src/rdbms/templates/error.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="common" file="common.mako" />

--- a/apps/rdbms/src/rdbms/templates/execute.mako
+++ b/apps/rdbms/src/rdbms/templates/execute.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter, commonshare, _ko
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="common" file="common.mako" />

--- a/apps/rdbms/src/rdbms/views.py
+++ b/apps/rdbms/src/rdbms/views.py
@@ -17,10 +17,10 @@
 
 import logging
 import json
+import sys
 
 from functools import wraps
 
-from django.utils.translation import ugettext as _
 from django.urls import reverse
 
 from desktop.context_processors import get_app_name
@@ -32,6 +32,11 @@ from librdbms.design import SQLdesign
 
 from beeswax import models as beeswax_models
 from beeswax.views import safe_get_design
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/search/src/search/conf.py
+++ b/apps/search/src/search/conf.py
@@ -15,9 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.utils.translation import ugettext_lazy as _
+import sys
 
 from desktop.lib.conf import Config, coerce_bool
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _
+else:
+  from django.utils.translation import ugettext_lazy as _
 
 
 SOLR_URL = Config(

--- a/apps/search/src/search/models.py
+++ b/apps/search/src/search/models.py
@@ -19,16 +19,21 @@ from builtins import str
 import json
 import logging
 import re
+import sys
 
 from django.urls import reverse
 from django.db import models
 from django.utils.html import escape
-from django.utils.translation import ugettext_lazy as _t
 
 from libsolr.api import SolrApi
 from useradmin.models import User
 
 from search.conf import SOLR_URL
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext_lazy as _t
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/search/src/search/views.py
+++ b/apps/search/src/search/views.py
@@ -16,8 +16,7 @@
 
 from builtins import str
 import logging
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.lib.django_util import JsonResponse
 from desktop.lib.exceptions_renderable import PopupException
@@ -26,6 +25,11 @@ from indexer.management.commands import indexer_setup
 from search.management.commands import search_setup
 
 from desktop.auth.backend import is_admin
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/security/src/security/api/hdfs.py
+++ b/apps/security/src/security/api/hdfs.py
@@ -18,12 +18,16 @@
 from __future__ import print_function
 from builtins import str
 import json
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.lib.django_util import JsonResponse
 from desktop.lib.exceptions_renderable import PopupException
 from filebrowser.views import display, listdir_paged
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 def _get_acl_name(acl):

--- a/apps/security/src/security/api/hive.py
+++ b/apps/security/src/security/api/hive.py
@@ -18,9 +18,8 @@
 from builtins import str
 import json
 import logging
+import sys
 import time
-
-from django.utils.translation import ugettext as _
 
 from desktop.lib.django_util import JsonResponse
 
@@ -29,6 +28,11 @@ from libsentry.sentry_site import get_sentry_server_admin_groups
 from hadoop.cluster import get_defaultfs
 
 from beeswax.api import autocomplete
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/security/src/security/api/sentry.py
+++ b/apps/security/src/security/api/sentry.py
@@ -18,9 +18,8 @@
 from builtins import str
 import json
 import logging
+import sys
 import time
-
-from django.utils.translation import ugettext as _
 
 from desktop.lib.django_util import JsonResponse
 from desktop.lib.exceptions_renderable import PopupException
@@ -28,6 +27,11 @@ from hadoop.cluster import get_defaultfs
 
 from libsentry.api2 import get_api
 from libsentry.sentry_site import get_sentry_server_admin_groups
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/security/src/security/conf.py
+++ b/apps/security/src/security/conf.py
@@ -15,11 +15,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.utils.translation import ugettext as _, ugettext_lazy as _t
+import sys
 
 from desktop.lib.conf import Config, coerce_bool
 
 from security.settings import NICE_NAME
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _, gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext as _, ugettext_lazy as _t
 
 
 HIVE_V1 = Config(

--- a/apps/security/src/security/templates/hdfs.mako
+++ b/apps/security/src/security/templates/hdfs.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+import sys
 from desktop.views import commonheader, commonfooter, _ko
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 

--- a/apps/security/src/security/templates/hive.mako
+++ b/apps/security/src/security/templates/hive.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+import sys
 from desktop.views import commonheader, commonfooter, _ko
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/apps/security/src/security/templates/layout.mako
+++ b/apps/security/src/security/templates/layout.mako
@@ -15,7 +15,11 @@
 ## limitations under the License.
 
 <%!
-from django.utils.translation import ugettext as _
+import sys
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 from security.conf import HIVE_V1, HIVE_V2, SOLR_V2
 
 def is_selected(section, matcher):

--- a/apps/security/src/security/templates/sentry.mako
+++ b/apps/security/src/security/templates/sentry.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+import sys
 from desktop.views import commonheader, commonfooter, _ko
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/apps/spark/src/spark/conf.py
+++ b/apps/spark/src/spark/conf.py
@@ -19,12 +19,15 @@ import logging
 import os
 import sys
 
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
-
 from desktop.conf import default_ssl_validate
 from desktop.lib.conf import Config, coerce_bool
 from spark.settings import NICE_NAME
 from beeswax.conf import get_use_sasl_default
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/sqoop/src/sqoop/api/connector.py
+++ b/apps/sqoop/src/sqoop/api/connector.py
@@ -19,8 +19,7 @@ from __future__ import absolute_import
 import json
 import logging
 import socket
-
-from django.utils.translation import ugettext as _
+import sys
 
 from sqoop import client, conf
 from sqoop.api.decorators import get_connector_or_exception
@@ -30,6 +29,11 @@ from desktop.lib.rest.http_client import RestException
 from sqoop.api.exception import handle_rest_exception
 from sqoop.api.utils import list_to_dict
 from django.views.decorators.cache import never_cache
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 __all__ = ['get_connectors', 'connectors', 'connector']
 

--- a/apps/sqoop/src/sqoop/api/decorators.py
+++ b/apps/sqoop/src/sqoop/api/decorators.py
@@ -18,8 +18,8 @@
 from __future__ import absolute_import
 import json
 import logging
+import sys
 
-from django.utils.translation import ugettext as _
 from django.utils.functional import wraps
 
 from desktop.lib.django_util import render
@@ -27,6 +27,11 @@ from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.rest.http_client import RestException
 from sqoop.api.exception import handle_rest_exception
 from sqoop import client, conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 __all__ = ['get_job_or_exception']

--- a/apps/sqoop/src/sqoop/api/driver.py
+++ b/apps/sqoop/src/sqoop/api/driver.py
@@ -19,8 +19,7 @@ from __future__ import absolute_import
 import json
 import logging
 import socket
-
-from django.utils.translation import ugettext as _
+import sys
 
 from sqoop import client, conf
 from desktop.lib.django_util import JsonResponse
@@ -28,6 +27,11 @@ from desktop.lib.exceptions import StructuredException
 from desktop.lib.rest.http_client import RestException
 from sqoop.api.exception import handle_rest_exception
 from django.views.decorators.cache import never_cache
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 __all__ = ['driver']
 

--- a/apps/sqoop/src/sqoop/api/exception.py
+++ b/apps/sqoop/src/sqoop/api/exception.py
@@ -18,9 +18,14 @@
 from builtins import str
 import logging
 import socket
+import sys
 
-from django.utils.translation import ugettext as _
 from django.utils.encoding import smart_str
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/sqoop/src/sqoop/api/job.py
+++ b/apps/sqoop/src/sqoop/api/job.py
@@ -18,9 +18,9 @@
 from __future__ import absolute_import
 import json
 import logging
+import sys
 
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext as _
 from django.views.decorators.cache import never_cache
 
 from sqoop import client, conf
@@ -31,6 +31,11 @@ from desktop.lib.exceptions import StructuredException
 from desktop.lib.rest.http_client import RestException
 from sqoop.api.exception import handle_rest_exception
 from sqoop.api.utils import list_to_dict
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 __all__ = ['get_jobs', 'create_job', 'update_job', 'job', 'jobs', 'job_clone', 'job_delete', 'job_start', 'job_stop', 'job_status']

--- a/apps/sqoop/src/sqoop/api/link.py
+++ b/apps/sqoop/src/sqoop/api/link.py
@@ -19,9 +19,9 @@ from __future__ import absolute_import
 import json
 import logging
 import socket
+import sys
 
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext as _
 
 from sqoop import client, conf
 from sqoop.client.exception import SqoopException
@@ -32,6 +32,11 @@ from desktop.lib.rest.http_client import RestException
 from sqoop.api.exception import handle_rest_exception
 from sqoop.api.utils import list_to_dict
 from django.views.decorators.cache import never_cache
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 __all__ = ['get_links', 'create_link', 'update_link', 'link', 'links', 'link_clone', 'link_delete']
 

--- a/apps/sqoop/src/sqoop/api/submission.py
+++ b/apps/sqoop/src/sqoop/api/submission.py
@@ -19,8 +19,7 @@ from __future__ import absolute_import
 import json
 import logging
 import socket
-
-from django.utils.translation import ugettext as _
+import sys
 
 from sqoop import client, conf
 from sqoop.api.decorators import get_submission_or_exception
@@ -30,6 +29,11 @@ from desktop.lib.rest.http_client import RestException
 from sqoop.api.exception import handle_rest_exception
 from sqoop.api.utils import list_to_dict
 from django.views.decorators.cache import never_cache
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 __all__ = ['get_submissions', 'submissions']
 

--- a/apps/sqoop/src/sqoop/client/resource.py
+++ b/apps/sqoop/src/sqoop/client/resource.py
@@ -15,11 +15,15 @@
 # limitations under the License.
 
 import json
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.lib.python_util import force_dict_to_strings
 from desktop.lib.rest.resource import Resource
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 class SqoopResource(Resource):

--- a/apps/sqoop/src/sqoop/conf.py
+++ b/apps/sqoop/src/sqoop/conf.py
@@ -16,13 +16,17 @@
 # limitations under the License.
 
 import os
-
-from django.utils.translation import ugettext_lazy as _t
+import sys
 
 from desktop.conf import default_ssl_validate
 from desktop.lib.conf import Config, coerce_bool
 
 from sqoop.settings import NICE_NAME
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext_lazy as _t
 
 
 SERVER_URL = Config(

--- a/apps/sqoop/src/sqoop/templates/app.mako
+++ b/apps/sqoop/src/sqoop/templates/app.mako
@@ -14,10 +14,14 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter, _ko
   from desktop import conf
-  from django.utils.translation import ugettext as _
   from django.urls import reverse
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/apps/useradmin/src/useradmin/conf.py
+++ b/apps/useradmin/src/useradmin/conf.py
@@ -18,8 +18,14 @@
 Configuration options for the "user admin" application
 """
 
+import sys
+
 from desktop.lib.conf import Config, ConfigSection, coerce_bool
-from django.utils.translation import ugettext_lazy as _
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _
+else:
+  from django.utils.translation import ugettext_lazy as _
 
 HOME_DIR_PERMISSIONS = Config(
     key="home_dir_permissions",

--- a/apps/useradmin/src/useradmin/forms.py
+++ b/apps/useradmin/src/useradmin/forms.py
@@ -18,12 +18,12 @@
 from builtins import object
 import logging
 import re
+import sys
 
 import django.contrib.auth.forms
 from django import forms
 from django.forms import ValidationError
 from django.forms.utils import ErrorList
-from django.utils.translation import get_language, ugettext as _, ugettext_lazy as _t
 
 from desktop import conf as desktop_conf
 from desktop.conf import ENABLE_ORGANIZATIONS
@@ -33,6 +33,11 @@ from desktop.settings import LANGUAGES
 from useradmin.hue_password_policy import hue_get_password_validators
 from useradmin.models import GroupPermission, HuePermission, get_default_user_group, User, Group, Organization
 from useradmin.organization import get_user_request_organization
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import get_language, gettext as _, gettext_lazy as _t
+else:
+  from django.utils.translation import get_language, ugettext as _, ugettext_lazy as _t
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/useradmin/src/useradmin/hue_password_policy.py
+++ b/apps/useradmin/src/useradmin/hue_password_policy.py
@@ -15,14 +15,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+import sys
 
 from builtins import object
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
 from useradmin.conf import PASSWORD_POLICY
 
-import re
-
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _
+else:
+  from django.utils.translation import ugettext_lazy as _
 
 _PASSWORD_POLICY = None
 

--- a/apps/useradmin/src/useradmin/management/commands/import_ldap_group.py
+++ b/apps/useradmin/src/useradmin/management/commands/import_ldap_group.py
@@ -15,13 +15,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 from desktop.conf import LDAP
 
 from useradmin import ldap_access
 from useradmin.views import import_ldap_groups
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 
 class Command(BaseCommand):

--- a/apps/useradmin/src/useradmin/management/commands/import_ldap_user.py
+++ b/apps/useradmin/src/useradmin/management/commands/import_ldap_user.py
@@ -15,13 +15,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 from desktop.conf import LDAP
 
 from useradmin import ldap_access
 from useradmin.views import import_ldap_users
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 
 class Command(BaseCommand):

--- a/apps/useradmin/src/useradmin/management/commands/sync_ldap_users_and_groups.py
+++ b/apps/useradmin/src/useradmin/management/commands/sync_ldap_users_and_groups.py
@@ -14,13 +14,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import sys
+
 from django.core.management.base import BaseCommand
-from django.utils.translation import ugettext_lazy as _t
 
 from desktop.conf import LDAP
 
 from useradmin import ldap_access
 from useradmin.views import sync_ldap_users_and_groups
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext_lazy as _t
 
 class Command(BaseCommand):
   """

--- a/apps/useradmin/src/useradmin/management/commands/useradmin_sync_with_unix.py
+++ b/apps/useradmin/src/useradmin/management/commands/useradmin_sync_with_unix.py
@@ -15,10 +15,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from django.core.management.base import BaseCommand
-from django.utils.translation import ugettext_lazy as _
 
 from useradmin.views import sync_unix_users_and_groups
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _
+else:
+  from django.utils.translation import ugettext_lazy as _
 
 
 class Command(BaseCommand):

--- a/apps/useradmin/src/useradmin/middleware.py
+++ b/apps/useradmin/src/useradmin/middleware.py
@@ -22,12 +22,12 @@ from builtins import object
 import logging
 import math
 from datetime import datetime
+import sys
 
 from django.contrib import messages
 from django.contrib.sessions.models import Session
 from django.db import DatabaseError
 from django.db.models import Q
-from django.utils.translation import ugettext as _
 from django.utils.deprecation import MiddlewareMixin
 
 from desktop.auth.views import dt_logout
@@ -37,6 +37,11 @@ from desktop.lib.security_util import get_localhost_name
 from useradmin import ldap_access
 from useradmin.models import UserProfile, get_profile, User
 from useradmin.views import import_ldap_users
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/useradmin/src/useradmin/models.py
+++ b/apps/useradmin/src/useradmin/models.py
@@ -40,6 +40,7 @@ elaborations to manipulate this row by row. This does not map nicely onto action
 import collections
 import json
 import logging
+import sys
 
 from datetime import datetime
 from enum import Enum
@@ -49,7 +50,6 @@ from django.contrib.auth import models as auth_models
 from django.contrib.auth.models import AbstractUser, BaseUserManager
 from django.core.cache import cache
 from django.utils import timezone as dtz
-from django.utils.translation import ugettext_lazy as _t
 
 from desktop import appmanager
 from desktop.conf import ENABLE_ORGANIZATIONS, ENABLE_CONNECTORS
@@ -60,6 +60,11 @@ from desktop.monkey_patches import monkey_patch_username_validator
 
 from useradmin.conf import DEFAULT_USER_GROUP
 from useradmin.permissions import HuePermission, GroupPermission, LdapGroup
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext_lazy as _t
 
 if ENABLE_ORGANIZATIONS.get():
   from useradmin.organization import OrganizationUser as User, OrganizationGroup as Group, get_organization, Organization

--- a/apps/useradmin/src/useradmin/organization.py
+++ b/apps/useradmin/src/useradmin/organization.py
@@ -16,15 +16,20 @@
 # limitations under the License.
 
 import logging
+import sys
 import uuid
 
 from crequest.middleware import CrequestMiddleware
 
 from django.contrib.auth.models import models, AbstractUser, BaseUserManager
 from django.utils.functional import SimpleLazyObject
-from django.utils.translation import ugettext_lazy as _t
 
 from desktop.conf import ENABLE_ORGANIZATIONS
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext_lazy as _t
 
 
 LOG = logging.getLogger(__name__)

--- a/apps/useradmin/src/useradmin/permissions.py
+++ b/apps/useradmin/src/useradmin/permissions.py
@@ -15,16 +15,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from crequest.middleware import CrequestMiddleware
 
 from django.db import connection, models, transaction
-from django.utils.translation import ugettext_lazy as _t
 
 from desktop.conf import ENABLE_ORGANIZATIONS, ENABLE_CONNECTORS
 from desktop.lib.connectors.models import Connector
 
 from useradmin.organization import _fitered_queryset, get_user_request_organization
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext_lazy as _t
 
 if ENABLE_ORGANIZATIONS.get():
   from useradmin.organization import OrganizationGroup as Group, Organization

--- a/apps/useradmin/src/useradmin/templates/add_ldap_users.mako
+++ b/apps/useradmin/src/useradmin/templates/add_ldap_users.mako
@@ -14,9 +14,13 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from desktop.views import commonheader, commonfooter
 from desktop.lib.django_util import extract_field_data
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="layout.mako" />

--- a/apps/useradmin/src/useradmin/templates/change_password.mako
+++ b/apps/useradmin/src/useradmin/templates/change_password.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 from useradmin.hue_password_policy import is_password_policy_enabled, get_password_hint
 %>
 

--- a/apps/useradmin/src/useradmin/templates/confirm.mako
+++ b/apps/useradmin/src/useradmin/templates/confirm.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 ${ commonheader(title, "useradmin", user, request) | n,unicode }
 <div class="container-fluid">

--- a/apps/useradmin/src/useradmin/templates/edit_group.mako
+++ b/apps/useradmin/src/useradmin/templates/edit_group.mako
@@ -16,8 +16,6 @@
 <%!
 import sys
 
-from django.utils.translation import ugettext as _
-
 from desktop.conf import ENABLE_ORGANIZATIONS
 from desktop.lib.django_util import extract_field_data
 from desktop.views import commonheader, commonfooter
@@ -25,8 +23,10 @@ from desktop.views import commonheader, commonfooter
 if sys.version_info[0] > 2:
   from urllib.parse import quote as urllib_quote
   unicode = str
+  from django.utils.translation import gettext as _
 else:
   from urllib import quote as urllib_quote
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="layout.mako" />

--- a/apps/useradmin/src/useradmin/templates/edit_permissions.mako
+++ b/apps/useradmin/src/useradmin/templates/edit_permissions.mako
@@ -16,16 +16,16 @@
 <%!
 import sys
 
-from django.utils.translation import ugettext as _
-
 from desktop.conf import ENABLE_ORGANIZATIONS
 from desktop.views import commonheader, commonfooter
 
 if sys.version_info[0] > 2:
   from urllib.parse import quote as urllib_quote
   unicode = str
+  from django.utils.translation import gettext as _
 else:
   from urllib import quote as urllib_quote
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="layout.mako" />

--- a/apps/useradmin/src/useradmin/templates/edit_user.mako
+++ b/apps/useradmin/src/useradmin/templates/edit_user.mako
@@ -14,7 +14,7 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.auth.backend import is_admin, is_hue_admin
 from desktop.conf import ENABLE_ORGANIZATIONS, ENABLE_CONNECTORS
@@ -22,6 +22,11 @@ from desktop.views import commonheader, commonfooter
 
 from useradmin.hue_password_policy import is_password_policy_enabled, get_password_hint
 from useradmin.views import is_user_locked_out
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="layout.mako" />

--- a/apps/useradmin/src/useradmin/templates/layout.mako
+++ b/apps/useradmin/src/useradmin/templates/layout.mako
@@ -15,7 +15,12 @@
 ## limitations under the License.
 
 <%!
-from django.utils.translation import ugettext as _
+import sys
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 from desktop.auth.backend import is_admin
 from desktop.conf import USE_DEFAULT_CONFIGURATION, ENABLE_ORGANIZATIONS

--- a/apps/useradmin/src/useradmin/templates/list_configurations.mako
+++ b/apps/useradmin/src/useradmin/templates/list_configurations.mako
@@ -14,13 +14,18 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from django.contrib.auth.models import Group
-from django.utils.translation import ugettext as _
 
 from desktop.views import commonheader, commonfooter
 from desktop.views import _ko
 
 from useradmin.models import group_permissions
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/apps/useradmin/src/useradmin/templates/list_groups.mako
+++ b/apps/useradmin/src/useradmin/templates/list_groups.mako
@@ -14,13 +14,18 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.auth.backend import is_admin
 from desktop.conf import ENABLE_ORGANIZATIONS
 from desktop.views import commonheader, commonfooter, antixss
 
 from useradmin.models import group_permissions
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 

--- a/apps/useradmin/src/useradmin/templates/list_organizations.mako
+++ b/apps/useradmin/src/useradmin/templates/list_organizations.mako
@@ -14,13 +14,18 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.auth.backend import is_admin
 from desktop.conf import ENABLE_ORGANIZATIONS
 from desktop.views import commonheader, commonfooter, antixss
 
 from useradmin.models import group_permissions
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/apps/useradmin/src/useradmin/templates/list_permissions.mako
+++ b/apps/useradmin/src/useradmin/templates/list_permissions.mako
@@ -14,13 +14,18 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.auth.backend import is_admin
 from desktop.conf import ENABLE_ORGANIZATIONS
 from desktop.views import commonheader, commonfooter
 
 from useradmin.models import group_permissions, Group
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/apps/useradmin/src/useradmin/templates/list_users.mako
+++ b/apps/useradmin/src/useradmin/templates/list_users.mako
@@ -14,13 +14,18 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from django.template.defaultfilters import date, time
-from django.utils.translation import ugettext as _
 
 from desktop.auth.backend import is_admin
 from desktop.conf import ENABLE_ORGANIZATIONS
 from desktop.lib.django_util import USERNAME_RE_RULE
 from desktop.views import commonheader, commonfooter, antixss
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/apps/useradmin/src/useradmin/templates/sync_ldap_users_groups.mako
+++ b/apps/useradmin/src/useradmin/templates/sync_ldap_users_groups.mako
@@ -15,9 +15,12 @@
 ## limitations under the License.
 <%!
 import sys
-from django.utils.translation import ugettext as _
+
 if sys.version_info[0] > 2:
   unicode = str
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%def name="render_field(field)">

--- a/apps/useradmin/src/useradmin/templates/view_user.mako
+++ b/apps/useradmin/src/useradmin/templates/view_user.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="layout" file="layout.mako" />

--- a/apps/useradmin/src/useradmin/views.py
+++ b/apps/useradmin/src/useradmin/views.py
@@ -40,7 +40,6 @@ from django.forms.utils import ErrorList
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.utils.encoding import smart_str
-from django.utils.translation import get_language, ugettext as _
 
 import desktop.conf
 from desktop.auth.backend import is_admin
@@ -60,6 +59,9 @@ from useradmin.models import HuePermission, UserProfile, LdapGroup, get_profile,
 
 if sys.version_info[0] > 2:
   unicode = str
+  from django.utils.translation import get_language, gettext as _
+else:
+  from django.utils.translation import get_language, ugettext as _
 
 if ENABLE_ORGANIZATIONS.get():
   from useradmin.forms import OrganizationUserChangeForm as UserChangeForm, OrganizationSuperUserChangeForm as SuperUserChangeForm

--- a/apps/zookeeper/src/zookeeper/templates/clients.mako
+++ b/apps/zookeeper/src/zookeeper/templates/clients.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="shared" file="shared_components.mako" />

--- a/apps/zookeeper/src/zookeeper/templates/create.mako
+++ b/apps/zookeeper/src/zookeeper/templates/create.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="shared" file="shared_components.mako" />

--- a/apps/zookeeper/src/zookeeper/templates/edit.mako
+++ b/apps/zookeeper/src/zookeeper/templates/edit.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="shared" file="shared_components.mako" />

--- a/apps/zookeeper/src/zookeeper/templates/index.mako
+++ b/apps/zookeeper/src/zookeeper/templates/index.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="shared" file="shared_components.mako" />

--- a/apps/zookeeper/src/zookeeper/templates/shared_components.mako
+++ b/apps/zookeeper/src/zookeeper/templates/shared_components.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from django.template.defaultfilters import urlencode, escape
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%def name="header(breadcrumbs, clusters, withBody=True)">

--- a/apps/zookeeper/src/zookeeper/templates/tree.mako
+++ b/apps/zookeeper/src/zookeeper/templates/tree.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
   from desktop.auth.backend import is_admin
 %>
 

--- a/apps/zookeeper/src/zookeeper/templates/view.mako
+++ b/apps/zookeeper/src/zookeeper/templates/view.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="shared" file="shared_components.mako" />

--- a/apps/zookeeper/src/zookeeper/views.py
+++ b/apps/zookeeper/src/zookeeper/views.py
@@ -19,10 +19,10 @@
 from builtins import map
 import json
 import logging
+import sys
 
 from django.http import Http404
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 
 from desktop.lib.django_util import JsonResponse, render
 from desktop.lib.exceptions_renderable import PopupException
@@ -35,6 +35,11 @@ from zookeeper.rest import ZooKeeper
 from zookeeper.utils import get_cluster_or_404
 
 from desktop.auth.backend import is_admin
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 def _get_global_overview():

--- a/desktop/core/src/desktop/api.py
+++ b/desktop/core/src/desktop/api.py
@@ -17,18 +17,23 @@
 
 import logging
 import json
+import sys
 import time
 
 from collections import defaultdict
 
 from django.utils import html
-from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_GET, require_POST
 
 import desktop.conf
 from desktop.lib.django_util import JsonResponse
 from desktop.lib.i18n import force_unicode
 from desktop.models import Document, DocumentTag, Document2, Directory
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/core/src/desktop/api2.py
+++ b/desktop/core/src/desktop/api2.py
@@ -32,7 +32,6 @@ from django.db import transaction
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.utils.html import escape
-from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_POST
 
@@ -59,8 +58,10 @@ from desktop.views import serve_403_error
 
 if sys.version_info[0] > 2:
   from io import StringIO as string_io
+  from django.utils.translation import gettext as _
 else:
   from StringIO import StringIO as string_io
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/core/src/desktop/app_template/src/app_name/templates/shared_components.mako
+++ b/desktop/core/src/desktop/app_template/src/app_name/templates/shared_components.mako
@@ -14,7 +14,11 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ${'<%!'}
-from django.utils.translation import ugettext as _
+import sys
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 ${'%>'}
 
 ${'<%!'}

--- a/desktop/core/src/desktop/appmanager.py
+++ b/desktop/core/src/desktop/appmanager.py
@@ -23,11 +23,14 @@ import sys
 import traceback
 import pkg_resources
 
-from django.utils.translation import ugettext as _
-
 import desktop
 
 from desktop.lib.paths import get_desktop_root
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 # Directories where apps and libraries are to be found

--- a/desktop/core/src/desktop/auth/decorators.py
+++ b/desktop/core/src/desktop/auth/decorators.py
@@ -18,13 +18,18 @@
 
 import json
 import logging
+import sys
 
 from django.utils.functional import wraps
-from django.utils.translation import ugettext as _
 
 from desktop.auth.backend import is_admin, is_hue_admin
 from desktop.conf import ENABLE_ORGANIZATIONS
 from desktop.lib.exceptions_renderable import PopupException
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/core/src/desktop/auth/forms.py
+++ b/desktop/core/src/desktop/auth/forms.py
@@ -17,6 +17,7 @@
 
 import datetime
 import logging
+import sys
 
 from django.conf import settings
 from django.contrib.auth import authenticate, get_backends
@@ -24,12 +25,16 @@ from django.contrib.auth.forms import AuthenticationForm as DjangoAuthentication
 from django.forms import CharField, TextInput, PasswordInput, ChoiceField, ValidationError, Form
 from django.utils.safestring import mark_safe
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 from desktop import conf
 from useradmin.hue_password_policy import hue_get_password_validators
 
 from desktop.auth.backend import is_admin
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 if conf.ENABLE_ORGANIZATIONS.get():
   from useradmin.models import User

--- a/desktop/core/src/desktop/auth/views.py
+++ b/desktop/core/src/desktop/auth/views.py
@@ -35,7 +35,6 @@ from django.contrib.auth import login, get_backends, authenticate
 from django.contrib.sessions.models import Session
 from django.http import HttpResponseRedirect
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 
 from hadoop.fs.exceptions import WebHdfsException
 from notebook.connectors.base import get_api
@@ -56,8 +55,10 @@ from desktop.settings import LOAD_BALANCER_COOKIE
 
 if sys.version_info[0] > 2:
   from urllib.parse import urlencode as urllib_urlencode
+  from django.utils.translation import gettext as _
 else:
   from urllib import urlencode as urllib_urlencode
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -27,7 +27,6 @@ import sys
 from collections import OrderedDict
 
 from django.db import connection
-from django.utils.translation import ugettext_lazy as _
 
 from metadata.metadata_sites import get_navigator_audit_log_dir, get_navigator_audit_max_file_size
 
@@ -40,8 +39,10 @@ from desktop.lib.paths import get_desktop_root, get_run_root
 
 if sys.version_info[0] > 2:
   from builtins import str as new_str
+  from django.utils.translation import gettext_lazy as _
 else:
   new_str = unicode
+  from django.utils.translation import ugettext_lazy as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/core/src/desktop/configuration/api.py
+++ b/desktop/core/src/desktop/configuration/api.py
@@ -17,11 +17,11 @@
 
 import json
 import logging
+import sys
 
 from django.contrib.auth.models import Group, User
 from django.db import transaction
 from django.db.models import Q
-from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 
 from desktop.lib.django_util import JsonResponse
@@ -31,6 +31,11 @@ from desktop.models import DefaultConfiguration
 
 from notebook.connectors.hiveserver2 import HiveConfiguration, ImpalaConfiguration
 from notebook.connectors.spark_shell import SparkConfiguration
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 try:
   from oozie.models2 import WorkflowConfiguration as OozieWorkflowConfiguration

--- a/desktop/core/src/desktop/converters.py
+++ b/desktop/core/src/desktop/converters.py
@@ -18,16 +18,21 @@
 from builtins import object
 import json
 import logging
+import sys
 import time
 
 from django.db import transaction
-from django.utils.translation import ugettext as _
 
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.models import Document, DocumentPermission, DocumentTag, Document2, Directory, Document2Permission
 from notebook.api import _historify
 from notebook.models import import_saved_beeswax_query, import_saved_java_job, import_saved_mapreduce_job, \
   import_saved_pig_script, import_saved_shell_job
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/core/src/desktop/decorators.py
+++ b/desktop/core/src/desktop/decorators.py
@@ -16,13 +16,17 @@
 # limitations under the License.
 
 import logging
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.auth.backend import is_admin
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.django_util import JsonResponse
 from desktop.lib.i18n import force_unicode
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 try:
   from functools import wraps

--- a/desktop/core/src/desktop/lib/analytics/models.py
+++ b/desktop/core/src/desktop/lib/analytics/models.py
@@ -16,11 +16,16 @@
 # limitations under the License.
 
 import logging
+import sys
 
 from django.db import connection, models, transaction
 from django.db.models import Q
 from django.db.models.query import QuerySet
-from django.utils.translation import ugettext as _, ugettext_lazy as _t
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _, gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext as _, ugettext_lazy as _t
 
 
 # TODO: ORM queries

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -17,6 +17,7 @@
 
 import logging
 import json
+import sys
 from urllib.parse import urlsplit
 from pprint import pprint
 from tabulate import tabulate
@@ -35,8 +36,12 @@ from notebook.connectors.base import _get_snippet_name
 from useradmin.models import User
 
 from django.http import HttpResponse
-from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_exempt
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/core/src/desktop/lib/conf.py
+++ b/desktop/core/src/desktop/lib/conf.py
@@ -79,7 +79,6 @@ import subprocess
 import sys
 
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext_lazy as _t
 from configobj import ConfigObj, ConfigObjError
 
 from desktop.lib.paths import get_desktop_root, get_build_dir
@@ -88,6 +87,11 @@ try:
   from collections import OrderedDict
 except ImportError:
   from ordereddict import OrderedDict # Python 2.6
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext_lazy as _t
 
 
 # Magical object for use as a "symbol"

--- a/desktop/core/src/desktop/lib/connectors/api.py
+++ b/desktop/core/src/desktop/lib/connectors/api.py
@@ -17,8 +17,7 @@
 
 import json
 import logging
-
-from django.utils.translation import ugettext as _
+import sys
 
 from useradmin.models import update_app_permissions
 from notebook.conf import config_validator, _connector_to_iterpreter
@@ -31,6 +30,10 @@ from desktop.lib.connectors.models import _get_installed_connectors, get_connect
     _augment_connector_properties
 from desktop.lib.connectors.types import get_connectors_types, get_connector_categories, get_connector_by_type
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/core/src/desktop/lib/connectors/models.py
+++ b/desktop/core/src/desktop/lib/connectors/models.py
@@ -17,11 +17,11 @@
 
 import json
 import logging
+import sys
 
 from django.db import connection, models, transaction
 from django.db.models import Q
 from django.db.models.query import QuerySet
-from django.utils.translation import ugettext as _, ugettext_lazy as _t
 
 from useradmin.organization import _fitered_queryset, get_user_request_organization
 
@@ -29,6 +29,11 @@ from desktop.conf import CONNECTORS, ENABLE_ORGANIZATIONS
 from desktop.lib.connectors.types import get_connectors_types
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.i18n import smart_unicode
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _, gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext as _, ugettext_lazy as _t
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/core/src/desktop/lib/connectors/types.py
+++ b/desktop/core/src/desktop/lib/connectors/types.py
@@ -17,11 +17,15 @@
 
 import json
 import logging
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.conf import CONNECTORS_BLACKLIST, CONNECTORS_WHITELIST
 from desktop.lib.exceptions_renderable import PopupException
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/core/src/desktop/lib/django_util.py
+++ b/desktop/core/src/desktop/lib/django_util.py
@@ -23,6 +23,7 @@ import re
 import json
 import socket
 import datetime
+import sys
 
 from django.conf import settings
 from django.core import serializers
@@ -37,7 +38,6 @@ from django.template.context import RequestContext
 from django.template.loader import render_to_string as django_render_to_string
 from django.urls import reverse
 from django.utils.http import urlencode # this version is unicode-friendly
-from django.utils.translation import ungettext, ugettext
 from django.utils.timezone import get_current_timezone
 
 import desktop.conf
@@ -45,6 +45,11 @@ import desktop.lib.thrift_util
 from desktop.lib import django_mako
 from desktop.lib.json_utils import JSONEncoderForHTML
 from desktop.monkey_patches import monkey_patch_request_context_init
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import ngettext as _t, gettext as _
+else:
+  from django.utils.translation import ungettext as _t, ugettext as _
 
 
 LOG = logging.getLogger(__name__)
@@ -422,13 +427,13 @@ def timesince(d=None, now=None, abbreviate=False, separator=','):
     )
   else:
     chunks = (
-      (60 * 60 * 24 * 365, lambda n: ungettext('year', 'years', n)),
-      (60 * 60 * 24 * 30, lambda n: ungettext('month', 'months', n)),
-      (60 * 60 * 24 * 7, lambda n: ungettext('week', 'weeks', n)),
-      (60 * 60 * 24, lambda n: ungettext('day', 'days', n)),
-      (60 * 60, lambda n: ungettext('hour', 'hours', n)),
-      (60, lambda n: ungettext('minute', 'minutes', n)),
-      (1, lambda n: ungettext('second', 'seconds', n)),
+      (60 * 60 * 24 * 365, lambda n: _t('year', 'years', n)),
+      (60 * 60 * 24 * 30, lambda n: _t('month', 'months', n)),
+      (60 * 60 * 24 * 7, lambda n: _t('week', 'weeks', n)),
+      (60 * 60 * 24, lambda n: _t('day', 'days', n)),
+      (60 * 60, lambda n: _t('hour', 'hours', n)),
+      (60, lambda n: _t('minute', 'minutes', n)),
+      (1, lambda n: _t('second', 'seconds', n)),
     )
 
   # Convert datetime.date to datetime.datetime for comparison.
@@ -449,26 +454,26 @@ def timesince(d=None, now=None, abbreviate=False, separator=','):
   if since <= 0:
     # d is in the future compared to now, stop processing.
     if abbreviate:
-      return u'0' + ugettext('s')
+      return u'0' + _('s')
     else:
-      return u'0 ' + ugettext('seconds')
+      return u'0 ' + _('seconds')
   for i, (seconds, name) in enumerate(chunks):
     count = since // seconds
     if count != 0:
       break
   if abbreviate:
-    s = ugettext('%(number)d%(type)s') % {'number': count, 'type': name(count)}
+    s = _('%(number)d%(type)s') % {'number': count, 'type': name(count)}
   else:
-    s = ugettext('%(number)d %(type)s') % {'number': count, 'type': name(count)}
+    s = _('%(number)d %(type)s') % {'number': count, 'type': name(count)}
   if i + 1 < len(chunks):
     # Now get the second item
     seconds2, name2 = chunks[i + 1]
     count2 = (since - (seconds * count)) // seconds2
     if count2 != 0:
       if abbreviate:
-        s += ugettext('%(separator)s %(number)d%(type)s') % {'separator': separator, 'number': count2, 'type': name2(count2)}
+        s += _('%(separator)s %(number)d%(type)s') % {'separator': separator, 'number': count2, 'type': name2(count2)}
       else:
-        s += ugettext('%(separator)s %(number)d %(type)s') % {'separator': separator, 'number': count2, 'type': name2(count2)}
+        s += _('%(separator)s %(number)d %(type)s') % {'separator': separator, 'number': count2, 'type': name2(count2)}
   return s
 
 

--- a/desktop/core/src/desktop/lib/idbroker/conf.py
+++ b/desktop/core/src/desktop/lib/idbroker/conf.py
@@ -16,10 +16,14 @@
 from __future__ import absolute_import
 
 import logging
+import sys
 
 from hadoop.core_site import get_conf
 
-from django.utils.translation import ugettext_lazy as _t
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext_lazy as _t
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/core/src/desktop/lib/python_util.py
+++ b/desktop/core/src/desktop/lib/python_util.py
@@ -23,11 +23,15 @@ import select
 import socket
 import sys
 
-from django.utils.translation import ugettext as _
 from desktop import conf
 from desktop.lib.i18n import smart_str
 
 from codecs import BOM_UTF8, BOM_UTF16_BE, BOM_UTF16_LE, BOM_UTF32_BE, BOM_UTF32_LE
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 BOMS = (
     (BOM_UTF8, "UTF-8"),

--- a/desktop/core/src/desktop/lib/security_util.py
+++ b/desktop/core/src/desktop/lib/security_util.py
@@ -17,8 +17,12 @@
 
 import re
 import socket
+import sys
 
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 # Pattern to replace with hostname
 HOSTNAME_PATTERN = '_HOST'

--- a/desktop/core/src/desktop/lib/tasks/compress_files/compress_utils.py
+++ b/desktop/core/src/desktop/lib/tasks/compress_files/compress_utils.py
@@ -21,7 +21,6 @@ import json
 import sys
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 
 from desktop.conf import DEFAULT_USER
 from desktop.lib.paths import get_desktop_root, SAFE_CHARACTERS_URI_COMPONENTS, SAFE_CHARACTERS_URI
@@ -31,8 +30,10 @@ from notebook.connectors.base import Notebook
 if sys.version_info[0] > 2:
   import urllib.request, urllib.error
   from urllib.parse import quote as urllib_quote
+  from django.utils.translation import gettext as _
 else:
   from urllib import quote as urllib_quote
+  from django.utils.translation import ugettext as _
 
 def compress_files_in_hdfs(request, file_names, upload_path, archive_name):
 

--- a/desktop/core/src/desktop/lib/tasks/extract_archive/extract_utils.py
+++ b/desktop/core/src/desktop/lib/tasks/extract_archive/extract_utils.py
@@ -18,16 +18,20 @@
 from future import standard_library
 standard_library.install_aliases()
 import json
+import sys
 import urllib.request, urllib.parse, urllib.error
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 
 from desktop.conf import DEFAULT_USER
 from desktop.lib.paths import get_desktop_root, SAFE_CHARACTERS_URI_COMPONENTS
 
 from notebook.connectors.base import Notebook
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 def extract_archive_in_hdfs(request, upload_path, file_name):
   _upload_extract_archive_script_to_hdfs(request.fs)

--- a/desktop/core/src/desktop/lib/thrift_util.py
+++ b/desktop/core/src/desktop/lib/thrift_util.py
@@ -41,7 +41,6 @@ from thrift.protocol.TBinaryProtocol import TBinaryProtocol
 from thrift.protocol.TMultiplexedProtocol import TMultiplexedProtocol
 
 from django.conf import settings
-from django.utils.translation import ugettext as _
 from desktop.conf import SASL_MAX_BUFFER, CHERRYPY_SERVER_THREADS, ENABLE_SMART_THRIFT_POOL
 
 from desktop.lib.apputil import WARN_LEVEL_CALL_DURATION_MS, INFO_LEVEL_CALL_DURATION_MS
@@ -53,6 +52,9 @@ from desktop.lib.exceptions import StructuredException, StructuredThriftTranspor
 
 if sys.version_info[0] > 2:
   from past.builtins import long
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/core/src/desktop/lib/vcs/apis/base_api.py
+++ b/desktop/core/src/desktop/lib/vcs/apis/base_api.py
@@ -17,8 +17,12 @@
 
 from builtins import object
 import logging
+import sys
 
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 from desktop.lib.exceptions_renderable import PopupException
 

--- a/desktop/core/src/desktop/lib/vcs/apis/github_api.py
+++ b/desktop/core/src/desktop/lib/vcs/apis/github_api.py
@@ -16,15 +16,20 @@
 # limitations under the License.
 
 import json
+import sys
 
 from django.http import HttpResponseBadRequest, HttpResponseRedirect
-from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_GET
 
 from desktop.lib.django_util import JsonResponse
 
 from desktop.lib.vcs.github_client import GithubClient
 from desktop.lib.vcs.apis.base_api import Api
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 class GithubApi(Api):

--- a/desktop/core/src/desktop/lib/vcs/apis/github_readonly_api.py
+++ b/desktop/core/src/desktop/lib/vcs/apis/github_readonly_api.py
@@ -24,7 +24,6 @@ import re
 import sys
 
 from django.http import HttpResponseBadRequest
-from django.utils.translation import ugettext as _
 
 from desktop.lib.django_util import JsonResponse
 from desktop.lib.rest.http_client import HttpClient, RestException
@@ -37,9 +36,11 @@ from desktop.lib.vcs.github_client import GithubClientException
 if sys.version_info[0] > 2:
   import urllib.request, urllib.error
   from urllib.parse import unquote as urllib_unquote, urlsplit as lib_urlsplit, urlunsplit as lib_urlunsplit
+  from django.utils.translation import gettext as _
 else:
   from urllib import unquote as urllib_unquote
   from urlparse import urlsplit as lib_urlsplit, urlunsplit as lib_urlunsplit
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/core/src/desktop/management/commands/config_dump.py
+++ b/desktop/core/src/desktop/management/commands/config_dump.py
@@ -25,8 +25,12 @@ from __future__ import print_function
 from django.core.management.base import BaseCommand
 import desktop.appmanager
 import textwrap
+import sys
 
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 from desktop.lib.conf import BoundContainer, is_anonymous
 

--- a/desktop/core/src/desktop/management/commands/config_upgrade.py
+++ b/desktop/core/src/desktop/management/commands/config_upgrade.py
@@ -22,13 +22,17 @@ s/<old_value>/<new_value>/
 This will rewrite the configurations if any changes are required.
 """
 import logging
+import sys
 
 import os, glob, string
 import desktop.conf
 import desktop.log
 from desktop.lib.paths import get_desktop_root
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/core/src/desktop/management/commands/create_desktop_app.py
+++ b/desktop/core/src/desktop/management/commands/create_desktop_app.py
@@ -24,11 +24,12 @@ from django.core.management.base import CommandError, BaseCommand
 from mako.template import Template
 
 import logging
-from django.utils.translation import ugettext as _
 
 if sys.version_info[0] > 2:
   open_file = open
+  from django.utils.translation import gettext as _
 else:
+  from django.utils.translation import ugettext as _
   open_file = file
 
 LOG = logging.getLogger(__name__)

--- a/desktop/core/src/desktop/management/commands/create_proxy_app.py
+++ b/desktop/core/src/desktop/management/commands/create_proxy_app.py
@@ -24,11 +24,12 @@ from django.core.management.base import CommandError, BaseCommand
 from mako.template import Template
 
 import logging
-from django.utils.translation import ugettext as _
 
 if sys.version_info[0] > 2:
   open_file = open
+  from django.utils.translation import gettext as _
 else:
+  from django.utils.translation import ugettext as _
   open_file = file
 
 LOG = logging.getLogger(__name__)

--- a/desktop/core/src/desktop/management/commands/create_test_fs.py
+++ b/desktop/core/src/desktop/management/commands/create_test_fs.py
@@ -16,12 +16,17 @@
 
 from __future__ import print_function
 import os
+import sys
 
 from django.core.management.base import BaseCommand
 
 from desktop.lib.paths import get_build_dir
 from hadoop.fs import fs_for_testing
-from django.utils.translation import ugettext as _
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 class Command(BaseCommand):
   """Creates file system for testing."""

--- a/desktop/core/src/desktop/management/commands/create_user_directories.py
+++ b/desktop/core/src/desktop/management/commands/create_user_directories.py
@@ -17,13 +17,18 @@
 # limitations under the License.
 
 import logging
+import sys
 
 from django.core.management.base import CommandError, BaseCommand
-from django.utils.translation import ugettext_lazy as _
 
 from useradmin.models import User
 
 from desktop.models import Document2
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _
+else:
+  from django.utils.translation import ugettext_lazy as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/core/src/desktop/management/commands/desktop_document_cleanup.py
+++ b/desktop/core/src/desktop/management/commands/desktop_document_cleanup.py
@@ -17,13 +17,13 @@
 # limitations under the License.
 
 import os
+import sys
 import time
 
 from importlib import import_module
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 from beeswax.models import SavedQuery
 from beeswax.models import Session
 from datetime import date, timedelta
@@ -35,6 +35,11 @@ import logging
 import logging.handlers
 
 import desktop.conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/core/src/desktop/management/commands/ldaptest.py
+++ b/desktop/core/src/desktop/management/commands/ldaptest.py
@@ -36,8 +36,13 @@ import sys
 
 from desktop.conf import LDAP
 from django.core.management.base import BaseCommand
-from django.utils.translation import ugettext as _
 from useradmin import ldap_access
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
+
 
 LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.DEBUG)

--- a/desktop/core/src/desktop/management/commands/runcelery.py
+++ b/desktop/core/src/desktop/management/commands/runcelery.py
@@ -24,7 +24,11 @@ from desktop.lib.daemon_utils import drop_privileges_if_necessary
 
 from django.core.management.base import BaseCommand
 from django.utils import autoreload
-from django.utils.translation import ugettext as _
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 SERVER_HELP = r"""
   Run celery worker.

--- a/desktop/core/src/desktop/management/commands/runcpserver.py
+++ b/desktop/core/src/desktop/management/commands/runcpserver.py
@@ -21,7 +21,11 @@ from desktop import conf
 from desktop import supervisor
 import os
 import sys
-from django.utils.translation import ugettext as _
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 SERVER_HELP = r"""
   Run Hue using either the CherryPy server or the Spawning server, based on

--- a/desktop/core/src/desktop/management/commands/rungunicornserver.py
+++ b/desktop/core/src/desktop/management/commands/rungunicornserver.py
@@ -27,10 +27,14 @@ import gunicorn.app.base
 from desktop import conf
 from django.core.management.base import BaseCommand
 from django.core.wsgi import get_wsgi_application
-from django.utils.translation import ugettext as _
 
 from gunicorn import util
 from gunicorn.six import iteritems
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 GUNICORN_SERVER_HELP = r"""
   Run Hue using the Gunicorn WSGI server in asynchronous mode.

--- a/desktop/core/src/desktop/management/commands/runpylint.py
+++ b/desktop/core/src/desktop/management/commands/runpylint.py
@@ -22,7 +22,11 @@ import sys
 
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
-from django.utils.translation import ugettext as _
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 from desktop.lib import paths
 

--- a/desktop/core/src/desktop/middleware.py
+++ b/desktop/core/src/desktop/middleware.py
@@ -25,6 +25,7 @@ import mimetypes
 import os.path
 import re
 import socket
+import sys
 import tempfile
 import time
 import traceback
@@ -42,7 +43,6 @@ from django.core import exceptions
 from django.http import HttpResponseNotAllowed, HttpResponseForbidden
 from django.urls import resolve
 from django.http import HttpResponseRedirect, HttpResponse
-from django.utils.translation import ugettext as _
 from django.utils.http import urlquote, is_safe_url
 from django.utils.deprecation import MiddlewareMixin
 
@@ -62,6 +62,11 @@ from desktop.lib.exceptions import StructuredException
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.log import get_audit_logger
 from desktop.log.access import access_log, log_page_hit, access_warn
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/core/src/desktop/models.py
+++ b/desktop/core/src/desktop/models.py
@@ -38,7 +38,6 @@ from django.contrib.contenttypes.fields import GenericRelation, GenericForeignKe
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.urls import reverse, NoReverseMatch
-from django.utils.translation import ugettext as _, ugettext_lazy as _t
 
 from dashboard.conf import get_engines, HAS_REPORT_ENABLED, IS_ENABLED as DASHBOARD_ENABLED
 from kafka.conf import has_kafka
@@ -64,8 +63,10 @@ from filebrowser.conf import REMOTE_STORAGE_HOME
 
 if sys.version_info[0] > 2:
   from urllib.parse import quote as urllib_quote
+  from django.utils.translation import gettext as _, gettext_lazy as _t
 else:
   from urllib import quote as urllib_quote
+  from django.utils.translation import ugettext as _, ugettext_lazy as _t
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -32,8 +32,6 @@ import uuid
 
 import django_opentracing
 
-from django.utils.translation import ugettext_lazy as _
-
 import desktop.redaction
 
 from desktop.lib.paths import get_desktop_root, get_run_root
@@ -42,6 +40,10 @@ from desktop.lib.python_util import force_dict_to_strings
 from aws.conf import is_enabled as is_s3_enabled
 from azure.conf import is_abfs_enabled
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _
+else:
+  from django.utils.translation import ugettext_lazy as _
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(__file__)), '..', '..', '..'))

--- a/desktop/core/src/desktop/templates/403.mako
+++ b/desktop/core/src/desktop/templates/403.mako
@@ -15,7 +15,11 @@
 ## limitations under the License.
 
 <%!
-from django.utils.translation import ugettext as _
+import sys
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 from desktop.views import commonheader, commonfooter
 %>
 

--- a/desktop/core/src/desktop/templates/403_csrf.mako
+++ b/desktop/core/src/desktop/templates/403_csrf.mako
@@ -15,7 +15,11 @@
 ## limitations under the License.
 
 <%!
-from django.utils.translation import ugettext as _
+import sys
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 from desktop.views import commonheader, commonfooter
 %>
 ${ commonheader(_('403 - CSRF error'), "", user, request) | n,unicode }

--- a/desktop/core/src/desktop/templates/404.mako
+++ b/desktop/core/src/desktop/templates/404.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 %if not is_embeddable:

--- a/desktop/core/src/desktop/templates/500.mako
+++ b/desktop/core/src/desktop/templates/500.mako
@@ -15,9 +15,13 @@
 ## limitations under the License.
 
 <%!
+import sys
 from desktop.lib.i18n import smart_unicode
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 from desktop.auth.backend import is_admin
 %>
 

--- a/desktop/core/src/desktop/templates/about_layout.mako
+++ b/desktop/core/src/desktop/templates/about_layout.mako
@@ -15,7 +15,11 @@
 ## limitations under the License.
 
 <%!
-from django.utils.translation import ugettext as _
+import sys
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 from desktop.auth.backend import is_admin, is_hue_admin
 from desktop.conf import METRICS, has_connectors, ANALYTICS

--- a/desktop/core/src/desktop/templates/actionbar.mako
+++ b/desktop/core/src/desktop/templates/actionbar.mako
@@ -14,7 +14,11 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-    from django.utils.translation import ugettext as _
+import sys
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%def name="render()">

--- a/desktop/core/src/desktop/templates/analytics.mako
+++ b/desktop/core/src/desktop/templates/analytics.mako
@@ -14,10 +14,15 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop import conf
 from desktop.views import commonheader, commonfooter
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%

--- a/desktop/core/src/desktop/templates/assist_m.mako
+++ b/desktop/core/src/desktop/templates/assist_m.mako
@@ -14,9 +14,13 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from desktop import conf
 from desktop.views import commonheader_m, commonfooter_m
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 ${ commonheader_m(_('Assist'), 'assist', user, request) | n,unicode }

--- a/desktop/core/src/desktop/templates/catalog.mako
+++ b/desktop/core/src/desktop/templates/catalog.mako
@@ -14,10 +14,15 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
 
   from desktop.views import commonheader, commonfooter, _ko
   from desktop import conf
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <div id="catalogComponents" class="main-content">

--- a/desktop/core/src/desktop/templates/check_config.mako
+++ b/desktop/core/src/desktop/templates/check_config.mako
@@ -15,10 +15,15 @@
 ## limitations under the License.
 
 <%!
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.conf import has_connectors
 from desktop.auth.backend import is_hue_admin
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 % if is_hue_admin(user):

--- a/desktop/core/src/desktop/templates/common_dashboard.mako
+++ b/desktop/core/src/desktop/templates/common_dashboard.mako
@@ -22,11 +22,16 @@
 #
 
 <%!
+  import sys
   from desktop import conf
-  from django.utils.translation import ugettext as _
 
   from dashboard.conf import HAS_REPORT_ENABLED, USE_GRIDSTER, USE_NEW_ADD_METHOD
   from desktop.views import _ko
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%def name="import_layout(with_deferred=False)">

--- a/desktop/core/src/desktop/templates/common_footer.mako
+++ b/desktop/core/src/desktop/templates/common_footer.mako
@@ -14,11 +14,16 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from django.http import HttpRequest
-from django.utils.translation import ugettext as _
 
 from desktop.lib.i18n import smart_unicode
 from desktop.views import login_modal
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="commonHeaderFooterComponents" file="/common_header_footer_components.mako" />

--- a/desktop/core/src/desktop/templates/common_footer_m.mako
+++ b/desktop/core/src/desktop/templates/common_footer_m.mako
@@ -14,10 +14,15 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from django.http import HttpRequest
-from django.utils.translation import ugettext as _
 from django.template.defaultfilters import escape, escapejs
 from desktop.lib.i18n import smart_unicode
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 

--- a/desktop/core/src/desktop/templates/common_header.mako
+++ b/desktop/core/src/desktop/templates/common_header.mako
@@ -14,7 +14,7 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-from django.utils.translation import ugettext as _
+import sys
 from webpack_loader.templatetags.webpack_loader import render_bundle
 
 from metadata.conf import has_optimizer, OPTIMIZER
@@ -25,6 +25,11 @@ from desktop.conf import USE_NEW_EDITOR
 from desktop.models import hue_version
 from desktop.lib.i18n import smart_unicode
 from desktop.webpack_utils import get_hue_bundles
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 home_url = url('desktop_views_home')
 if USE_NEW_EDITOR.get():

--- a/desktop/core/src/desktop/templates/common_header_footer_components.mako
+++ b/desktop/core/src/desktop/templates/common_header_footer_components.mako
@@ -14,7 +14,8 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-from django.utils.translation import ugettext as _
+import sys
+
 from django.template.defaultfilters import escape, escapejs
 
 from desktop import conf
@@ -24,6 +25,11 @@ from desktop.views import _ko
 from beeswax.conf import LIST_PARTITIONS_LIMIT
 from indexer.conf import ENABLE_NEW_INDEXER
 from metadata.conf import has_optimizer, OPTIMIZER
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%def name="header_i18n_redirection()">

--- a/desktop/core/src/desktop/templates/common_header_m.mako
+++ b/desktop/core/src/desktop/templates/common_header_m.mako
@@ -14,16 +14,22 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
+
 from desktop import conf
 from desktop.lib.i18n import smart_unicode
 from desktop.webpack_utils import get_hue_bundles
-from django.utils.translation import ugettext as _
 from metadata.conf import has_optimizer, OPTIMIZER
 
 home_url = url('desktop_views_home')
 from desktop.conf import USE_NEW_EDITOR
 
 from webpack_loader.templatetags.webpack_loader import render_bundle
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 if USE_NEW_EDITOR.get():
   home_url = url('desktop_views_home2')

--- a/desktop/core/src/desktop/templates/common_home.mako
+++ b/desktop/core/src/desktop/templates/common_home.mako
@@ -14,11 +14,16 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-  from django.utils.translation import ugettext as _
+  import sys 
 
   from desktop.views import commonheader, commonfooter, _ko
   from desktop import conf
   from desktop.auth.backend import is_admin
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="docBrowser" file="/document_browser.mako" />

--- a/desktop/core/src/desktop/templates/common_import_export.mako
+++ b/desktop/core/src/desktop/templates/common_import_export.mako
@@ -14,7 +14,11 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-from django.utils.translation import ugettext as _
+import sys
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <script src="${ static('desktop/ext/js/bootstrap-fileupload.js') }" type="text/javascript" charset="utf-8"></script>

--- a/desktop/core/src/desktop/templates/common_notebook_ko_components.mako
+++ b/desktop/core/src/desktop/templates/common_notebook_ko_components.mako
@@ -16,7 +16,7 @@
 
 <%!
 import logging
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop import conf
 from desktop.lib.i18n import smart_unicode
@@ -24,6 +24,11 @@ from desktop.views import _ko
 
 from beeswax.conf import DOWNLOAD_ROW_LIMIT, DOWNLOAD_BYTES_LIMIT
 from notebook.conf import ENABLE_SQL_INDEXER
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 

--- a/desktop/core/src/desktop/templates/common_share.mako
+++ b/desktop/core/src/desktop/templates/common_share.mako
@@ -14,7 +14,11 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-from django.utils.translation import ugettext as _
+import sys
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <script type="text/html" id="user-search-autocomp-item">

--- a/desktop/core/src/desktop/templates/common_share2.mako
+++ b/desktop/core/src/desktop/templates/common_share2.mako
@@ -14,7 +14,11 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-from django.utils.translation import ugettext as _
+import sys
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <div id="documentShareModal" class="modal hide fade">

--- a/desktop/core/src/desktop/templates/common_tree.mako
+++ b/desktop/core/src/desktop/templates/common_tree.mako
@@ -22,7 +22,11 @@
 #
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%def name="import_templates(itemClick=None, iconClick=None, itemDblClick=None, itemSelected=None, iconModifier=None, styleModifier=None, styleModifierPullRight=None, showMore=None, anchorProperty=None, strikedProperty=None, itemChecked=None, component='')">

--- a/desktop/core/src/desktop/templates/config_alert_dock.mako
+++ b/desktop/core/src/desktop/templates/config_alert_dock.mako
@@ -14,7 +14,11 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-from django.utils.translation import ugettext as _
+import sys
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 % if error_list:

--- a/desktop/core/src/desktop/templates/config_ko_components.mako
+++ b/desktop/core/src/desktop/templates/config_ko_components.mako
@@ -15,10 +15,15 @@
 ## limitations under the License.
 
 <%!
+import sys
 from desktop import conf
 from desktop.lib.i18n import smart_unicode
-from django.utils.translation import ugettext as _
 from desktop.views import _ko
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%def name="config()">

--- a/desktop/core/src/desktop/templates/connectors/connectors.mako
+++ b/desktop/core/src/desktop/templates/connectors/connectors.mako
@@ -14,10 +14,15 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.conf import CUSTOM
 from desktop.views import commonheader, commonfooter
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="../actionbar.mako" />

--- a/desktop/core/src/desktop/templates/document_browser.mako
+++ b/desktop/core/src/desktop/templates/document_browser.mako
@@ -15,11 +15,16 @@
 ## limitations under the License.
 
 <%!
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop import conf
 from desktop.lib.i18n import smart_unicode
 from desktop.views import _ko
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%def name="docBrowser(is_embeddable=False)">

--- a/desktop/core/src/desktop/templates/error.mako
+++ b/desktop/core/src/desktop/templates/error.mako
@@ -14,11 +14,16 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from desktop.views import commonheader, commonfooter
 from desktop.lib.i18n import smart_unicode
-from django.utils.translation import ugettext as _
 from desktop import conf
 from desktop.auth.backend import is_admin
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 %if not is_embeddable:

--- a/desktop/core/src/desktop/templates/global_js_constants.mako
+++ b/desktop/core/src/desktop/templates/global_js_constants.mako
@@ -15,7 +15,7 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
 
   from desktop import conf
   from desktop.auth.backend import is_admin, is_hue_admin
@@ -35,6 +35,11 @@
   from metastore.views import has_write_access
   from notebook.conf import ENABLE_NOTEBOOK_2, ENABLE_QUERY_ANALYSIS, ENABLE_QUERY_BUILDER, ENABLE_QUERY_SCHEDULING, ENABLE_SQL_INDEXER, \
       get_ordered_interpreters, SHOW_NOTEBOOKS
+  
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="sqlDocIndex" file="/sql_doc_index.mako" />

--- a/desktop/core/src/desktop/templates/home.mako
+++ b/desktop/core/src/desktop/templates/home.mako
@@ -14,11 +14,16 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter, commonshare, _ko
-  from django.utils.translation import ugettext as _
 
   from desktop.conf import USE_NEW_EDITOR
   use_new_home = USE_NEW_EDITOR.get()
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 ${ commonheader(_('Welcome Home'), "home", user, request) | n,unicode }

--- a/desktop/core/src/desktop/templates/home2.mako
+++ b/desktop/core/src/desktop/templates/home2.mako
@@ -14,10 +14,15 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
 
   from desktop.views import commonheader, commonfooter, _ko
   from desktop import conf
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="common_home" file="/common_home.mako" />

--- a/desktop/core/src/desktop/templates/hue.mako
+++ b/desktop/core/src/desktop/templates/hue.mako
@@ -15,7 +15,7 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
 
   from desktop import conf
   from desktop.conf import IS_MULTICLUSTER_ONLY, has_multi_clusters
@@ -32,6 +32,11 @@
 
   from desktop.auth.backend import is_admin
   from webpack_loader.templatetags.webpack_loader import render_bundle
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="hueIcons" file="/hue_icons.mako" />

--- a/desktop/core/src/desktop/templates/hue_ace_autocompleter.mako
+++ b/desktop/core/src/desktop/templates/hue_ace_autocompleter.mako
@@ -15,8 +15,14 @@
 ## limitations under the License.
 
 <%!
-from django.utils.translation import ugettext as _
+import sys
+
 from desktop.views import _ko
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%def name="hueAceAutocompleter()">

--- a/desktop/core/src/desktop/templates/ko_editor.mako
+++ b/desktop/core/src/desktop/templates/ko_editor.mako
@@ -15,10 +15,15 @@
 ## limitations under the License.
 
 <%!
+import sys
 from desktop import conf
 from desktop.lib.i18n import smart_unicode
-from django.utils.translation import ugettext as _
 from desktop.views import _ko
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <div>${_('I\'m an editor')}</div>

--- a/desktop/core/src/desktop/templates/ko_metastore.mako
+++ b/desktop/core/src/desktop/templates/ko_metastore.mako
@@ -15,9 +15,13 @@
 ## limitations under the License.
 
 <%!
+import sys
 from desktop import conf
 from desktop.lib.i18n import smart_unicode
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 from desktop.views import _ko
 %>
 

--- a/desktop/core/src/desktop/templates/login.mako
+++ b/desktop/core/src/desktop/templates/login.mako
@@ -15,12 +15,17 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
 
   from useradmin.hue_password_policy import is_password_policy_enabled, get_password_hint
 
   from desktop.conf import CUSTOM, ENABLE_ORGANIZATIONS
   from desktop.views import commonheader, commonfooter
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="hueIcons" file="/hue_icons.mako" />

--- a/desktop/core/src/desktop/templates/login_modal.mako
+++ b/desktop/core/src/desktop/templates/login_modal.mako
@@ -15,8 +15,14 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop import conf
-  from django.utils.translation import ugettext as _
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
+
   from useradmin.hue_password_policy import is_password_policy_enabled, get_password_hint
 %>
 

--- a/desktop/core/src/desktop/templates/logs.mako
+++ b/desktop/core/src/desktop/templates/logs.mako
@@ -14,11 +14,17 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import re
+import sys
+
 from desktop.lib.conf import BoundConfig
 from desktop.lib.i18n import smart_unicode
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
-import re
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/desktop/core/src/desktop/templates/metrics.mako
+++ b/desktop/core/src/desktop/templates/metrics.mako
@@ -14,9 +14,15 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
+
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
 from desktop import conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%

--- a/desktop/core/src/desktop/templates/oidc_failed.mako
+++ b/desktop/core/src/desktop/templates/oidc_failed.mako
@@ -15,8 +15,14 @@
 ## limitations under the License.
 
 <%!
-from django.utils.translation import ugettext as _
+import sys
+
 from desktop.views import commonheader, commonfooter
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 %if not is_embeddable:

--- a/desktop/core/src/desktop/templates/popup_error.mako
+++ b/desktop/core/src/desktop/templates/popup_error.mako
@@ -15,10 +15,16 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
+
 from desktop.views import commonheader, commonfooter
 from desktop.lib.i18n import smart_unicode
-from django.utils.translation import ugettext as _
 from desktop.auth.backend import is_admin
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 %if not is_embeddable:

--- a/desktop/core/src/desktop/templates/scheduler/submit_job_popup.mako
+++ b/desktop/core/src/desktop/templates/scheduler/submit_job_popup.mako
@@ -15,6 +15,10 @@
 ## limitations under the License.
 
 <%!
+import sys
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
   from django.utils.translation import ugettext as _
 %>
 

--- a/desktop/core/src/desktop/templates/sql_syntax_dropdown.mako
+++ b/desktop/core/src/desktop/templates/sql_syntax_dropdown.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+import sys
 from desktop.lib.i18n import smart_unicode
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%def name="sqlSyntaxDropdown()">

--- a/desktop/core/src/desktop/templates/threads.mako
+++ b/desktop/core/src/desktop/templates/threads.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from desktop.views import commonheader, commonfooter
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/desktop/core/src/desktop/templates/unfurl_link.mako
+++ b/desktop/core/src/desktop/templates/unfurl_link.mako
@@ -15,9 +15,14 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
 
   from desktop import conf
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <!DOCTYPE html>

--- a/desktop/core/src/desktop/templates/unsupported.mako
+++ b/desktop/core/src/desktop/templates/unsupported.mako
@@ -14,7 +14,11 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 <!DOCTYPE html>
 <html lang="en">

--- a/desktop/core/src/desktop/views.py
+++ b/desktop/core/src/desktop/views.py
@@ -39,7 +39,6 @@ from django.http import HttpResponse
 from django.http.response import StreamingHttpResponse
 from django.urls import reverse
 from django.shortcuts import redirect
-from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 from configobj import ConfigObj, get_extra_values, ConfigObjError
 from wsgiref.util import FileWrapper
@@ -69,8 +68,10 @@ from useradmin.models import get_profile
 
 if sys.version_info[0] > 2:
   from io import StringIO as string_io
+  from django.utils.translation import gettext as _
 else:
   from StringIO import StringIO as string_io
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/aws/src/aws/conf.py
+++ b/desktop/libs/aws/src/aws/conf.py
@@ -18,14 +18,19 @@ from __future__ import absolute_import
 import logging
 import os
 import re
+import sys
 
 
 import requests
-from django.utils.translation import ugettext_lazy as _, ugettext as _t
 
 from desktop.lib.conf import Config, UnspecifiedConfigSection, ConfigSection, coerce_bool, coerce_password_from_script
 from desktop.lib.idbroker import conf as conf_idbroker
 from hadoop.core_site import get_s3a_access_key, get_s3a_secret_key, get_s3a_session_token
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _, gettext as _t
+else:
+  from django.utils.translation import ugettext_lazy as _, ugettext as _t
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/aws/src/aws/s3/s3fs.py
+++ b/desktop/libs/aws/src/aws/s3/s3fs.py
@@ -31,8 +31,6 @@ from boto.s3.connection import Location
 from boto.s3.key import Key
 from boto.s3.prefix import Prefix
 
-from django.utils.translation import ugettext as _
-
 from aws import s3
 from aws.conf import get_default_region, get_locations, PERMISSION_ACTION_S3
 from aws.s3 import normpath, s3file, translate_s3_error, S3A_ROOT
@@ -41,9 +39,11 @@ from aws.s3.s3stat import S3Stat
 if sys.version_info[0] > 2:
   import urllib.request, urllib.error
   from urllib.parse import quote as urllib_quote, urlparse as lib_urlparse
+  from django.utils.translation import gettext as _
 else:
   from urllib import quote as urllib_quote
   from urlparse import urlparse as lib_urlparse
+  from django.utils.translation import ugettext as _
 
 DEFAULT_READ_SIZE = 1024 * 1024  # 1MB
 BUCKET_NAME_PATTERN = re.compile("^((?:(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9_\-]*[a-zA-Z0-9])\.)*(?:[A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9_\-]*[A-Za-z0-9]))$")

--- a/desktop/libs/aws/src/aws/s3/upload.py
+++ b/desktop/libs/aws/src/aws/s3/upload.py
@@ -33,12 +33,15 @@ else:
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.files.uploadhandler import FileUploadHandler, SkipFile, StopFutureHandlers, StopUpload, UploadFileException
-from django.utils.translation import ugettext as _
 
 from desktop.lib.fsmanager import get_client
 from aws.s3 import parse_uri
 from aws.s3.s3fs import S3FileSystemException
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 DEFAULT_WRITE_SIZE = 1024 * 1024 * 50  # TODO: set in configuration (currently 50 MiB)
 

--- a/desktop/libs/azure/src/azure/abfs/upload.py
+++ b/desktop/libs/azure/src/azure/abfs/upload.py
@@ -25,11 +25,15 @@ else:
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.files.uploadhandler import FileUploadHandler, SkipFile, StopFutureHandlers, StopUpload, UploadFileException
-from django.utils.translation import ugettext as _
 
 from desktop.lib import fsmanager
 from azure.abfs.__init__ import parse_uri
 from azure.abfs.abfs import ABFSFileSystemException
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 DEFAULT_WRITE_SIZE = 30 * 1000 * 1000 # TODO: set in configuration
 

--- a/desktop/libs/azure/src/azure/conf.py
+++ b/desktop/libs/azure/src/azure/conf.py
@@ -16,13 +16,17 @@
 from __future__ import absolute_import
 
 import logging
-
-from django.utils.translation import ugettext_lazy as _t
+import sys
 
 from desktop.lib.conf import Config, UnspecifiedConfigSection, ConfigSection, coerce_password_from_script
 from desktop.lib.idbroker import conf as conf_idbroker
 
 from hadoop import core_site
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext_lazy as _t
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/libs/dashboard/src/dashboard/api.py
+++ b/desktop/libs/dashboard/src/dashboard/api.py
@@ -22,8 +22,6 @@ import logging
 import sys
 import uuid
 
-from django.utils.translation import ugettext as _
-
 from desktop.conf import ENABLE_DOWNLOAD
 from desktop.lib.django_util import JsonResponse
 from desktop.lib.exceptions_renderable import PopupException
@@ -47,9 +45,11 @@ from dashboard.models import Collection2, augment_solr_response, pairwise2, augm
   NESTED_FACET_FORM, COMPARE_FACET, QUERY_FACET, extract_solr_exception_message
 
 if sys.version_info[0] > 2:
-    from django.utils.encoding import force_str
+  from django.utils.encoding import force_str
+  from django.utils.translation import gettext as _
 else:
-    from django.utils.encoding import force_unicode as force_str
+  from django.utils.encoding import force_unicode as force_str
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/libs/dashboard/src/dashboard/conf.py
+++ b/desktop/libs/dashboard/src/dashboard/conf.py
@@ -15,12 +15,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.utils.translation import ugettext as _, ugettext_lazy as _t
+import sys
 
 from desktop.lib.conf import Config, UnspecifiedConfigSection, ConfigSection, coerce_bool
 from desktop.appmanager import get_apps_dict
 
 from notebook.conf import get_ordered_interpreters
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _, gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext as _, ugettext_lazy as _t
 
 
 def is_enabled():

--- a/desktop/libs/dashboard/src/dashboard/decorators.py
+++ b/desktop/libs/dashboard/src/dashboard/decorators.py
@@ -17,14 +17,18 @@
 
 import logging
 import json
+import sys
 
 from django.utils.functional import wraps
-from django.utils.translation import ugettext as _
 
 from desktop.conf import USE_NEW_EDITOR
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.models import Document2
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/libs/dashboard/src/dashboard/facet_builder.py
+++ b/desktop/libs/dashboard/src/dashboard/facet_builder.py
@@ -26,6 +26,7 @@ import logging
 import math
 import numbers
 import re
+import sys
 import urllib.request, urllib.parse, urllib.error
 
 from datetime import datetime, timedelta
@@ -34,7 +35,10 @@ from math import log
 from time import mktime
 from dateutil.relativedelta import *
 
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/dashboard/src/dashboard/models.py
+++ b/desktop/libs/dashboard/src/dashboard/models.py
@@ -29,10 +29,10 @@ import json
 import logging
 import numbers
 import re
+import sys
 
 from django.urls import reverse
 from django.utils.html import escape
-from django.utils.translation import ugettext as _
 
 from desktop.lib.i18n import smart_unicode, smart_str, force_unicode
 from desktop.models import get_data_link, Document2
@@ -40,6 +40,10 @@ from notebook.connectors.base import Notebook, _get_snippet_name
 
 from dashboard.dashboard_api import get_engine
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/libs/dashboard/src/dashboard/templates/admin_collections.mako
+++ b/desktop/libs/dashboard/src/dashboard/templates/admin_collections.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="common_admin_collections" file="common_admin_collections.mako" />

--- a/desktop/libs/dashboard/src/dashboard/templates/admin_collections_m.mako
+++ b/desktop/libs/dashboard/src/dashboard/templates/admin_collections_m.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader_m, commonfooter_m
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="common_admin_collections" file="common_admin_collections.mako" />

--- a/desktop/libs/dashboard/src/dashboard/templates/common_admin_collections.mako
+++ b/desktop/libs/dashboard/src/dashboard/templates/common_admin_collections.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter, commonshare, commonimportexport, _ko
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="macros" file="macros.mako" />

--- a/desktop/libs/dashboard/src/dashboard/templates/common_search.mako
+++ b/desktop/libs/dashboard/src/dashboard/templates/common_search.mako
@@ -15,12 +15,17 @@
 ## limitations under the License.
 
 <%!
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop import conf
 from desktop.views import commonheader, commonfooter, _ko, commonshare
 
 from dashboard.conf import USE_GRIDSTER, USE_NEW_ADD_METHOD, HAS_REPORT_ENABLED, HAS_WIDGET_FILTER, HAS_TREE_WIDGET
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="dashboard" file="common_dashboard.mako" />

--- a/desktop/libs/dashboard/src/dashboard/templates/macros.mako
+++ b/desktop/libs/dashboard/src/dashboard/templates/macros.mako
@@ -19,12 +19,12 @@ import sys
 
 from itertools import izip
 
-from django.utils.translation import ugettext as _
-
 if sys.version_info[0] > 2:
   from urllib.parse import quote as urllib_quote
+  from django.utils.translation import gettext as _
 else:
   from urllib import quote as urllib_quote
+  from django.utils.translation import ugettext as _
 
 
 # <http://github.com/mzsanford/twitter-text-java>

--- a/desktop/libs/dashboard/src/dashboard/templates/no_collections.mako
+++ b/desktop/libs/dashboard/src/dashboard/templates/no_collections.mako
@@ -15,10 +15,15 @@
 ## limitations under the License.
 
 <%!
-from django.utils.translation import ugettext as _
+import sys
 from desktop.views import commonheader, commonfooter
 from indexer.conf import ENABLE_NEW_INDEXER
 from desktop.auth.backend import is_admin
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="macros" file="macros.mako" />

--- a/desktop/libs/dashboard/src/dashboard/templates/search.mako
+++ b/desktop/libs/dashboard/src/dashboard/templates/search.mako
@@ -15,10 +15,15 @@
 ## limitations under the License.
 
 <%!
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.views import commonheader, commonfooter, _ko, commonshare
 from desktop import conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="common_search" file="common_search.mako" />

--- a/desktop/libs/dashboard/src/dashboard/templates/search_m.mako
+++ b/desktop/libs/dashboard/src/dashboard/templates/search_m.mako
@@ -15,10 +15,15 @@
 ## limitations under the License.
 
 <%!
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.views import commonheader_m, commonfooter_m, _ko
 from desktop import conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="common_search" file="common_search.mako" />

--- a/desktop/libs/dashboard/src/dashboard/views.py
+++ b/desktop/libs/dashboard/src/dashboard/views.py
@@ -18,10 +18,10 @@
 import json
 import logging
 import re
+import sys
 
 from django.urls import reverse
 from django.utils.html import escape
-from django.utils.translation import ugettext as _
 
 from desktop.conf import USE_NEW_EDITOR
 from desktop.lib.django_util import JsonResponse, render
@@ -37,6 +37,11 @@ from dashboard.decorators import allow_owner_only
 from dashboard.conf import get_engines
 from dashboard.controller import DashboardController, can_edit_index
 from dashboard.models import Collection2
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/hadoop/src/hadoop/conf.py
+++ b/desktop/libs/hadoop/src/hadoop/conf.py
@@ -18,11 +18,15 @@
 import fnmatch
 import logging
 import os
-
-from django.utils.translation import ugettext_lazy as _t
+import sys
 
 from desktop.conf import default_ssl_validate, has_connectors
 from desktop.lib.conf import Config, UnspecifiedConfigSection, ConfigSection, coerce_bool
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext_lazy as _t
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/hadoop/src/hadoop/fs/hadoopfs.py
+++ b/desktop/libs/hadoop/src/hadoop/fs/hadoopfs.py
@@ -37,7 +37,6 @@ import subprocess
 import sys
 
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext as _
 
 from desktop.lib import i18n
 
@@ -48,9 +47,11 @@ from hadoop.fs.exceptions import PermissionDeniedException
 if sys.version_info[0] > 2:
   from django.utils.encoding import force_str
   from urllib.parse import urlsplit as lib_urlsplit
+  from django.utils.translation import gettext as _
 else:
   from django.utils.encoding import force_unicode as force_str
   from urlparse import urlsplit as lib_urlsplit
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/libs/hadoop/src/hadoop/fs/upload.py
+++ b/desktop/libs/hadoop/src/hadoop/fs/upload.py
@@ -28,16 +28,21 @@ See http://docs.djangoproject.com/en/1.2/topics/http/file-uploads/
 from builtins import object
 import errno
 import logging
+import sys
 import time
 
 from django.core.files.uploadhandler import FileUploadHandler, StopFutureHandlers, StopUpload, UploadFileException, SkipFile
-from django.utils.translation import ugettext as _
 
 from desktop.lib import fsmanager
 
 import hadoop.cluster
 from hadoop.conf import UPLOAD_CHUNK_SIZE
 from hadoop.fs.exceptions import WebHdfsException
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py
+++ b/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py
@@ -33,7 +33,6 @@ import time
 import urllib.request, urllib.error
 
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext as _
 
 import hadoop.conf
 import desktop.conf
@@ -48,9 +47,11 @@ from hadoop.hdfs_site import get_nn_sentry_prefixes, get_umask_mode, get_supergr
 
 if sys.version_info[0] > 2:
   from urllib.parse import unquote as urllib_quote, urlparse
+  from django.utils.translation import gettext as _
 else:
   from urllib import unquote as urllib_quote
   from urlparse import urlparse
+  from django.utils.translation import ugettext as _
 
 
 DEFAULT_HDFS_SUPERUSER = desktop.conf.DEFAULT_HDFS_SUPERUSER.get()

--- a/desktop/libs/hadoop/src/hadoop/yarn/resource_manager_api.py
+++ b/desktop/libs/hadoop/src/hadoop/yarn/resource_manager_api.py
@@ -19,9 +19,8 @@ from builtins import object
 import json
 import logging
 import posixpath
+import sys
 import threading
-
-from django.utils.translation import ugettext as _
 
 from desktop.conf import DEFAULT_USER
 from desktop.lib.exceptions_renderable import PopupException
@@ -30,6 +29,11 @@ from desktop.lib.rest.http_client import HttpClient
 from desktop.lib.rest.resource import Resource
 
 from hadoop import cluster
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/hadoop/src/hadoop/yarn/spark_history_server_api.py
+++ b/desktop/libs/hadoop/src/hadoop/yarn/spark_history_server_api.py
@@ -28,7 +28,6 @@ import urllib.parse
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.rest.http_client import HttpClient
 from desktop.lib.rest.resource import Resource
-from django.utils.translation import ugettext as _
 from hadoop import cluster
 from hadoop.yarn.clients import get_log_client
 
@@ -36,8 +35,10 @@ from lxml import html
 
 if sys.version_info[0] > 2:
   from urllib.parse import urlsplit as lib_urlsplit
+  from django.utils.translation import gettext as _
 else:
   from urlparse import urlsplit as lib_urlsplit
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/libs/indexer/src/indexer/api.py
+++ b/desktop/libs/indexer/src/indexer/api.py
@@ -21,8 +21,7 @@ import itertools
 import json
 import logging
 import re
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.lib.django_util import JsonResponse
 from desktop.lib.exceptions_renderable import PopupException
@@ -30,6 +29,11 @@ from desktop.lib.exceptions_renderable import PopupException
 from indexer.controller import CollectionManagerController
 from indexer.solr_client import SolrClient
 from indexer.utils import fields_from_log, field_values_from_separated_file, get_type_from_morphline_type, get_field_types
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/indexer/src/indexer/api3.py
+++ b/desktop/libs/indexer/src/indexer/api3.py
@@ -26,7 +26,6 @@ import urllib.error
 import sys
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 
 LOG = logging.getLogger(__name__)
@@ -65,10 +64,12 @@ from indexer.indexers.flume import FlumeIndexer
 if sys.version_info[0] > 2:
   from io import StringIO as string_io
   from urllib.parse import urlparse, unquote as urllib_unquote
+  from django.utils.translation import gettext as _
 else:
   from StringIO import StringIO as string_io
   from urllib import unquote as urllib_unquote
   from urlparse import urlparse
+  from django.utils.translation import ugettext as _
 
 try:
   from beeswax.server import dbms

--- a/desktop/libs/indexer/src/indexer/argument.py
+++ b/desktop/libs/indexer/src/indexer/argument.py
@@ -14,8 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.import logging
 
+import sys
+
 from builtins import object
-from django.utils.translation import ugettext as _
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 class Argument(object):

--- a/desktop/libs/indexer/src/indexer/conf.py
+++ b/desktop/libs/indexer/src/indexer/conf.py
@@ -21,16 +21,16 @@ import logging
 import os
 import sys
 
-from django.utils.translation import ugettext_lazy as _t
-
 from desktop.lib.conf import Config
 from libsolr import conf as libsolr_conf
 from libzookeeper import conf as libzookeeper_conf
 
 if sys.version_info[0] > 2:
   from urllib.parse import urlparse
+  from django.utils.translation import gettext_lazy as _t
 else:
   from urlparse import urlparse
+  from django.utils.translation import ugettext_lazy as _t
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/libs/indexer/src/indexer/controller.py
+++ b/desktop/libs/indexer/src/indexer/controller.py
@@ -22,8 +22,8 @@ import logging
 import numbers
 import os
 import shutil
+import sys
 
-from django.utils.translation import ugettext as _
 import tablib
 
 from desktop.lib.exceptions_renderable import PopupException
@@ -35,6 +35,11 @@ from search.conf import SOLR_URL, SECURITY_ENABLED
 from indexer.conf import CORE_INSTANCE_DIR
 from indexer.utils import copy_configs, field_values_from_log, field_values_from_separated_file
 from indexer.solr_client import SolrClient
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/indexer/src/indexer/file_format.py
+++ b/desktop/libs/indexer/src/indexer/file_format.py
@@ -25,8 +25,6 @@ import itertools
 import logging
 import sys
 
-from django.utils.translation import ugettext as _
-
 from desktop.lib import i18n
 
 from indexer.argument import CheckboxArgument, TextDelimiterArgument
@@ -37,7 +35,9 @@ from indexer.indexers.morphline_operations import get_operator
 if sys.version_info[0] > 2:
   from io import StringIO as string_io
   from past.builtins import long
+  from django.utils.translation import gettext as _
 else:
+  from django.utils.translation import ugettext as _
   from StringIO import StringIO as string_io
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/indexer/src/indexer/indexers/base.py
+++ b/desktop/libs/indexer/src/indexer/indexers/base.py
@@ -15,12 +15,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.conf import has_connectors
 from desktop.lib.connectors.models import _get_installed_connectors
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.i18n import smart_unicode
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 def get_api(user, connector_id):

--- a/desktop/libs/indexer/src/indexer/indexers/envelope.py
+++ b/desktop/libs/indexer/src/indexer/indexers/envelope.py
@@ -17,9 +17,9 @@
 from builtins import object
 import logging
 import os
+import sys
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 
 from hadoop.fs.hadoopfs import Hdfs
 from indexer.conf import CONFIG_JARS_LIBS_PATH, config_morphline_path
@@ -28,6 +28,11 @@ from notebook.models import make_notebook
 from useradmin.models import User
 
 from desktop.lib.exceptions_renderable import PopupException
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/indexer/src/indexer/indexers/flink_sql.py
+++ b/desktop/libs/indexer/src/indexer/indexers/flink_sql.py
@@ -19,7 +19,6 @@ import sys
 import uuid
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 
 from notebook.models import make_notebook
 from useradmin.models import User
@@ -29,7 +28,9 @@ from desktop.lib.exceptions_renderable import PopupException
 
 if sys.version_info[0] > 2:
   from urllib.parse import urlparse, unquote as urllib_unquote
+  from django.utils.translation import gettext as _
 else:
+  from django.utils.translation import ugettext as _
   from urllib import unquote as urllib_unquote
   from urlparse import urlparse
 

--- a/desktop/libs/indexer/src/indexer/indexers/flume.py
+++ b/desktop/libs/indexer/src/indexer/indexers/flume.py
@@ -17,9 +17,9 @@
 from builtins import object
 import logging
 import os
+import sys
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 
 from libzookeeper.conf import zkensemble
 from indexer.conf import config_morphline_path
@@ -27,6 +27,11 @@ from metadata.manager_client import ManagerApi
 from useradmin.models import User
 
 from desktop.lib.exceptions_renderable import PopupException
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/indexer/src/indexer/indexers/morphline.py
+++ b/desktop/libs/indexer/src/indexer/indexers/morphline.py
@@ -17,11 +17,11 @@
 from builtins import object
 import logging
 import os
+import sys
 
 from collections import deque
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 from mako.lookup import TemplateLookup
 
 from desktop.models import Document2
@@ -34,6 +34,11 @@ from indexer.fields import get_field_type
 from indexer.file_format import get_file_format_instance, get_file_format_class
 from indexer.indexers.morphline_operations import get_checked_args
 from indexer.solr_client import SolrClient
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/indexer/src/indexer/indexers/morphline_operations.py
+++ b/desktop/libs/indexer/src/indexer/indexers/morphline_operations.py
@@ -14,10 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.import logging
 
+import sys
+
 from builtins import object
-from django.utils.translation import ugettext as _
 
 from indexer.argument import TextArgument, CheckboxArgument, MappingArgument
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 class Operator(object):

--- a/desktop/libs/indexer/src/indexer/indexers/phoenix_sql.py
+++ b/desktop/libs/indexer/src/indexer/indexers/phoenix_sql.py
@@ -19,13 +19,14 @@ import sys
 import uuid
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 
 from notebook.models import make_notebook
 
 if sys.version_info[0] > 2:
   from urllib.parse import urlparse, unquote as urllib_unquote
+  from django.utils.translation import gettext as _
 else:
+  from django.utils.translation import ugettext as _
   from urllib import unquote as urllib_unquote
   from urlparse import urlparse
 

--- a/desktop/libs/indexer/src/indexer/indexers/rdbms.py
+++ b/desktop/libs/indexer/src/indexer/indexers/rdbms.py
@@ -17,10 +17,10 @@
 
 import json
 import logging
+import sys
 import uuid
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 
 from librdbms.conf import DATABASES, get_database_password, get_server_choices, get_connector_name
 from librdbms.jdbc import Jdbc
@@ -32,6 +32,11 @@ from useradmin.models import User
 
 from desktop.lib.django_util import JsonResponse
 from desktop.lib.i18n import smart_str
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/indexer/src/indexer/indexers/sql.py
+++ b/desktop/libs/indexer/src/indexer/indexers/sql.py
@@ -25,7 +25,6 @@ import uuid
 from collections import OrderedDict
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 
 from azure.abfs.__init__ import abfspath
 from hadoop.fs.hadoopfs import Hdfs
@@ -37,7 +36,9 @@ from desktop.lib.exceptions_renderable import PopupException
 
 if sys.version_info[0] > 2:
   from urllib.parse import urlparse, unquote as urllib_unquote
+  from django.utils.translation import gettext as _
 else:
+  from django.utils.translation import ugettext as _
   from urllib import unquote as urllib_unquote
   from urlparse import urlparse
 

--- a/desktop/libs/indexer/src/indexer/management/commands/indexer_setup.py
+++ b/desktop/libs/indexer/src/indexer/management/commands/indexer_setup.py
@@ -20,14 +20,19 @@ from builtins import zip
 import itertools
 import logging
 import os
+import sys
 
 from django.core.management.base import BaseCommand
-from django.utils.translation import ugettext as _
 
 from useradmin.models import install_sample_user
 
 from indexer import utils
 from indexer.solr_client import SolrClient
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/indexer/src/indexer/solr_api.py
+++ b/desktop/libs/indexer/src/indexer/solr_api.py
@@ -17,8 +17,8 @@
 
 import json
 import logging
+import sys
 
-from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_GET, require_POST
 
 from desktop.lib.django_util import JsonResponse
@@ -26,6 +26,11 @@ from desktop.lib.i18n import smart_unicode
 from libsolr.api import SolrApi
 
 from indexer.solr_client import SolrClient
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/indexer/src/indexer/solr_client.py
+++ b/desktop/libs/indexer/src/indexer/solr_client.py
@@ -21,8 +21,7 @@ import logging
 import json
 import os
 import shutil
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.i18n import smart_str
@@ -31,6 +30,11 @@ from libzookeeper.models import ZookeeperClient
 
 from indexer.conf import CORE_INSTANCE_DIR, get_solr_ensemble
 from indexer.utils import copy_configs
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/indexer/src/indexer/templates/collections.mako
+++ b/desktop/libs/indexer/src/indexer/templates/collections.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/desktop/libs/indexer/src/indexer/templates/importer.mako
+++ b/desktop/libs/indexer/src/indexer/templates/importer.mako
@@ -15,7 +15,7 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
 
   from desktop import conf
   from desktop.views import commonheader, commonfooter, commonshare, commonimportexport, _ko
@@ -25,6 +25,11 @@
   from notebook.conf import ENABLE_SQL_INDEXER
 
   from indexer.conf import ENABLE_NEW_INDEXER, ENABLE_SQOOP, ENABLE_KAFKA, CONFIG_INDEXER_LIBS_PATH, ENABLE_SCALABLE_INDEXER, ENABLE_ALTUS, ENABLE_ENVELOPE, ENABLE_FIELD_EDITOR
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/desktop/libs/indexer/src/indexer/templates/indexer.mako
+++ b/desktop/libs/indexer/src/indexer/templates/indexer.mako
@@ -15,10 +15,14 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
 
   from desktop import conf
   from desktop.views import commonheader, commonfooter, commonshare, commonimportexport
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/desktop/libs/indexer/src/indexer/templates/indexes.mako
+++ b/desktop/libs/indexer/src/indexer/templates/indexes.mako
@@ -15,10 +15,16 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+
   from desktop import conf
 
   from desktop.views import commonheader, commonfooter, commonshare, commonimportexport, _ko
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/desktop/libs/indexer/src/indexer/templates/topics.mako
+++ b/desktop/libs/indexer/src/indexer/templates/topics.mako
@@ -15,10 +15,16 @@
 ## limitations under the License.
 
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+
   from desktop import conf
 
   from desktop.views import commonheader, commonfooter, commonshare, commonimportexport, _ko
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />

--- a/desktop/libs/indexer/src/indexer/utils.py
+++ b/desktop/libs/indexer/src/indexer/utils.py
@@ -34,7 +34,6 @@ import uuid
 from dateutil.parser import parse
 
 from django.conf import settings
-from django.utils.translation import ugettext as _
 
 from desktop.lib.i18n import force_unicode, smart_str
 
@@ -43,7 +42,9 @@ from indexer.models import DATE_FIELD_TYPES, TEXT_FIELD_TYPES, INTEGER_FIELD_TYP
 
 if sys.version_info[0] > 2:
   from io import StringIO as string_io
+  from django.utils.translation import gettext as _
 else:
+  from django.utils.translation import ugettext as _
   from StringIO import StringIO as string_io
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/indexer/src/indexer/views.py
+++ b/desktop/libs/indexer/src/indexer/views.py
@@ -17,8 +17,7 @@
 
 import logging
 import json
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.lib.django_util import JsonResponse, render
 from desktop.lib.exceptions_renderable import PopupException
@@ -29,6 +28,11 @@ from indexer.fields import FIELD_TYPES, Field
 from indexer.file_format import get_file_indexable_format_types
 from indexer.management.commands import indexer_setup
 from indexer.indexers.morphline_operations import OPERATORS
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/kafka/src/kafka/conf.py
+++ b/desktop/libs/kafka/src/kafka/conf.py
@@ -16,10 +16,14 @@
 # limitations under the License.
 
 import logging
-
-from django.utils.translation import ugettext_lazy as _t
+import sys
 
 from desktop.lib.conf import Config, ConfigSection, coerce_bool
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext_lazy as _t
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/kafka/src/kafka/kafka_api.py
+++ b/desktop/libs/kafka/src/kafka/kafka_api.py
@@ -18,8 +18,7 @@
 
 import json
 import logging
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.lib.django_util import JsonResponse
 from desktop.lib.i18n import force_unicode
@@ -28,6 +27,11 @@ from notebook.models import _get_notebook_api
 
 from kafka.conf import has_kafka_api
 from kafka.kafka_client import KafkaApi, KafkaApiException
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/kafka/src/kafka/kafka_client.py
+++ b/desktop/libs/kafka/src/kafka/kafka_client.py
@@ -19,10 +19,9 @@
 from builtins import object
 import logging
 import json
+import sys
 
 from subprocess import call
-
-from django.utils.translation import ugettext as _
 
 from desktop.lib.rest.http_client import RestException, HttpClient
 from desktop.lib.rest.resource import Resource
@@ -30,6 +29,11 @@ from desktop.lib.i18n import smart_unicode
 
 from kafka.conf import KAFKA
 from libzookeeper.conf import zkensemble
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/kafka/src/kafka/ksql_client.py
+++ b/desktop/libs/kafka/src/kafka/ksql_client.py
@@ -19,14 +19,18 @@
 from builtins import object
 import logging
 import json
+import sys
 
 from django.core.cache import cache
-from django.utils.translation import ugettext as _
 
 from desktop.lib.i18n import smart_unicode
 from desktop.lib.rest.http_client import RestException
 from desktop.conf import has_channels
 
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 if has_channels():
   from notebook.consumer import _send_to_channel

--- a/desktop/libs/liboauth/src/liboauth/backend.py
+++ b/desktop/libs/liboauth/src/liboauth/backend.py
@@ -27,8 +27,6 @@ import sys
 
 LOG = logging.getLogger(__name__)
 
-from django.utils.translation import ugettext as _
-
 from desktop.auth.backend import force_username_case, DesktopBackendBase
 
 from useradmin.models import get_profile, get_default_user_group, UserProfile, User
@@ -48,7 +46,9 @@ except ImportError:
 
 if sys.version_info[0] > 2:
   from urllib.parse import urlencode as lib_urlencode
+  from django.utils.translation import gettext as _
 else:
+  from django.utils.translation import ugettext as _
   from urllib import urlencode as lib_urlencode
 
 

--- a/desktop/libs/liboauth/src/liboauth/conf.py
+++ b/desktop/libs/liboauth/src/liboauth/conf.py
@@ -16,10 +16,14 @@
 # limitations under the License.
 
 import os
-
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
+import sys
 
 from desktop.lib.conf import Config, coerce_bool, coerce_csv, coerce_json_dict
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 
 CONSUMER_KEY_TWITTER = Config(

--- a/desktop/libs/liboauth/src/liboauth/templates/oauth-login.mako
+++ b/desktop/libs/liboauth/src/liboauth/templates/oauth-login.mako
@@ -14,8 +14,12 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+import sys
 from desktop import conf
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 <!DOCTYPE html>
 <html lang="en">

--- a/desktop/libs/liboauth/src/liboauth/views.py
+++ b/desktop/libs/liboauth/src/liboauth/views.py
@@ -19,6 +19,7 @@ from future import standard_library
 standard_library.install_aliases()
 
 import logging
+import sys
 
 LOG = logging.getLogger(__name__)
 
@@ -34,7 +35,6 @@ from django.contrib.auth import login, get_backends, authenticate
 from django.contrib.sessions.models import Session
 from django.http import HttpResponseRedirect
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 from hadoop.fs.exceptions import WebHdfsException
 from useradmin.models import User
 from useradmin.views import ensure_home_directory
@@ -47,6 +47,11 @@ from desktop.log.access import access_warn, last_access_map
 
 import liboauth.conf
 from liboauth.backend import OAuthBackend
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 @login_notrequired

--- a/desktop/libs/liboozie/src/liboozie/conf.py
+++ b/desktop/libs/liboozie/src/liboozie/conf.py
@@ -19,11 +19,14 @@ from builtins import oct, object
 import logging
 import sys
 
-from django.utils.translation import ugettext as _, ugettext_lazy as _t
-
 from desktop import appmanager
 from desktop.conf import default_ssl_validate
 from desktop.lib.conf import Config, coerce_bool, validate_path
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _, gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext as _, ugettext_lazy as _t
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/liboozie/src/liboozie/credentials.py
+++ b/desktop/libs/liboozie/src/liboozie/credentials.py
@@ -17,8 +17,12 @@
 
 from builtins import object
 import logging
+import sys
 
-from django.utils.translation import ugettext as _
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/liboozie/src/liboozie/submission2.py
+++ b/desktop/libs/liboozie/src/liboozie/submission2.py
@@ -19,12 +19,12 @@ from builtins import object
 import errno
 import logging
 import os
+import sys
 import time
 
 from string import Template
 
 from django.utils.functional import wraps
-from django.utils.translation import ugettext as _
 
 from beeswax.hive_site import get_hive_site_content
 from desktop.lib.exceptions_renderable import PopupException
@@ -42,6 +42,11 @@ from hadoop.fs.hadoopfs import Hdfs
 from liboozie.conf import REMOTE_DEPLOYMENT_DIR, USE_LIBPATH_FOR_JARS
 from liboozie.credentials import Credentials
 from liboozie.oozie_api import get_oozie
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/liboozie/src/liboozie/submittion.py
+++ b/desktop/libs/liboozie/src/liboozie/submittion.py
@@ -20,10 +20,10 @@ import errno
 import logging
 import os
 import re
+import sys
 import time
 
 from django.utils.functional import wraps
-from django.utils.translation import ugettext as _
 
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.i18n import smart_str
@@ -34,6 +34,11 @@ from hadoop.fs.hadoopfs import Hdfs
 from liboozie.oozie_api import get_oozie
 from liboozie.conf import REMOTE_DEPLOYMENT_DIR
 from liboozie.credentials import Credentials
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/libs/liboozie/src/liboozie/types.py
+++ b/desktop/libs/liboozie/src/liboozie/types.py
@@ -41,14 +41,15 @@ from desktop.log.access import access_warn
 import hadoop.confparse
 from liboozie.utils import parse_timestamp, format_time, catch_unicode_time
 
-from django.utils.translation import ugettext as _
 from django.urls import reverse
 
 from desktop.auth.backend import is_admin
 
 if sys.version_info[0] > 2:
   from io import BytesIO as string_io
+  from django.utils.translation import gettext as _
 else:
+  from django.utils.translation import ugettext as _
   from cStringIO import StringIO as string_io
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/librdbms/src/librdbms/conf.py
+++ b/desktop/libs/librdbms/src/librdbms/conf.py
@@ -15,11 +15,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
+import sys
+
 from desktop.lib.conf import Config, UnspecifiedConfigSection,\
                              ConfigSection, coerce_json_dict,\
                              coerce_password_from_script
 from desktop.conf import coerce_database
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 
 DATABASES = UnspecifiedConfigSection(

--- a/desktop/libs/librdbms/src/librdbms/design.py
+++ b/desktop/libs/librdbms/src/librdbms/design.py
@@ -22,12 +22,17 @@ The HQLdesign class can (de)serialize a design to/from a QueryDict.
 from builtins import object
 import json
 import logging
+import sys
 
 import django.http
-from django.utils.translation import ugettext as _
 
 from beeswax.design import normalize_form_dict, denormalize_form_dict, split_statements
 from notebook.sql_utils import strip_trailing_semicolon
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/libs/librdbms/src/librdbms/server/mysql_lib.py
+++ b/desktop/libs/librdbms/src/librdbms/server/mysql_lib.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 import logging
+import sys
 
 try:
     import MySQLdb as Database
@@ -32,10 +33,14 @@ if (version < (1,2,1) or (version[:3] == (1, 2, 1) and
     from django.core.exceptions import ImproperlyConfigured
     raise ImproperlyConfigured("MySQLdb-1.2.1p2 or newer is required; you have %s" % Database.__version__)
 
-from django.utils.translation import ugettext as _
 from MySQLdb.converters import FIELD_TYPE
 
 from librdbms.server.rdbms_base_lib import BaseRDBMSDataTable, BaseRDBMSResult, BaseRDMSClient
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/libsaml/src/libsaml/conf.py
+++ b/desktop/libs/libsaml/src/libsaml/conf.py
@@ -19,10 +19,14 @@ import json
 import logging
 import os
 import subprocess
-
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
+import sys
 
 from desktop.lib.conf import Config, coerce_bool, coerce_csv, coerce_password_from_script
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/libs/libsentry/src/libsentry/api.py
+++ b/desktop/libs/libsentry/src/libsentry/api.py
@@ -17,9 +17,8 @@
 
 from builtins import object
 import logging
+import sys
 import threading
-
-from django.utils.translation import ugettext as _
 
 from desktop.lib.exceptions import StructuredThriftTransportException
 from desktop.lib.exceptions_renderable import PopupException
@@ -27,6 +26,11 @@ from desktop.lib.exceptions_renderable import PopupException
 from libsentry.client import SentryClient
 from libsentry.sentry_ha import get_next_available_server, create_client
 from libsentry.sentry_site import get_sentry_server, is_ha_enabled
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/libsentry/src/libsentry/api2.py
+++ b/desktop/libs/libsentry/src/libsentry/api2.py
@@ -17,9 +17,8 @@
 
 from builtins import object
 import logging
+import sys
 import threading
-
-from django.utils.translation import ugettext as _
 
 from desktop.lib.exceptions import StructuredThriftTransportException
 from desktop.lib.exceptions_renderable import PopupException
@@ -27,6 +26,11 @@ from desktop.lib.exceptions_renderable import PopupException
 from libsentry.client2 import SentryClient
 from libsentry.sentry_ha import get_next_available_server, create_client
 from libsentry.sentry_site import get_sentry_server, is_ha_enabled
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/libsentry/src/libsentry/conf.py
+++ b/desktop/libs/libsentry/src/libsentry/conf.py
@@ -17,9 +17,14 @@
 
 import logging
 import os
+import sys
 
-from django.utils.translation import ugettext_lazy as _t
 from desktop.lib.conf import Config
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext_lazy as _t
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/libsentry/src/libsentry/sentry_ha.py
+++ b/desktop/libs/libsentry/src/libsentry/sentry_ha.py
@@ -16,15 +16,19 @@
 # limitations under the License.
 
 import logging
+import sys
 import time
-
-from django.utils.translation import ugettext as _
 
 from desktop.lib.exceptions import StructuredThriftTransportException
 from desktop.lib.exceptions_renderable import PopupException
 
 from libsentry.client2 import SentryClient
 from libsentry.sentry_site import get_sentry_server
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/libsentry/src/libsentry/sentry_site.py
+++ b/desktop/libs/libsentry/src/libsentry/sentry_site.py
@@ -19,8 +19,7 @@ import errno
 import logging
 import os.path
 import random
-
-from django.utils.translation import ugettext as _
+import sys
 
 from hadoop import confparse
 
@@ -28,6 +27,11 @@ from desktop.lib import security_util
 from desktop.lib.exceptions_renderable import PopupException
 
 from libsentry.conf import SENTRY_CONF_DIR, HOSTNAME, PORT
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/libsolr/src/libsolr/api.py
+++ b/desktop/libs/libsolr/src/libsolr/api.py
@@ -29,8 +29,6 @@ import sys
 
 from itertools import groupby
 
-from django.utils.translation import ugettext as _
-
 from dashboard.facet_builder import _compute_range_facet
 from dashboard.models import Collection2
 from desktop.lib.exceptions_renderable import PopupException
@@ -46,7 +44,9 @@ if sys.version_info[0] > 2:
   from urllib.parse import quote as urllib_quote
   from urllib.parse import unquote as urllib_unquote
   new_str = str
+  from django.utils.translation import gettext as _
 else:
+  from django.utils.translation import ugettext as _
   from urllib import quote as urllib_quote
   from urllib import unquote as urllib_unquote
   new_str = unicode

--- a/desktop/libs/libsolr/src/libsolr/conf.py
+++ b/desktop/libs/libsolr/src/libsolr/conf.py
@@ -20,8 +20,6 @@ standard_library.install_aliases()
 import logging
 import sys
 
-from django.utils.translation import ugettext_lazy as _t
-
 from desktop.lib.conf import Config, coerce_bool
 from desktop.conf import default_ssl_validate
 from libzookeeper.conf import ENSEMBLE
@@ -29,7 +27,9 @@ from libzookeeper.conf import ENSEMBLE
 if sys.version_info[0] > 2:
   from urllib.parse import urlparse
   new_str = str
+  from django.utils.translation import gettext_lazy as _t
 else:
+  from django.utils.translation import ugettext_lazy as _t
   from urlparse import urlparse
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/metadata/src/metadata/analytic_db_api.py
+++ b/desktop/libs/metadata/src/metadata/analytic_db_api.py
@@ -16,13 +16,18 @@
 # limitations under the License.
 
 import logging
+import sys
 
-from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 
 from desktop.lib.django_util import JsonResponse
 from desktop.lib.i18n import force_unicode
 from notebook.connectors.altus import AnalyticDbApi, DataWarehouse2Api
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/metadata/src/metadata/catalog/atlas_client.py
+++ b/desktop/libs/metadata/src/metadata/catalog/atlas_client.py
@@ -19,8 +19,7 @@
 import json
 import logging
 import re
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.lib.exceptions_renderable import raise_popup_exception
 from desktop.lib.rest import resource
@@ -28,6 +27,11 @@ from desktop.lib.rest.http_client import HttpClient, RestException
 
 from metadata.conf import CATALOG, get_catalog_search_cluster
 from metadata.catalog.base import CatalogAuthException, CatalogApiException, CatalogEntityDoesNotExistException, Api
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/libs/metadata/src/metadata/catalog/base.py
+++ b/desktop/libs/metadata/src/metadata/catalog/base.py
@@ -15,11 +15,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 from builtins import object
-from django.utils.translation import ugettext as _
 
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.i18n import smart_unicode
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 def get_api(request, interface):

--- a/desktop/libs/metadata/src/metadata/catalog/dummy_client.py
+++ b/desktop/libs/metadata/src/metadata/catalog/dummy_client.py
@@ -17,10 +17,14 @@
 # limitations under the License.
 
 import logging
-
-from django.utils.translation import ugettext as _
+import sys
 
 from metadata.catalog.base import Api
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/metadata/src/metadata/catalog/navigator_client.py
+++ b/desktop/libs/metadata/src/metadata/catalog/navigator_client.py
@@ -19,11 +19,11 @@
 import json
 import logging
 import re
+import sys
 
 from itertools import islice
 
 from django.core.cache import cache
-from django.utils.translation import ugettext as _
 
 from desktop.lib.rest import resource
 from desktop.lib.rest.unsecure_http_client import UnsecureHttpClient
@@ -36,6 +36,11 @@ from libsentry.sentry_site import get_hive_sentry_provider
 from metadata.conf import NAVIGATOR, get_navigator_auth_password, get_navigator_auth_username
 from metadata.catalog.base import CatalogAuthException, CatalogApiException, CatalogEntityDoesNotExistException, Api
 from metadata.metadata_sites import get_navigator_hue_server_name
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 VERSION = 'v9'

--- a/desktop/libs/metadata/src/metadata/catalog_api.py
+++ b/desktop/libs/metadata/src/metadata/catalog_api.py
@@ -20,12 +20,12 @@ from builtins import next
 import json
 import logging
 import re
+import sys
 
 from collections import OrderedDict
 
 from django.http import Http404
 from django.utils.html import escape
-from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 
 from desktop.lib.django_util import JsonResponse
@@ -34,6 +34,11 @@ from desktop.lib.i18n import force_unicode, smart_str
 from metadata.catalog.base import get_api
 from metadata.catalog.navigator_client import CatalogApiException, CatalogEntityDoesNotExistException, CatalogAuthException
 from metadata.conf import has_catalog, CATALOG, has_catalog_file_search, NAVIGATOR
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/metadata/src/metadata/conf.py
+++ b/desktop/libs/metadata/src/metadata/conf.py
@@ -17,10 +17,9 @@
 
 import logging
 import os
+import sys
 
 from subprocess import CalledProcessError
-
-from django.utils.translation import ugettext_lazy as _t
 
 from desktop.conf import AUTH_USERNAME as DEFAULT_AUTH_USERNAME, CLUSTER_ID as DEFAULT_CLUSTER_ID
 from desktop.lib.conf import Config, ConfigSection, coerce_bool, coerce_password_from_script
@@ -28,6 +27,11 @@ from desktop.lib.paths import get_config_root, get_desktop_root
 
 from metadata.settings import DJANGO_APPS
 from metadata.catalog import atlas_flags
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t
+else:
+  from django.utils.translation import ugettext_lazy as _t
 
 
 OPTIMIZER_AUTH_PASSWORD = None

--- a/desktop/libs/metadata/src/metadata/dataeng_api.py
+++ b/desktop/libs/metadata/src/metadata/dataeng_api.py
@@ -17,14 +17,19 @@
 
 import logging
 import json
+import sys
 
-from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 
 from desktop.lib.django_util import JsonResponse
 from desktop.lib.i18n import force_unicode
 
 from notebook.connectors.altus import DataEngApi
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/metadata/src/metadata/manager_api.py
+++ b/desktop/libs/metadata/src/metadata/manager_api.py
@@ -19,10 +19,10 @@
 import json
 import logging
 import os
+import sys
 
 from django.http import Http404
 from django.utils.html import escape
-from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 
 from desktop.auth.backend import is_admin
@@ -34,6 +34,11 @@ from indexer.conf import config_morphline_path
 from metadata.catalog.navigator_client import CatalogApiException
 from metadata.conf import has_catalog
 from metadata.manager_client import ManagerApi
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/metadata/src/metadata/manager_client.py
+++ b/desktop/libs/metadata/src/metadata/manager_client.py
@@ -25,7 +25,6 @@ import logging
 import sys
 
 from django.core.cache import cache
-from django.utils.translation import ugettext as _
 
 from desktop.lib.rest.http_client import RestException, HttpClient
 from desktop.lib.rest.resource import Resource
@@ -36,7 +35,9 @@ from metadata.conf import MANAGER, get_navigator_auth_username, get_navigator_au
 
 if sys.version_info[0] > 2:
   from urllib.parse import quote as urllib_quote
+  from django.utils.translation import gettext as _
 else:
+  from django.utils.translation import ugettext as _
   from urllib import quote as urllib_quote
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/metadata/src/metadata/optimizer/base.py
+++ b/desktop/libs/metadata/src/metadata/optimizer/base.py
@@ -15,11 +15,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 from builtins import object
-from django.utils.translation import ugettext as _
 
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.i18n import smart_unicode
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 def get_api(user, interface):

--- a/desktop/libs/metadata/src/metadata/optimizer/dummy_client.py
+++ b/desktop/libs/metadata/src/metadata/optimizer/dummy_client.py
@@ -17,12 +17,16 @@
 # limitations under the License.
 
 import logging
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.lib.exceptions_renderable import PopupException
 
 from metadata.optimizer.base import Api
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/metadata/src/metadata/optimizer/optimizer_client.py
+++ b/desktop/libs/metadata/src/metadata/optimizer/optimizer_client.py
@@ -20,6 +20,7 @@ from builtins import object
 import json
 import logging
 import os
+import sys
 import time
 import uuid
 
@@ -27,7 +28,6 @@ from tempfile import NamedTemporaryFile
 
 from django.core.cache import cache
 from django.utils.functional import wraps
-from django.utils.translation import ugettext as _
 
 from desktop.auth.backend import is_admin
 from desktop.lib.exceptions_renderable import PopupException
@@ -38,6 +38,11 @@ from libsentry.sentry_site import get_hive_sentry_provider
 from libsentry.privilege_checker import get_checker, MissingSentryPrivilegeException
 
 from metadata.conf import OPTIMIZER, get_optimizer_url
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/metadata/src/metadata/optimizer/optimizer_rest_client.py
+++ b/desktop/libs/metadata/src/metadata/optimizer/optimizer_rest_client.py
@@ -18,14 +18,18 @@
 
 import json
 import logging
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.lib.rest.http_client import HttpClient
 from desktop.lib.rest.resource import Resource
 
 from metadata.conf import OPTIMIZER, get_optimizer_url
 from metadata.optimizer.optimizer_client import OptimizerClient
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/metadata/src/metadata/optimizer_api.py
+++ b/desktop/libs/metadata/src/metadata/optimizer_api.py
@@ -20,9 +20,9 @@ import base64
 import json
 import logging
 import struct
+import sys
 
 from django.http import Http404
-from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 
 from desktop.auth.backend import is_admin
@@ -36,6 +36,11 @@ from notebook.models import Notebook
 from metadata.optimizer.base import get_api
 from metadata.optimizer.optimizer_client import NavOptException, _get_table_name, _clean_query
 from metadata.conf import OPTIMIZER
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/libs/metadata/src/metadata/prometheus_api.py
+++ b/desktop/libs/metadata/src/metadata/prometheus_api.py
@@ -18,15 +18,20 @@
 
 import json
 import logging
+import sys
 
 from django.utils.html import escape
-from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 
 from desktop.lib.django_util import JsonResponse
 from desktop.lib.i18n import force_unicode
 
 from metadata.prometheus_client import PrometheusApi
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/metadata/src/metadata/prometheus_client.py
+++ b/desktop/libs/metadata/src/metadata/prometheus_client.py
@@ -18,15 +18,20 @@
 
 from builtins import object
 import logging
+import sys
 
 from django.core.cache import cache
-from django.utils.translation import ugettext as _
 
 from desktop.lib.rest.http_client import RestException, HttpClient
 from desktop.lib.rest.resource import Resource
 from desktop.lib.i18n import smart_unicode
 
 from metadata.conf import PROMETHEUS
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/metadata/src/metadata/workload_analytics_api.py
+++ b/desktop/libs/metadata/src/metadata/workload_analytics_api.py
@@ -17,14 +17,19 @@
 
 import logging
 import json
+import sys
 
-from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 
 from desktop.lib.django_util import JsonResponse
 from desktop.lib.i18n import force_unicode
 
 from metadata.workload_analytics_client import WorkfloadAnalyticsClient
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/metadata/src/metadata/workload_analytics_client.py
+++ b/desktop/libs/metadata/src/metadata/workload_analytics_client.py
@@ -17,10 +17,14 @@
 
 from builtins import object
 import logging
-
-from django.utils.translation import ugettext as _
+import sys
 
 from notebook.connectors.altus import _exec
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/notebook/src/notebook/api.py
+++ b/desktop/libs/notebook/src/notebook/api.py
@@ -25,7 +25,6 @@ import sys
 
 from django.urls import reverse
 from django.db.models import Q
-from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_GET, require_POST
 import opentracing.tracer
 
@@ -47,7 +46,9 @@ from notebook.models import escape_rows, make_notebook, upgrade_session_properti
 
 if sys.version_info[0] > 2:
   from urllib.parse import unquote as urllib_unquote
+  from django.utils.translation import gettext as _
 else:
+  from django.utils.translation import ugettext as _
   from urllib import unquote as urllib_unquote
 
 

--- a/desktop/libs/notebook/src/notebook/conf.py
+++ b/desktop/libs/notebook/src/notebook/conf.py
@@ -17,16 +17,21 @@
 
 import json
 import logging
+import sys
 
 from collections import OrderedDict
 
 from django.test.client import Client
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 from desktop import appmanager
 from desktop.conf import is_oozie_enabled, has_connectors, is_cm_managed
 from desktop.lib.conf import Config, UnspecifiedConfigSection, ConfigSection, coerce_json_dict, coerce_bool, coerce_csv
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/notebook/src/notebook/connectors/altus.py
+++ b/desktop/libs/notebook/src/notebook/connectors/altus.py
@@ -18,16 +18,21 @@
 from builtins import object
 import logging
 import json
+import sys
 
 from datetime import datetime, timedelta
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.rest.http_client import HttpClient
 from desktop.lib.rest.resource import Resource
 from metadata.conf import ALTUS, K8S
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/libs/notebook/src/notebook/connectors/altus_adb.py
+++ b/desktop/libs/notebook/src/notebook/connectors/altus_adb.py
@@ -23,7 +23,6 @@ import json
 import sys
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 
 from notebook.connectors.altus import AnalyticDbApi
 from notebook.connectors.base import Api, QueryError
@@ -31,7 +30,9 @@ from notebook.connectors.base import Api, QueryError
 if sys.version_info[0] > 2:
   import urllib.request, urllib.error
   from urllib.parse import quote as urllib_quote, quote_plus as urllib_quote_plus
+  from django.utils.translation import gettext as _
 else:
+  from django.utils.translation import ugettext as _
   from urllib import quote as urllib_quote, quote_plus as urllib_quote_plus
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/notebook/src/notebook/connectors/base.py
+++ b/desktop/libs/notebook/src/notebook/connectors/base.py
@@ -19,10 +19,10 @@ from builtins import object
 import json
 import logging
 import re
+import sys
 import time
 import uuid
 
-from django.utils.translation import ugettext as _
 from django.utils.encoding import smart_str
 
 from desktop.auth.backend import is_admin
@@ -35,6 +35,11 @@ from metadata.optimizer.base import get_api as get_optimizer_api
 
 from notebook.conf import get_ordered_interpreters
 from notebook.sql_utils import get_current_statement
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/notebook/src/notebook/connectors/dataeng.py
+++ b/desktop/libs/notebook/src/notebook/connectors/dataeng.py
@@ -17,15 +17,20 @@
 
 import logging
 import re
+import sys
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 
 from metadata.workload_analytics_client import WorkfloadAnalyticsClient
 
 from notebook.connectors.altus import DataEngApi as AltusDataEngApi
 from notebook.connectors.base import Api, QueryError
 from jobbrowser.apis.data_eng_api import RUNNING_STATES
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/notebook/src/notebook/connectors/flink_sql.py
+++ b/desktop/libs/notebook/src/notebook/connectors/flink_sql.py
@@ -20,14 +20,18 @@ from __future__ import absolute_import
 import logging
 import json
 import posixpath
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.lib.i18n import force_unicode
 from desktop.lib.rest.http_client import HttpClient, RestException
 from desktop.lib.rest.resource import Resource
 
 from notebook.connectors.base import Api, QueryError
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/notebook/src/notebook/connectors/hbase.py
+++ b/desktop/libs/notebook/src/notebook/connectors/hbase.py
@@ -18,14 +18,19 @@
 from __future__ import absolute_import
 
 import logging
+import sys
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.i18n import force_unicode
 
 from notebook.connectors.base import Api, QueryError
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/notebook/src/notebook/connectors/hive_metastore.py
+++ b/desktop/libs/notebook/src/notebook/connectors/hive_metastore.py
@@ -16,10 +16,9 @@
 # limitations under the License.
 
 import logging
+import sys
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
-
 
 from desktop.lib.exceptions import StructuredException
 from desktop.lib.exceptions_renderable import PopupException
@@ -27,6 +26,11 @@ from desktop.lib.i18n import force_unicode, smart_str
 from desktop.lib.rest.http_client import RestException
 
 from notebook.connectors.base import Api, QueryError, QueryExpired, OperationTimeout, OperationNotSupported
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py
+++ b/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py
@@ -28,7 +28,6 @@ import struct
 import sys
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
 
 from desktop.auth.backend import is_admin
 from desktop.conf import USE_DEFAULT_CONFIGURATION, has_connectors
@@ -46,7 +45,9 @@ from notebook.connectors.base import Api, QueryError, QueryExpired, OperationTim
 
 if sys.version_info[0] > 2:
   from urllib.parse import quote as urllib_quote, unquote as urllib_unquote
+  from django.utils.translation import gettext as _
 else:
+  from django.utils.translation import ugettext as _
   from urllib import quote as urllib_quote, unquote as urllib_unquote
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/notebook/src/notebook/connectors/jdbc.py
+++ b/desktop/libs/notebook/src/notebook/connectors/jdbc.py
@@ -19,13 +19,16 @@ from builtins import object
 import logging
 import sys
 
-from django.utils.translation import ugettext as _
-
 from beeswax import data_export
 from desktop.lib.i18n import force_unicode, smart_str
 from librdbms.jdbc import Jdbc, query_and_fetch
 
 from notebook.connectors.base import Api, QueryError, AuthenticationRequired, _get_snippet_name
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/notebook/src/notebook/connectors/kafka.py
+++ b/desktop/libs/notebook/src/notebook/connectors/kafka.py
@@ -18,13 +18,17 @@
 from __future__ import absolute_import
 
 import logging
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.lib.i18n import force_unicode
 from kafka.kafka_api import get_topics
 
 from notebook.connectors.base import Api, QueryError
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/notebook/src/notebook/connectors/ksql.py
+++ b/desktop/libs/notebook/src/notebook/connectors/ksql.py
@@ -20,14 +20,18 @@ from __future__ import absolute_import
 
 import logging
 import json
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.lib.i18n import force_unicode
 from desktop.conf import has_channels
 from kafka.ksql_client import KSqlApi as KSqlClientApi
 
 from notebook.connectors.base import Api, QueryError
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/notebook/src/notebook/connectors/oozie_batch.py
+++ b/desktop/libs/notebook/src/notebook/connectors/oozie_batch.py
@@ -17,16 +17,21 @@
 
 import logging
 import re
+import sys
 import time
 
 from django.urls import reverse
 from django.http import QueryDict
-from django.utils.translation import ugettext as _
 
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.models import Document2
 
 from notebook.connectors.base import Api, QueryError
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/notebook/src/notebook/connectors/solr.py
+++ b/desktop/libs/notebook/src/notebook/connectors/solr.py
@@ -17,8 +17,7 @@
 
 from builtins import object
 import logging
-
-from django.utils.translation import ugettext as _
+import sys
 
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.i18n import force_unicode
@@ -26,6 +25,11 @@ from indexer.solr_client import SolrClient
 
 from notebook.connectors.base import Api, QueryError
 from notebook.models import escape_rows
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/notebook/src/notebook/connectors/spark_shell.py
+++ b/desktop/libs/notebook/src/notebook/connectors/spark_shell.py
@@ -18,9 +18,8 @@
 from builtins import range, object
 import logging
 import re
+import sys
 import time
-
-from django.utils.translation import ugettext as _
 
 from desktop.conf import USE_DEFAULT_CONFIGURATION
 from desktop.lib.exceptions_renderable import PopupException
@@ -30,6 +29,11 @@ from desktop.models import DefaultConfiguration
 
 from notebook.data_export import download as spark_download
 from notebook.connectors.base import Api, QueryError, SessionExpired, _get_snippet_session
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
+++ b/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
@@ -64,7 +64,6 @@ import textwrap
 from string import Template
 
 from django.core.cache import caches
-from django.utils.translation import ugettext as _
 from sqlalchemy import create_engine, inspect, Table, MetaData
 from sqlalchemy.exc import OperationalError, UnsupportedCompilationError, CompileError
 
@@ -80,7 +79,9 @@ if sys.version_info[0] > 2:
   from urllib.parse import quote_plus as urllib_quote_plus
   from past.builtins import long
   from io import StringIO
+  from django.utils.translation import gettext as _
 else:
+  from django.utils.translation import ugettext as _
   from urllib import quote_plus as urllib_quote_plus
   from cStringIO import StringIO
 

--- a/desktop/libs/notebook/src/notebook/connectors/sqlflow.py
+++ b/desktop/libs/notebook/src/notebook/connectors/sqlflow.py
@@ -21,17 +21,21 @@ from __future__ import absolute_import
 import logging
 import json
 import os
+import sys
 
 import sqlflow
 from sqlflow.rows import Rows
-
-from django.utils.translation import ugettext as _
 
 from desktop.lib.i18n import force_unicode
 
 from notebook.connectors.base import Api, QueryError
 from notebook.decorators import ssh_error_handler, rewrite_ssh_api_url
 from notebook.models import escape_rows
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/notebook/src/notebook/decorators.py
+++ b/desktop/libs/notebook/src/notebook/decorators.py
@@ -20,11 +20,11 @@ import json
 import logging
 import math
 import re
+import sys
 
 from django.forms import ValidationError
 from django.http import Http404
 from django.utils.functional import wraps
-from django.utils.translation import ugettext as _
 
 from dashboard.models import extract_solr_exception_message
 from desktop.lib.django_util import JsonResponse
@@ -37,6 +37,11 @@ from notebook.conf import check_has_missing_permission, ENABLE_NOTEBOOK_2
 from notebook.connectors.base import QueryExpired, QueryError, SessionExpired, AuthenticationRequired, OperationTimeout, \
   OperationNotSupported
 from notebook.models import _get_editor_type
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/libs/notebook/src/notebook/models.py
+++ b/desktop/libs/notebook/src/notebook/models.py
@@ -32,7 +32,6 @@ from django.contrib.sessions.models import Session
 from django.db.models import Count
 from django.db.models.functions import Trunc
 from django.utils.html import escape
-from django.utils.translation import ugettext as _
 
 from desktop.conf import has_connectors, TASK_SERVER
 from desktop.lib.connectors.models import _get_installed_connectors
@@ -46,7 +45,9 @@ from notebook.connectors.base import Notebook, get_api as _get_api, get_interpre
 
 if sys.version_info[0] > 2:
   from urllib.parse import quote as urllib_quote
+  from django.utils.translation import gettext as _
 else:
+  from django.utils.translation import ugettext as _
   from urllib import quote as urllib_quote
 
 

--- a/desktop/libs/notebook/src/notebook/templates/editor.mako
+++ b/desktop/libs/notebook/src/notebook/templates/editor.mako
@@ -14,7 +14,11 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
-  from django.utils.translation import ugettext as _
+  import sys
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 
   from desktop.views import commonfooter, commonshare
   from desktop import conf

--- a/desktop/libs/notebook/src/notebook/templates/editor2.mako
+++ b/desktop/libs/notebook/src/notebook/templates/editor2.mako
@@ -14,13 +14,17 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
   from desktop import conf
   from desktop.views import _ko, antixss
   from desktop.webpack_utils import get_hue_bundles
-  from django.utils.translation import ugettext as _
   from metadata.conf import OPTIMIZER
   from notebook.conf import ENABLE_QUERY_SCHEDULING, ENABLE_EXTERNAL_STATEMENT, ENABLE_PRESENTATION
   from webpack_loader.templatetags.webpack_loader import render_bundle
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="configKoComponents" file="/config_ko_components.mako" />

--- a/desktop/libs/notebook/src/notebook/templates/editor_components.mako
+++ b/desktop/libs/notebook/src/notebook/templates/editor_components.mako
@@ -15,7 +15,7 @@
 ## limitations under the License.
 
 <%!
-from django.utils.translation import ugettext as _
+import sys
 
 from webpack_loader.templatetags.webpack_loader import render_bundle
 
@@ -28,6 +28,11 @@ from desktop.webpack_utils import get_hue_bundles
 from metadata.conf import has_optimizer, OPTIMIZER
 
 from notebook.conf import ENABLE_QUERY_BUILDER, ENABLE_QUERY_SCHEDULING, ENABLE_BATCH_EXECUTE, ENABLE_EXTERNAL_STATEMENT, ENABLE_PRESENTATION
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 %>
 
 <%def name="includes(is_embeddable=False, suffix='')">

--- a/desktop/libs/notebook/src/notebook/templates/editor_m.mako
+++ b/desktop/libs/notebook/src/notebook/templates/editor_m.mako
@@ -14,10 +14,16 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
+
   from desktop.views import commonheader_m, commonfooter_m
   from desktop import conf
-  from django.utils.translation import ugettext as _
   from desktop.views import _ko
+
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 ${ commonheader_m(editor_type, editor_type, user, request, "68px") | n,unicode }

--- a/desktop/libs/notebook/src/notebook/templates/notebook.mako
+++ b/desktop/libs/notebook/src/notebook/templates/notebook.mako
@@ -14,11 +14,15 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 <%!
+  import sys
   from desktop.auth.backend import is_admin
   from desktop.conf import ENABLE_CONNECTORS
   from desktop.views import commonfooter, commonshare
 
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 
 <%namespace name="configKoComponents" file="/config_ko_components.mako" />

--- a/desktop/libs/notebook/src/notebook/templates/notebooks.mako
+++ b/desktop/libs/notebook/src/notebook/templates/notebooks.mako
@@ -15,8 +15,12 @@
 ## limitations under the License.
 
 <%!
+  import sys
   from desktop.views import commonheader, commonfooter, commonimportexport, _ko
-  from django.utils.translation import ugettext as _
+  if sys.version_info[0] > 2:
+    from django.utils.translation import gettext as _
+  else:
+    from django.utils.translation import ugettext as _
 %>
 <%namespace name="actionbar" file="actionbar.mako" />
 

--- a/desktop/libs/notebook/src/notebook/views.py
+++ b/desktop/libs/notebook/src/notebook/views.py
@@ -18,11 +18,11 @@
 from builtins import object
 import json
 import logging
+import sys
 
 from django.urls import reverse
 from django.db.models import Q
 from django.shortcuts import redirect
-from django.utils.translation import ugettext as _
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.http import require_POST
 
@@ -45,6 +45,11 @@ from notebook.connectors.spark_shell import SparkApi
 from notebook.decorators import check_editor_access_permission, check_document_access_permission, check_document_modify_permission
 from notebook.management.commands.notebook_setup import Command
 from notebook.models import make_notebook, _get_editor_type, get_api, _get_dialect_example
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
 
 
 LOG = logging.getLogger(__name__)

--- a/tools/ops/script_runner/lib/custom_commands/management/commands/backend_test_curl.py
+++ b/tools/ops/script_runner/lib/custom_commands/management/commands/backend_test_curl.py
@@ -22,9 +22,9 @@ import logging
 import datetime
 import time
 import subprocess
+import sys
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 import desktop.conf
 from desktop.conf import TIME_ZONE
@@ -34,6 +34,11 @@ from hadoop import conf as hdfs_conf
 from hadoop import cluster
 
 from hue_curl import Curl
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 DEFAULT_LOG_DIR = 'logs'
 log_dir = os.getenv("DESKTOP_LOG_DIR", DEFAULT_LOG_DIR)

--- a/tools/ops/script_runner/lib/custom_commands/management/commands/c6_test_command.py
+++ b/tools/ops/script_runner/lib/custom_commands/management/commands/c6_test_command.py
@@ -25,10 +25,14 @@ import logging
 
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 from django.contrib.auth.models import User
 
 import desktop.conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/tools/ops/script_runner/lib/custom_commands/management/commands/change_owner_of_docs.py
+++ b/tools/ops/script_runner/lib/custom_commands/management/commands/change_owner_of_docs.py
@@ -24,11 +24,15 @@ import re
 import logging
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 from django.contrib.auth.models import User
 from desktop.models import Document2
 
 import desktop.conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/tools/ops/script_runner/lib/custom_commands/management/commands/db_query_test.py
+++ b/tools/ops/script_runner/lib/custom_commands/management/commands/db_query_test.py
@@ -24,11 +24,15 @@ import re
 import logging
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 from django.db.backends.oracle.base import Oracle_datetime
 from django.db import connection
 
 import desktop.conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/tools/ops/script_runner/lib/custom_commands/management/commands/delete_user.py
+++ b/tools/ops/script_runner/lib/custom_commands/management/commands/delete_user.py
@@ -24,10 +24,14 @@ import re
 import logging
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 from django.contrib.auth.models import User
 
 import desktop.conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/tools/ops/script_runner/lib/custom_commands/management/commands/estimate_concurrent_users.py
+++ b/tools/ops/script_runner/lib/custom_commands/management/commands/estimate_concurrent_users.py
@@ -27,7 +27,6 @@ import subprocess
 from collections import OrderedDict
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 import desktop.conf
 from desktop.conf import TIME_ZONE
@@ -35,6 +34,11 @@ from search.conf import SOLR_URL, SECURITY_ENABLED as SOLR_SECURITY_ENABLED
 from liboozie.conf import OOZIE_URL, SECURITY_ENABLED as OOZIE_SECURITY_ENABLED
 from hadoop import conf as hdfs_conf
 from hadoop import cluster
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 DEFAULT_LOG_DIR = 'logs'
 log_dir = os.getenv("DESKTOP_LOG_DIR", DEFAULT_LOG_DIR)

--- a/tools/ops/script_runner/lib/custom_commands/management/commands/hue_desktop_document_cleanup.py
+++ b/tools/ops/script_runner/lib/custom_commands/management/commands/hue_desktop_document_cleanup.py
@@ -17,13 +17,13 @@
 # limitations under the License.
 
 import os
+import sys
 import time
 
 from importlib import import_module
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 from beeswax.models import SavedQuery
 from beeswax.models import Session
 from datetime import date, timedelta
@@ -34,8 +34,12 @@ from desktop.models import Document2
 import logging
 import logging.handlers
 
-
 import desktop.conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 logging.basicConfig()
 LOG = logging.getLogger(__name__)

--- a/tools/ops/script_runner/lib/custom_commands/management/commands/list_groups.py
+++ b/tools/ops/script_runner/lib/custom_commands/management/commands/list_groups.py
@@ -24,10 +24,14 @@ import re
 import logging
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 from django.contrib.auth.models import User, Group
 
 import desktop.conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/tools/ops/script_runner/lib/custom_commands/management/commands/promote_to_superuser.py
+++ b/tools/ops/script_runner/lib/custom_commands/management/commands/promote_to_superuser.py
@@ -24,10 +24,14 @@ import re
 import logging
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 from django.contrib.auth.models import User
 
 import desktop.conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/tools/ops/script_runner/lib/custom_commands/management/commands/remove_doc2_without_content_object.py
+++ b/tools/ops/script_runner/lib/custom_commands/management/commands/remove_doc2_without_content_object.py
@@ -22,7 +22,6 @@ import sys
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 import desktop.conf
 from desktop.models import Document, Document2
 from django.contrib.auth.models import User
@@ -30,6 +29,11 @@ import desktop.conf
 
 import logging
 import logging.handlers
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/tools/ops/script_runner/lib/custom_commands/management/commands/remove_orphaned_docs.py
+++ b/tools/ops/script_runner/lib/custom_commands/management/commands/remove_orphaned_docs.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 import os
+import sys
 import time
 import uuid
 
@@ -24,7 +25,6 @@ from importlib import import_module
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 from datetime import date, timedelta
 from django.db.utils import DatabaseError
 import desktop.conf
@@ -39,6 +39,11 @@ import logging.handlers
 
 
 import desktop.conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/tools/ops/script_runner/lib/custom_commands/management/commands/rename_duplicate_users.py
+++ b/tools/ops/script_runner/lib/custom_commands/management/commands/rename_duplicate_users.py
@@ -18,15 +18,20 @@
 import os
 import logging
 import datetime
+import sys
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 from django.contrib.auth.models import User
 from django.db import models, transaction
 from django.contrib.auth.models import User
 
 
 import desktop.conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 LOG = logging.getLogger(__name__)
 

--- a/tools/ops/script_runner/lib/custom_commands/management/commands/run_hive_impala_query.py
+++ b/tools/ops/script_runner/lib/custom_commands/management/commands/run_hive_impala_query.py
@@ -22,11 +22,15 @@ import datetime
 import time
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 from django.contrib.auth.models import User
 
 import desktop.conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 logging.basicConfig()
 LOG = logging.getLogger(__name__)

--- a/tools/ops/script_runner/lib/custom_commands/management/commands/set_default_editor.py
+++ b/tools/ops/script_runner/lib/custom_commands/management/commands/set_default_editor.py
@@ -22,12 +22,16 @@ import datetime
 import time
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 from django.contrib.auth.models import User
 from desktop.models import set_user_preferences
 
 import desktop.conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 logging.basicConfig()
 LOG = logging.getLogger(__name__)

--- a/tools/ops/script_runner/lib/custom_commands/management/commands/share_all_workflows.py
+++ b/tools/ops/script_runner/lib/custom_commands/management/commands/share_all_workflows.py
@@ -19,7 +19,6 @@ import os
 import sys
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _t, ugettext as _
 import desktop.conf
 from desktop.models import Document2
 from django.contrib.auth.models import User, Group
@@ -27,6 +26,11 @@ import desktop.conf
 
 import logging
 import logging.handlers
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
…on.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy()

## What changes were proposed in this pull request?

- ugettext_lazy -> gettext_lazy and ugettext -> gettext
## How was this patch tested?

- https://docs.djangoproject.com/en/1.11/_modules/django/utils/translation/
- https://docs.djangoproject.com/en/3.1/internals/deprecation/
- https://docs.djangoproject.com/en/3.0/_modules/django/utils/translation/
