### PR TITLE
support clone django babel through http proxy

### DIFF
--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -63,4 +63,4 @@ sqlparse==0.4.1
 tablib==0.13.0
 thrift==0.13.0
 thrift-sasl==0.4.2
-git+git://github.com/gethue/django-babel.git
+git+https://github.com/gethue/django-babel.git


### PR DESCRIPTION
## What changes were proposed in this pull request?

It allow user can install django-babel through proxy.

## How was this patch tested?

- Manual tests
