### PR TITLE
Truncated warning message is not being displayed #GH-1895 

### DIFF
--- a/apps/beeswax/src/beeswax/tests.py
+++ b/apps/beeswax/src/beeswax/tests.py
@@ -125,7 +125,7 @@ def get_csv(client, result_response):
   assert_true(content['isSuccess'])
   csv_link = '/beeswax/download/%s/csv' % content['id']
   csv_resp = client.get(csv_link)
-  return ''.join(csv_resp.streaming_content)
+  return ''.join(csv_resp.content)
 
 
 class TestHive(object):
@@ -310,7 +310,7 @@ for x in sys.stdin:
     # Download the data
     response = self.client.get(content["download_urls"]["csv"])
     # Header line plus data lines...
-    assert_equal(257, ''.join(response.streaming_content).count("\n"))
+    assert_equal(257, ''.join(response.content).count("\n"))
 
 
   def test_api_get_session(self):
@@ -849,7 +849,7 @@ for x in sys.stdin:
     handle = self.db.execute_and_wait(query)
     # Get the result in csv. Should have 3 + 1 header row.
     csv_resp = download(handle, 'csv', self.db)
-    csv_content = ''.join(csv_resp.streaming_content)
+    csv_content = ''.join(csv_resp.content)
     assert_equal(len(csv_content.strip().split('\n')), limit + 1)
 
 
@@ -891,7 +891,7 @@ for x in sys.stdin:
     handle = self.db.execute_and_wait(query)
 
     resp = download(handle, 'csv', self.db)
-    csv_resp = ''.join(resp.streaming_content)
+    csv_resp = ''.join(resp.content)
     csv_data = [[int(col) if col.isdigit() else col for col in row.split(',')] for row in csv_resp.strip().split('\r\n')]
 
     assert_equal(sheet_data, csv_data)
@@ -915,7 +915,7 @@ for x in sys.stdin:
       query = hql_query(hql)
       handle = self.db.execute_and_wait(query)
       resp = download(handle, 'csv', self.db)
-      content = "".join(resp.streaming_content)
+      content = "".join(resp.content)
       assert_true(len(content) <= 1024)
     finally:
       finish()

--- a/apps/impala/src/impala/tests.py
+++ b/apps/impala/src/impala/tests.py
@@ -260,7 +260,7 @@ class TestImpalaIntegration(object):
       handle = self.db.execute_and_wait(query)
       # Get the result in csv. Should have 5 + 1 header row.
       csv_resp = download(handle, 'csv', self.db)
-      csv_content = ''.join(csv_resp.streaming_content)
+      csv_content = ''.join(csv_resp.content)
       assert_equal(len(csv_content.strip().split('\n')), 5 + 1)
 
 
@@ -268,21 +268,21 @@ class TestImpalaIntegration(object):
 
       handle = self.db.execute_and_wait(query)
       csv_resp = download(handle, 'csv', self.db)
-      csv_content = ''.join(csv_resp.streaming_content)
+      csv_content = ''.join(csv_resp.content)
       assert_equal(len(csv_content.strip().split('\n')), 1)
 
       query = hql_query(hql % {'limit': 'LIMIT 1'})
 
       handle = self.db.execute_and_wait(query)
       csv_resp = download(handle, 'csv', self.db)
-      csv_content = ''.join(csv_resp.streaming_content)
+      csv_content = ''.join(csv_resp.content)
       assert_equal(len(csv_content.strip().split('\n')), 1 + 1)
 
       query = hql_query(hql % {'limit': 'LIMIT 2'})
 
       handle = self.db.execute_and_wait(query)
       csv_resp = download(handle, 'csv', self.db)
-      csv_content = ''.join(csv_resp.streaming_content)
+      csv_content = ''.join(csv_resp.content)
       assert_equal(len(csv_content.strip().split('\n')), 1 + 2)
     finally:
       data_export.FETCH_SIZE = FETCH_SIZE

--- a/apps/search/src/search/tests.py
+++ b/apps/search/src/search/tests.py
@@ -494,7 +494,7 @@ class TestWithMockedSolr(TestSearchBase):
         'collection': json.dumps(self._get_collection_param(self.collection)),
         'query': json.dumps(QUERY)
     })
-    csv_response_content = b''.join(csv_response.streaming_content)
+    csv_response_content = b''.join(csv_response.content)
     assert_equal('application/csv', csv_response['Content-Type'])
     assert_equal('attachment; filename="query_result.csv"', csv_response['Content-Disposition'])
     assert_equal(4 + 1 + 1, len(csv_response_content.split(b'\n')), csv_response_content.split(b'\n'))

--- a/desktop/core/src/desktop/lib/export_csvxls.py
+++ b/desktop/core/src/desktop/lib/export_csvxls.py
@@ -30,7 +30,7 @@ import six
 import sys
 import tablib
 
-from django.http import StreamingHttpResponse, HttpResponse
+from django.http import HttpResponse
 from django.utils.encoding import smart_str
 from django.utils.http import urlquote
 from desktop.lib import i18n
@@ -146,7 +146,7 @@ def make_response(generator, format, name, encoding=None, user_agent=None): #TOD
   """
   content_type = FORMAT_TO_CONTENT_TYPE.get(format, 'application/octet-stream')
   if format == 'csv':
-    resp = StreamingHttpResponse(generator, content_type=content_type)
+    resp = HttpResponse(generator, content_type=content_type)
     try:
       del resp['Content-Length']
     except KeyError:

--- a/desktop/core/src/desktop/lib/export_csvxls_tests.py
+++ b/desktop/core/src/desktop/lib/export_csvxls_tests.py
@@ -42,7 +42,7 @@ def test_export_csv():
   generator = create_generator(content_generator(headers, data), "csv")
   response = make_response(generator, "csv", "foo")
   assert_equal("application/csv", response["content-type"])
-  content = b''.join(response.streaming_content)
+  content = b''.join(response.content)
   assert_equal(b'x,y\r\n1,2\r\n3,4\r\n"5,6",7\r\nNULL,NULL\r\nhttp://gethue.com,http://gethue.com\r\n', content)
   assert_equal('attachment; filename="foo.csv"', response["content-disposition"])
 
@@ -50,7 +50,7 @@ def test_export_csv():
   generator = create_generator(content_generator(headers, data), "csv")
   response = make_response(generator, "csv", u'gんtbhんjk？￥n')
   assert_equal("application/csv", response["content-type"])
-  content = b''.join(response.streaming_content)
+  content = b''.join(response.content)
   assert_equal(b'x,y\r\n1,2\r\n3,4\r\n"5,6",7\r\nNULL,NULL\r\nhttp://gethue.com,http://gethue.com\r\n', content)
   assert_equal('attachment; filename="g%E3%82%93tbh%E3%82%93jk%EF%BC%9F%EF%BF%A5n.csv"', response["content-disposition"])
 
@@ -61,7 +61,7 @@ def test_export_csv():
       user_agent='Mozilla / 5.0(Macintosh; Intel Mac OS X 10.12;rv:59.0) Gecko / 20100101 Firefox / 59.0)'
   )
   assert_equal("application/csv", response["content-type"])
-  content = b''.join(response.streaming_content)
+  content = b''.join(response.content)
   assert_equal(b'x,y\r\n1,2\r\n3,4\r\n"5,6",7\r\nNULL,NULL\r\nhttp://gethue.com,http://gethue.com\r\n', content)
   assert_equal(
       'attachment; filename*="g%E3%82%93tbh%E3%82%93jk%EF%BC%9F%EF%BF%A5n.csv"',

--- a/desktop/core/src/desktop/templates/common_notebook_ko_components.mako
+++ b/desktop/core/src/desktop/templates/common_notebook_ko_components.mako
@@ -504,7 +504,7 @@ from notebook.conf import ENABLE_SQL_INDEXER
             window.clearInterval(self.checkDownloadInterval);
             try {
               var cookieContent = $.cookie('download-' + self.snippet.id());
-              var result = JSON.parse(cookieContent.substr(1, cookieContent.length - 2).replace(/\\"/g, '"').replace(/\\054/g, ','));
+              var result = JSON.parse(cookieContent.replace(/\\"/g, '"').replace(/\\054/g, ','));
               self.downloadTruncated(result.truncated);
               self.downloadCounter(result.row_counter);
               self.isDownloading(false);

--- a/desktop/libs/dashboard/src/dashboard/tests.py
+++ b/desktop/libs/dashboard/src/dashboard/tests.py
@@ -497,7 +497,7 @@ class TestWithMockedSolr(TestSearchBase):
         'collection': json.dumps(self._get_collection_param(self.collection)),
         'query': json.dumps(QUERY)
     })
-    csv_response_content = b''.join(csv_response.streaming_content)
+    csv_response_content = b''.join(csv_response.content)
     assert_equal('application/csv', csv_response['Content-Type'])
     assert_equal('attachment; filename="query_result.csv"', csv_response['Content-Disposition'])
     assert_equal(4 + 1 + 1, len(csv_response_content.split(b'\n')), csv_response_content.split(b'\n'))

--- a/desktop/libs/notebook/src/notebook/connectors/base.py
+++ b/desktop/libs/notebook/src/notebook/connectors/base.py
@@ -552,7 +552,7 @@ class Api(object):
     max_bytes = conf.DOWNLOAD_BYTES_LIMIT.get()
 
     content_generator = data_export.DataAdapter(result_wrapper, max_rows=max_rows, max_bytes=max_bytes)
-    return export_csvxls.create_generator(content_generator, file_format)
+    return content_generator
 
   def get_log(self, notebook, snippet, startFrom=None, size=None):
     return 'No logs'

--- a/desktop/libs/notebook/src/notebook/views.py
+++ b/desktop/libs/notebook/src/notebook/views.py
@@ -379,14 +379,14 @@ def download(request):
   file_name = _get_snippet_name(notebook)
 
   content_generator = get_api(request, snippet).download(notebook, snippet, file_format=file_format)
-  response = export_csvxls.make_response(content_generator, file_format, file_name, user_agent=user_agent)
+  response = export_csvxls.make_response(export_csvxls.create_generator(content_generator, file_format), file_format, file_name, user_agent=user_agent)
 
   if snippet['id']:
     response.set_cookie(
       'download-%s' % snippet['id'],
       json.dumps({
-        'truncated': 'false',
-        'row_counter': '0'
+        'truncated': content_generator.is_truncated,
+        'row_counter': content_generator.row_counter
       }),
       max_age=DOWNLOAD_COOKIE_AGE
     )


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Truncated warning message is not being displayed #GH-1895 

## How was this patch tested?

- Tested Manually with Steps mentioned in : https://github.com/cloudera/hue/issues/1895
- Fix works fine, attached image of resolution.
-
<img width="654" alt="Screenshot 2021-03-16 at 3 44 10 PM" src="https://user-images.githubusercontent.com/18462803/111292693-74db8480-866e-11eb-9733-940ad36ab34f.png">
