### PR TITLE
[Django40_warning] RemovedInDjango40Warning: django.conf.urls.url() is deprecated in favor of django.urls.re_path()

### DIFF
--- a/apps/about/src/about/urls.py
+++ b/apps/about/src/about/urls.py
@@ -15,8 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from about import views as about_views
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   url(r'^$', about_views.admin_wizard, name='index'),

--- a/apps/about/src/about/urls.py
+++ b/apps/about/src/about/urls.py
@@ -19,14 +19,14 @@ import sys
 
 from about import views as about_views
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-  url(r'^$', about_views.admin_wizard, name='index'),
-  url(r'^admin_wizard$', about_views.admin_wizard, name='admin_wizard'),
+  re_path(r'^$', about_views.admin_wizard, name='index'),
+  re_path(r'^admin_wizard$', about_views.admin_wizard, name='admin_wizard'),
 
-  url(r'^update_preferences$', about_views.update_preferences, name='update_preferences'),
+  re_path(r'^update_preferences$', about_views.update_preferences, name='update_preferences'),
 ]

--- a/apps/beeswax/src/beeswax/urls.py
+++ b/apps/beeswax/src/beeswax/urls.py
@@ -22,98 +22,98 @@ from beeswax import create_database as beeswax_create_database
 from beeswax import create_table as beeswax_create_table
 from beeswax import api as beeswax_api
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-  url(r'^$', beeswax_views.index, name='index'),
+  re_path(r'^$', beeswax_views.index, name='index'),
 
-  url(r'^execute/?$', beeswax_views.execute_query, name='execute_query'),
-  url(r'^execute/design/(?P<design_id>\d+)$', beeswax_views.execute_query, name='execute_design'),
-  url(r'^execute/query/(?P<query_history_id>\d+)$', beeswax_views.execute_query, name='watch_query_history'),
-  url(r'^results/(?P<id>\d+)/(?P<first_row>\d+)$', beeswax_views.view_results, name='view_results'),
-  url(r'^download/(?P<id>\d+)/(?P<format>\w+)$', beeswax_views.download, name='download'),
+  re_path(r'^execute/?$', beeswax_views.execute_query, name='execute_query'),
+  re_path(r'^execute/design/(?P<design_id>\d+)$', beeswax_views.execute_query, name='execute_design'),
+  re_path(r'^execute/query/(?P<query_history_id>\d+)$', beeswax_views.execute_query, name='watch_query_history'),
+  re_path(r'^results/(?P<id>\d+)/(?P<first_row>\d+)$', beeswax_views.view_results, name='view_results'),
+  re_path(r'^download/(?P<id>\d+)/(?P<format>\w+)$', beeswax_views.download, name='download'),
 
-  url(r'^my_queries$', beeswax_views.my_queries, name='my_queries'),
-  url(r'^list_designs$', beeswax_views.list_designs, name='list_designs'),
-  url(r'^list_trashed_designs$', beeswax_views.list_trashed_designs, name='list_trashed_designs'),
-  url(r'^delete_designs$', beeswax_views.delete_design, name='delete_design'),
-  url(r'^restore_designs$', beeswax_views.restore_design, name='restore_design'),
-  url(r'^clone_design/(?P<design_id>\d+)$', beeswax_views.clone_design, name='clone_design'),
-  url(r'^query_history$', beeswax_views.list_query_history, name='list_query_history'),
+  re_path(r'^my_queries$', beeswax_views.my_queries, name='my_queries'),
+  re_path(r'^list_designs$', beeswax_views.list_designs, name='list_designs'),
+  re_path(r'^list_trashed_designs$', beeswax_views.list_trashed_designs, name='list_trashed_designs'),
+  re_path(r'^delete_designs$', beeswax_views.delete_design, name='delete_design'),
+  re_path(r'^restore_designs$', beeswax_views.restore_design, name='restore_design'),
+  re_path(r'^clone_design/(?P<design_id>\d+)$', beeswax_views.clone_design, name='clone_design'),
+  re_path(r'^query_history$', beeswax_views.list_query_history, name='list_query_history'),
 
-  url(r'^configuration/?$', beeswax_views.configuration, name='configuration'),
-  url(r'^install_examples$', beeswax_views.install_examples, name='install_examples'),
-  url(r'^query_cb/done/(?P<server_id>\S+)$', beeswax_views.query_done_cb, name='query_done_cb'),
+  re_path(r'^configuration/?$', beeswax_views.configuration, name='configuration'),
+  re_path(r'^install_examples$', beeswax_views.install_examples, name='install_examples'),
+  re_path(r'^query_cb/done/(?P<server_id>\S+)$', beeswax_views.query_done_cb, name='query_done_cb'),
 ]
 
 urlpatterns += [
-  url(r'^create/database$', beeswax_create_database.create_database, name='create_database'),
+  re_path(r'^create/database$', beeswax_create_database.create_database, name='create_database'),
 ]
 
 urlpatterns += [
-  url(r'^create/create_table/(?P<database>\w+)$', beeswax_create_table.create_table, name='create_table'),
-  url(r'^create/import_wizard/(?P<database>\w+)$', beeswax_create_table.import_wizard, name='import_wizard'),
-  url(r'^create/auto_load/(?P<database>\w+)$', beeswax_create_table.load_after_create, name='load_after_create'),
+  re_path(r'^create/create_table/(?P<database>\w+)$', beeswax_create_table.create_table, name='create_table'),
+  re_path(r'^create/import_wizard/(?P<database>\w+)$', beeswax_create_table.import_wizard, name='import_wizard'),
+  re_path(r'^create/auto_load/(?P<database>\w+)$', beeswax_create_table.load_after_create, name='load_after_create'),
 ]
 
 urlpatterns += [
-  url(r'^api/session/?$', beeswax_api.get_session, name='api_get_session'),
-  url(r'^api/session/(?P<session_id>\d+)/?$', beeswax_api.get_session, name='api_get_session'),
-  url(r'^api/session/(?P<session_id>\d+)/close/?$', beeswax_api.close_session, name='api_close_session'),
-  url(r'^api/settings/?$', beeswax_api.get_settings, name='get_settings'),
-  url(r'^api/functions/?$', beeswax_api.get_functions, name='get_functions'),
+  re_path(r'^api/session/?$', beeswax_api.get_session, name='api_get_session'),
+  re_path(r'^api/session/(?P<session_id>\d+)/?$', beeswax_api.get_session, name='api_get_session'),
+  re_path(r'^api/session/(?P<session_id>\d+)/close/?$', beeswax_api.close_session, name='api_close_session'),
+  re_path(r'^api/settings/?$', beeswax_api.get_settings, name='get_settings'),
+  re_path(r'^api/functions/?$', beeswax_api.get_functions, name='get_functions'),
 
   # Deprecated by Notebook API
-  url(r'^api/autocomplete/?$', beeswax_api.autocomplete, name='api_autocomplete_databases'),
-  url(r'^api/autocomplete/(?P<database>\w+)/?$', beeswax_api.autocomplete, name='api_autocomplete_tables'),
-  url(r'^api/autocomplete/(?P<database>\w+)/(?P<table>\w+)/?$', beeswax_api.autocomplete, name='api_autocomplete_columns'),
-  url(r'^api/autocomplete/(?P<database>\w+)/(?P<table>\w+)/(?P<column>\w+)/?$', beeswax_api.autocomplete, name='api_autocomplete_column'),
-  url(
+  re_path(r'^api/autocomplete/?$', beeswax_api.autocomplete, name='api_autocomplete_databases'),
+  re_path(r'^api/autocomplete/(?P<database>\w+)/?$', beeswax_api.autocomplete, name='api_autocomplete_tables'),
+  re_path(r'^api/autocomplete/(?P<database>\w+)/(?P<table>\w+)/?$', beeswax_api.autocomplete, name='api_autocomplete_columns'),
+  re_path(r'^api/autocomplete/(?P<database>\w+)/(?P<table>\w+)/(?P<column>\w+)/?$', beeswax_api.autocomplete, name='api_autocomplete_column'),
+  re_path(
     r'^api/autocomplete/(?P<database>\w+)/(?P<table>\w+)/(?P<column>\w+)/(?P<nested>.+)/?$',
     beeswax_api.autocomplete,
     name='api_autocomplete_nested'
   ),
 
-  url(r'^api/design(?:/(?P<design_id>\d+))?/?$', beeswax_api.save_query_design, name='api_save_design'),
-  url(r'^api/design/(?P<design_id>\d+)/get$', beeswax_api.fetch_saved_design, name='api_fetch_saved_design'),
+  re_path(r'^api/design(?:/(?P<design_id>\d+))?/?$', beeswax_api.save_query_design, name='api_save_design'),
+  re_path(r'^api/design/(?P<design_id>\d+)/get$', beeswax_api.fetch_saved_design, name='api_fetch_saved_design'),
 
-  url(r'^api/query/(?P<query_history_id>\d+)/get$', beeswax_api.fetch_query_history, name='api_fetch_query_history'),
-  url(r'^api/query/parameters$', beeswax_api.parameters, name='api_parameters'),
-  url(r'^api/query/execute(?:/(?P<design_id>\d+))?/?$', beeswax_api.execute, name='api_execute'),
-  url(r'^api/query/(?P<query_history_id>\d+)/cancel/?$', beeswax_api.cancel_query, name='api_cancel_query'),
-  url(r'^api/query/(?P<query_history_id>\d+)/close/?$', beeswax_api.close_operation, name='api_close_operation'),
-  url(
+  re_path(r'^api/query/(?P<query_history_id>\d+)/get$', beeswax_api.fetch_query_history, name='api_fetch_query_history'),
+  re_path(r'^api/query/parameters$', beeswax_api.parameters, name='api_parameters'),
+  re_path(r'^api/query/execute(?:/(?P<design_id>\d+))?/?$', beeswax_api.execute, name='api_execute'),
+  re_path(r'^api/query/(?P<query_history_id>\d+)/cancel/?$', beeswax_api.cancel_query, name='api_cancel_query'),
+  re_path(r'^api/query/(?P<query_history_id>\d+)/close/?$', beeswax_api.close_operation, name='api_close_operation'),
+  re_path(
     r'^api/query/(?P<query_history_id>\d+)/results/save/hive/table/?$',
     beeswax_api.save_results_hive_table,
     name='api_save_results_hive_table'
   ),
-  url(
+  re_path(
     r'^api/query/(?P<query_history_id>\d+)/results/save/hdfs/file/?$',
     beeswax_api.save_results_hdfs_file,
     name='api_save_results_hdfs_file'
   ),
-  url(
+  re_path(
     r'^api/query/(?P<query_history_id>\d+)/results/save/hdfs/directory/?$',
     beeswax_api.save_results_hdfs_directory,
     name='api_save_results_hdfs_directory'
   ),
-  url(r'^api/watch/json/(?P<id>\d+)/?$', beeswax_api.watch_query_refresh_json, name='api_watch_query_refresh_json'),
+  re_path(r'^api/watch/json/(?P<id>\d+)/?$', beeswax_api.watch_query_refresh_json, name='api_watch_query_refresh_json'),
 
-  url(r'^api/query/clear_history/?$', beeswax_api.clear_history, name='clear_history'),
+  re_path(r'^api/query/clear_history/?$', beeswax_api.clear_history, name='clear_history'),
 
-  url(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/?$', beeswax_api.describe_table, name='describe_table'),
-  url(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/indexes/?$', beeswax_api.get_indexes, name='get_indexes'),
-  url(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/sample/?$', beeswax_api.get_sample_data, name='get_sample_data'),
-  url(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/(?P<column>\w+)/sample/?$', beeswax_api.get_sample_data, name='get_sample_data_column'),
-  url(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/stats(?:/(?P<column>\w+))?/?$', beeswax_api.get_table_stats, name='get_table_stats'),
-  url(
+  re_path(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/?$', beeswax_api.describe_table, name='describe_table'),
+  re_path(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/indexes/?$', beeswax_api.get_indexes, name='get_indexes'),
+  re_path(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/sample/?$', beeswax_api.get_sample_data, name='get_sample_data'),
+  re_path(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/(?P<column>\w+)/sample/?$', beeswax_api.get_sample_data, name='get_sample_data_column'),
+  re_path(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/stats(?:/(?P<column>\w+))?/?$', beeswax_api.get_table_stats, name='get_table_stats'),
+  re_path(
     r'^api/table/(?P<database>\w+)/(?P<table>\w+)/terms/(?P<column>\w+)(?:/(?P<prefix>\w+))?/?$',
     beeswax_api.get_top_terms,
     name='get_top_terms'
   ),
 
-  url(r'^api/analyze/(?P<database>\w+)/(?P<table>\w+)(?:/(?P<columns>\w+))?/?$', beeswax_api.analyze_table, name='analyze_table'),
+  re_path(r'^api/analyze/(?P<database>\w+)/(?P<table>\w+)(?:/(?P<columns>\w+))?/?$', beeswax_api.analyze_table, name='analyze_table'),
 ]

--- a/apps/beeswax/src/beeswax/urls.py
+++ b/apps/beeswax/src/beeswax/urls.py
@@ -71,7 +71,11 @@ urlpatterns += [
   url(r'^api/autocomplete/(?P<database>\w+)/?$', beeswax_api.autocomplete, name='api_autocomplete_tables'),
   url(r'^api/autocomplete/(?P<database>\w+)/(?P<table>\w+)/?$', beeswax_api.autocomplete, name='api_autocomplete_columns'),
   url(r'^api/autocomplete/(?P<database>\w+)/(?P<table>\w+)/(?P<column>\w+)/?$', beeswax_api.autocomplete, name='api_autocomplete_column'),
-  url(r'^api/autocomplete/(?P<database>\w+)/(?P<table>\w+)/(?P<column>\w+)/(?P<nested>.+)/?$', beeswax_api.autocomplete, name='api_autocomplete_nested'),
+  url(
+    r'^api/autocomplete/(?P<database>\w+)/(?P<table>\w+)/(?P<column>\w+)/(?P<nested>.+)/?$',
+    beeswax_api.autocomplete,
+    name='api_autocomplete_nested'
+  ),
 
   url(r'^api/design(?:/(?P<design_id>\d+))?/?$', beeswax_api.save_query_design, name='api_save_design'),
   url(r'^api/design/(?P<design_id>\d+)/get$', beeswax_api.fetch_saved_design, name='api_fetch_saved_design'),
@@ -81,9 +85,21 @@ urlpatterns += [
   url(r'^api/query/execute(?:/(?P<design_id>\d+))?/?$', beeswax_api.execute, name='api_execute'),
   url(r'^api/query/(?P<query_history_id>\d+)/cancel/?$', beeswax_api.cancel_query, name='api_cancel_query'),
   url(r'^api/query/(?P<query_history_id>\d+)/close/?$', beeswax_api.close_operation, name='api_close_operation'),
-  url(r'^api/query/(?P<query_history_id>\d+)/results/save/hive/table/?$', beeswax_api.save_results_hive_table, name='api_save_results_hive_table'),
-  url(r'^api/query/(?P<query_history_id>\d+)/results/save/hdfs/file/?$', beeswax_api.save_results_hdfs_file, name='api_save_results_hdfs_file'),
-  url(r'^api/query/(?P<query_history_id>\d+)/results/save/hdfs/directory/?$', beeswax_api.save_results_hdfs_directory, name='api_save_results_hdfs_directory'),
+  url(
+    r'^api/query/(?P<query_history_id>\d+)/results/save/hive/table/?$',
+    beeswax_api.save_results_hive_table,
+    name='api_save_results_hive_table'
+  ),
+  url(
+    r'^api/query/(?P<query_history_id>\d+)/results/save/hdfs/file/?$',
+    beeswax_api.save_results_hdfs_file,
+    name='api_save_results_hdfs_file'
+  ),
+  url(
+    r'^api/query/(?P<query_history_id>\d+)/results/save/hdfs/directory/?$',
+    beeswax_api.save_results_hdfs_directory,
+    name='api_save_results_hdfs_directory'
+  ),
   url(r'^api/watch/json/(?P<id>\d+)/?$', beeswax_api.watch_query_refresh_json, name='api_watch_query_refresh_json'),
 
   url(r'^api/query/clear_history/?$', beeswax_api.clear_history, name='clear_history'),
@@ -93,7 +109,11 @@ urlpatterns += [
   url(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/sample/?$', beeswax_api.get_sample_data, name='get_sample_data'),
   url(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/(?P<column>\w+)/sample/?$', beeswax_api.get_sample_data, name='get_sample_data_column'),
   url(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/stats(?:/(?P<column>\w+))?/?$', beeswax_api.get_table_stats, name='get_table_stats'),
-  url(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/terms/(?P<column>\w+)(?:/(?P<prefix>\w+))?/?$', beeswax_api.get_top_terms, name='get_top_terms'),
+  url(
+    r'^api/table/(?P<database>\w+)/(?P<table>\w+)/terms/(?P<column>\w+)(?:/(?P<prefix>\w+))?/?$',
+    beeswax_api.get_top_terms,
+    name='get_top_terms'
+  ),
 
   url(r'^api/analyze/(?P<database>\w+)/(?P<table>\w+)(?:/(?P<columns>\w+))?/?$', beeswax_api.analyze_table, name='analyze_table'),
 ]

--- a/apps/beeswax/src/beeswax/urls.py
+++ b/apps/beeswax/src/beeswax/urls.py
@@ -70,7 +70,9 @@ urlpatterns += [
   re_path(r'^api/autocomplete/?$', beeswax_api.autocomplete, name='api_autocomplete_databases'),
   re_path(r'^api/autocomplete/(?P<database>\w+)/?$', beeswax_api.autocomplete, name='api_autocomplete_tables'),
   re_path(r'^api/autocomplete/(?P<database>\w+)/(?P<table>\w+)/?$', beeswax_api.autocomplete, name='api_autocomplete_columns'),
-  re_path(r'^api/autocomplete/(?P<database>\w+)/(?P<table>\w+)/(?P<column>\w+)/?$', beeswax_api.autocomplete, name='api_autocomplete_column'),
+  re_path(
+    r'^api/autocomplete/(?P<database>\w+)/(?P<table>\w+)/(?P<column>\w+)/?$', beeswax_api.autocomplete, name='api_autocomplete_column'
+  ),
   re_path(
     r'^api/autocomplete/(?P<database>\w+)/(?P<table>\w+)/(?P<column>\w+)/(?P<nested>.+)/?$',
     beeswax_api.autocomplete,
@@ -107,8 +109,12 @@ urlpatterns += [
   re_path(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/?$', beeswax_api.describe_table, name='describe_table'),
   re_path(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/indexes/?$', beeswax_api.get_indexes, name='get_indexes'),
   re_path(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/sample/?$', beeswax_api.get_sample_data, name='get_sample_data'),
-  re_path(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/(?P<column>\w+)/sample/?$', beeswax_api.get_sample_data, name='get_sample_data_column'),
-  re_path(r'^api/table/(?P<database>\w+)/(?P<table>\w+)/stats(?:/(?P<column>\w+))?/?$', beeswax_api.get_table_stats, name='get_table_stats'),
+  re_path(
+    r'^api/table/(?P<database>\w+)/(?P<table>\w+)/(?P<column>\w+)/sample/?$', beeswax_api.get_sample_data, name='get_sample_data_column'
+  ),
+  re_path(
+    r'^api/table/(?P<database>\w+)/(?P<table>\w+)/stats(?:/(?P<column>\w+))?/?$', beeswax_api.get_table_stats, name='get_table_stats'
+  ),
   re_path(
     r'^api/table/(?P<database>\w+)/(?P<table>\w+)/terms/(?P<column>\w+)(?:/(?P<prefix>\w+))?/?$',
     beeswax_api.get_top_terms,

--- a/apps/beeswax/src/beeswax/urls.py
+++ b/apps/beeswax/src/beeswax/urls.py
@@ -15,11 +15,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from beeswax import views as beeswax_views
 from beeswax import create_database as beeswax_create_database
 from beeswax import create_table as beeswax_create_table
 from beeswax import api as beeswax_api
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   url(r'^$', beeswax_views.index, name='index'),

--- a/apps/filebrowser/src/filebrowser/urls.py
+++ b/apps/filebrowser/src/filebrowser/urls.py
@@ -20,46 +20,46 @@ import sys
 from filebrowser import views as filebrowser_views
 from filebrowser import api as filebrowser_api
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
   # Base view
-  url(r'^$', filebrowser_views.index, name='index'),
+  re_path(r'^$', filebrowser_views.index, name='index'),
 
   # Catch-all for viewing a file (display) or a directory (listdir)
-  url(r'^view=(?P<path>.*)$', filebrowser_views.view, name='filebrowser.views.view'),
+  re_path(r'^view=(?P<path>.*)$', filebrowser_views.view, name='filebrowser.views.view'),
 
-  url(r'^listdir=(?P<path>.*)$', filebrowser_views.listdir, name='listdir'),
-  url(r'^display=(?P<path>.*)$', filebrowser_views.display, name='display'),
-  url(r'^stat=(?P<path>.*)$', filebrowser_views.stat, name='stat'),
-  url(r'^content_summary=(?P<path>.*)$', filebrowser_views.content_summary, name='content_summary'),
-  url(r'^download=(?P<path>.*)$', filebrowser_views.download, name='filebrowser_views_download'),
-  url(r'^status$', filebrowser_views.status, name='status'),
-  url(r'^home_relative_view=(?P<path>.*)$', filebrowser_views.home_relative_view, name='home_relative_view'),
-  url(r'^edit=(?P<path>.*)$', filebrowser_views.edit, name='filebrowser_views_edit'),
+  re_path(r'^listdir=(?P<path>.*)$', filebrowser_views.listdir, name='listdir'),
+  re_path(r'^display=(?P<path>.*)$', filebrowser_views.display, name='display'),
+  re_path(r'^stat=(?P<path>.*)$', filebrowser_views.stat, name='stat'),
+  re_path(r'^content_summary=(?P<path>.*)$', filebrowser_views.content_summary, name='content_summary'),
+  re_path(r'^download=(?P<path>.*)$', filebrowser_views.download, name='filebrowser_views_download'),
+  re_path(r'^status$', filebrowser_views.status, name='status'),
+  re_path(r'^home_relative_view=(?P<path>.*)$', filebrowser_views.home_relative_view, name='home_relative_view'),
+  re_path(r'^edit=(?P<path>.*)$', filebrowser_views.edit, name='filebrowser_views_edit'),
 
   # POST operations
-  url(r'^save$', filebrowser_views.save_file, name="filebrowser_views_save_file"),
-  url(r'^upload/file$', filebrowser_views.upload_file, name='upload_file'),
-  url(r'^extract_archive', filebrowser_views.extract_archive_using_batch_job, name='extract_archive_using_batch_job'),
-  url(r'^compress_files', filebrowser_views.compress_files_using_batch_job, name='compress_files_using_batch_job'),
-  url(r'^trash/restore$', filebrowser_views.trash_restore, name='trash_restore'),
-  url(r'^trash/purge$', filebrowser_views.trash_purge, name='trash_purge'),
-  url(r'^rename$', filebrowser_views.rename, name='rename'),
-  url(r'^mkdir$', filebrowser_views.mkdir, name='mkdir'),
-  url(r'^touch$', filebrowser_views.touch, name='touch'),
-  url(r'^move$', filebrowser_views.move, name='move'),
-  url(r'^copy$', filebrowser_views.copy, name='copy'),
-  url(r'^set_replication$', filebrowser_views.set_replication, name='set_replication'),
-  url(r'^rmtree$', filebrowser_views.rmtree, name='rmtree'),
-  url(r'^chmod$', filebrowser_views.chmod, name='chmod'),
-  url(r'^chown$', filebrowser_views.chown, name='chown'),
+  re_path(r'^save$', filebrowser_views.save_file, name="filebrowser_views_save_file"),
+  re_path(r'^upload/file$', filebrowser_views.upload_file, name='upload_file'),
+  re_path(r'^extract_archive', filebrowser_views.extract_archive_using_batch_job, name='extract_archive_using_batch_job'),
+  re_path(r'^compress_files', filebrowser_views.compress_files_using_batch_job, name='compress_files_using_batch_job'),
+  re_path(r'^trash/restore$', filebrowser_views.trash_restore, name='trash_restore'),
+  re_path(r'^trash/purge$', filebrowser_views.trash_purge, name='trash_purge'),
+  re_path(r'^rename$', filebrowser_views.rename, name='rename'),
+  re_path(r'^mkdir$', filebrowser_views.mkdir, name='mkdir'),
+  re_path(r'^touch$', filebrowser_views.touch, name='touch'),
+  re_path(r'^move$', filebrowser_views.move, name='move'),
+  re_path(r'^copy$', filebrowser_views.copy, name='copy'),
+  re_path(r'^set_replication$', filebrowser_views.set_replication, name='set_replication'),
+  re_path(r'^rmtree$', filebrowser_views.rmtree, name='rmtree'),
+  re_path(r'^chmod$', filebrowser_views.chmod, name='chmod'),
+  re_path(r'^chown$', filebrowser_views.chown, name='chown'),
 ]
 
 # API
 urlpatterns += [
-  url(r'^api/get_filesystems/?', filebrowser_api.get_filesystems, name='get_filesystems'),
+  re_path(r'^api/get_filesystems/?', filebrowser_api.get_filesystems, name='get_filesystems'),
 ]

--- a/apps/filebrowser/src/filebrowser/urls.py
+++ b/apps/filebrowser/src/filebrowser/urls.py
@@ -15,9 +15,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from filebrowser import views as filebrowser_views
 from filebrowser import api as filebrowser_api
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   # Base view

--- a/apps/hbase/src/hbase/urls.py
+++ b/apps/hbase/src/hbase/urls.py
@@ -15,8 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from hbase import views as hbase_views
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   url(r'^$', hbase_views.app, name='index'),

--- a/apps/hbase/src/hbase/urls.py
+++ b/apps/hbase/src/hbase/urls.py
@@ -19,14 +19,14 @@ import sys
 
 from hbase import views as hbase_views
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-  url(r'^$', hbase_views.app, name='index'),
-  url(r'api/(?P<url>.+)$', hbase_views.api_router),
+  re_path(r'^$', hbase_views.app, name='index'),
+  re_path(r'api/(?P<url>.+)$', hbase_views.api_router),
 
-  url(r'^install_examples$', hbase_views.install_examples, name='install_examples'),
+  re_path(r'^install_examples$', hbase_views.install_examples, name='install_examples'),
 ]

--- a/apps/help/src/help/urls.py
+++ b/apps/help/src/help/urls.py
@@ -15,8 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from help import views as help_views
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   url(r'^$', help_views.view, { "app": "desktop", "path": "/index.html" }),

--- a/apps/help/src/help/urls.py
+++ b/apps/help/src/help/urls.py
@@ -25,6 +25,6 @@ else:
   from django.urls import re_path as url
 
 urlpatterns = [
-  url(r'^$', help_views.view, { "app": "desktop", "path": "/index.html" }),
+  url(r'^$', help_views.view, {"app": "desktop", "path": "/index.html"}),
   url(r'^(?P<app>\w*)(?P<path>/.*)$', help_views.view, name='help.views.view'),
 ]

--- a/apps/help/src/help/urls.py
+++ b/apps/help/src/help/urls.py
@@ -19,12 +19,12 @@ import sys
 
 from help import views as help_views
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-  url(r'^$', help_views.view, {"app": "desktop", "path": "/index.html"}),
-  url(r'^(?P<app>\w*)(?P<path>/.*)$', help_views.view, name='help.views.view'),
+  re_path(r'^$', help_views.view, {"app": "desktop", "path": "/index.html"}),
+  re_path(r'^(?P<app>\w*)(?P<path>/.*)$', help_views.view, name='help.views.view'),
 ]

--- a/apps/hive/src/hive/urls.py
+++ b/apps/hive/src/hive/urls.py
@@ -15,7 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 
 urlpatterns = [

--- a/apps/hive/src/hive/urls.py
+++ b/apps/hive/src/hive/urls.py
@@ -17,10 +17,10 @@
 
 import sys
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 
 urlpatterns = [

--- a/apps/impala/src/impala/urls.py
+++ b/apps/impala/src/impala/urls.py
@@ -15,10 +15,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
 
 from beeswax.urls import urlpatterns as beeswax_urls
 from impala import api as impala_api
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   url(r'^api/invalidate$', impala_api.invalidate, name='invalidate'),

--- a/apps/impala/src/impala/urls.py
+++ b/apps/impala/src/impala/urls.py
@@ -20,19 +20,19 @@ import sys
 from beeswax.urls import urlpatterns as beeswax_urls
 from impala import api as impala_api
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-  url(r'^api/invalidate$', impala_api.invalidate, name='invalidate'),
-  url(r'^api/refresh/(?P<database>\w+)/(?P<table>\w+)$', impala_api.refresh_table, name='refresh_table'),
-  url(r'^api/query/(?P<query_history_id>\d+)/exec_summary$', impala_api.get_exec_summary, name='get_exec_summary'),
-  url(r'^api/query/(?P<query_history_id>\d+)/runtime_profile', impala_api.get_runtime_profile, name='get_runtime_profile'),
-  url(r'^api/query/alanize$', impala_api.alanize, name='alanize'),
-  url(r'^api/query/alanize/fix$', impala_api.alanize_fix, name='alanize_fix'),
-  url(r'^api/query/alanize/metrics', impala_api.alanize_metrics, name='alanize_metrics'),
+  re_path(r'^api/invalidate$', impala_api.invalidate, name='invalidate'),
+  re_path(r'^api/refresh/(?P<database>\w+)/(?P<table>\w+)$', impala_api.refresh_table, name='refresh_table'),
+  re_path(r'^api/query/(?P<query_history_id>\d+)/exec_summary$', impala_api.get_exec_summary, name='get_exec_summary'),
+  re_path(r'^api/query/(?P<query_history_id>\d+)/runtime_profile', impala_api.get_runtime_profile, name='get_runtime_profile'),
+  re_path(r'^api/query/alanize$', impala_api.alanize, name='alanize'),
+  re_path(r'^api/query/alanize/fix$', impala_api.alanize_fix, name='alanize_fix'),
+  re_path(r'^api/query/alanize/metrics', impala_api.alanize_metrics, name='alanize_metrics'),
 ]
 
 urlpatterns += beeswax_urls

--- a/apps/jobbrowser/src/jobbrowser/urls.py
+++ b/apps/jobbrowser/src/jobbrowser/urls.py
@@ -20,60 +20,60 @@ import sys
 from jobbrowser import views as jobbrowser_views
 from jobbrowser import api2 as jobbrowser_api2
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
   # "Default"
-  url(r'^$', jobbrowser_views.jobs),
-  url(r'^jobs/?$', jobbrowser_views.jobs, name='jobs'),
-  url(r'^jobs/(?P<job>\w+)$', jobbrowser_views.single_job, name='jobbrowser.views.single_job'),
-  url(r'^jobs/(?P<job>\w+)/counters$', jobbrowser_views.job_counters, name='job_counters'),
-  url(r'^jobs/(?P<job>\w+)/kill$', jobbrowser_views.kill_job, name='kill_job'),
-  url(r'^jobs/(?P<job>\w+)/single_logs$', jobbrowser_views.job_single_logs, name='jobbrowser.views.job_single_logs'),
-  url(r'^jobs/(?P<job>\w+)/tasks$', jobbrowser_views.tasks, name='jobbrowser.views.tasks'),
-  url(r'^jobs/(?P<job>\w+)/tasks/(?P<taskid>\w+)$', jobbrowser_views.single_task, name='jobbrowser.views.single_task'), # TODO s/single// ?
-  url(r'^jobs/(?P<job>\w+)/tasks/(?P<taskid>\w+)/attempts/(?P<attemptid>\w+)$',
+  re_path(r'^$', jobbrowser_views.jobs),
+  re_path(r'^jobs/?$', jobbrowser_views.jobs, name='jobs'),
+  re_path(r'^jobs/(?P<job>\w+)$', jobbrowser_views.single_job, name='jobbrowser.views.single_job'),
+  re_path(r'^jobs/(?P<job>\w+)/counters$', jobbrowser_views.job_counters, name='job_counters'),
+  re_path(r'^jobs/(?P<job>\w+)/kill$', jobbrowser_views.kill_job, name='kill_job'),
+  re_path(r'^jobs/(?P<job>\w+)/single_logs$', jobbrowser_views.job_single_logs, name='jobbrowser.views.job_single_logs'),
+  re_path(r'^jobs/(?P<job>\w+)/tasks$', jobbrowser_views.tasks, name='jobbrowser.views.tasks'),
+  re_path(r'^jobs/(?P<job>\w+)/tasks/(?P<taskid>\w+)$', jobbrowser_views.single_task, name='jobbrowser.views.single_task'), # TODO s/single// ?
+  re_path(r'^jobs/(?P<job>\w+)/tasks/(?P<taskid>\w+)/attempts/(?P<attemptid>\w+)$',
   jobbrowser_views.single_task_attempt, name='single_task_attempt'),
-  url(r'^jobs/(?P<job>\w+)/tasks/(?P<taskid>\w+)/attempts/(?P<attemptid>\w+)/counters$',
+  re_path(r'^jobs/(?P<job>\w+)/tasks/(?P<taskid>\w+)/attempts/(?P<attemptid>\w+)/counters$',
   jobbrowser_views.task_attempt_counters, name='task_attempt_counters'),
-  url(r'^jobs/(?P<job>\w+)/tasks/(?P<taskid>\w+)/attempts/(?P<attemptid>\w+)/logs$',
+  re_path(r'^jobs/(?P<job>\w+)/tasks/(?P<taskid>\w+)/attempts/(?P<attemptid>\w+)/logs$',
   jobbrowser_views.single_task_attempt_logs, name='single_task_attempt_logs'),
-  url(r'^jobs/(\w+)/tasks/(\w+)/attempts/(?P<attemptid>\w+)/kill$', jobbrowser_views.kill_task_attempt, name='kill_task_attempt'),
-  url(r'^trackers/(?P<trackerid>.+)$', jobbrowser_views.single_tracker, name='single_tracker'),
-  url(r'^container/(?P<node_manager_http_address>.+)/(?P<containerid>.+)$', jobbrowser_views.container, name='jobbrowser.views.container'),
+  re_path(r'^jobs/(\w+)/tasks/(\w+)/attempts/(?P<attemptid>\w+)/kill$', jobbrowser_views.kill_task_attempt, name='kill_task_attempt'),
+  re_path(r'^trackers/(?P<trackerid>.+)$', jobbrowser_views.single_tracker, name='single_tracker'),
+  re_path(r'^container/(?P<node_manager_http_address>.+)/(?P<containerid>.+)$', jobbrowser_views.container, name='jobbrowser.views.container'),
 
   # MR2 specific
-  url(r'^jobs/(?P<job>\w+)/job_attempt_logs/(?P<attempt_index>\d+)$', jobbrowser_views.job_attempt_logs, name='job_attempt_logs'),
-  url(r'^jobs/(?P<job>\w+)/job_attempt_logs_json/(?P<attempt_index>\d+)(?:/(?P<name>\w+))?(?:/(?P<offset>[\d-]+))?/?$',
+  re_path(r'^jobs/(?P<job>\w+)/job_attempt_logs/(?P<attempt_index>\d+)$', jobbrowser_views.job_attempt_logs, name='job_attempt_logs'),
+  re_path(r'^jobs/(?P<job>\w+)/job_attempt_logs_json/(?P<attempt_index>\d+)(?:/(?P<name>\w+))?(?:/(?P<offset>[\d-]+))?/?$',
   jobbrowser_views.job_attempt_logs_json, name='job_attempt_logs_json'),
-  url(r'^jobs/(?P<jobid>\w+)/job_not_assigned/(?P<path>.+)$', jobbrowser_views.job_not_assigned, name='job_not_assigned'),
+  re_path(r'^jobs/(?P<jobid>\w+)/job_not_assigned/(?P<path>.+)$', jobbrowser_views.job_not_assigned, name='job_not_assigned'),
 
   # Unused
-  url(r'^jobs/(?P<job>\w+)/setpriority$', jobbrowser_views.set_job_priority, name='set_job_priority'),
-  url(r'^trackers$', jobbrowser_views.trackers, name='trackers'),
-  url(r'^clusterstatus$', jobbrowser_views.clusterstatus, name='clusterstatus'),
-  url(r'^queues$', jobbrowser_views.queues, name='queues'),
-  url(r'^jobbrowser$', jobbrowser_views.jobbrowser, name='jobbrowser'),
-  url(r'^dock_jobs/?$', jobbrowser_views.dock_jobs, name='dock_jobs'),
+  re_path(r'^jobs/(?P<job>\w+)/setpriority$', jobbrowser_views.set_job_priority, name='set_job_priority'),
+  re_path(r'^trackers$', jobbrowser_views.trackers, name='trackers'),
+  re_path(r'^clusterstatus$', jobbrowser_views.clusterstatus, name='clusterstatus'),
+  re_path(r'^queues$', jobbrowser_views.queues, name='queues'),
+  re_path(r'^jobbrowser$', jobbrowser_views.jobbrowser, name='jobbrowser'),
+  re_path(r'^dock_jobs/?$', jobbrowser_views.dock_jobs, name='dock_jobs'),
 ]
 
 # V2
 urlpatterns += [
-  url(r'apps$', jobbrowser_views.apps, name='jobbrowser.views.apps'),
+  re_path(r'apps$', jobbrowser_views.apps, name='jobbrowser.views.apps'),
 ]
 
 urlpatterns += [
-  url(r'api/jobs(?:/(?P<interface>.+))?/?', jobbrowser_api2.jobs, name='jobs'),
-  url(r'api/job/logs', jobbrowser_api2.logs, name='logs'),
-  url(r'api/job/profile', jobbrowser_api2.profile, name='profile'),
-  url(r'api/job/action(?:/(?P<interface>.+))?(?:/(?P<action>.+))?/?', jobbrowser_api2.action, name='action'),
-  url(r'api/job(?:/(?P<interface>.+))?/?', jobbrowser_api2.job, name='job'),
+  re_path(r'api/jobs(?:/(?P<interface>.+))?/?', jobbrowser_api2.jobs, name='jobs'),
+  re_path(r'api/job/logs', jobbrowser_api2.logs, name='logs'),
+  re_path(r'api/job/profile', jobbrowser_api2.profile, name='profile'),
+  re_path(r'api/job/action(?:/(?P<interface>.+))?(?:/(?P<action>.+))?/?', jobbrowser_api2.action, name='action'),
+  re_path(r'api/job(?:/(?P<interface>.+))?/?', jobbrowser_api2.job, name='job'),
 ]
 
 urlpatterns += [
-  url(r'^query-store/data-bundle/(?P<id>.*)$', jobbrowser_api2.query_store_download_bundle),
-  url(r'^query-store/(?P<path>.*)$', jobbrowser_api2.query_store_api),
+  re_path(r'^query-store/data-bundle/(?P<id>.*)$', jobbrowser_api2.query_store_download_bundle),
+  re_path(r'^query-store/(?P<path>.*)$', jobbrowser_api2.query_store_api),
 ]

--- a/apps/jobbrowser/src/jobbrowser/urls.py
+++ b/apps/jobbrowser/src/jobbrowser/urls.py
@@ -34,7 +34,9 @@ urlpatterns = [
   re_path(r'^jobs/(?P<job>\w+)/kill$', jobbrowser_views.kill_job, name='kill_job'),
   re_path(r'^jobs/(?P<job>\w+)/single_logs$', jobbrowser_views.job_single_logs, name='jobbrowser.views.job_single_logs'),
   re_path(r'^jobs/(?P<job>\w+)/tasks$', jobbrowser_views.tasks, name='jobbrowser.views.tasks'),
-  re_path(r'^jobs/(?P<job>\w+)/tasks/(?P<taskid>\w+)$', jobbrowser_views.single_task, name='jobbrowser.views.single_task'), # TODO s/single// ?
+  re_path(
+    r'^jobs/(?P<job>\w+)/tasks/(?P<taskid>\w+)$', jobbrowser_views.single_task, name='jobbrowser.views.single_task'
+  ),                                                                                                                 # TODO s/single// ?
   re_path(r'^jobs/(?P<job>\w+)/tasks/(?P<taskid>\w+)/attempts/(?P<attemptid>\w+)$',
   jobbrowser_views.single_task_attempt, name='single_task_attempt'),
   re_path(r'^jobs/(?P<job>\w+)/tasks/(?P<taskid>\w+)/attempts/(?P<attemptid>\w+)/counters$',
@@ -43,7 +45,9 @@ urlpatterns = [
   jobbrowser_views.single_task_attempt_logs, name='single_task_attempt_logs'),
   re_path(r'^jobs/(\w+)/tasks/(\w+)/attempts/(?P<attemptid>\w+)/kill$', jobbrowser_views.kill_task_attempt, name='kill_task_attempt'),
   re_path(r'^trackers/(?P<trackerid>.+)$', jobbrowser_views.single_tracker, name='single_tracker'),
-  re_path(r'^container/(?P<node_manager_http_address>.+)/(?P<containerid>.+)$', jobbrowser_views.container, name='jobbrowser.views.container'),
+  re_path(
+    r'^container/(?P<node_manager_http_address>.+)/(?P<containerid>.+)$', jobbrowser_views.container, name='jobbrowser.views.container'
+  ),
 
   # MR2 specific
   re_path(r'^jobs/(?P<job>\w+)/job_attempt_logs/(?P<attempt_index>\d+)$', jobbrowser_views.job_attempt_logs, name='job_attempt_logs'),

--- a/apps/jobbrowser/src/jobbrowser/urls.py
+++ b/apps/jobbrowser/src/jobbrowser/urls.py
@@ -15,10 +15,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
 
 from jobbrowser import views as jobbrowser_views
 from jobbrowser import api2 as jobbrowser_api2
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   # "Default"

--- a/apps/jobsub/src/jobsub/urls.py
+++ b/apps/jobsub/src/jobsub/urls.py
@@ -19,24 +19,24 @@ import sys
 
 from jobsub import views as jobsub_views
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
   # The base view is the "list" view, which we alias as /
-  url(r'^$', jobsub_views.list_designs),
+  re_path(r'^$', jobsub_views.list_designs),
 
   # Not available on Hue 4
-  url(r'^not_available$', jobsub_views.not_available),
+  re_path(r'^not_available$', jobsub_views.not_available),
 
   # Actions: get, save, clone, delete, submit, new.
-  url(r'^designs$', jobsub_views.list_designs, name="jobsub.views.list_designs"),
-  url(r'^designs/(?P<design_id>\d+)$', jobsub_views.get_design, name="jobsub.views.get_design"),
-  url(r'^designs/(?P<node_type>\w+)/new$', jobsub_views.new_design, name="jobsub.views.new_design"),
-  url(r'^designs/(?P<design_id>\d+)/save$', jobsub_views.save_design, name="jobsub.views.save_design"),
-  url(r'^designs/(?P<design_id>\d+)/clone$', jobsub_views.clone_design, name="jobsub.views.clone_design"),
-  url(r'^designs/(?P<design_id>\d+)/delete$', jobsub_views.delete_design, name="jobsub.views.delete_design"),
-  url(r'^designs/(?P<design_id>\d+)/restore$', jobsub_views.restore_design, name="jobsub.views.restore_design"),
+  re_path(r'^designs$', jobsub_views.list_designs, name="jobsub.views.list_designs"),
+  re_path(r'^designs/(?P<design_id>\d+)$', jobsub_views.get_design, name="jobsub.views.get_design"),
+  re_path(r'^designs/(?P<node_type>\w+)/new$', jobsub_views.new_design, name="jobsub.views.new_design"),
+  re_path(r'^designs/(?P<design_id>\d+)/save$', jobsub_views.save_design, name="jobsub.views.save_design"),
+  re_path(r'^designs/(?P<design_id>\d+)/clone$', jobsub_views.clone_design, name="jobsub.views.clone_design"),
+  re_path(r'^designs/(?P<design_id>\d+)/delete$', jobsub_views.delete_design, name="jobsub.views.delete_design"),
+  re_path(r'^designs/(?P<design_id>\d+)/restore$', jobsub_views.restore_design, name="jobsub.views.restore_design"),
 ]

--- a/apps/jobsub/src/jobsub/urls.py
+++ b/apps/jobsub/src/jobsub/urls.py
@@ -15,8 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from jobsub import views as jobsub_views
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   # The base view is the "list" view, which we alias as /

--- a/apps/metastore/src/metastore/urls.py
+++ b/apps/metastore/src/metastore/urls.py
@@ -41,8 +41,16 @@ urlpatterns = [
   url(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/read$', metastore_views.read_table, name='read_table'),
   url(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/queries$', metastore_views.table_queries, name='table_queries'),
   url(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/partitions/?$', metastore_views.describe_partitions, name='describe_partitions'),
-  url(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/partitions/(?P<partition_spec>.+?)/read$', metastore_views.read_partition, name='read_partition'),
-  url(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/partitions/(?P<partition_spec>.+?)/browse$', metastore_views.browse_partition, name='browse_partition'),
+  url(
+    r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/partitions/(?P<partition_spec>.+?)/read$',
+    metastore_views.read_partition,
+    name='read_partition'
+  ),
+  url(
+    r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/partitions/(?P<partition_spec>.+?)/browse$',
+    metastore_views.browse_partition,
+    name='browse_partition'
+  ),
   url(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/partitions/drop$', metastore_views.drop_partition, name='drop_partition'),
   url(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/alter_column$', metastore_views.alter_column, name='alter_column'),
 ]

--- a/apps/metastore/src/metastore/urls.py
+++ b/apps/metastore/src/metastore/urls.py
@@ -19,38 +19,38 @@ import sys
 
 from metastore import views as metastore_views
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-  url(r'^$', metastore_views.index, name='index'),
+  re_path(r'^$', metastore_views.index, name='index'),
 
-  url(r'^databases/?$', metastore_views.databases, name='databases'),
-  url(r'^databases/drop/?$', metastore_views.drop_database, name='drop_database'),
-  url(r'^databases/(?P<database>[^/?]*)/alter$', metastore_views.alter_database, name='alter_database'),
-  url(r'^databases/(?P<database>[^/?]*)/metadata$', metastore_views.get_database_metadata, name='get_database_metadata'),
+  re_path(r'^databases/?$', metastore_views.databases, name='databases'),
+  re_path(r'^databases/drop/?$', metastore_views.drop_database, name='drop_database'),
+  re_path(r'^databases/(?P<database>[^/?]*)/alter$', metastore_views.alter_database, name='alter_database'),
+  re_path(r'^databases/(?P<database>[^/?]*)/metadata$', metastore_views.get_database_metadata, name='get_database_metadata'),
 
-  url(r'^tables(?:/(?P<database>[^/?]*))?/?$', metastore_views.show_tables, name='show_tables'),
-  url(r'^tables/drop/(?P<database>[^/?]*)$', metastore_views.drop_table, name='drop_table'),
-  url(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/?$', metastore_views.describe_table, name='describe_table'),
-  url(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/alter$', metastore_views.alter_table, name='alter_table'),
-  url(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/metadata$', metastore_views.get_table_metadata, name='get_table_metadata'),
-  url(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/load$', metastore_views.load_table, name='load_table'),
-  url(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/read$', metastore_views.read_table, name='read_table'),
-  url(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/queries$', metastore_views.table_queries, name='table_queries'),
-  url(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/partitions/?$', metastore_views.describe_partitions, name='describe_partitions'),
-  url(
+  re_path(r'^tables(?:/(?P<database>[^/?]*))?/?$', metastore_views.show_tables, name='show_tables'),
+  re_path(r'^tables/drop/(?P<database>[^/?]*)$', metastore_views.drop_table, name='drop_table'),
+  re_path(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/?$', metastore_views.describe_table, name='describe_table'),
+  re_path(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/alter$', metastore_views.alter_table, name='alter_table'),
+  re_path(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/metadata$', metastore_views.get_table_metadata, name='get_table_metadata'),
+  re_path(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/load$', metastore_views.load_table, name='load_table'),
+  re_path(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/read$', metastore_views.read_table, name='read_table'),
+  re_path(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/queries$', metastore_views.table_queries, name='table_queries'),
+  re_path(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/partitions/?$', metastore_views.describe_partitions, name='describe_partitions'),
+  re_path(
     r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/partitions/(?P<partition_spec>.+?)/read$',
     metastore_views.read_partition,
     name='read_partition'
   ),
-  url(
+  re_path(
     r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/partitions/(?P<partition_spec>.+?)/browse$',
     metastore_views.browse_partition,
     name='browse_partition'
   ),
-  url(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/partitions/drop$', metastore_views.drop_partition, name='drop_partition'),
-  url(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/alter_column$', metastore_views.alter_column, name='alter_column'),
+  re_path(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/partitions/drop$', metastore_views.drop_partition, name='drop_partition'),
+  re_path(r'^table/(?P<database>[^/?]*)/(?P<table>\w+)/alter_column$', metastore_views.alter_column, name='alter_column'),
 ]

--- a/apps/metastore/src/metastore/urls.py
+++ b/apps/metastore/src/metastore/urls.py
@@ -15,8 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from metastore import views as metastore_views
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   url(r'^$', metastore_views.index, name='index'),

--- a/apps/oozie/src/oozie/urls.py
+++ b/apps/oozie/src/oozie/urls.py
@@ -73,7 +73,9 @@ urlpatterns = [
   re_path(r'^clone_bundle/(?P<bundle>\d+)$', oozie_views_editor.clone_bundle, name='clone_bundle'),
   re_path(r'^delete_bundle$', oozie_views_editor.delete_bundle, name='delete_bundle'),
   re_path(r'^restore_bundle$', oozie_views_editor.restore_bundle, name='restore_bundle'),
-  re_path(r'^create_bundled_coordinator/(?P<bundle>\d+)$', oozie_views_editor.create_bundled_coordinator, name='create_bundled_coordinator'),
+  re_path(
+    r'^create_bundled_coordinator/(?P<bundle>\d+)$', oozie_views_editor.create_bundled_coordinator, name='create_bundled_coordinator'
+  ),
   re_path(
     r'^edit_bundled_coordinator/(?P<bundle>\d+)/(?P<bundled_coordinator>\d+)$',
     oozie_views_editor.edit_bundled_coordinator,
@@ -165,7 +167,9 @@ urlpatterns += [
     oozie_views_dashboard.rerun_oozie_coordinator,
     name='rerun_oozie_coord'
   ),
-  re_path(r'^rerun_oozie_bundle/(?P<job_id>[-\w]+)/(?P<app_path>.+?)$', oozie_views_dashboard.rerun_oozie_bundle, name='rerun_oozie_bundle'),
+  re_path(
+    r'^rerun_oozie_bundle/(?P<job_id>[-\w]+)/(?P<app_path>.+?)$', oozie_views_dashboard.rerun_oozie_bundle, name='rerun_oozie_bundle'
+  ),
   re_path(r'^sync_coord_workflow/(?P<job_id>[-\w]+)$', oozie_views_dashboard.sync_coord_workflow, name='sync_coord_workflow'),
   re_path(
     r'^manage_oozie_jobs/(?P<job_id>[-\w]+)/(?P<action>(start|suspend|resume|kill|rerun|change|ignore))$',

--- a/apps/oozie/src/oozie/urls.py
+++ b/apps/oozie/src/oozie/urls.py
@@ -22,162 +22,162 @@ from oozie.views import editor2 as oozie_views_editor2
 from oozie.views import api as oozie_views_api
 from oozie.views import dashboard as oozie_views_dashboard
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 IS_URL_NAMESPACED = True
 
 
 urlpatterns = [
 
-  url(r'^list_workflows/?$', oozie_views_editor.list_workflows, name='list_workflows'),
-  url(r'^list_trashed_workflows/?$', oozie_views_editor.list_trashed_workflows, name='list_trashed_workflows'),
-  url(r'^create_workflow/?$', oozie_views_editor.create_workflow, name='create_workflow'),
-  url(r'^edit_workflow/(?P<workflow>\d+)/?$', oozie_views_editor.edit_workflow, name='edit_workflow'),
-  url(r'^delete_workflow$', oozie_views_editor.delete_workflow, name='delete_workflow'),
-  url(r'^restore_workflow/?$', oozie_views_editor.restore_workflow, name='restore_workflow'),
-  url(r'^clone_workflow/(?P<workflow>\d+)$', oozie_views_editor.clone_workflow, name='clone_workflow'),
-  url(r'^submit_workflow/(?P<workflow>\d+)$', oozie_views_editor.submit_workflow, name='submit_workflow'),
-  url(r'^schedule_workflow/(?P<workflow>\d+)$', oozie_views_editor.schedule_workflow, name='schedule_workflow'),
-  url(r'^import_workflow/?$', oozie_views_editor.import_workflow, name='import_workflow'),
-  url(r'^import_coordinator/?$', oozie_views_editor.import_coordinator, name='import_coordinator'),
-  url(r'^export_workflow/(?P<workflow>\d+)$', oozie_views_editor.export_workflow, name='export_workflow'),
+  re_path(r'^list_workflows/?$', oozie_views_editor.list_workflows, name='list_workflows'),
+  re_path(r'^list_trashed_workflows/?$', oozie_views_editor.list_trashed_workflows, name='list_trashed_workflows'),
+  re_path(r'^create_workflow/?$', oozie_views_editor.create_workflow, name='create_workflow'),
+  re_path(r'^edit_workflow/(?P<workflow>\d+)/?$', oozie_views_editor.edit_workflow, name='edit_workflow'),
+  re_path(r'^delete_workflow$', oozie_views_editor.delete_workflow, name='delete_workflow'),
+  re_path(r'^restore_workflow/?$', oozie_views_editor.restore_workflow, name='restore_workflow'),
+  re_path(r'^clone_workflow/(?P<workflow>\d+)$', oozie_views_editor.clone_workflow, name='clone_workflow'),
+  re_path(r'^submit_workflow/(?P<workflow>\d+)$', oozie_views_editor.submit_workflow, name='submit_workflow'),
+  re_path(r'^schedule_workflow/(?P<workflow>\d+)$', oozie_views_editor.schedule_workflow, name='schedule_workflow'),
+  re_path(r'^import_workflow/?$', oozie_views_editor.import_workflow, name='import_workflow'),
+  re_path(r'^import_coordinator/?$', oozie_views_editor.import_coordinator, name='import_coordinator'),
+  re_path(r'^export_workflow/(?P<workflow>\d+)$', oozie_views_editor.export_workflow, name='export_workflow'),
 
-  url(r'^list_coordinators(?:/(?P<workflow_id>[-\w]+))?/?$', oozie_views_editor.list_coordinators, name='list_coordinators'),
-  url(r'^list_trashed_coordinators/?$', oozie_views_editor.list_trashed_coordinators, name='list_trashed_coordinators'),
-  url(r'^create_coordinator(?:/(?P<workflow>[-\w]+))?/?$', oozie_views_editor.create_coordinator, name='create_coordinator'),
-  url(r'^edit_coordinator/(?P<coordinator>[-\w]+)$', oozie_views_editor.edit_coordinator, name='edit_coordinator'),
-  url(r'^delete_coordinator$', oozie_views_editor.delete_coordinator, name='delete_coordinator'),
-  url(r'^restore_coordinator$', oozie_views_editor.restore_coordinator, name='restore_coordinator'),
-  url(r'^clone_coordinator/(?P<coordinator>\d+)$', oozie_views_editor.clone_coordinator, name='clone_coordinator'),
-  url(
+  re_path(r'^list_coordinators(?:/(?P<workflow_id>[-\w]+))?/?$', oozie_views_editor.list_coordinators, name='list_coordinators'),
+  re_path(r'^list_trashed_coordinators/?$', oozie_views_editor.list_trashed_coordinators, name='list_trashed_coordinators'),
+  re_path(r'^create_coordinator(?:/(?P<workflow>[-\w]+))?/?$', oozie_views_editor.create_coordinator, name='create_coordinator'),
+  re_path(r'^edit_coordinator/(?P<coordinator>[-\w]+)$', oozie_views_editor.edit_coordinator, name='edit_coordinator'),
+  re_path(r'^delete_coordinator$', oozie_views_editor.delete_coordinator, name='delete_coordinator'),
+  re_path(r'^restore_coordinator$', oozie_views_editor.restore_coordinator, name='restore_coordinator'),
+  re_path(r'^clone_coordinator/(?P<coordinator>\d+)$', oozie_views_editor.clone_coordinator, name='clone_coordinator'),
+  re_path(
     r'^create_coordinator_dataset/(?P<coordinator>[-\w]+)$',
     oozie_views_editor.create_coordinator_dataset,
     name='create_coordinator_dataset'
   ),
-  url(r'^edit_coordinator_dataset/(?P<dataset>\d+)$', oozie_views_editor.edit_coordinator_dataset, name='edit_coordinator_dataset'),
-  url(
+  re_path(r'^edit_coordinator_dataset/(?P<dataset>\d+)$', oozie_views_editor.edit_coordinator_dataset, name='edit_coordinator_dataset'),
+  re_path(
     r'^create_coordinator_data/(?P<coordinator>[-\w]+)/(?P<data_type>(input|output))$',
     oozie_views_editor.create_coordinator_data,
     name='create_coordinator_data'
   ),
-  url(r'^submit_coordinator/(?P<coordinator>\d+)$', oozie_views_editor.submit_coordinator, name='submit_coordinator'),
+  re_path(r'^submit_coordinator/(?P<coordinator>\d+)$', oozie_views_editor.submit_coordinator, name='submit_coordinator'),
 
-  url(r'^list_bundles$', oozie_views_editor.list_bundles, name='list_bundles'),
-  url(r'^list_trashed_bundles$', oozie_views_editor.list_trashed_bundles, name='list_trashed_bundles'),
-  url(r'^create_bundle$', oozie_views_editor.create_bundle, name='create_bundle'),
-  url(r'^edit_bundle/(?P<bundle>\d+)$', oozie_views_editor.edit_bundle, name='edit_bundle'),
-  url(r'^submit_bundle/(?P<bundle>\d+)$', oozie_views_editor.submit_bundle, name='submit_bundle'),
-  url(r'^clone_bundle/(?P<bundle>\d+)$', oozie_views_editor.clone_bundle, name='clone_bundle'),
-  url(r'^delete_bundle$', oozie_views_editor.delete_bundle, name='delete_bundle'),
-  url(r'^restore_bundle$', oozie_views_editor.restore_bundle, name='restore_bundle'),
-  url(r'^create_bundled_coordinator/(?P<bundle>\d+)$', oozie_views_editor.create_bundled_coordinator, name='create_bundled_coordinator'),
-  url(
+  re_path(r'^list_bundles$', oozie_views_editor.list_bundles, name='list_bundles'),
+  re_path(r'^list_trashed_bundles$', oozie_views_editor.list_trashed_bundles, name='list_trashed_bundles'),
+  re_path(r'^create_bundle$', oozie_views_editor.create_bundle, name='create_bundle'),
+  re_path(r'^edit_bundle/(?P<bundle>\d+)$', oozie_views_editor.edit_bundle, name='edit_bundle'),
+  re_path(r'^submit_bundle/(?P<bundle>\d+)$', oozie_views_editor.submit_bundle, name='submit_bundle'),
+  re_path(r'^clone_bundle/(?P<bundle>\d+)$', oozie_views_editor.clone_bundle, name='clone_bundle'),
+  re_path(r'^delete_bundle$', oozie_views_editor.delete_bundle, name='delete_bundle'),
+  re_path(r'^restore_bundle$', oozie_views_editor.restore_bundle, name='restore_bundle'),
+  re_path(r'^create_bundled_coordinator/(?P<bundle>\d+)$', oozie_views_editor.create_bundled_coordinator, name='create_bundled_coordinator'),
+  re_path(
     r'^edit_bundled_coordinator/(?P<bundle>\d+)/(?P<bundled_coordinator>\d+)$',
     oozie_views_editor.edit_bundled_coordinator,
     name='edit_bundled_coordinator'
   ),
 
-  url(r'^list_history$', oozie_views_editor.list_history, name='list_history'), # Unused
-  url(r'^list_history/(?P<record_id>[-\w]+)$', oozie_views_editor.list_history_record, name='list_history_record'),
-  url(r'^install_examples/?$', oozie_views_editor.install_examples, name='install_examples'),
+  re_path(r'^list_history$', oozie_views_editor.list_history, name='list_history'), # Unused
+  re_path(r'^list_history/(?P<record_id>[-\w]+)$', oozie_views_editor.list_history_record, name='list_history_record'),
+  re_path(r'^install_examples/?$', oozie_views_editor.install_examples, name='install_examples'),
 ]
 
 urlpatterns += [
 
-  url(r'^editor/workflow/list/?$', oozie_views_editor2.list_editor_workflows, name='list_editor_workflows'),
-  url(r'^editor/workflow/edit/?$', oozie_views_editor2.edit_workflow, name='edit_workflow'),
-  url(r'^editor/workflow/new/?$', oozie_views_editor2.new_workflow, name='new_workflow'),
-  url(r'^editor/workflow/delete/?$', oozie_views_editor2.delete_job, name='delete_editor_workflow'),
-  url(r'^editor/workflow/copy/?$', oozie_views_editor2.copy_workflow, name='copy_workflow'),
-  url(r'^editor/workflow/save/?$', oozie_views_editor2.save_workflow, name='save_workflow'),
-  url(r'^editor/workflow/submit/(?P<doc_id>\d+)$', oozie_views_editor2.submit_workflow, name='editor_submit_workflow'),
-  url(
+  re_path(r'^editor/workflow/list/?$', oozie_views_editor2.list_editor_workflows, name='list_editor_workflows'),
+  re_path(r'^editor/workflow/edit/?$', oozie_views_editor2.edit_workflow, name='edit_workflow'),
+  re_path(r'^editor/workflow/new/?$', oozie_views_editor2.new_workflow, name='new_workflow'),
+  re_path(r'^editor/workflow/delete/?$', oozie_views_editor2.delete_job, name='delete_editor_workflow'),
+  re_path(r'^editor/workflow/copy/?$', oozie_views_editor2.copy_workflow, name='copy_workflow'),
+  re_path(r'^editor/workflow/save/?$', oozie_views_editor2.save_workflow, name='save_workflow'),
+  re_path(r'^editor/workflow/submit/(?P<doc_id>\d+)$', oozie_views_editor2.submit_workflow, name='editor_submit_workflow'),
+  re_path(
     r'^editor/workflow/submit_single_action/(?P<doc_id>\d+)/(?P<node_id>.+)$',
     oozie_views_editor2.submit_single_action,
     name='submit_single_action'
   ),
-  url(r'^editor/workflow/new_node/?$', oozie_views_editor2.new_node, name='new_node'),
-  url(r'^editor/workflow/add_node/?$', oozie_views_editor2.add_node, name='add_node'),
-  url(r'^editor/workflow/parameters/?$', oozie_views_editor2.workflow_parameters, name='workflow_parameters'),
-  url(r'^editor/workflow/action/parameters/?$', oozie_views_editor2.action_parameters, name='action_parameters'),
-  url(r'^editor/workflow/gen_xml/?$', oozie_views_editor2.gen_xml_workflow, name='gen_xml_workflow'),
-  url(r'^editor/workflow/open_v1/?$', oozie_views_editor2.open_old_workflow, name='open_old_workflow'),
+  re_path(r'^editor/workflow/new_node/?$', oozie_views_editor2.new_node, name='new_node'),
+  re_path(r'^editor/workflow/add_node/?$', oozie_views_editor2.add_node, name='add_node'),
+  re_path(r'^editor/workflow/parameters/?$', oozie_views_editor2.workflow_parameters, name='workflow_parameters'),
+  re_path(r'^editor/workflow/action/parameters/?$', oozie_views_editor2.action_parameters, name='action_parameters'),
+  re_path(r'^editor/workflow/gen_xml/?$', oozie_views_editor2.gen_xml_workflow, name='gen_xml_workflow'),
+  re_path(r'^editor/workflow/open_v1/?$', oozie_views_editor2.open_old_workflow, name='open_old_workflow'),
 
-  url(r'^editor/coordinator/list/?$', oozie_views_editor2.list_editor_coordinators, name='list_editor_coordinators'),
-  url(r'^editor/coordinator/edit/?$', oozie_views_editor2.edit_coordinator, name='edit_coordinator'),
-  url(r'^editor/coordinator/new/?$', oozie_views_editor2.new_coordinator, name='new_coordinator'),
-  url(r'^editor/coordinator/delete/?$', oozie_views_editor2.delete_job, name='delete_editor_coordinator'),
-  url(r'^editor/coordinator/copy/?$', oozie_views_editor2.copy_coordinator, name='copy_coordinator'),
-  url(r'^editor/coordinator/save/?$', oozie_views_editor2.save_coordinator, name='save_coordinator'),
-  url(r'^editor/coordinator/submit/(?P<doc_id>[-\w]+)$', oozie_views_editor2.submit_coordinator, name='editor_submit_coordinator'),
-  url(r'^editor/coordinator/gen_xml/?$', oozie_views_editor2.gen_xml_coordinator, name='gen_xml_coordinator'),
-  url(r'^editor/coordinator/open_v1/?$', oozie_views_editor2.open_old_coordinator, name='open_old_coordinator'),
-  url(r'^editor/coordinator/parameters/?$', oozie_views_editor2.coordinator_parameters, name='coordinator_parameters'),
+  re_path(r'^editor/coordinator/list/?$', oozie_views_editor2.list_editor_coordinators, name='list_editor_coordinators'),
+  re_path(r'^editor/coordinator/edit/?$', oozie_views_editor2.edit_coordinator, name='edit_coordinator'),
+  re_path(r'^editor/coordinator/new/?$', oozie_views_editor2.new_coordinator, name='new_coordinator'),
+  re_path(r'^editor/coordinator/delete/?$', oozie_views_editor2.delete_job, name='delete_editor_coordinator'),
+  re_path(r'^editor/coordinator/copy/?$', oozie_views_editor2.copy_coordinator, name='copy_coordinator'),
+  re_path(r'^editor/coordinator/save/?$', oozie_views_editor2.save_coordinator, name='save_coordinator'),
+  re_path(r'^editor/coordinator/submit/(?P<doc_id>[-\w]+)$', oozie_views_editor2.submit_coordinator, name='editor_submit_coordinator'),
+  re_path(r'^editor/coordinator/gen_xml/?$', oozie_views_editor2.gen_xml_coordinator, name='gen_xml_coordinator'),
+  re_path(r'^editor/coordinator/open_v1/?$', oozie_views_editor2.open_old_coordinator, name='open_old_coordinator'),
+  re_path(r'^editor/coordinator/parameters/?$', oozie_views_editor2.coordinator_parameters, name='coordinator_parameters'),
 
-  url(r'^editor/bundle/list/?$', oozie_views_editor2.list_editor_bundles, name='list_editor_bundles'),
-  url(r'^editor/bundle/edit/?$', oozie_views_editor2.edit_bundle, name='edit_bundle'),
-  url(r'^editor/bundle/new/?$', oozie_views_editor2.new_bundle, name='new_bundle'),
-  url(r'^editor/bundle/delete/?$', oozie_views_editor2.delete_job, name='delete_editor_bundle'),
-  url(r'^editor/bundle/copy/?$', oozie_views_editor2.copy_bundle, name='copy_bundle'),
-  url(r'^editor/bundle/save/?$', oozie_views_editor2.save_bundle, name='save_bundle'),
-  url(r'^editor/bundle/submit/(?P<doc_id>\d+)$', oozie_views_editor2.submit_bundle, name='editor_submit_bundle'),
-  url(r'^editor/bundle/open_v1/?$', oozie_views_editor2.open_old_bundle, name='open_old_bundle'),
+  re_path(r'^editor/bundle/list/?$', oozie_views_editor2.list_editor_bundles, name='list_editor_bundles'),
+  re_path(r'^editor/bundle/edit/?$', oozie_views_editor2.edit_bundle, name='edit_bundle'),
+  re_path(r'^editor/bundle/new/?$', oozie_views_editor2.new_bundle, name='new_bundle'),
+  re_path(r'^editor/bundle/delete/?$', oozie_views_editor2.delete_job, name='delete_editor_bundle'),
+  re_path(r'^editor/bundle/copy/?$', oozie_views_editor2.copy_bundle, name='copy_bundle'),
+  re_path(r'^editor/bundle/save/?$', oozie_views_editor2.save_bundle, name='save_bundle'),
+  re_path(r'^editor/bundle/submit/(?P<doc_id>\d+)$', oozie_views_editor2.submit_bundle, name='editor_submit_bundle'),
+  re_path(r'^editor/bundle/open_v1/?$', oozie_views_editor2.open_old_bundle, name='open_old_bundle'),
 ]
 
 
 urlpatterns += [
 
-  url(r'^workflows/?$', oozie_views_api.workflows, name='workflows'),
-  url(r'^workflows/(?P<workflow>\d+)$', oozie_views_api.workflow, name='workflow'),
-  url(r'^workflows/(?P<workflow>\d+)/save$', oozie_views_api.workflow_save, name='workflow_save'),
-  url(r'^workflows/(?P<workflow>\d+)/actions$', oozie_views_api.workflow_actions, name='workflow_actions'),
-  url(
+  re_path(r'^workflows/?$', oozie_views_api.workflows, name='workflows'),
+  re_path(r'^workflows/(?P<workflow>\d+)$', oozie_views_api.workflow, name='workflow'),
+  re_path(r'^workflows/(?P<workflow>\d+)/save$', oozie_views_api.workflow_save, name='workflow_save'),
+  re_path(r'^workflows/(?P<workflow>\d+)/actions$', oozie_views_api.workflow_actions, name='workflow_actions'),
+  re_path(
     r'^workflows/(?P<workflow>\d+)/nodes/(?P<node_type>\w+)/validate$',
     oozie_views_api.workflow_validate_node,
     name='workflow_validate_node'
   ),
-  url(r'^workflows/autocomplete_properties/?$', oozie_views_api.autocomplete_properties, name='autocomplete_properties'),
+  re_path(r'^workflows/autocomplete_properties/?$', oozie_views_api.autocomplete_properties, name='autocomplete_properties'),
 ]
 
 
 urlpatterns += [
 
-  url(r'^$', oozie_views_dashboard.list_oozie_workflows, name='index'),
+  re_path(r'^$', oozie_views_dashboard.list_oozie_workflows, name='index'),
 
-  url(r'^list_oozie_workflows/?$', oozie_views_dashboard.list_oozie_workflows, name='list_oozie_workflows'),
-  url(r'^list_oozie_coordinators/?$', oozie_views_dashboard.list_oozie_coordinators, name='list_oozie_coordinators'),
-  url(r'^list_oozie_bundles/?$', oozie_views_dashboard.list_oozie_bundles, name='list_oozie_bundles'),
-  url(r'^list_oozie_workflow/(?P<job_id>[-\w]+)/?$', oozie_views_dashboard.list_oozie_workflow, name='list_oozie_workflow'),
-  url(r'^list_oozie_coordinator/(?P<job_id>[-\w]+)/?$', oozie_views_dashboard.list_oozie_coordinator, name='list_oozie_coordinator'),
-  url(
+  re_path(r'^list_oozie_workflows/?$', oozie_views_dashboard.list_oozie_workflows, name='list_oozie_workflows'),
+  re_path(r'^list_oozie_coordinators/?$', oozie_views_dashboard.list_oozie_coordinators, name='list_oozie_coordinators'),
+  re_path(r'^list_oozie_bundles/?$', oozie_views_dashboard.list_oozie_bundles, name='list_oozie_bundles'),
+  re_path(r'^list_oozie_workflow/(?P<job_id>[-\w]+)/?$', oozie_views_dashboard.list_oozie_workflow, name='list_oozie_workflow'),
+  re_path(r'^list_oozie_coordinator/(?P<job_id>[-\w]+)/?$', oozie_views_dashboard.list_oozie_coordinator, name='list_oozie_coordinator'),
+  re_path(
     r'^list_oozie_workflow_action/(?P<action>[-\w@]+)/?$',
     oozie_views_dashboard.list_oozie_workflow_action,
     name='list_oozie_workflow_action'
   ),
-  url(r'^list_oozie_bundle/(?P<job_id>[-\w]+)$', oozie_views_dashboard.list_oozie_bundle, name='list_oozie_bundle'),
+  re_path(r'^list_oozie_bundle/(?P<job_id>[-\w]+)$', oozie_views_dashboard.list_oozie_bundle, name='list_oozie_bundle'),
 
-  url(r'^rerun_oozie_job/(?P<job_id>[-\w]+)(?:/(?P<app_path>.+?))?/?$', oozie_views_dashboard.rerun_oozie_job, name='rerun_oozie_job'),
-  url(
+  re_path(r'^rerun_oozie_job/(?P<job_id>[-\w]+)(?:/(?P<app_path>.+?))?/?$', oozie_views_dashboard.rerun_oozie_job, name='rerun_oozie_job'),
+  re_path(
     r'^rerun_oozie_coord/(?P<job_id>[-\w]+)(?:/(?P<app_path>.+?))?/?$',
     oozie_views_dashboard.rerun_oozie_coordinator,
     name='rerun_oozie_coord'
   ),
-  url(r'^rerun_oozie_bundle/(?P<job_id>[-\w]+)/(?P<app_path>.+?)$', oozie_views_dashboard.rerun_oozie_bundle, name='rerun_oozie_bundle'),
-  url(r'^sync_coord_workflow/(?P<job_id>[-\w]+)$', oozie_views_dashboard.sync_coord_workflow, name='sync_coord_workflow'),
-  url(
+  re_path(r'^rerun_oozie_bundle/(?P<job_id>[-\w]+)/(?P<app_path>.+?)$', oozie_views_dashboard.rerun_oozie_bundle, name='rerun_oozie_bundle'),
+  re_path(r'^sync_coord_workflow/(?P<job_id>[-\w]+)$', oozie_views_dashboard.sync_coord_workflow, name='sync_coord_workflow'),
+  re_path(
     r'^manage_oozie_jobs/(?P<job_id>[-\w]+)/(?P<action>(start|suspend|resume|kill|rerun|change|ignore))$',
     oozie_views_dashboard.manage_oozie_jobs,
     name='manage_oozie_jobs'
   ),
-  url(r'^bulk_manage_oozie_jobs/?$', oozie_views_dashboard.bulk_manage_oozie_jobs, name='bulk_manage_oozie_jobs'),
+  re_path(r'^bulk_manage_oozie_jobs/?$', oozie_views_dashboard.bulk_manage_oozie_jobs, name='bulk_manage_oozie_jobs'),
 
-  url(r'^submit_external_job/(?P<application_path>.+?)$', oozie_views_dashboard.submit_external_job, name='submit_external_job'),
-  url(r'^get_oozie_job_log/(?P<job_id>[-\w]+)$', oozie_views_dashboard.get_oozie_job_log, name='get_oozie_job_log'),
+  re_path(r'^submit_external_job/(?P<application_path>.+?)$', oozie_views_dashboard.submit_external_job, name='submit_external_job'),
+  re_path(r'^get_oozie_job_log/(?P<job_id>[-\w]+)$', oozie_views_dashboard.get_oozie_job_log, name='get_oozie_job_log'),
 
-  url(r'^list_oozie_info/?$', oozie_views_dashboard.list_oozie_info, name='list_oozie_info'),
+  re_path(r'^list_oozie_info/?$', oozie_views_dashboard.list_oozie_info, name='list_oozie_info'),
 
-  url(r'^list_oozie_sla/?$', oozie_views_dashboard.list_oozie_sla, name='list_oozie_sla'),
+  re_path(r'^list_oozie_sla/?$', oozie_views_dashboard.list_oozie_sla, name='list_oozie_sla'),
 ]

--- a/apps/oozie/src/oozie/urls.py
+++ b/apps/oozie/src/oozie/urls.py
@@ -15,12 +15,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from oozie.views import editor as oozie_views_editor
 from oozie.views import editor2 as oozie_views_editor2
 from oozie.views import api as oozie_views_api
 from oozie.views import dashboard as oozie_views_dashboard
 
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 IS_URL_NAMESPACED = True
 

--- a/apps/oozie/src/oozie/urls.py
+++ b/apps/oozie/src/oozie/urls.py
@@ -52,9 +52,17 @@ urlpatterns = [
   url(r'^delete_coordinator$', oozie_views_editor.delete_coordinator, name='delete_coordinator'),
   url(r'^restore_coordinator$', oozie_views_editor.restore_coordinator, name='restore_coordinator'),
   url(r'^clone_coordinator/(?P<coordinator>\d+)$', oozie_views_editor.clone_coordinator, name='clone_coordinator'),
-  url(r'^create_coordinator_dataset/(?P<coordinator>[-\w]+)$', oozie_views_editor.create_coordinator_dataset, name='create_coordinator_dataset'),
+  url(
+    r'^create_coordinator_dataset/(?P<coordinator>[-\w]+)$',
+    oozie_views_editor.create_coordinator_dataset,
+    name='create_coordinator_dataset'
+  ),
   url(r'^edit_coordinator_dataset/(?P<dataset>\d+)$', oozie_views_editor.edit_coordinator_dataset, name='edit_coordinator_dataset'),
-  url(r'^create_coordinator_data/(?P<coordinator>[-\w]+)/(?P<data_type>(input|output))$', oozie_views_editor.create_coordinator_data, name='create_coordinator_data'),
+  url(
+    r'^create_coordinator_data/(?P<coordinator>[-\w]+)/(?P<data_type>(input|output))$',
+    oozie_views_editor.create_coordinator_data,
+    name='create_coordinator_data'
+  ),
   url(r'^submit_coordinator/(?P<coordinator>\d+)$', oozie_views_editor.submit_coordinator, name='submit_coordinator'),
 
   url(r'^list_bundles$', oozie_views_editor.list_bundles, name='list_bundles'),
@@ -66,7 +74,11 @@ urlpatterns = [
   url(r'^delete_bundle$', oozie_views_editor.delete_bundle, name='delete_bundle'),
   url(r'^restore_bundle$', oozie_views_editor.restore_bundle, name='restore_bundle'),
   url(r'^create_bundled_coordinator/(?P<bundle>\d+)$', oozie_views_editor.create_bundled_coordinator, name='create_bundled_coordinator'),
-  url(r'^edit_bundled_coordinator/(?P<bundle>\d+)/(?P<bundled_coordinator>\d+)$', oozie_views_editor.edit_bundled_coordinator, name='edit_bundled_coordinator'),
+  url(
+    r'^edit_bundled_coordinator/(?P<bundle>\d+)/(?P<bundled_coordinator>\d+)$',
+    oozie_views_editor.edit_bundled_coordinator,
+    name='edit_bundled_coordinator'
+  ),
 
   url(r'^list_history$', oozie_views_editor.list_history, name='list_history'), # Unused
   url(r'^list_history/(?P<record_id>[-\w]+)$', oozie_views_editor.list_history_record, name='list_history_record'),
@@ -82,7 +94,11 @@ urlpatterns += [
   url(r'^editor/workflow/copy/?$', oozie_views_editor2.copy_workflow, name='copy_workflow'),
   url(r'^editor/workflow/save/?$', oozie_views_editor2.save_workflow, name='save_workflow'),
   url(r'^editor/workflow/submit/(?P<doc_id>\d+)$', oozie_views_editor2.submit_workflow, name='editor_submit_workflow'),
-  url(r'^editor/workflow/submit_single_action/(?P<doc_id>\d+)/(?P<node_id>.+)$', oozie_views_editor2.submit_single_action, name='submit_single_action'),
+  url(
+    r'^editor/workflow/submit_single_action/(?P<doc_id>\d+)/(?P<node_id>.+)$',
+    oozie_views_editor2.submit_single_action,
+    name='submit_single_action'
+  ),
   url(r'^editor/workflow/new_node/?$', oozie_views_editor2.new_node, name='new_node'),
   url(r'^editor/workflow/add_node/?$', oozie_views_editor2.add_node, name='add_node'),
   url(r'^editor/workflow/parameters/?$', oozie_views_editor2.workflow_parameters, name='workflow_parameters'),
@@ -118,7 +134,11 @@ urlpatterns += [
   url(r'^workflows/(?P<workflow>\d+)$', oozie_views_api.workflow, name='workflow'),
   url(r'^workflows/(?P<workflow>\d+)/save$', oozie_views_api.workflow_save, name='workflow_save'),
   url(r'^workflows/(?P<workflow>\d+)/actions$', oozie_views_api.workflow_actions, name='workflow_actions'),
-  url(r'^workflows/(?P<workflow>\d+)/nodes/(?P<node_type>\w+)/validate$', oozie_views_api.workflow_validate_node, name='workflow_validate_node'),
+  url(
+    r'^workflows/(?P<workflow>\d+)/nodes/(?P<node_type>\w+)/validate$',
+    oozie_views_api.workflow_validate_node,
+    name='workflow_validate_node'
+  ),
   url(r'^workflows/autocomplete_properties/?$', oozie_views_api.autocomplete_properties, name='autocomplete_properties'),
 ]
 
@@ -132,14 +152,26 @@ urlpatterns += [
   url(r'^list_oozie_bundles/?$', oozie_views_dashboard.list_oozie_bundles, name='list_oozie_bundles'),
   url(r'^list_oozie_workflow/(?P<job_id>[-\w]+)/?$', oozie_views_dashboard.list_oozie_workflow, name='list_oozie_workflow'),
   url(r'^list_oozie_coordinator/(?P<job_id>[-\w]+)/?$', oozie_views_dashboard.list_oozie_coordinator, name='list_oozie_coordinator'),
-  url(r'^list_oozie_workflow_action/(?P<action>[-\w@]+)/?$', oozie_views_dashboard.list_oozie_workflow_action, name='list_oozie_workflow_action'),
+  url(
+    r'^list_oozie_workflow_action/(?P<action>[-\w@]+)/?$',
+    oozie_views_dashboard.list_oozie_workflow_action,
+    name='list_oozie_workflow_action'
+  ),
   url(r'^list_oozie_bundle/(?P<job_id>[-\w]+)$', oozie_views_dashboard.list_oozie_bundle, name='list_oozie_bundle'),
 
   url(r'^rerun_oozie_job/(?P<job_id>[-\w]+)(?:/(?P<app_path>.+?))?/?$', oozie_views_dashboard.rerun_oozie_job, name='rerun_oozie_job'),
-  url(r'^rerun_oozie_coord/(?P<job_id>[-\w]+)(?:/(?P<app_path>.+?))?/?$', oozie_views_dashboard.rerun_oozie_coordinator, name='rerun_oozie_coord'),
+  url(
+    r'^rerun_oozie_coord/(?P<job_id>[-\w]+)(?:/(?P<app_path>.+?))?/?$',
+    oozie_views_dashboard.rerun_oozie_coordinator,
+    name='rerun_oozie_coord'
+  ),
   url(r'^rerun_oozie_bundle/(?P<job_id>[-\w]+)/(?P<app_path>.+?)$', oozie_views_dashboard.rerun_oozie_bundle, name='rerun_oozie_bundle'),
   url(r'^sync_coord_workflow/(?P<job_id>[-\w]+)$', oozie_views_dashboard.sync_coord_workflow, name='sync_coord_workflow'),
-  url(r'^manage_oozie_jobs/(?P<job_id>[-\w]+)/(?P<action>(start|suspend|resume|kill|rerun|change|ignore))$', oozie_views_dashboard.manage_oozie_jobs, name='manage_oozie_jobs'),
+  url(
+    r'^manage_oozie_jobs/(?P<job_id>[-\w]+)/(?P<action>(start|suspend|resume|kill|rerun|change|ignore))$',
+    oozie_views_dashboard.manage_oozie_jobs,
+    name='manage_oozie_jobs'
+  ),
   url(r'^bulk_manage_oozie_jobs/?$', oozie_views_dashboard.bulk_manage_oozie_jobs, name='bulk_manage_oozie_jobs'),
 
   url(r'^submit_external_job/(?P<application_path>.+?)$', oozie_views_dashboard.submit_external_job, name='submit_external_job'),

--- a/apps/pig/src/pig/urls.py
+++ b/apps/pig/src/pig/urls.py
@@ -15,8 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from pig import views as pig_views
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   url(r'^$', pig_views.app, name='index'),

--- a/apps/pig/src/pig/urls.py
+++ b/apps/pig/src/pig/urls.py
@@ -19,24 +19,24 @@ import sys
 
 from pig import views as pig_views
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-  url(r'^$', pig_views.app, name='index'),
+  re_path(r'^$', pig_views.app, name='index'),
 
-  url(r'^app/?$', pig_views.app, name='app'),
+  re_path(r'^app/?$', pig_views.app, name='app'),
 
   # Ajax
-  url(r'^scripts/?$', pig_views.scripts, name='scripts'),
-  url(r'^dashboard/?$', pig_views.dashboard, name='dashboard'),
-  url(r'^save/?$', pig_views.save, name='save'),
-  url(r'^run/?$', pig_views.run, name='run'),
-  url(r'^copy/?$', pig_views.copy, name='copy'),
-  url(r'^delete/?$', pig_views.delete, name='delete'),
-  url(r'^watch/(?P<job_id>[-\w]+)$', pig_views.watch, name='watch'),
-  url(r'^stop/?$', pig_views.stop, name='stop'),
-  url(r'^install_examples$', pig_views.install_examples, name='install_examples'),
+  re_path(r'^scripts/?$', pig_views.scripts, name='scripts'),
+  re_path(r'^dashboard/?$', pig_views.dashboard, name='dashboard'),
+  re_path(r'^save/?$', pig_views.save, name='save'),
+  re_path(r'^run/?$', pig_views.run, name='run'),
+  re_path(r'^copy/?$', pig_views.copy, name='copy'),
+  re_path(r'^delete/?$', pig_views.delete, name='delete'),
+  re_path(r'^watch/(?P<job_id>[-\w]+)$', pig_views.watch, name='watch'),
+  re_path(r'^stop/?$', pig_views.stop, name='stop'),
+  re_path(r'^install_examples$', pig_views.install_examples, name='install_examples'),
 ]

--- a/apps/proxy/src/proxy/urls.py
+++ b/apps/proxy/src/proxy/urls.py
@@ -15,8 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from proxy import views as proxy_views
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   # Prefix the names of your views with the app name.

--- a/apps/proxy/src/proxy/urls.py
+++ b/apps/proxy/src/proxy/urls.py
@@ -19,12 +19,12 @@ import sys
 
 from proxy import views as proxy_views
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
   # Prefix the names of your views with the app name.
-  url(r'^(?P<host>[^/]+)/(?P<port>\d+)(?P<path>/.*)$', proxy_views.proxy, name="proxy.views.proxy"),
+  re_path(r'^(?P<host>[^/]+)/(?P<port>\d+)(?P<path>/.*)$', proxy_views.proxy, name="proxy.views.proxy"),
 ]

--- a/apps/rdbms/src/rdbms/urls.py
+++ b/apps/rdbms/src/rdbms/urls.py
@@ -22,44 +22,44 @@ from rdbms import api as rdbms_api
 from beeswax import views as beeswax_views
 from beeswax import api as beeswax_api
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 # Views
 urlpatterns = [
-  url(r'^$', rdbms_views.index, name='index'),
-  url(r'^execute/?$', rdbms_views.execute_query, name='execute_query'),
-  url(r'^execute/design/(?P<design_id>\d+)$', rdbms_views.execute_query, name='execute_design'),
-  url(r'^execute/query/(?P<query_history_id>\d+)$', rdbms_views.execute_query, name='watch_query_history')
+  re_path(r'^$', rdbms_views.index, name='index'),
+  re_path(r'^execute/?$', rdbms_views.execute_query, name='execute_query'),
+  re_path(r'^execute/design/(?P<design_id>\d+)$', rdbms_views.execute_query, name='execute_design'),
+  re_path(r'^execute/query/(?P<query_history_id>\d+)$', rdbms_views.execute_query, name='watch_query_history')
 ]
 
 # APIs
 urlpatterns += [
-  url(r'^api/servers/?$', rdbms_api.servers, name='api_servers'),
-  url(r'^api/servers/(?P<server>\w+)/databases/?$', rdbms_api.databases, name='api_databases'),
-  url(r'^api/servers/(?P<server>\w+)/databases/(?P<database>.+?)/tables/?$', rdbms_api.tables, name='api_tables'),
-  url(r'^api/servers/(?P<server>\w+)/databases/(?P<database>.+?)/tables/(?P<table>\w+)/columns/?$', rdbms_api.columns, name='api_columns'),
-  url(r'^api/query(?:/(?P<design_id>\d+))?/?$', rdbms_api.save_query, name='api_save_query'),
-  url(r'^api/query/(?P<design_id>\d+)/get$', rdbms_api.fetch_saved_query, name='api_fetch_saved_query'),
-  url(r'^api/execute(?:/(?P<design_id>\d+))?/?$', rdbms_api.execute_query, name='api_execute_query'),
-  url(r'^api/explain/?$', rdbms_api.explain_query, name='api_explain_query'),
-  url(r'^api/results/(?P<id>\d+)/(?P<first_row>\d+)$', rdbms_api.fetch_results, name='api_fetch_results')
+  re_path(r'^api/servers/?$', rdbms_api.servers, name='api_servers'),
+  re_path(r'^api/servers/(?P<server>\w+)/databases/?$', rdbms_api.databases, name='api_databases'),
+  re_path(r'^api/servers/(?P<server>\w+)/databases/(?P<database>.+?)/tables/?$', rdbms_api.tables, name='api_tables'),
+  re_path(r'^api/servers/(?P<server>\w+)/databases/(?P<database>.+?)/tables/(?P<table>\w+)/columns/?$', rdbms_api.columns, name='api_columns'),
+  re_path(r'^api/query(?:/(?P<design_id>\d+))?/?$', rdbms_api.save_query, name='api_save_query'),
+  re_path(r'^api/query/(?P<design_id>\d+)/get$', rdbms_api.fetch_saved_query, name='api_fetch_saved_query'),
+  re_path(r'^api/execute(?:/(?P<design_id>\d+))?/?$', rdbms_api.execute_query, name='api_execute_query'),
+  re_path(r'^api/explain/?$', rdbms_api.explain_query, name='api_explain_query'),
+  re_path(r'^api/results/(?P<id>\d+)/(?P<first_row>\d+)$', rdbms_api.fetch_results, name='api_fetch_results')
 ]
 
 urlpatterns += [
-  url(r'^my_queries$', beeswax_views.my_queries, name='my_queries'),
-  url(r'^list_designs$', beeswax_views.list_designs, name='list_designs'),
-  url(r'^list_trashed_designs$', beeswax_views.list_trashed_designs, name='list_trashed_designs'),
-  url(r'^delete_designs$', beeswax_views.delete_design, name='delete_design'),
-  url(r'^restore_designs$', beeswax_views.restore_design, name='restore_design'),
-  url(r'^clone_design/(?P<design_id>\d+)$', beeswax_views.clone_design, name='clone_design'),
-  url(r'^query_history$', beeswax_views.list_query_history, name='list_query_history')
+  re_path(r'^my_queries$', beeswax_views.my_queries, name='my_queries'),
+  re_path(r'^list_designs$', beeswax_views.list_designs, name='list_designs'),
+  re_path(r'^list_trashed_designs$', beeswax_views.list_trashed_designs, name='list_trashed_designs'),
+  re_path(r'^delete_designs$', beeswax_views.delete_design, name='delete_design'),
+  re_path(r'^restore_designs$', beeswax_views.restore_design, name='restore_design'),
+  re_path(r'^clone_design/(?P<design_id>\d+)$', beeswax_views.clone_design, name='clone_design'),
+  re_path(r'^query_history$', beeswax_views.list_query_history, name='list_query_history')
 ]
 
 urlpatterns += [
-  url(r'^autocomplete/$', beeswax_api.autocomplete, name='api_autocomplete_databases'),
-  url(r'^autocomplete/(?P<database>\w+)/$', beeswax_api.autocomplete, name='api_autocomplete_tables'),
-  url(r'^autocomplete/(?P<database>\w+)/(?P<table>\w+)$', beeswax_api.autocomplete, name='api_autocomplete_columns')
+  re_path(r'^autocomplete/$', beeswax_api.autocomplete, name='api_autocomplete_databases'),
+  re_path(r'^autocomplete/(?P<database>\w+)/$', beeswax_api.autocomplete, name='api_autocomplete_tables'),
+  re_path(r'^autocomplete/(?P<database>\w+)/(?P<table>\w+)$', beeswax_api.autocomplete, name='api_autocomplete_columns')
 ]

--- a/apps/rdbms/src/rdbms/urls.py
+++ b/apps/rdbms/src/rdbms/urls.py
@@ -15,11 +15,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from rdbms import views as rdbms_views
 from rdbms import api as rdbms_api
 from beeswax import views as beeswax_views
 from beeswax import api as beeswax_api
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 # Views
 urlpatterns = [

--- a/apps/rdbms/src/rdbms/urls.py
+++ b/apps/rdbms/src/rdbms/urls.py
@@ -40,7 +40,9 @@ urlpatterns += [
   re_path(r'^api/servers/?$', rdbms_api.servers, name='api_servers'),
   re_path(r'^api/servers/(?P<server>\w+)/databases/?$', rdbms_api.databases, name='api_databases'),
   re_path(r'^api/servers/(?P<server>\w+)/databases/(?P<database>.+?)/tables/?$', rdbms_api.tables, name='api_tables'),
-  re_path(r'^api/servers/(?P<server>\w+)/databases/(?P<database>.+?)/tables/(?P<table>\w+)/columns/?$', rdbms_api.columns, name='api_columns'),
+  re_path(
+    r'^api/servers/(?P<server>\w+)/databases/(?P<database>.+?)/tables/(?P<table>\w+)/columns/?$', rdbms_api.columns, name='api_columns'
+  ),
   re_path(r'^api/query(?:/(?P<design_id>\d+))?/?$', rdbms_api.save_query, name='api_save_query'),
   re_path(r'^api/query/(?P<design_id>\d+)/get$', rdbms_api.fetch_saved_query, name='api_fetch_saved_query'),
   re_path(r'^api/execute(?:/(?P<design_id>\d+))?/?$', rdbms_api.execute_query, name='api_execute_query'),

--- a/apps/search/src/search/urls.py
+++ b/apps/search/src/search/urls.py
@@ -15,11 +15,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from search import views as search_views
 from dashboard import views as dashboard_views
 from dashboard import api as dashboard_api
 
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   url(r'^install_examples$', search_views.install_examples, name='install_examples'),

--- a/apps/search/src/search/urls.py
+++ b/apps/search/src/search/urls.py
@@ -21,46 +21,46 @@ from search import views as search_views
 from dashboard import views as dashboard_views
 from dashboard import api as dashboard_api
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-  url(r'^install_examples$', search_views.install_examples, name='install_examples'),
+  re_path(r'^install_examples$', search_views.install_examples, name='install_examples'),
 ]
 
 
 # Those are all deprecated and dashboard.urls.py is the new reference.
 
 urlpatterns += [
-  url(r'^$', dashboard_views.index, name='index'),
-  url(r'^m$', dashboard_views.index_m, name='index_m'),
-  url(r'^save$', dashboard_views.save, name='save'),
-  url(r'^new_search', dashboard_views.new_search, name='new_search'),
-  url(r'^browse/(?P<name>.+)', dashboard_views.browse, name='browse'),
-  url(r'^browse_m/(?P<name>.+)', dashboard_views.browse_m, name='browse_m'),
+  re_path(r'^$', dashboard_views.index, name='index'),
+  re_path(r'^m$', dashboard_views.index_m, name='index_m'),
+  re_path(r'^save$', dashboard_views.save, name='save'),
+  re_path(r'^new_search', dashboard_views.new_search, name='new_search'),
+  re_path(r'^browse/(?P<name>.+)', dashboard_views.browse, name='browse'),
+  re_path(r'^browse_m/(?P<name>.+)', dashboard_views.browse_m, name='browse_m'),
 
   # Admin
-  url(r'^admin/collections$', dashboard_views.admin_collections, name='admin_collections'),
-  url(r'^admin/collection_delete$', dashboard_views.admin_collection_delete, name='admin_collection_delete'),
-  url(r'^admin/collection_copy$', dashboard_views.admin_collection_copy, name='admin_collection_copy'),
+  re_path(r'^admin/collections$', dashboard_views.admin_collections, name='admin_collections'),
+  re_path(r'^admin/collection_delete$', dashboard_views.admin_collection_delete, name='admin_collection_delete'),
+  re_path(r'^admin/collection_copy$', dashboard_views.admin_collection_copy, name='admin_collection_copy'),
 ]
 
 
 urlpatterns += [
-  url(r'^search$', dashboard_api.search, name='search'),
-  url(r'^suggest/?$', dashboard_api.query_suggest, name='query_suggest'),
-  url(r'^index/fields/dynamic$', dashboard_api.index_fields_dynamic, name='index_fields_dynamic'),
-  url(r'^index/fields/nested_documents', dashboard_api.nested_documents, name='nested_documents'),
-  url(r'^template/new_facet$', dashboard_api.new_facet, name='new_facet'),
-  url(r'^get_document$', dashboard_api.get_document, name='get_document'),
-  url(r'^update_document$', dashboard_api.update_document, name='update_document'),
-  url(r'^get_range_facet$', dashboard_api.get_range_facet, name='get_range_facet'),
-  url(r'^download$', dashboard_api.download, name='download'),
-  url(r'^get_timeline$', dashboard_api.get_timeline, name='get_timeline'),
-  url(r'^get_collection$', dashboard_api.get_collection, name='get_collection'),
-  url(r'^get_collections$', dashboard_api.get_collections, name='get_collections'),
-  url(r'^get_stats$', dashboard_api.get_stats, name='get_stats'),
-  url(r'^get_terms$', dashboard_api.get_terms, name='get_terms'),
+  re_path(r'^search$', dashboard_api.search, name='search'),
+  re_path(r'^suggest/?$', dashboard_api.query_suggest, name='query_suggest'),
+  re_path(r'^index/fields/dynamic$', dashboard_api.index_fields_dynamic, name='index_fields_dynamic'),
+  re_path(r'^index/fields/nested_documents', dashboard_api.nested_documents, name='nested_documents'),
+  re_path(r'^template/new_facet$', dashboard_api.new_facet, name='new_facet'),
+  re_path(r'^get_document$', dashboard_api.get_document, name='get_document'),
+  re_path(r'^update_document$', dashboard_api.update_document, name='update_document'),
+  re_path(r'^get_range_facet$', dashboard_api.get_range_facet, name='get_range_facet'),
+  re_path(r'^download$', dashboard_api.download, name='download'),
+  re_path(r'^get_timeline$', dashboard_api.get_timeline, name='get_timeline'),
+  re_path(r'^get_collection$', dashboard_api.get_collection, name='get_collection'),
+  re_path(r'^get_collections$', dashboard_api.get_collections, name='get_collections'),
+  re_path(r'^get_stats$', dashboard_api.get_stats, name='get_stats'),
+  re_path(r'^get_terms$', dashboard_api.get_terms, name='get_terms'),
 ]

--- a/apps/security/src/security/urls.py
+++ b/apps/security/src/security/urls.py
@@ -22,88 +22,88 @@ from security.api import hdfs as security_api_hdfs
 from security.api import hive as security_api_hive
 from security.api import sentry as security_api_sentry 
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-  url(r'^$', security_views.hive, name='index'),
-  url(r'^hive$', security_views.hive, name='hive'),
-  url(r'^hive2$', security_views.hive2, name='hive2'),
-  url(r'^solr$', security_views.solr, name='solr'),
-  url(r'^hdfs$', security_views.hdfs, name='hdfs'),
+  re_path(r'^$', security_views.hive, name='index'),
+  re_path(r'^hive$', security_views.hive, name='hive'),
+  re_path(r'^hive2$', security_views.hive2, name='hive2'),
+  re_path(r'^solr$', security_views.solr, name='solr'),
+  re_path(r'^hdfs$', security_views.hdfs, name='hdfs'),
 ]
 
 
 urlpatterns += [
-  url(r'^api/hdfs/list(?P<path>/.*)$', security_api_hdfs.list_hdfs, name='list_hdfs'),
-  url(r'^api/hdfs/get_acls$', security_api_hdfs.get_acls, name='get_acls'),
-  url(r'^api/hdfs/update_acls', security_api_hdfs.update_acls, name='update_acls'),
-  url(r'^api/hdfs/bulk_delete_acls', security_api_hdfs.bulk_delete_acls, name='bulk_delete_acls'),
-  url(r'^api/hdfs/bulk_add_acls', security_api_hdfs.bulk_add_acls, name='bulk_add_acls'),
-  url(r'^api/hdfs/bulk_sync_acls', security_api_hdfs.bulk_sync_acls, name='bulk_sync_acls'),
+  re_path(r'^api/hdfs/list(?P<path>/.*)$', security_api_hdfs.list_hdfs, name='list_hdfs'),
+  re_path(r'^api/hdfs/get_acls$', security_api_hdfs.get_acls, name='get_acls'),
+  re_path(r'^api/hdfs/update_acls', security_api_hdfs.update_acls, name='update_acls'),
+  re_path(r'^api/hdfs/bulk_delete_acls', security_api_hdfs.bulk_delete_acls, name='bulk_delete_acls'),
+  re_path(r'^api/hdfs/bulk_add_acls', security_api_hdfs.bulk_add_acls, name='bulk_add_acls'),
+  re_path(r'^api/hdfs/bulk_sync_acls', security_api_hdfs.bulk_sync_acls, name='bulk_sync_acls'),
 ]
 
 
 urlpatterns += [
-  url(r'^api/hive/fetch_hive_path', security_api_hive.fetch_hive_path, name='fetch_hive_path'),
+  re_path(r'^api/hive/fetch_hive_path', security_api_hive.fetch_hive_path, name='fetch_hive_path'),
 
-  url(r'^api/hive/list_sentry_roles_by_group', security_api_hive.list_sentry_roles_by_group, name='list_sentry_roles_by_group'),
-  url(r'^api/hive/list_sentry_privileges_by_role', security_api_hive.list_sentry_privileges_by_role, name='list_sentry_privileges_by_role'),
-  url(
+  re_path(r'^api/hive/list_sentry_roles_by_group', security_api_hive.list_sentry_roles_by_group, name='list_sentry_roles_by_group'),
+  re_path(r'^api/hive/list_sentry_privileges_by_role', security_api_hive.list_sentry_privileges_by_role, name='list_sentry_privileges_by_role'),
+  re_path(
     r'^api/hive/list_sentry_privileges_for_provider$',
     security_api_hive.list_sentry_privileges_for_provider,
     name='list_sentry_privileges_for_provider'
   ),
-  url(
+  re_path(
     r'^api/hive/list_sentry_privileges_by_authorizable',
     security_api_hive.list_sentry_privileges_by_authorizable,
     name='list_sentry_privileges_by_authorizable'
   ),
-  url(r'^api/hive/create_sentry_role', security_api_hive.create_sentry_role, name='create_sentry_role'),
-  url(r'^api/hive/update_role_groups', security_api_hive.update_role_groups, name='update_role_groups'),
-  url(r'^api/hive/drop_sentry_role', security_api_hive.drop_sentry_role, name='drop_sentry_role'),
-  url(r'^api/hive/create_role$', security_api_hive.create_role, name='create_role'),
-  url(r'^api/hive/save_privileges$', security_api_hive.save_privileges, name='save_privileges'),
-  url(r'^api/hive/bulk_delete_privileges', security_api_hive.bulk_delete_privileges, name='bulk_delete_privileges'),
-  url(r'^api/hive/bulk_add_privileges', security_api_hive.bulk_add_privileges, name='bulk_add_privileges'),
-  url(r'^api/hive/grant_privilege', security_api_hive.grant_privilege, name='grant_privilege'),
+  re_path(r'^api/hive/create_sentry_role', security_api_hive.create_sentry_role, name='create_sentry_role'),
+  re_path(r'^api/hive/update_role_groups', security_api_hive.update_role_groups, name='update_role_groups'),
+  re_path(r'^api/hive/drop_sentry_role', security_api_hive.drop_sentry_role, name='drop_sentry_role'),
+  re_path(r'^api/hive/create_role$', security_api_hive.create_role, name='create_role'),
+  re_path(r'^api/hive/save_privileges$', security_api_hive.save_privileges, name='save_privileges'),
+  re_path(r'^api/hive/bulk_delete_privileges', security_api_hive.bulk_delete_privileges, name='bulk_delete_privileges'),
+  re_path(r'^api/hive/bulk_add_privileges', security_api_hive.bulk_add_privileges, name='bulk_add_privileges'),
+  re_path(r'^api/hive/grant_privilege', security_api_hive.grant_privilege, name='grant_privilege'),
 
   # Unused: API is for blind bulk operations
-  url(r'^api/hive/rename_sentry_privilege', security_api_hive.rename_sentry_privilege, name='rename_sentry_privilege'),
+  re_path(r'^api/hive/rename_sentry_privilege', security_api_hive.rename_sentry_privilege, name='rename_sentry_privilege'),
 ]
 
 
 # Generic API V2
 urlpatterns += [
-  url(r'^api/sentry/fetch_authorizables', security_api_sentry.fetch_authorizables, name='fetch_authorizables'),
+  re_path(r'^api/sentry/fetch_authorizables', security_api_sentry.fetch_authorizables, name='fetch_authorizables'),
 
-  url(r'^api/sentry/list_sentry_roles_by_group', security_api_sentry.list_sentry_roles_by_group, name='list_sentry_roles_by_group'),
-  url(
+  re_path(r'^api/sentry/list_sentry_roles_by_group', security_api_sentry.list_sentry_roles_by_group, name='list_sentry_roles_by_group'),
+  re_path(
     r'^api/sentry/list_sentry_privileges_by_role',
     security_api_sentry.list_sentry_privileges_by_role,
     name='list_sentry_privileges_by_role'
   ),
-  url(
+  re_path(
     r'^api/sentry/list_sentry_privileges_for_provider$',
     security_api_sentry.list_sentry_privileges_for_provider,
     name='list_sentry_privileges_for_provider'
   ),
-  url(
+  re_path(
     r'^api/sentry/list_sentry_privileges_by_authorizable',
     security_api_sentry.list_sentry_privileges_by_authorizable,
     name='list_sentry_privileges_by_authorizable'
   ),
-  url(r'^api/sentry/create_sentry_role', security_api_sentry.create_sentry_role, name='create_sentry_role'),
-  url(r'^api/sentry/update_role_groups', security_api_sentry.update_role_groups, name='update_role_groups'),
-  url(r'^api/sentry/drop_sentry_role', security_api_sentry.drop_sentry_role, name='drop_sentry_role'),
-  url(r'^api/sentry/create_role$', security_api_sentry.create_role, name='create_role'),
-  url(r'^api/sentry/save_privileges$', security_api_sentry.save_privileges, name='save_privileges'),
-  url(r'^api/sentry/bulk_delete_privileges', security_api_sentry.bulk_delete_privileges, name='bulk_delete_privileges'),
-  url(r'^api/sentry/bulk_add_privileges', security_api_sentry.bulk_add_privileges, name='bulk_add_privileges'),
-  url(r'^api/sentry/grant_privilege', security_api_sentry.grant_privilege, name='grant_privilege'),
+  re_path(r'^api/sentry/create_sentry_role', security_api_sentry.create_sentry_role, name='create_sentry_role'),
+  re_path(r'^api/sentry/update_role_groups', security_api_sentry.update_role_groups, name='update_role_groups'),
+  re_path(r'^api/sentry/drop_sentry_role', security_api_sentry.drop_sentry_role, name='drop_sentry_role'),
+  re_path(r'^api/sentry/create_role$', security_api_sentry.create_role, name='create_role'),
+  re_path(r'^api/sentry/save_privileges$', security_api_sentry.save_privileges, name='save_privileges'),
+  re_path(r'^api/sentry/bulk_delete_privileges', security_api_sentry.bulk_delete_privileges, name='bulk_delete_privileges'),
+  re_path(r'^api/sentry/bulk_add_privileges', security_api_sentry.bulk_add_privileges, name='bulk_add_privileges'),
+  re_path(r'^api/sentry/grant_privilege', security_api_sentry.grant_privilege, name='grant_privilege'),
 
   # Unused: API is for blind bulk operations
-  url(r'^api/sentry/rename_sentry_privilege', security_api_sentry.rename_sentry_privilege, name='rename_sentry_privilege'),
+  re_path(r'^api/sentry/rename_sentry_privilege', security_api_sentry.rename_sentry_privilege, name='rename_sentry_privilege'),
 ]

--- a/apps/security/src/security/urls.py
+++ b/apps/security/src/security/urls.py
@@ -50,7 +50,9 @@ urlpatterns += [
   re_path(r'^api/hive/fetch_hive_path', security_api_hive.fetch_hive_path, name='fetch_hive_path'),
 
   re_path(r'^api/hive/list_sentry_roles_by_group', security_api_hive.list_sentry_roles_by_group, name='list_sentry_roles_by_group'),
-  re_path(r'^api/hive/list_sentry_privileges_by_role', security_api_hive.list_sentry_privileges_by_role, name='list_sentry_privileges_by_role'),
+  re_path(
+    r'^api/hive/list_sentry_privileges_by_role', security_api_hive.list_sentry_privileges_by_role, name='list_sentry_privileges_by_role'
+  ),
   re_path(
     r'^api/hive/list_sentry_privileges_for_provider$',
     security_api_hive.list_sentry_privileges_for_provider,

--- a/apps/security/src/security/urls.py
+++ b/apps/security/src/security/urls.py
@@ -51,8 +51,16 @@ urlpatterns += [
 
   url(r'^api/hive/list_sentry_roles_by_group', security_api_hive.list_sentry_roles_by_group, name='list_sentry_roles_by_group'),
   url(r'^api/hive/list_sentry_privileges_by_role', security_api_hive.list_sentry_privileges_by_role, name='list_sentry_privileges_by_role'),
-  url(r'^api/hive/list_sentry_privileges_for_provider$', security_api_hive.list_sentry_privileges_for_provider, name='list_sentry_privileges_for_provider'),
-  url(r'^api/hive/list_sentry_privileges_by_authorizable', security_api_hive.list_sentry_privileges_by_authorizable, name='list_sentry_privileges_by_authorizable'),
+  url(
+    r'^api/hive/list_sentry_privileges_for_provider$',
+    security_api_hive.list_sentry_privileges_for_provider,
+    name='list_sentry_privileges_for_provider'
+  ),
+  url(
+    r'^api/hive/list_sentry_privileges_by_authorizable',
+    security_api_hive.list_sentry_privileges_by_authorizable,
+    name='list_sentry_privileges_by_authorizable'
+  ),
   url(r'^api/hive/create_sentry_role', security_api_hive.create_sentry_role, name='create_sentry_role'),
   url(r'^api/hive/update_role_groups', security_api_hive.update_role_groups, name='update_role_groups'),
   url(r'^api/hive/drop_sentry_role', security_api_hive.drop_sentry_role, name='drop_sentry_role'),
@@ -72,9 +80,21 @@ urlpatterns += [
   url(r'^api/sentry/fetch_authorizables', security_api_sentry.fetch_authorizables, name='fetch_authorizables'),
 
   url(r'^api/sentry/list_sentry_roles_by_group', security_api_sentry.list_sentry_roles_by_group, name='list_sentry_roles_by_group'),
-  url(r'^api/sentry/list_sentry_privileges_by_role', security_api_sentry.list_sentry_privileges_by_role, name='list_sentry_privileges_by_role'),
-  url(r'^api/sentry/list_sentry_privileges_for_provider$', security_api_sentry.list_sentry_privileges_for_provider, name='list_sentry_privileges_for_provider'),
-  url(r'^api/sentry/list_sentry_privileges_by_authorizable', security_api_sentry.list_sentry_privileges_by_authorizable, name='list_sentry_privileges_by_authorizable'),
+  url(
+    r'^api/sentry/list_sentry_privileges_by_role',
+    security_api_sentry.list_sentry_privileges_by_role,
+    name='list_sentry_privileges_by_role'
+  ),
+  url(
+    r'^api/sentry/list_sentry_privileges_for_provider$',
+    security_api_sentry.list_sentry_privileges_for_provider,
+    name='list_sentry_privileges_for_provider'
+  ),
+  url(
+    r'^api/sentry/list_sentry_privileges_by_authorizable',
+    security_api_sentry.list_sentry_privileges_by_authorizable,
+    name='list_sentry_privileges_by_authorizable'
+  ),
   url(r'^api/sentry/create_sentry_role', security_api_sentry.create_sentry_role, name='create_sentry_role'),
   url(r'^api/sentry/update_role_groups', security_api_sentry.update_role_groups, name='update_role_groups'),
   url(r'^api/sentry/drop_sentry_role', security_api_sentry.drop_sentry_role, name='drop_sentry_role'),

--- a/apps/security/src/security/urls.py
+++ b/apps/security/src/security/urls.py
@@ -15,11 +15,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from security import views as security_views
 from security.api import hdfs as security_api_hdfs
 from security.api import hive as security_api_hive
 from security.api import sentry as security_api_sentry 
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   url(r'^$', security_views.hive, name='index'),

--- a/apps/sqoop/src/sqoop/urls.py
+++ b/apps/sqoop/src/sqoop/urls.py
@@ -32,7 +32,9 @@ urlpatterns = [
 urlpatterns += [
   re_path(r'^api/autocomplete/databases/?$', sqoop_api.autocomplete, name='autocomplete_databases'),
   re_path(r'^api/autocomplete/databases/(?P<database>.+)/tables/?$', sqoop_api.autocomplete, name='autocomplete_tables'),
-  re_path(r'^api/autocomplete/databases/(?P<database>.+)/tables/(?P<table>.+)/columns/?$', sqoop_api.autocomplete, name='autocomplete_fields'),
+  re_path(
+    r'^api/autocomplete/databases/(?P<database>.+)/tables/(?P<table>.+)/columns/?$', sqoop_api.autocomplete, name='autocomplete_fields'
+  ),
   re_path(r'^api/driver/?$', sqoop_api.driver, name='driver'),
   re_path(r'^api/connectors', sqoop_api.connectors, name='connectors'),
   re_path(r'^api/connectors/(?P<connector_id>\d+)/?$', sqoop_api.connector, name='connector'),

--- a/apps/sqoop/src/sqoop/urls.py
+++ b/apps/sqoop/src/sqoop/urls.py
@@ -20,32 +20,32 @@ import sys
 from sqoop import views as sqoop_views
 from sqoop import api as sqoop_api
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-  url(r'^$', sqoop_views.app, name='index')
+  re_path(r'^$', sqoop_views.app, name='index')
 ]
 
 urlpatterns += [
-  url(r'^api/autocomplete/databases/?$', sqoop_api.autocomplete, name='autocomplete_databases'),
-  url(r'^api/autocomplete/databases/(?P<database>.+)/tables/?$', sqoop_api.autocomplete, name='autocomplete_tables'),
-  url(r'^api/autocomplete/databases/(?P<database>.+)/tables/(?P<table>.+)/columns/?$', sqoop_api.autocomplete, name='autocomplete_fields'),
-  url(r'^api/driver/?$', sqoop_api.driver, name='driver'),
-  url(r'^api/connectors', sqoop_api.connectors, name='connectors'),
-  url(r'^api/connectors/(?P<connector_id>\d+)/?$', sqoop_api.connector, name='connector'),
-  url(r'^api/links/?$', sqoop_api.links, name='links'),
-  url(r'^api/links/(?P<link_id>\d+)/?$', sqoop_api.link, name='link'),
-  url(r'^api/links/(?P<link_id>\d+)/clone/?$', sqoop_api.link_clone, name='link_clone'),
-  url(r'^api/links/(?P<link_id>\d+)/delete/?$', sqoop_api.link_delete, name='link_delete'),
-  url(r'^api/jobs/?$', sqoop_api.jobs, name='jobs'),
-  url(r'^api/jobs/(?P<job_id>\d+)/?$', sqoop_api.job, name='job'),
-  url(r'^api/jobs/(?P<job_id>\d+)/clone/?$', sqoop_api.job_clone, name='job_clone'),
-  url(r'^api/jobs/(?P<job_id>\d+)/delete/?$', sqoop_api.job_delete, name='job_delete'),
-  url(r'^api/jobs/(?P<job_id>\d+)/start/?$', sqoop_api.job_start, name='job_start'),
-  url(r'^api/jobs/(?P<job_id>\d+)/stop/?$', sqoop_api.job_stop, name='job_stop'),
-  url(r'^api/jobs/(?P<job_id>\d+)/status/?$', sqoop_api.job_status, name='job_status'),
-  url(r'^api/submissions/?$', sqoop_api.submissions, name='submissions')
+  re_path(r'^api/autocomplete/databases/?$', sqoop_api.autocomplete, name='autocomplete_databases'),
+  re_path(r'^api/autocomplete/databases/(?P<database>.+)/tables/?$', sqoop_api.autocomplete, name='autocomplete_tables'),
+  re_path(r'^api/autocomplete/databases/(?P<database>.+)/tables/(?P<table>.+)/columns/?$', sqoop_api.autocomplete, name='autocomplete_fields'),
+  re_path(r'^api/driver/?$', sqoop_api.driver, name='driver'),
+  re_path(r'^api/connectors', sqoop_api.connectors, name='connectors'),
+  re_path(r'^api/connectors/(?P<connector_id>\d+)/?$', sqoop_api.connector, name='connector'),
+  re_path(r'^api/links/?$', sqoop_api.links, name='links'),
+  re_path(r'^api/links/(?P<link_id>\d+)/?$', sqoop_api.link, name='link'),
+  re_path(r'^api/links/(?P<link_id>\d+)/clone/?$', sqoop_api.link_clone, name='link_clone'),
+  re_path(r'^api/links/(?P<link_id>\d+)/delete/?$', sqoop_api.link_delete, name='link_delete'),
+  re_path(r'^api/jobs/?$', sqoop_api.jobs, name='jobs'),
+  re_path(r'^api/jobs/(?P<job_id>\d+)/?$', sqoop_api.job, name='job'),
+  re_path(r'^api/jobs/(?P<job_id>\d+)/clone/?$', sqoop_api.job_clone, name='job_clone'),
+  re_path(r'^api/jobs/(?P<job_id>\d+)/delete/?$', sqoop_api.job_delete, name='job_delete'),
+  re_path(r'^api/jobs/(?P<job_id>\d+)/start/?$', sqoop_api.job_start, name='job_start'),
+  re_path(r'^api/jobs/(?P<job_id>\d+)/stop/?$', sqoop_api.job_stop, name='job_stop'),
+  re_path(r'^api/jobs/(?P<job_id>\d+)/status/?$', sqoop_api.job_status, name='job_status'),
+  re_path(r'^api/submissions/?$', sqoop_api.submissions, name='submissions')
 ]

--- a/apps/sqoop/src/sqoop/urls.py
+++ b/apps/sqoop/src/sqoop/urls.py
@@ -15,9 +15,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from sqoop import views as sqoop_views
 from sqoop import api as sqoop_api
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   url(r'^$', sqoop_views.app, name='index')

--- a/apps/useradmin/src/useradmin/urls.py
+++ b/apps/useradmin/src/useradmin/urls.py
@@ -22,34 +22,34 @@ from desktop.lib.django_util import get_username_re_rule, get_groupname_re_rule
 from useradmin import views as useradmin_views
 from useradmin import api as useradmin_api
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 username_re = get_username_re_rule()
 groupname_re = get_groupname_re_rule()
 
 
 urlpatterns = [
-  url(r'^$', useradmin_views.list_users, name="useradmin.views.list_users"),
-  url(r'^users/?$', useradmin_views.list_users, name="useradmin.views.list_users"),
-  url(r'^groups/?$', useradmin_views.list_groups, name="useradmin.views.list_groups"),
-  url(r'^permissions/?$', useradmin_views.list_permissions, name="useradmin.views.list_permissions"),
-  url(r'^configurations/?$', useradmin_views.list_configurations, name="useradmin.views.list_configurations"),
-  url(r'^organizations/?$', useradmin_views.list_organizations, name="useradmin.views.list_organizations"),
-  url(r'^users/edit/(?P<username>%s)$' % (username_re,), useradmin_views.edit_user, name="useradmin.views.edit_user"),
-  url(r'^users/add_ldap_users$', useradmin_views.add_ldap_users, name="useradmin.views.add_ldap_users"),
-  url(r'^users/add_ldap_groups$', useradmin_views.add_ldap_groups, name="useradmin.views.add_ldap_groups"),
-  url(r'^users/sync_ldap_users_groups$', useradmin_views.sync_ldap_users_groups, name="useradmin_views_sync_ldap_users_groups"),
-  url(r'^groups/edit/(?P<name>%s)$' % (groupname_re,), useradmin_views.edit_group, name="useradmin.views.edit_group"),
-  url(r'^permissions/edit/(?P<app>.+?)/(?P<priv>.+?)/?$', useradmin_views.edit_permission, name="useradmin.views.edit_permission"),
-  url(r'^users/new$', useradmin_views.edit_user, name="useradmin.views.edit_user"),
-  url(r'^groups/new$', useradmin_views.edit_group, name="useradmin.views.edit_group"),
-  url(r'^users/delete', useradmin_views.delete_user, name="useradmin.views.delete_user"),
-  url(r'^groups/delete$', useradmin_views.delete_group, name="useradmin.views.delete_group"),
+  re_path(r'^$', useradmin_views.list_users, name="useradmin.views.list_users"),
+  re_path(r'^users/?$', useradmin_views.list_users, name="useradmin.views.list_users"),
+  re_path(r'^groups/?$', useradmin_views.list_groups, name="useradmin.views.list_groups"),
+  re_path(r'^permissions/?$', useradmin_views.list_permissions, name="useradmin.views.list_permissions"),
+  re_path(r'^configurations/?$', useradmin_views.list_configurations, name="useradmin.views.list_configurations"),
+  re_path(r'^organizations/?$', useradmin_views.list_organizations, name="useradmin.views.list_organizations"),
+  re_path(r'^users/edit/(?P<username>%s)$' % (username_re,), useradmin_views.edit_user, name="useradmin.views.edit_user"),
+  re_path(r'^users/add_ldap_users$', useradmin_views.add_ldap_users, name="useradmin.views.add_ldap_users"),
+  re_path(r'^users/add_ldap_groups$', useradmin_views.add_ldap_groups, name="useradmin.views.add_ldap_groups"),
+  re_path(r'^users/sync_ldap_users_groups$', useradmin_views.sync_ldap_users_groups, name="useradmin_views_sync_ldap_users_groups"),
+  re_path(r'^groups/edit/(?P<name>%s)$' % (groupname_re,), useradmin_views.edit_group, name="useradmin.views.edit_group"),
+  re_path(r'^permissions/edit/(?P<app>.+?)/(?P<priv>.+?)/?$', useradmin_views.edit_permission, name="useradmin.views.edit_permission"),
+  re_path(r'^users/new$', useradmin_views.edit_user, name="useradmin.views.edit_user"),
+  re_path(r'^groups/new$', useradmin_views.edit_group, name="useradmin.views.edit_group"),
+  re_path(r'^users/delete', useradmin_views.delete_user, name="useradmin.views.delete_user"),
+  re_path(r'^groups/delete$', useradmin_views.delete_group, name="useradmin.views.delete_group"),
 ]
 
 urlpatterns += [
-  url(r'^api/get_users/?', useradmin_api.get_users, name='api_get_users'),
+  re_path(r'^api/get_users/?', useradmin_api.get_users, name='api_get_users'),
 ]

--- a/apps/useradmin/src/useradmin/urls.py
+++ b/apps/useradmin/src/useradmin/urls.py
@@ -15,13 +15,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
 
 from desktop.lib.django_util import get_username_re_rule, get_groupname_re_rule
 
 from useradmin import views as useradmin_views
 from useradmin import api as useradmin_api
 
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 username_re = get_username_re_rule()
 groupname_re = get_groupname_re_rule()

--- a/apps/zookeeper/src/zookeeper/urls.py
+++ b/apps/zookeeper/src/zookeeper/urls.py
@@ -15,8 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from zookeeper import views as zookeeper_views
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   url(r'^$', zookeeper_views.index, name='index'),

--- a/apps/zookeeper/src/zookeeper/urls.py
+++ b/apps/zookeeper/src/zookeeper/urls.py
@@ -19,18 +19,18 @@ import sys
 
 from zookeeper import views as zookeeper_views
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-  url(r'^$', zookeeper_views.index, name='index'),
-  url(r'view/(?P<id>\w+)$', zookeeper_views.view, name='view'),
-  url(r'clients/(?P<id>\w+)/(?P<host>.+)$', zookeeper_views.clients, name='clients'),
-  url(r'tree/(?P<id>\w+)/(?P<path>.+)$', zookeeper_views.tree, name='tree'),
-  url(r'create/(?P<id>\w+)/(?P<path>.*)$', zookeeper_views.create, name='create'),
-  url(r'delete/(?P<id>\w+)/(?P<path>.*)$', zookeeper_views.delete, name='delete'),
-  url(r'edit/base64/(?P<id>\w+)/(?P<path>.*)$', zookeeper_views.edit_as_base64, name='edit_as_base64'),
-  url(r'edit/text/(?P<id>\w+)/(?P<path>.*)$', zookeeper_views.edit_as_text, name='edit_as_text'),
+  re_path(r'^$', zookeeper_views.index, name='index'),
+  re_path(r'view/(?P<id>\w+)$', zookeeper_views.view, name='view'),
+  re_path(r'clients/(?P<id>\w+)/(?P<host>.+)$', zookeeper_views.clients, name='clients'),
+  re_path(r'tree/(?P<id>\w+)/(?P<path>.+)$', zookeeper_views.tree, name='tree'),
+  re_path(r'create/(?P<id>\w+)/(?P<path>.*)$', zookeeper_views.create, name='create'),
+  re_path(r'delete/(?P<id>\w+)/(?P<path>.*)$', zookeeper_views.delete, name='delete'),
+  re_path(r'edit/base64/(?P<id>\w+)/(?P<path>.*)$', zookeeper_views.edit_as_base64, name='edit_as_base64'),
+  re_path(r'edit/text/(?P<id>\w+)/(?P<path>.*)$', zookeeper_views.edit_as_text, name='edit_as_text'),
 ]

--- a/desktop/core/src/desktop/app_template/src/app_name/urls.py
+++ b/desktop/core/src/desktop/app_template/src/app_name/urls.py
@@ -15,8 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from ${app_name} import views
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   url(r'^$', views.index),

--- a/desktop/core/src/desktop/app_template/src/app_name/urls.py
+++ b/desktop/core/src/desktop/app_template/src/app_name/urls.py
@@ -19,11 +19,11 @@ import sys
 
 from ${app_name} import views
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-  url(r'^$', views.index),
+  re_path(r'^$', views.index),
 ]

--- a/desktop/core/src/desktop/app_template_proxy/src/app_name/urls.py
+++ b/desktop/core/src/desktop/app_template_proxy/src/app_name/urls.py
@@ -15,8 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 import ${app_name}
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   url(r'^$', ${app_name}.views.index),

--- a/desktop/core/src/desktop/app_template_proxy/src/app_name/urls.py
+++ b/desktop/core/src/desktop/app_template_proxy/src/app_name/urls.py
@@ -19,11 +19,11 @@ import sys
 
 import ${app_name}
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-  url(r'^$', ${app_name}.views.index),
+  re_path(r'^$', ${app_name}.views.index),
 ]

--- a/desktop/core/src/desktop/lib/analytics/urls.py
+++ b/desktop/core/src/desktop/lib/analytics/urls.py
@@ -19,14 +19,14 @@ import sys
 
 from desktop.lib.analytics import views, api
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 
 urlpatterns = [
-  url(r'^$', views.index, name='desktop.lib.analytics.views.index'),
+  re_path(r'^$', views.index, name='desktop.lib.analytics.views.index'),
 
-  url(r'^api/admin_stats/?$', api.admin_stats, name='analytics.api.admin_stats'),
+  re_path(r'^api/admin_stats/?$', api.admin_stats, name='analytics.api.admin_stats'),
 ]

--- a/desktop/core/src/desktop/lib/analytics/urls.py
+++ b/desktop/core/src/desktop/lib/analytics/urls.py
@@ -15,9 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
 
 from desktop.lib.analytics import views, api
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 
 urlpatterns = [

--- a/desktop/core/src/desktop/lib/botserver/urls.py
+++ b/desktop/core/src/desktop/lib/botserver/urls.py
@@ -19,11 +19,11 @@ import sys
 
 from desktop.lib.botserver import views
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-  url(r'^events/', views.slack_events, name='slack_events')
+  re_path(r'^events/', views.slack_events, name='slack_events')
 ]

--- a/desktop/core/src/desktop/lib/botserver/urls.py
+++ b/desktop/core/src/desktop/lib/botserver/urls.py
@@ -15,8 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from desktop.lib.botserver import views
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   url(r'^events/', views.slack_events, name='slack_events')

--- a/desktop/core/src/desktop/lib/connectors/urls.py
+++ b/desktop/core/src/desktop/lib/connectors/urls.py
@@ -15,9 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
 
 from desktop.lib.connectors import views, api
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 
 urlpatterns = [

--- a/desktop/core/src/desktop/lib/connectors/urls.py
+++ b/desktop/core/src/desktop/lib/connectors/urls.py
@@ -19,23 +19,23 @@ import sys
 
 from desktop.lib.connectors import views, api
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 
 urlpatterns = [
-  url(r'^$', views.index, name='desktop.lib.connectors.views.index'),
+  re_path(r'^$', views.index, name='desktop.lib.connectors.views.index'),
 
-  url(r'^api/types/?$', api.get_connector_types, name='connectors.api.get_connector_types'),
-  url(r'^api/instances/?$', api.get_connectors_instances, name='connectors.api.get_connectors_instances'),
+  re_path(r'^api/types/?$', api.get_connector_types, name='connectors.api.get_connector_types'),
+  re_path(r'^api/instances/?$', api.get_connectors_instances, name='connectors.api.get_connectors_instances'),
 
-  url(r'^api/instance/new/(?P<dialect>[\w\-]+)/(?P<interface>[\w\-]+)$', api.new_connector, name='connectors.api.new_connector'),
-  url(r'^api/instance/get/(?P<id>\d+)$', api.get_connector, name='connectors.api.get_connector'),
-  url(r'^api/instance/delete/?$', api.delete_connector, name='connectors.api.delete_connector'),
-  url(r'^api/instance/update/?$', api.update_connector, name='connectors.api.update_connector'),
-  url(r'^api/instance/test/?$', api.test_connector, name='connectors.api.test_connector'),
+  re_path(r'^api/instance/new/(?P<dialect>[\w\-]+)/(?P<interface>[\w\-]+)$', api.new_connector, name='connectors.api.new_connector'),
+  re_path(r'^api/instance/get/(?P<id>\d+)$', api.get_connector, name='connectors.api.get_connector'),
+  re_path(r'^api/instance/delete/?$', api.delete_connector, name='connectors.api.delete_connector'),
+  re_path(r'^api/instance/update/?$', api.update_connector, name='connectors.api.update_connector'),
+  re_path(r'^api/instance/test/?$', api.test_connector, name='connectors.api.test_connector'),
 
-  url(r'^api/examples/install/?$', api.install_connector_examples, name='connectors.api.install_connector_examples'),
+  re_path(r'^api/examples/install/?$', api.install_connector_examples, name='connectors.api.install_connector_examples'),
 ]

--- a/desktop/core/src/desktop/lib/metrics/urls.py
+++ b/desktop/core/src/desktop/lib/metrics/urls.py
@@ -15,9 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
 
 from desktop.lib.metrics import views
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   url(r'^$', views.index, name='desktop.lib.metrics.views.index'),

--- a/desktop/core/src/desktop/lib/metrics/urls.py
+++ b/desktop/core/src/desktop/lib/metrics/urls.py
@@ -19,11 +19,11 @@ import sys
 
 from desktop.lib.metrics import views
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-  url(r'^$', views.index, name='desktop.lib.metrics.views.index'),
+  re_path(r'^$', views.index, name='desktop.lib.metrics.views.index'),
 ]

--- a/desktop/core/src/desktop/lib/scheduler/urls.py
+++ b/desktop/core/src/desktop/lib/scheduler/urls.py
@@ -15,9 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
 
 from desktop.lib.scheduler import api
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 
 urlpatterns = [

--- a/desktop/core/src/desktop/lib/scheduler/urls.py
+++ b/desktop/core/src/desktop/lib/scheduler/urls.py
@@ -19,15 +19,15 @@ import sys
 
 from desktop.lib.scheduler import api
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 
 urlpatterns = [
-  url(r'^api/schedule/new/?$', api.get_schedule, name='scheduler.api.new_schedule'),
-  url(r'^api/schedule/edit/?$', api.get_schedule, name='scheduler.api.edit_schedule'),
-  url(r'^api/schedule/submit/(?P<doc_id>[-\w]+)?$', api.submit_schedule, name='scheduler.api.submit_schedule'),
-  url(r'^api/schedule/list/?$', api.list_schedules, name='scheduler.api.list_schedules'),
+  re_path(r'^api/schedule/new/?$', api.get_schedule, name='scheduler.api.new_schedule'),
+  re_path(r'^api/schedule/edit/?$', api.get_schedule, name='scheduler.api.edit_schedule'),
+  re_path(r'^api/schedule/submit/(?P<doc_id>[-\w]+)?$', api.submit_schedule, name='scheduler.api.submit_schedule'),
+  re_path(r'^api/schedule/list/?$', api.list_schedules, name='scheduler.api.list_schedules'),
 ]

--- a/desktop/core/src/desktop/tests.py
+++ b/desktop/core/src/desktop/tests.py
@@ -73,11 +73,11 @@ from desktop.views import check_config, home, generate_configspec, load_confs, c
 if sys.version_info[0] > 2:
   from io import StringIO as string_io
   from unittest.mock import patch, Mock
-  from django.urls import re_path as url
+  from django.urls import re_path
 else:
   from cStringIO import StringIO as string_io
   from mock import patch, Mock
-  from django.conf.urls import url
+  from django.conf.urls import url as re_path
 
 
 LOG = logging.getLogger(__name__)
@@ -404,8 +404,8 @@ def test_error_handling():
 
   # Add an error view
   error_url_pat = [
-      url('^500_internal_error$', error_raising_view),
-      url('^popup_exception$', popup_exception_view)
+      re_path('^500_internal_error$', error_raising_view),
+      re_path('^popup_exception$', popup_exception_view)
   ]
   desktop.urls.urlpatterns.extend(error_url_pat)
   try:

--- a/desktop/core/src/desktop/tests.py
+++ b/desktop/core/src/desktop/tests.py
@@ -35,7 +35,6 @@ from configobj import ConfigObj
 from django.db.models import query, CharField, SmallIntegerField
 from django.core.management import call_command
 from django.core.paginator import Paginator
-from django.conf.urls import url
 from django.db import connection
 from django.urls import reverse
 from django.test.client import Client
@@ -74,9 +73,11 @@ from desktop.views import check_config, home, generate_configspec, load_confs, c
 if sys.version_info[0] > 2:
   from io import StringIO as string_io
   from unittest.mock import patch, Mock
+  from django.urls import re_path as url
 else:
   from cStringIO import StringIO as string_io
   from mock import patch, Mock
+  from django.conf.urls import url
 
 
 LOG = logging.getLogger(__name__)

--- a/desktop/core/src/desktop/urls.py
+++ b/desktop/core/src/desktop/urls.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 
 import logging
 import re
+import sys
 
 
 # FIXME: This could be replaced with hooking into the `AppConfig.ready()`
@@ -33,7 +34,6 @@ import desktop.lib.metrics.file_reporter
 desktop.lib.metrics.file_reporter.start_file_reporter()
 
 from django.conf import settings
-from django.conf.urls import include, url
 from django.views.static import serve
 
 from notebook import views as notebook_views
@@ -49,6 +49,11 @@ from desktop.conf import METRICS, USE_NEW_EDITOR, ENABLE_DJANGO_DEBUG_TOOL, ANAL
 from desktop.configuration import api as desktop_configuration_api
 from desktop.lib.vcs import api as desktop_lib_vcs_api
 from desktop.settings import is_oidc_configured
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import include, url
+else:
+  from django.urls import include, re_path as url
 
 # Django expects handler404 and handler500 to be defined.
 # django.conf.urls provides them. But we want to override them.

--- a/desktop/core/src/desktop/urls.py
+++ b/desktop/core/src/desktop/urls.py
@@ -50,10 +50,10 @@ from desktop.configuration import api as desktop_configuration_api
 from desktop.lib.vcs import api as desktop_lib_vcs_api
 from desktop.settings import is_oidc_configured
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import include, url
+if sys.version_info[0] > 2:
+  from django.urls import include, re_path
 else:
-  from django.urls import include, re_path as url
+  from django.conf.urls import include, url as re_path
 
 # Django expects handler404 and handler500 to be defined.
 # django.conf.urls provides them. But we want to override them.
@@ -65,168 +65,168 @@ handler500 = 'desktop.views.serve_500_error'
 
 # Some django-wide URLs
 dynamic_patterns = [
-  url(r'^hue/accounts/login', desktop_auth_views.dt_login, name='desktop_auth_views_dt_login'),
-  url(r'^accounts/login/?$', desktop_auth_views.dt_login), # Deprecated
-  url(r'^accounts/logout/?$', desktop_auth_views.dt_logout, {'next_page': '/'}),
-  url(r'^profile$', desktop_auth_views.profile),
-  url(r'^login/oauth/?$', desktop_auth_views.oauth_login),
-  url(r'^login/oauth_authenticated/?$', desktop_auth_views.oauth_authenticated),
-  url(r'^hue/oidc_failed', desktop_auth_views.oidc_failed),
+  re_path(r'^hue/accounts/login', desktop_auth_views.dt_login, name='desktop_auth_views_dt_login'),
+  re_path(r'^accounts/login/?$', desktop_auth_views.dt_login), # Deprecated
+  re_path(r'^accounts/logout/?$', desktop_auth_views.dt_logout, {'next_page': '/'}),
+  re_path(r'^profile$', desktop_auth_views.profile),
+  re_path(r'^login/oauth/?$', desktop_auth_views.oauth_login),
+  re_path(r'^login/oauth_authenticated/?$', desktop_auth_views.oauth_authenticated),
+  re_path(r'^hue/oidc_failed', desktop_auth_views.oidc_failed),
 ]
 
 if USE_NEW_EDITOR.get():
   dynamic_patterns += [
-    url(r'^home/?$', desktop_views.home2, name='desktop_views_home2'),
-    url(r'^home2$', desktop_views.home, name='desktop_views_home'),
-    url(r'^home_embeddable$', desktop_views.home_embeddable),
+    re_path(r'^home/?$', desktop_views.home2, name='desktop_views_home2'),
+    re_path(r'^home2$', desktop_views.home, name='desktop_views_home'),
+    re_path(r'^home_embeddable$', desktop_views.home_embeddable),
   ]
 else:
   dynamic_patterns += [
-    url(r'^home$', desktop_views.home, name='desktop_views_home'),
-    url(r'^home2$', desktop_views.home2, name='desktop_views_home2')
+    re_path(r'^home$', desktop_views.home, name='desktop_views_home'),
+    re_path(r'^home2$', desktop_views.home2, name='desktop_views_home2')
   ]
 
 dynamic_patterns += [
-  url(r'^logs$', desktop_views.log_view, name="desktop.views.log_view"),
-  url(r'^desktop/log_analytics$', desktop_views.log_analytics),
-  url(r'^desktop/log_js_error$', desktop_views.log_js_error),
-  url(r'^desktop/dump_config$', desktop_views.dump_config, name="desktop.views.dump_config"),
-  url(r'^desktop/download_logs$', desktop_views.download_log_view),
-  url(r'^desktop/get_debug_level', desktop_views.get_debug_level),
-  url(r'^desktop/set_all_debug', desktop_views.set_all_debug),
-  url(r'^desktop/reset_all_debug', desktop_views.reset_all_debug),
-  url(r'^bootstrap.js$', desktop_views.bootstrap), # unused
+  re_path(r'^logs$', desktop_views.log_view, name="desktop.views.log_view"),
+  re_path(r'^desktop/log_analytics$', desktop_views.log_analytics),
+  re_path(r'^desktop/log_js_error$', desktop_views.log_js_error),
+  re_path(r'^desktop/dump_config$', desktop_views.dump_config, name="desktop.views.dump_config"),
+  re_path(r'^desktop/download_logs$', desktop_views.download_log_view),
+  re_path(r'^desktop/get_debug_level', desktop_views.get_debug_level),
+  re_path(r'^desktop/set_all_debug', desktop_views.set_all_debug),
+  re_path(r'^desktop/reset_all_debug', desktop_views.reset_all_debug),
+  re_path(r'^bootstrap.js$', desktop_views.bootstrap), # unused
 
-  url(r'^desktop/status_bar/?$', desktop_views.status_bar),
-  url(r'^desktop/debug/is_alive$', desktop_views.is_alive),
-  url(r'^desktop/debug/is_idle$', desktop_views.is_idle),
-  url(r'^desktop/debug/threads$', desktop_views.threads, name="desktop.views.threads"),
-  url(r'^desktop/debug/memory$', desktop_views.memory),
-  url(r'^desktop/debug/check_config$', desktop_views.check_config, name="desktop.views.check_config"),
-  url(r'^desktop/debug/check_config_ajax$', desktop_views.check_config_ajax),
-  url(r'^desktop/log_frontend_event$', desktop_views.log_frontend_event),
+  re_path(r'^desktop/status_bar/?$', desktop_views.status_bar),
+  re_path(r'^desktop/debug/is_alive$', desktop_views.is_alive),
+  re_path(r'^desktop/debug/is_idle$', desktop_views.is_idle),
+  re_path(r'^desktop/debug/threads$', desktop_views.threads, name="desktop.views.threads"),
+  re_path(r'^desktop/debug/memory$', desktop_views.memory),
+  re_path(r'^desktop/debug/check_config$', desktop_views.check_config, name="desktop.views.check_config"),
+  re_path(r'^desktop/debug/check_config_ajax$', desktop_views.check_config_ajax),
+  re_path(r'^desktop/log_frontend_event$', desktop_views.log_frontend_event),
 
   # Catch-up gist
-  url(r'^hue/gist/?$', desktop_api2.gist_get),
+  re_path(r'^hue/gist/?$', desktop_api2.gist_get),
 
   # Mobile
-  url(r'^assist_m', desktop_views.assist_m),
+  re_path(r'^assist_m', desktop_views.assist_m),
 
   # Hue 4
-  url(r'^hue.*/?$', desktop_views.hue, name='desktop_views_hue'),
-  url(r'^403$', desktop_views.path_forbidden),
-  url(r'^404$', desktop_views.not_found),
-  url(r'^500$', desktop_views.server_error),
+  re_path(r'^hue.*/?$', desktop_views.hue, name='desktop_views_hue'),
+  re_path(r'^403$', desktop_views.path_forbidden),
+  re_path(r'^404$', desktop_views.not_found),
+  re_path(r'^500$', desktop_views.server_error),
 
   # KO components, change to doc?name=ko_editor or similar
-  url(r'^ko_editor', desktop_views.ko_editor),
-  url(r'^ko_metastore', desktop_views.ko_metastore),
+  re_path(r'^ko_editor', desktop_views.ko_editor),
+  re_path(r'^ko_metastore', desktop_views.ko_metastore),
 
   # JS that needs to be mako
-  url(r'^desktop/globalJsConstants.js', desktop_views.global_js_constants),
+  re_path(r'^desktop/globalJsConstants.js', desktop_views.global_js_constants),
 
-  url(r'^desktop/topo/(?P<location>\w+)', desktop_views.topo),
+  re_path(r'^desktop/topo/(?P<location>\w+)', desktop_views.topo),
 
   # Web workers
-  url(r'^desktop/workers/aceSqlLocationWorker.js', desktop_views.ace_sql_location_worker),
-  url(r'^desktop/workers/aceSqlSyntaxWorker.js', desktop_views.ace_sql_syntax_worker),
+  re_path(r'^desktop/workers/aceSqlLocationWorker.js', desktop_views.ace_sql_location_worker),
+  re_path(r'^desktop/workers/aceSqlSyntaxWorker.js', desktop_views.ace_sql_syntax_worker),
 
-  url(r'^dynamic_bundle/(?P<config>\w+)/(?P<bundle_name>.+)', desktop_views.dynamic_bundle),
+  re_path(r'^dynamic_bundle/(?P<config>\w+)/(?P<bundle_name>.+)', desktop_views.dynamic_bundle),
 
   # Unsupported browsers
-  url(r'^boohoo$', desktop_views.unsupported, name='desktop_views_unsupported'),
+  re_path(r'^boohoo$', desktop_views.unsupported, name='desktop_views_unsupported'),
 
   # Top level web page!
-  url(r'^$', desktop_views.index, name="desktop_views.index"),
+  re_path(r'^$', desktop_views.index, name="desktop_views.index"),
 ]
 
 dynamic_patterns += [
   # Tags
-  url(r'^desktop/api/tag/add_tag$', desktop_api.add_tag),
-  url(r'^desktop/api/tag/remove_tag$', desktop_api.remove_tag),
-  url(r'^desktop/api/doc/tag$', desktop_api.tag),
-  url(r'^desktop/api/doc/update_tags$', desktop_api.update_tags),
-  url(r'^desktop/api/doc/get$', desktop_api.get_document),
+  re_path(r'^desktop/api/tag/add_tag$', desktop_api.add_tag),
+  re_path(r'^desktop/api/tag/remove_tag$', desktop_api.remove_tag),
+  re_path(r'^desktop/api/doc/tag$', desktop_api.tag),
+  re_path(r'^desktop/api/doc/update_tags$', desktop_api.update_tags),
+  re_path(r'^desktop/api/doc/get$', desktop_api.get_document),
 
   # Permissions
-  url(r'^desktop/api/doc/update_permissions', desktop_api.update_permissions),
+  re_path(r'^desktop/api/doc/update_permissions', desktop_api.update_permissions),
 ]
 
 dynamic_patterns += [
-  url(r'^desktop/api2/doc/open?$', desktop_api2.open_document),  # To keep before get_document
-  url(r'^desktop/api2/docs/?$', desktop_api2.search_documents),  # search documents for current user
-  url(r'^desktop/api2/doc/?$', desktop_api2.get_document),  # get doc/dir by path or UUID
+  re_path(r'^desktop/api2/doc/open?$', desktop_api2.open_document),  # To keep before get_document
+  re_path(r'^desktop/api2/docs/?$', desktop_api2.search_documents),  # search documents for current user
+  re_path(r'^desktop/api2/doc/?$', desktop_api2.get_document),  # get doc/dir by path or UUID
 
-  url(r'^desktop/api2/doc/move/?$', desktop_api2.move_document),
-  url(r'^desktop/api2/doc/mkdir/?$', desktop_api2.create_directory),
-  url(r'^desktop/api2/doc/update/?$', desktop_api2.update_document),
-  url(r'^desktop/api2/doc/delete/?$', desktop_api2.delete_document),
-  url(r'^desktop/api2/doc/copy/?$', desktop_api2.copy_document),
-  url(r'^desktop/api2/doc/restore/?$', desktop_api2.restore_document),
-  url(r'^desktop/api2/doc/share/link/?$', desktop_api2.share_document_link),
-  url(r'^desktop/api2/doc/share/?$', desktop_api2.share_document),
+  re_path(r'^desktop/api2/doc/move/?$', desktop_api2.move_document),
+  re_path(r'^desktop/api2/doc/mkdir/?$', desktop_api2.create_directory),
+  re_path(r'^desktop/api2/doc/update/?$', desktop_api2.update_document),
+  re_path(r'^desktop/api2/doc/delete/?$', desktop_api2.delete_document),
+  re_path(r'^desktop/api2/doc/copy/?$', desktop_api2.copy_document),
+  re_path(r'^desktop/api2/doc/restore/?$', desktop_api2.restore_document),
+  re_path(r'^desktop/api2/doc/share/link/?$', desktop_api2.share_document_link),
+  re_path(r'^desktop/api2/doc/share/?$', desktop_api2.share_document),
 
-  url(r'^desktop/api2/get_config/?$', desktop_api2.get_config),
-  url(r'^desktop/api2/get_hue_config/?$', desktop_api2.get_hue_config),
-  url(r'^desktop/api2/context/namespaces/(?P<interface>[\w\-]+)/?$', desktop_api2.get_context_namespaces),
-  url(r'^desktop/api2/context/computes/(?P<interface>[\w\-]+)/?$', desktop_api2.get_context_computes),
-  url(r'^desktop/api2/context/clusters/(?P<interface>[\w\-]+)/?$', desktop_api2.get_context_clusters),
-  url(r'^desktop/api2/user_preferences(?:/(?P<key>\w+))?/?$', desktop_api2.user_preferences, name="desktop.api2.user_preferences"),
+  re_path(r'^desktop/api2/get_config/?$', desktop_api2.get_config),
+  re_path(r'^desktop/api2/get_hue_config/?$', desktop_api2.get_hue_config),
+  re_path(r'^desktop/api2/context/namespaces/(?P<interface>[\w\-]+)/?$', desktop_api2.get_context_namespaces),
+  re_path(r'^desktop/api2/context/computes/(?P<interface>[\w\-]+)/?$', desktop_api2.get_context_computes),
+  re_path(r'^desktop/api2/context/clusters/(?P<interface>[\w\-]+)/?$', desktop_api2.get_context_clusters),
+  re_path(r'^desktop/api2/user_preferences(?:/(?P<key>\w+))?/?$', desktop_api2.user_preferences, name="desktop.api2.user_preferences"),
 
-  url(r'^desktop/api2/doc/export/?$', desktop_api2.export_documents),
-  url(r'^desktop/api2/doc/import/?$', desktop_api2.import_documents),
+  re_path(r'^desktop/api2/doc/export/?$', desktop_api2.export_documents),
+  re_path(r'^desktop/api2/doc/import/?$', desktop_api2.import_documents),
 
-  url(r'^desktop/api2/gist/create/?$', desktop_api2.gist_create),
-  url(r'^desktop/api2/gist/open/?$', desktop_api2.gist_get),
+  re_path(r'^desktop/api2/gist/create/?$', desktop_api2.gist_create),
+  re_path(r'^desktop/api2/gist/open/?$', desktop_api2.gist_get),
 
 
-  url(r'^desktop/api/search/entities/?$', desktop_api2.search_entities),
-  url(r'^desktop/api/search/entities_interactive/?$', desktop_api2.search_entities_interactive),
+  re_path(r'^desktop/api/search/entities/?$', desktop_api2.search_entities),
+  re_path(r'^desktop/api/search/entities_interactive/?$', desktop_api2.search_entities_interactive),
 ]
 
 dynamic_patterns += [
-  url(r'^editor', notebook_views.editor),
+  re_path(r'^editor', notebook_views.editor),
 ]
 
 # Default Configurations
 dynamic_patterns += [
-  url(r'^desktop/api/configurations/?$', desktop_configuration_api.default_configurations),
-  url(r'^desktop/api/configurations/user/?$', desktop_configuration_api.app_configuration_for_user),
-  url(r'^desktop/api/configurations/delete/?$', desktop_configuration_api.delete_default_configuration),
+  re_path(r'^desktop/api/configurations/?$', desktop_configuration_api.default_configurations),
+  re_path(r'^desktop/api/configurations/user/?$', desktop_configuration_api.app_configuration_for_user),
+  re_path(r'^desktop/api/configurations/delete/?$', desktop_configuration_api.delete_default_configuration),
 ]
 
 dynamic_patterns += [
-  url(r'^desktop/api/users/autocomplete', useradmin_views.list_for_autocomplete, name='useradmin_views_list_for_autocomplete'),
-  url(r'^desktop/api/users/?$', useradmin_views.get_users_by_id)
+  re_path(r'^desktop/api/users/autocomplete', useradmin_views.list_for_autocomplete, name='useradmin_views_list_for_autocomplete'),
+  re_path(r'^desktop/api/users/?$', useradmin_views.get_users_by_id)
 ]
 
 dynamic_patterns += [
-  url(r'^desktop/api/vcs/contents/?$', desktop_lib_vcs_api.contents),
-  url(r'^desktop/api/vcs/authorize/?$', desktop_lib_vcs_api.authorize),
+  re_path(r'^desktop/api/vcs/contents/?$', desktop_lib_vcs_api.contents),
+  re_path(r'^desktop/api/vcs/authorize/?$', desktop_lib_vcs_api.authorize),
 ]
 
 # Metrics specific
 if METRICS.ENABLE_WEB_METRICS.get():
   dynamic_patterns += [
-    url(r'^desktop/metrics/?', include('desktop.lib.metrics.urls'))
+    re_path(r'^desktop/metrics/?', include('desktop.lib.metrics.urls'))
   ]
 
 dynamic_patterns += [
-  url(r'^desktop/connectors/?', include('desktop.lib.connectors.urls'))
+  re_path(r'^desktop/connectors/?', include('desktop.lib.connectors.urls'))
 ]
 
 if ANALYTICS.IS_ENABLED.get():
   dynamic_patterns += [
-    url(r'^desktop/analytics/?', include('desktop.lib.analytics.urls'))
+    re_path(r'^desktop/analytics/?', include('desktop.lib.analytics.urls'))
   ]
 
 dynamic_patterns += [
-  url(r'^scheduler/', include('desktop.lib.scheduler.urls'))
+  re_path(r'^scheduler/', include('desktop.lib.scheduler.urls'))
 ]
 
 if ENABLE_PROMETHEUS.get():
   dynamic_patterns += [
-    url('', include('django_prometheus.urls')),
+    re_path('', include('django_prometheus.urls')),
   ]
 
 
@@ -234,11 +234,11 @@ static_patterns = []
 
 # SAML specific
 if settings.SAML_AUTHENTICATION:
-  static_patterns.append(url(r'^saml2/', include('libsaml.urls')))
+  static_patterns.append(re_path(r'^saml2/', include('libsaml.urls')))
 
 
 if settings.OAUTH_AUTHENTICATION:
-  static_patterns.append(url(r'^oauth/', include('liboauth.urls')))
+  static_patterns.append(re_path(r'^oauth/', include('liboauth.urls')))
 
 # Root each app at /appname if they have a "urls" module
 app_urls_patterns = []
@@ -249,11 +249,11 @@ for app in appmanager.DESKTOP_MODULES:
     else:
       namespace = None
     if namespace or app in appmanager.DESKTOP_APPS:
-      app_urls_patterns.append(url('^' + re.escape(app.name) + '/', include((app.urls, app.name), namespace=namespace)))
+      app_urls_patterns.append(re_path('^' + re.escape(app.name) + '/', include((app.urls, app.name), namespace=namespace)))
       app.urls_imported = True
 
 static_patterns.append(
-    url(r'^%s(?P<path>.*)$' % re.escape(settings.STATIC_URL.lstrip('/')),
+    re_path(r'^%s(?P<path>.*)$' % re.escape(settings.STATIC_URL.lstrip('/')),
       serve,
       {'document_root': settings.STATIC_ROOT})
 )
@@ -266,16 +266,16 @@ urlpatterns.extend(static_patterns)
 
 if settings.DEBUG and ENABLE_DJANGO_DEBUG_TOOL.get():
   urlpatterns += [
-    url(r'^__debug__/', include(debug_toolbar.urls)),
+    re_path(r'^__debug__/', include(debug_toolbar.urls)),
   ]
 
 if is_oidc_configured():
   urlpatterns += [
-    url(r'^oidc/', include('mozilla_django_oidc.urls')),
+    re_path(r'^oidc/', include('mozilla_django_oidc.urls')),
   ]
 
 # Slack botserver URLs
 if SLACK.IS_ENABLED.get():
   urlpatterns += [
-    url(r'^slack/', include('desktop.lib.botserver.urls')),
+    re_path(r'^slack/', include('desktop.lib.botserver.urls')),
   ]

--- a/desktop/libs/dashboard/src/dashboard/urls.py
+++ b/desktop/libs/dashboard/src/dashboard/urls.py
@@ -15,9 +15,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from dashboard import views as dashboard_views
 from dashboard import api as dashboard_api
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   url(r'^$', dashboard_views.index, name='index'),

--- a/desktop/libs/dashboard/src/dashboard/urls.py
+++ b/desktop/libs/dashboard/src/dashboard/urls.py
@@ -20,39 +20,39 @@ import sys
 from dashboard import views as dashboard_views
 from dashboard import api as dashboard_api
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-  url(r'^$', dashboard_views.index, name='index'),
-  url(r'^m$', dashboard_views.index_m, name='index_m'),
-  url(r'^save$', dashboard_views.save, name='save'),
-  url(r'^new_search', dashboard_views.new_search, name='new_search'),
-  url(r'^browse/(?P<name>[^/]+)/?', dashboard_views.browse, name='browse'),
-  url(r'^browse_m/(?P<name>[^/]+)/?', dashboard_views.browse_m, name='browse_m'),
+  re_path(r'^$', dashboard_views.index, name='index'),
+  re_path(r'^m$', dashboard_views.index_m, name='index_m'),
+  re_path(r'^save$', dashboard_views.save, name='save'),
+  re_path(r'^new_search', dashboard_views.new_search, name='new_search'),
+  re_path(r'^browse/(?P<name>[^/]+)/?', dashboard_views.browse, name='browse'),
+  re_path(r'^browse_m/(?P<name>[^/]+)/?', dashboard_views.browse_m, name='browse_m'),
 
   # Admin
-  url(r'^admin/collections$', dashboard_views.admin_collections, name='admin_collections'),
-  url(r'^admin/collection_delete$', dashboard_views.admin_collection_delete, name='admin_collection_delete'),
-  url(r'^admin/collection_copy$', dashboard_views.admin_collection_copy, name='admin_collection_copy'),
+  re_path(r'^admin/collections$', dashboard_views.admin_collections, name='admin_collections'),
+  re_path(r'^admin/collection_delete$', dashboard_views.admin_collection_delete, name='admin_collection_delete'),
+  re_path(r'^admin/collection_copy$', dashboard_views.admin_collection_copy, name='admin_collection_copy'),
 ]
 
 
 urlpatterns += [
-  url(r'^search$', dashboard_api.search, name='search'),
-  url(r'^suggest/?$', dashboard_api.query_suggest, name='query_suggest'),
-  url(r'^index/fields/dynamic$', dashboard_api.index_fields_dynamic, name='index_fields_dynamic'),
-  url(r'^index/fields/nested_documents', dashboard_api.nested_documents, name='nested_documents'),
-  url(r'^template/new_facet$', dashboard_api.new_facet, name='new_facet'),
-  url(r'^get_document$', dashboard_api.get_document, name='get_document'),
-  url(r'^update_document$', dashboard_api.update_document, name='update_document'),
-  url(r'^get_range_facet$', dashboard_api.get_range_facet, name='get_range_facet'),
-  url(r'^download$', dashboard_api.download, name='download'),
-  url(r'^get_timeline$', dashboard_api.get_timeline, name='get_timeline'),
-  url(r'^get_collection$', dashboard_api.get_collection, name='get_collection'),
-  url(r'^get_collections$', dashboard_api.get_collections, name='get_collections'),
-  url(r'^get_stats$', dashboard_api.get_stats, name='get_stats'),
-  url(r'^get_terms$', dashboard_api.get_terms, name='get_terms'),
+  re_path(r'^search$', dashboard_api.search, name='search'),
+  re_path(r'^suggest/?$', dashboard_api.query_suggest, name='query_suggest'),
+  re_path(r'^index/fields/dynamic$', dashboard_api.index_fields_dynamic, name='index_fields_dynamic'),
+  re_path(r'^index/fields/nested_documents', dashboard_api.nested_documents, name='nested_documents'),
+  re_path(r'^template/new_facet$', dashboard_api.new_facet, name='new_facet'),
+  re_path(r'^get_document$', dashboard_api.get_document, name='get_document'),
+  re_path(r'^update_document$', dashboard_api.update_document, name='update_document'),
+  re_path(r'^get_range_facet$', dashboard_api.get_range_facet, name='get_range_facet'),
+  re_path(r'^download$', dashboard_api.download, name='download'),
+  re_path(r'^get_timeline$', dashboard_api.get_timeline, name='get_timeline'),
+  re_path(r'^get_collection$', dashboard_api.get_collection, name='get_collection'),
+  re_path(r'^get_collections$', dashboard_api.get_collections, name='get_collections'),
+  re_path(r'^get_stats$', dashboard_api.get_stats, name='get_stats'),
+  re_path(r'^get_terms$', dashboard_api.get_terms, name='get_terms'),
 ]

--- a/desktop/libs/indexer/src/indexer/urls.py
+++ b/desktop/libs/indexer/src/indexer/urls.py
@@ -15,7 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from indexer import views as indexer_views
 from indexer import solr_api as indexer_solr_api
 from indexer import api3 as indexer_api3
@@ -23,6 +24,11 @@ from indexer.indexers import rdbms as indexer_indexers_rdbms
 from indexer import api as indexer_api
 
 from indexer.conf import ENABLE_NEW_INDEXER
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   url(r'^install_examples$', indexer_views.install_examples, name='install_examples'),

--- a/desktop/libs/indexer/src/indexer/urls.py
+++ b/desktop/libs/indexer/src/indexer/urls.py
@@ -25,16 +25,16 @@ from indexer import api as indexer_api
 
 from indexer.conf import ENABLE_NEW_INDEXER
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-  url(r'^install_examples$', indexer_views.install_examples, name='install_examples'),
+  re_path(r'^install_examples$', indexer_views.install_examples, name='install_examples'),
 
-  url(r'^importer/?$', indexer_views.importer, name='importer'),
-  url(
+  re_path(r'^importer/?$', indexer_views.importer, name='importer'),
+  re_path(
     r'^importer/prefill/(?P<source_type>[^/]+)/(?P<target_type>[^/]+)/(?P<target_path>[^/]+)?$',
     indexer_views.importer_prefill,
     name='importer_prefill'
@@ -43,62 +43,62 @@ urlpatterns = [
 
 if ENABLE_NEW_INDEXER.get():
   urlpatterns += [
-    url(r'^$', indexer_views.indexes, name='indexes'),
-    url(r'^indexes/?$', indexer_views.indexes, name='indexes'),
-    url(r'^indexes/(?P<index>[^/]+)/?$', indexer_views.indexes, name='indexes'),
-    url(r'^collections$', indexer_views.collections, name='collections'), # Old page
+    re_path(r'^$', indexer_views.indexes, name='indexes'),
+    re_path(r'^indexes/?$', indexer_views.indexes, name='indexes'),
+    re_path(r'^indexes/(?P<index>[^/]+)/?$', indexer_views.indexes, name='indexes'),
+    re_path(r'^collections$', indexer_views.collections, name='collections'), # Old page
   ]
 else:
   urlpatterns += [
-    url(r'^$', indexer_views.collections, name='collections'),
-    url(r'^indexes/?$', indexer_views.indexes, name='indexes'),
+    re_path(r'^$', indexer_views.collections, name='collections'),
+    re_path(r'^indexes/?$', indexer_views.indexes, name='indexes'),
   ]
 
 urlpatterns += [
-    url(r'^topics/?$', indexer_views.topics, name='topics'),
-    url(r'^topics/(?P<index>[^/]+)/?$', indexer_views.topics, name='topics'),
+    re_path(r'^topics/?$', indexer_views.topics, name='topics'),
+    re_path(r'^topics/(?P<index>[^/]+)/?$', indexer_views.topics, name='topics'),
 ]
 
 
 urlpatterns += [
   # V2
-  url(r'^api/aliases/create/?$', indexer_solr_api.create_alias, name='create_alias'),
-  url(r'^api/configs/list/?$', indexer_solr_api.list_configs, name='list_configs'),
-  url(r'^api/index/list/?$', indexer_solr_api.list_index, name='list_index'),
-  url(r'^api/indexes/list/?$', indexer_solr_api.list_indexes, name='list_indexes'),
-  url(r'^api/indexes/create/?$', indexer_solr_api.create_index, name='create_index'),
-  url(r'^api/indexes/index/?$', indexer_solr_api.index, name='index'),
-  url(r'^api/indexes/sample/?$', indexer_solr_api.sample_index, name='sample_index'),
-  url(r'^api/indexes/config/?$', indexer_solr_api.config_index, name='config_index'),
-  url(r'^api/indexes/delete/?$', indexer_solr_api.delete_indexes, name='delete_indexes'),
+  re_path(r'^api/aliases/create/?$', indexer_solr_api.create_alias, name='create_alias'),
+  re_path(r'^api/configs/list/?$', indexer_solr_api.list_configs, name='list_configs'),
+  re_path(r'^api/index/list/?$', indexer_solr_api.list_index, name='list_index'),
+  re_path(r'^api/indexes/list/?$', indexer_solr_api.list_indexes, name='list_indexes'),
+  re_path(r'^api/indexes/create/?$', indexer_solr_api.create_index, name='create_index'),
+  re_path(r'^api/indexes/index/?$', indexer_solr_api.index, name='index'),
+  re_path(r'^api/indexes/sample/?$', indexer_solr_api.sample_index, name='sample_index'),
+  re_path(r'^api/indexes/config/?$', indexer_solr_api.config_index, name='config_index'),
+  re_path(r'^api/indexes/delete/?$', indexer_solr_api.delete_indexes, name='delete_indexes'),
 ]
 
 urlpatterns += [
   # Importer
-  url(r'^api/indexer/guess_format/?$', indexer_api3.guess_format, name='guess_format'),
-  url(r'^api/indexer/guess_field_types/?$', indexer_api3.guess_field_types, name='guess_field_types'),
-  url(r'^api/indexer/index/?$', indexer_api3.index, name='index'),
+  re_path(r'^api/indexer/guess_format/?$', indexer_api3.guess_format, name='guess_format'),
+  re_path(r'^api/indexer/guess_field_types/?$', indexer_api3.guess_field_types, name='guess_field_types'),
+  re_path(r'^api/indexer/index/?$', indexer_api3.index, name='index'),
 
-  url(r'^api/importer/submit', indexer_api3.importer_submit, name='importer_submit'),
-  url(r'^api/importer/save/?$', indexer_api3.save_pipeline, name='save_pipeline'),
+  re_path(r'^api/importer/submit', indexer_api3.importer_submit, name='importer_submit'),
+  re_path(r'^api/importer/save/?$', indexer_api3.save_pipeline, name='save_pipeline'),
 ]
 
 urlpatterns += [
-  url(r'^api/indexer/indexers/get_db_component/?$', indexer_indexers_rdbms.get_db_component, name='get_db_component'),
-  url(r'^api/indexer/indexers/get_drivers/?$', indexer_indexers_rdbms.get_drivers, name='get_drivers'),
-  url(r'^api/indexer/indexers/jdbc_db_list/?$', indexer_indexers_rdbms.jdbc_db_list, name='jdbc_db_list')
+  re_path(r'^api/indexer/indexers/get_db_component/?$', indexer_indexers_rdbms.get_db_component, name='get_db_component'),
+  re_path(r'^api/indexer/indexers/get_drivers/?$', indexer_indexers_rdbms.get_drivers, name='get_drivers'),
+  re_path(r'^api/indexer/indexers/jdbc_db_list/?$', indexer_indexers_rdbms.jdbc_db_list, name='jdbc_db_list')
 ]
 
 
 # Deprecated
 urlpatterns += [
-  url(r'^api/fields/parse/?$', indexer_api.parse_fields, name='api_parse_fields'),
-  url(r'^api/autocomplete/?$', indexer_api.autocomplete, name='api_autocomplete'),
-  url(r'^api/collections/?$', indexer_api.collections, name='api_collections'),
-  url(r'^api/collections/create/?$', indexer_api.collections_create, name='api_collections_create'),
-  url(r'^api/collections/import/?$', indexer_api.collections_import, name='api_collections_import'),
-  url(r'^api/collections/remove/?$', indexer_api.collections_remove, name='api_collections_remove'),
-  url(r'^api/collections/(?P<collection>[^/]+)/fields/?$', indexer_api.collections_fields, name='api_collections_fields'),
-  url(r'^api/collections/(?P<collection>[^/]+)/update/?$', indexer_api.collections_update, name='api_collections_update'),
-  url(r'^api/collections/(?P<collection>[^/]+)/data/?$', indexer_api.collections_data, name='api_collections_data'),
+  re_path(r'^api/fields/parse/?$', indexer_api.parse_fields, name='api_parse_fields'),
+  re_path(r'^api/autocomplete/?$', indexer_api.autocomplete, name='api_autocomplete'),
+  re_path(r'^api/collections/?$', indexer_api.collections, name='api_collections'),
+  re_path(r'^api/collections/create/?$', indexer_api.collections_create, name='api_collections_create'),
+  re_path(r'^api/collections/import/?$', indexer_api.collections_import, name='api_collections_import'),
+  re_path(r'^api/collections/remove/?$', indexer_api.collections_remove, name='api_collections_remove'),
+  re_path(r'^api/collections/(?P<collection>[^/]+)/fields/?$', indexer_api.collections_fields, name='api_collections_fields'),
+  re_path(r'^api/collections/(?P<collection>[^/]+)/update/?$', indexer_api.collections_update, name='api_collections_update'),
+  re_path(r'^api/collections/(?P<collection>[^/]+)/data/?$', indexer_api.collections_data, name='api_collections_data'),
 ]

--- a/desktop/libs/kafka/src/kafka/urls.py
+++ b/desktop/libs/kafka/src/kafka/urls.py
@@ -19,13 +19,13 @@ import sys
 
 from kafka import kafka_api as kafka_kafka_api
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-  url(r'^api/topics/list/$', kafka_kafka_api.list_topics, name='list_topics'),
-  url(r'^api/topic/list/$', kafka_kafka_api.list_topic, name='list_topic'),
-  url(r'^api/topic/create/$', kafka_kafka_api.create_topic, name='create_topic'),
+  re_path(r'^api/topics/list/$', kafka_kafka_api.list_topics, name='list_topics'),
+  re_path(r'^api/topic/list/$', kafka_kafka_api.list_topic, name='list_topic'),
+  re_path(r'^api/topic/create/$', kafka_kafka_api.create_topic, name='create_topic'),
 ]

--- a/desktop/libs/kafka/src/kafka/urls.py
+++ b/desktop/libs/kafka/src/kafka/urls.py
@@ -15,8 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from kafka import kafka_api as kafka_kafka_api
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
   url(r'^api/topics/list/$', kafka_kafka_api.list_topics, name='list_topics'),

--- a/desktop/libs/liboauth/src/liboauth/urls.py
+++ b/desktop/libs/liboauth/src/liboauth/urls.py
@@ -19,13 +19,13 @@ import sys
 
 from liboauth import views as liboauth_views
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 urlpatterns = [
-       url(r'^accounts/login/$', liboauth_views.show_login_page, name='show_oauth_login'),
-       url(r'^social_login/oauth/?$', liboauth_views.oauth_login, name='oauth_login'),
-       url(r'^social_login/oauth_authenticated/?$', liboauth_views.oauth_authenticated, name='oauth_authenticated'),
+       re_path(r'^accounts/login/$', liboauth_views.show_login_page, name='show_oauth_login'),
+       re_path(r'^social_login/oauth/?$', liboauth_views.oauth_login, name='oauth_login'),
+       re_path(r'^social_login/oauth_authenticated/?$', liboauth_views.oauth_authenticated, name='oauth_authenticated'),
 ]

--- a/desktop/libs/liboauth/src/liboauth/urls.py
+++ b/desktop/libs/liboauth/src/liboauth/urls.py
@@ -15,8 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
+
 from liboauth import views as liboauth_views
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 urlpatterns = [
        url(r'^accounts/login/$', liboauth_views.show_login_page, name='show_oauth_login'),

--- a/desktop/libs/libsaml/src/libsaml/urls.py
+++ b/desktop/libs/libsaml/src/libsaml/urls.py
@@ -18,10 +18,10 @@
 import logging
 import sys
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 LOG = logging.getLogger(__name__)
 
@@ -41,18 +41,18 @@ except ImportError:
 
 if djangosaml2_views is not None:
   urlpatterns = [
-    url(r'^logout/$', djangosaml2_views.logout, name='saml2_logout')
+    re_path(r'^logout/$', djangosaml2_views.logout, name='saml2_logout')
   ]
 
   urlpatterns += [
-    url(r'^ls/$', libsaml_views.logout_service, name='saml2_ls'),
-    url(r'^acs/$', libsaml_views.assertion_consumer_service, name='saml2_acs'),
-    url(r'^login/$', libsaml_views.login, name='saml2_login'),
-    url(r'^metadata/$', libsaml_views.metadata, name='saml2_metadata'),
-    url(r'^test/$', libsaml_views.echo_attributes)
+    re_path(r'^ls/$', libsaml_views.logout_service, name='saml2_ls'),
+    re_path(r'^acs/$', libsaml_views.assertion_consumer_service, name='saml2_acs'),
+    re_path(r'^login/$', libsaml_views.login, name='saml2_login'),
+    re_path(r'^metadata/$', libsaml_views.metadata, name='saml2_metadata'),
+    re_path(r'^test/$', libsaml_views.echo_attributes)
   ]
 
   if logout_service_post is not None:
     urlpatterns += [
-      url(r'^ls/post/$', libsaml_views.logout_service_post, name='saml2_ls_post')
+      re_path(r'^ls/post/$', libsaml_views.logout_service_post, name='saml2_ls_post')
     ]

--- a/desktop/libs/libsaml/src/libsaml/urls.py
+++ b/desktop/libs/libsaml/src/libsaml/urls.py
@@ -16,8 +16,12 @@
 # limitations under the License.
 
 import logging
+import sys
 
-from django.conf.urls import url
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 LOG = logging.getLogger(__name__)
 

--- a/desktop/libs/metadata/src/metadata/urls.py
+++ b/desktop/libs/metadata/src/metadata/urls.py
@@ -22,107 +22,107 @@ from metadata import optimizer_api as metadata_optimizer_api
 from metadata import workload_analytics_api as metadata_workload_analytics_api
 from metadata import manager_api as metadata_manager_api
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 
 # Catalog
 urlpatterns = [
-  url(r'^api/catalog/search_entities/?$', metadata_catalog_api.search_entities, name='catalog_search_entities'),
-  url(
+  re_path(r'^api/catalog/search_entities/?$', metadata_catalog_api.search_entities, name='catalog_search_entities'),
+  re_path(
     r'^api/catalog/search_entities_interactive/?$',
     metadata_catalog_api.search_entities_interactive,
     name='catalog_search_entities_interactive'
   ),
-  url(r'^api/catalog/find_entity/?$', metadata_catalog_api.find_entity, name='catalog_find_entity'),
-  url(r'^api/catalog/get_entity/?$', metadata_catalog_api.get_entity, name='catalog_get_entity'),
-  url(r'^api/catalog/add_tags/?$', metadata_catalog_api.add_tags, name='catalog_add_tags'),
-  url(r'^api/catalog/delete_tags/?$', metadata_catalog_api.delete_tags, name='catalog_delete_tags'),
-  url(r'^api/catalog/list_tags/?$', metadata_catalog_api.list_tags, name='catalog_list_tags'),
-  url(r'^api/catalog/suggest/?$', metadata_catalog_api.suggest, name='catalog_suggest'),
-  url(r'^api/catalog/update_properties/?$', metadata_catalog_api.update_properties, name='catalog_update_properties'),
-  url(
+  re_path(r'^api/catalog/find_entity/?$', metadata_catalog_api.find_entity, name='catalog_find_entity'),
+  re_path(r'^api/catalog/get_entity/?$', metadata_catalog_api.get_entity, name='catalog_get_entity'),
+  re_path(r'^api/catalog/add_tags/?$', metadata_catalog_api.add_tags, name='catalog_add_tags'),
+  re_path(r'^api/catalog/delete_tags/?$', metadata_catalog_api.delete_tags, name='catalog_delete_tags'),
+  re_path(r'^api/catalog/list_tags/?$', metadata_catalog_api.list_tags, name='catalog_list_tags'),
+  re_path(r'^api/catalog/suggest/?$', metadata_catalog_api.suggest, name='catalog_suggest'),
+  re_path(r'^api/catalog/update_properties/?$', metadata_catalog_api.update_properties, name='catalog_update_properties'),
+  re_path(
     r'^api/catalog/delete_metadata_properties/?$',
     metadata_catalog_api.delete_metadata_properties,
     name='catalog_delete_metadata_properties'
   ),
-  url(r'^api/catalog/lineage/?$', metadata_catalog_api.get_lineage, name='catalog_get_lineage'),
+  re_path(r'^api/catalog/lineage/?$', metadata_catalog_api.get_lineage, name='catalog_get_lineage'),
 ]
 # Navigator API (deprecated, renamed to Catalog)
 urlpatterns += [
-  url(r'^api/navigator/search_entities/?$', metadata_catalog_api.search_entities, name='search_entities'),
-  url(
+  re_path(r'^api/navigator/search_entities/?$', metadata_catalog_api.search_entities, name='search_entities'),
+  re_path(
     r'^api/navigator/search_entities_interactive/?$',
     metadata_catalog_api.search_entities_interactive,
     name='search_entities_interactive'
   ),
-  url(r'^api/navigator/find_entity/?$', metadata_catalog_api.find_entity, name='find_entity'),
-  url(r'^api/navigator/get_entity/?$', metadata_catalog_api.get_entity, name='get_entity'),
-  url(r'^api/navigator/add_tags/?$', metadata_catalog_api.add_tags, name='add_tags'),
-  url(r'^api/navigator/delete_tags/?$', metadata_catalog_api.delete_tags, name='delete_tags'),
-  url(r'^api/navigator/list_tags/?$', metadata_catalog_api.list_tags, name='list_tags'),
-  url(r'^api/navigator/suggest/?$', metadata_catalog_api.suggest, name='suggest'),
-  url(r'^api/navigator/update_properties/?$', metadata_catalog_api.update_properties, name='update_properties'),
-  url(r'^api/navigator/delete_metadata_properties/?$', metadata_catalog_api.delete_metadata_properties, name='delete_metadata_properties'),
-  url(r'^api/navigator/lineage/?$', metadata_catalog_api.get_lineage, name='get_lineage'),
+  re_path(r'^api/navigator/find_entity/?$', metadata_catalog_api.find_entity, name='find_entity'),
+  re_path(r'^api/navigator/get_entity/?$', metadata_catalog_api.get_entity, name='get_entity'),
+  re_path(r'^api/navigator/add_tags/?$', metadata_catalog_api.add_tags, name='add_tags'),
+  re_path(r'^api/navigator/delete_tags/?$', metadata_catalog_api.delete_tags, name='delete_tags'),
+  re_path(r'^api/navigator/list_tags/?$', metadata_catalog_api.list_tags, name='list_tags'),
+  re_path(r'^api/navigator/suggest/?$', metadata_catalog_api.suggest, name='suggest'),
+  re_path(r'^api/navigator/update_properties/?$', metadata_catalog_api.update_properties, name='update_properties'),
+  re_path(r'^api/navigator/delete_metadata_properties/?$', metadata_catalog_api.delete_metadata_properties, name='delete_metadata_properties'),
+  re_path(r'^api/navigator/lineage/?$', metadata_catalog_api.get_lineage, name='get_lineage'),
 ]
 
 # Optimizer API
 urlpatterns += [
-  url(r'^api/optimizer/upload/history/?$', metadata_optimizer_api.upload_history, name='upload_history'),
-  url(r'^api/optimizer/upload/query/?$', metadata_optimizer_api.upload_query, name='upload_query'),
-  url(r'^api/optimizer/upload/table_stats/?$', metadata_optimizer_api.upload_table_stats, name='upload_table_stats'),
-  url(r'^api/optimizer/upload/status/?$', metadata_optimizer_api.upload_status, name='upload_status'),
+  re_path(r'^api/optimizer/upload/history/?$', metadata_optimizer_api.upload_history, name='upload_history'),
+  re_path(r'^api/optimizer/upload/query/?$', metadata_optimizer_api.upload_query, name='upload_query'),
+  re_path(r'^api/optimizer/upload/table_stats/?$', metadata_optimizer_api.upload_table_stats, name='upload_table_stats'),
+  re_path(r'^api/optimizer/upload/status/?$', metadata_optimizer_api.upload_status, name='upload_status'),
 
   #v2
-  url(r'^api/optimizer/get_tenant/?$', metadata_optimizer_api.get_tenant, name='get_tenant'),
+  re_path(r'^api/optimizer/get_tenant/?$', metadata_optimizer_api.get_tenant, name='get_tenant'),
 
-  url(r'^api/optimizer/top_databases/?$', metadata_optimizer_api.top_databases, name='top_databases'),
-  url(r'^api/optimizer/top_tables/?$', metadata_optimizer_api.top_tables, name='top_tables'),
-  url(r'^api/optimizer/top_columns/?$', metadata_optimizer_api.top_columns, name='top_columns'),
-  url(r'^api/optimizer/top_joins/?$', metadata_optimizer_api.top_joins, name='top_joins'),
-  url(r'^api/optimizer/top_filters/?$', metadata_optimizer_api.top_filters, name='top_filters'),
-  url(r'^api/optimizer/top_aggs/?$', metadata_optimizer_api.top_aggs, name='top_aggs'),
+  re_path(r'^api/optimizer/top_databases/?$', metadata_optimizer_api.top_databases, name='top_databases'),
+  re_path(r'^api/optimizer/top_tables/?$', metadata_optimizer_api.top_tables, name='top_tables'),
+  re_path(r'^api/optimizer/top_columns/?$', metadata_optimizer_api.top_columns, name='top_columns'),
+  re_path(r'^api/optimizer/top_joins/?$', metadata_optimizer_api.top_joins, name='top_joins'),
+  re_path(r'^api/optimizer/top_filters/?$', metadata_optimizer_api.top_filters, name='top_filters'),
+  re_path(r'^api/optimizer/top_aggs/?$', metadata_optimizer_api.top_aggs, name='top_aggs'),
 
-  url(r'^api/optimizer/table_details/?$', metadata_optimizer_api.table_details, name='table_details'),
+  re_path(r'^api/optimizer/table_details/?$', metadata_optimizer_api.table_details, name='table_details'),
 
-  url(r'^api/optimizer/query_risk/?$', metadata_optimizer_api.query_risk, name='query_risk'),
-  url(r'^api/optimizer/predict/?$', metadata_optimizer_api.predict, name='predict'),
-  url(r'^api/optimizer/query_compatibility/?$', metadata_optimizer_api.query_compatibility, name='query_compatibility'),
-  url(r'^api/optimizer/similar_queries/?$', metadata_optimizer_api.similar_queries, name='similar_queries'),
+  re_path(r'^api/optimizer/query_risk/?$', metadata_optimizer_api.query_risk, name='query_risk'),
+  re_path(r'^api/optimizer/predict/?$', metadata_optimizer_api.predict, name='predict'),
+  re_path(r'^api/optimizer/query_compatibility/?$', metadata_optimizer_api.query_compatibility, name='query_compatibility'),
+  re_path(r'^api/optimizer/similar_queries/?$', metadata_optimizer_api.similar_queries, name='similar_queries'),
 ]
 
 
 # Manager API
 urlpatterns += [
-  url(r'^api/manager/hello/?$', metadata_manager_api.hello, name='manager_hello'),
-  url(r'^api/manager/get_hosts/?$', metadata_manager_api.get_hosts, name='manager_hosts'),
-  url(r'^api/manager/update_flume_config/?$', metadata_manager_api.update_flume_config, name='manager_update_flume_config'),
+  re_path(r'^api/manager/hello/?$', metadata_manager_api.hello, name='manager_hello'),
+  re_path(r'^api/manager/get_hosts/?$', metadata_manager_api.get_hosts, name='manager_hosts'),
+  re_path(r'^api/manager/update_flume_config/?$', metadata_manager_api.update_flume_config, name='manager_update_flume_config'),
 ]
 
 
 # Prometheus API
 urlpatterns += [
-  url(r'^api/prometheus/query?$', prometheus_api.query, name='prometheus_query'),
+  re_path(r'^api/prometheus/query?$', prometheus_api.query, name='prometheus_query'),
 ]
 
 
 # Altus API
 urlpatterns += [
-  url(r'^api/analytic_db/create_cluster/?$', analytic_db_api.create_cluster, name='create_cluster'),
-  url(r'^api/analytic_db/update_cluster/?$', analytic_db_api.update_cluster, name='update_cluster'),
+  re_path(r'^api/analytic_db/create_cluster/?$', analytic_db_api.create_cluster, name='create_cluster'),
+  re_path(r'^api/analytic_db/update_cluster/?$', analytic_db_api.update_cluster, name='update_cluster'),
 ]
 urlpatterns += [
-  url(r'^api/dataeng/create_cluster/?$', dataeng_api.create_cluster, name='create_cluster'),
+  re_path(r'^api/dataeng/create_cluster/?$', dataeng_api.create_cluster, name='create_cluster'),
 ]
 urlpatterns += [
-  url(
+  re_path(
     r'^api/workload_analytics/get_operation_execution_details/?$',
     metadata_workload_analytics_api.get_operation_execution_details,
     name='get_operation_execution_details'
   ),
-  url(r'^api/workload_analytics/get_impala_query/?$', metadata_workload_analytics_api.get_impala_query, name='get_impala_query'),
-  url(r'^api/workload_analytics/get_environment/?$', metadata_workload_analytics_api.get_environment, name='get_environment'),
+  re_path(r'^api/workload_analytics/get_impala_query/?$', metadata_workload_analytics_api.get_impala_query, name='get_impala_query'),
+  re_path(r'^api/workload_analytics/get_environment/?$', metadata_workload_analytics_api.get_environment, name='get_environment'),
 ]

--- a/desktop/libs/metadata/src/metadata/urls.py
+++ b/desktop/libs/metadata/src/metadata/urls.py
@@ -65,7 +65,9 @@ urlpatterns += [
   re_path(r'^api/navigator/list_tags/?$', metadata_catalog_api.list_tags, name='list_tags'),
   re_path(r'^api/navigator/suggest/?$', metadata_catalog_api.suggest, name='suggest'),
   re_path(r'^api/navigator/update_properties/?$', metadata_catalog_api.update_properties, name='update_properties'),
-  re_path(r'^api/navigator/delete_metadata_properties/?$', metadata_catalog_api.delete_metadata_properties, name='delete_metadata_properties'),
+  re_path(
+    r'^api/navigator/delete_metadata_properties/?$', metadata_catalog_api.delete_metadata_properties, name='delete_metadata_properties'
+  ),
   re_path(r'^api/navigator/lineage/?$', metadata_catalog_api.get_lineage, name='get_lineage'),
 ]
 

--- a/desktop/libs/metadata/src/metadata/urls.py
+++ b/desktop/libs/metadata/src/metadata/urls.py
@@ -15,12 +15,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
 
 from metadata import catalog_api as metadata_catalog_api, analytic_db_api, dataeng_api, prometheus_api
 from metadata import optimizer_api as metadata_optimizer_api
 from metadata import workload_analytics_api as metadata_workload_analytics_api
 from metadata import manager_api as metadata_manager_api
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 
 # Catalog

--- a/desktop/libs/notebook/src/notebook/routing.py
+++ b/desktop/libs/notebook/src/notebook/routing.py
@@ -15,10 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# from django.urls import re_path # Django 2
-from django.conf.urls import url
+import sys
 
 from desktop.conf import has_channels
+
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 
 if has_channels():

--- a/desktop/libs/notebook/src/notebook/routing.py
+++ b/desktop/libs/notebook/src/notebook/routing.py
@@ -19,15 +19,15 @@ import sys
 
 from desktop.conf import has_channels
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 
 if has_channels():
   from notebook import consumer
 
   websocket_urlpatterns = [
-      url(r'ws/editor/results/(?P<query_uuid>[\w\-]+)/$', consumer.EditorConsumer),
+      re_path(r'ws/editor/results/(?P<query_uuid>[\w\-]+)/$', consumer.EditorConsumer),
   ]

--- a/desktop/libs/notebook/src/notebook/urls.py
+++ b/desktop/libs/notebook/src/notebook/urls.py
@@ -110,7 +110,9 @@ urlpatterns += [
     notebook_api.autocomplete,
     name='api_autocomplete_column'
   ),
-  re_path(r'^api/sample/(?P<server>[\w_\-/]+)/(?P<database>[^/?]*)/(?P<table>\w+)/?$', notebook_api.get_sample_data, name='api_sample_data'),
+  re_path(
+    r'^api/sample/(?P<server>[\w_\-/]+)/(?P<database>[^/?]*)/(?P<table>\w+)/?$', notebook_api.get_sample_data, name='api_sample_data'
+  ),
   re_path(
     r'^api/sample/(?P<server>[\w_\-/]+)/(?P<database>[^/?]*)/(?P<table>\w+)/(?P<column>\w+)/?$',
     notebook_api.get_sample_data,
@@ -122,5 +124,7 @@ urlpatterns += [
 urlpatterns += [
   re_path(r'^api/describe/(?P<database>[^/]*)/?$', notebook_api.describe, name='api_describe_database'),
   re_path(r'^api/describe/(?P<database>[^/]*)/(?P<table>[\w_\-]+)/?$', notebook_api.describe, name='api_describe_table'),
-  re_path(r'^api/describe/(?P<database>[^/]*)/(?P<table>\w+)/stats(?:/(?P<column>\w+))?/?$', notebook_api.describe, name='api_describe_column'),
+  re_path(
+    r'^api/describe/(?P<database>[^/]*)/(?P<table>\w+)/stats(?:/(?P<column>\w+))?/?$', notebook_api.describe, name='api_describe_column'
+  ),
 ]

--- a/desktop/libs/notebook/src/notebook/urls.py
+++ b/desktop/libs/notebook/src/notebook/urls.py
@@ -20,98 +20,98 @@ import sys
 from notebook import views as notebook_views
 from notebook import api as notebook_api
 
-if sys.version_info[0] < 3:
-  from django.conf.urls import url
+if sys.version_info[0] > 2:
+  from django.urls import re_path
 else:
-  from django.urls import re_path as url
+  from django.conf.urls import url as re_path
 
 # Views
 urlpatterns = [
-  url(r'^$', notebook_views.notebook, name='index'),
-  url(r'^notebook/?$', notebook_views.notebook, name='notebook'),
-  url(r'^notebook_embeddable/?$', notebook_views.notebook_embeddable, name='notebook_embeddable'),
-  url(r'^notebooks/?$', notebook_views.notebooks, name='notebooks'),
-  url(r'^new/?$', notebook_views.new, name='new'),
-  url(r'^download/?$', notebook_views.download, name='download'),
-  url(r'^install_examples/?$', notebook_views.install_examples, name='install_examples'),
-  url(r'^delete/?$', notebook_views.delete, name='delete'),
-  url(r'^copy/?$', notebook_views.copy, name='copy'),
+  re_path(r'^$', notebook_views.notebook, name='index'),
+  re_path(r'^notebook/?$', notebook_views.notebook, name='notebook'),
+  re_path(r'^notebook_embeddable/?$', notebook_views.notebook_embeddable, name='notebook_embeddable'),
+  re_path(r'^notebooks/?$', notebook_views.notebooks, name='notebooks'),
+  re_path(r'^new/?$', notebook_views.new, name='new'),
+  re_path(r'^download/?$', notebook_views.download, name='download'),
+  re_path(r'^install_examples/?$', notebook_views.install_examples, name='install_examples'),
+  re_path(r'^delete/?$', notebook_views.delete, name='delete'),
+  re_path(r'^copy/?$', notebook_views.copy, name='copy'),
 
-  url(r'^editor/?$', notebook_views.editor, name='editor'),
-  url(r'^editor_m/?$', notebook_views.editor_m, name='editor_m'),
-  url(r'^browse/(?P<database>[^/?]+)/(?P<table>\w+)(?:/(?P<partition_spec>.+?))?/?$', notebook_views.browse, name='browse'),
-  url(r'^execute_and_watch/?$', notebook_views.execute_and_watch, name='execute_and_watch'),
+  re_path(r'^editor/?$', notebook_views.editor, name='editor'),
+  re_path(r'^editor_m/?$', notebook_views.editor_m, name='editor_m'),
+  re_path(r'^browse/(?P<database>[^/?]+)/(?P<table>\w+)(?:/(?P<partition_spec>.+?))?/?$', notebook_views.browse, name='browse'),
+  re_path(r'^execute_and_watch/?$', notebook_views.execute_and_watch, name='execute_and_watch'),
 ]
 
 # APIs
 urlpatterns += [
-  url(r'^api/create_notebook/?$', notebook_api.create_notebook, name='create_notebook'),
-  url(r'^api/create_session/?$', notebook_api.create_session, name='create_session'),
-  url(r'^api/close_session/?$', notebook_api.close_session, name='close_session'),
-  url(r'^api/execute(?:/(?P<dialect>.+))?/?$', notebook_api.execute, name='execute'),
-  url(r'^api/check_status/?$', notebook_api.check_status, name='check_status'),
-  url(r'^api/fetch_result_data/?$', notebook_api.fetch_result_data, name='fetch_result_data'),
-  url(r'^api/fetch_result_metadata/?$', notebook_api.fetch_result_metadata, name='fetch_result_metadata'),
-  url(r'^api/fetch_result_size/?$', notebook_api.fetch_result_size, name='fetch_result_size'),
-  url(r'^api/cancel_statement/?$', notebook_api.cancel_statement, name='cancel_statement'),
-  url(r'^api/close_statement/?$', notebook_api.close_statement, name='close_statement'),
-  url(r'^api/get_logs/?$', notebook_api.get_logs, name='get_logs'),
+  re_path(r'^api/create_notebook/?$', notebook_api.create_notebook, name='create_notebook'),
+  re_path(r'^api/create_session/?$', notebook_api.create_session, name='create_session'),
+  re_path(r'^api/close_session/?$', notebook_api.close_session, name='close_session'),
+  re_path(r'^api/execute(?:/(?P<dialect>.+))?/?$', notebook_api.execute, name='execute'),
+  re_path(r'^api/check_status/?$', notebook_api.check_status, name='check_status'),
+  re_path(r'^api/fetch_result_data/?$', notebook_api.fetch_result_data, name='fetch_result_data'),
+  re_path(r'^api/fetch_result_metadata/?$', notebook_api.fetch_result_metadata, name='fetch_result_metadata'),
+  re_path(r'^api/fetch_result_size/?$', notebook_api.fetch_result_size, name='fetch_result_size'),
+  re_path(r'^api/cancel_statement/?$', notebook_api.cancel_statement, name='cancel_statement'),
+  re_path(r'^api/close_statement/?$', notebook_api.close_statement, name='close_statement'),
+  re_path(r'^api/get_logs/?$', notebook_api.get_logs, name='get_logs'),
 
-  url(r'^api/explain/?$', notebook_api.explain, name='explain'),
-  url(r'^api/format/?$', notebook_api.format, name='format'),
-  url(r'^api/get_external_statement/?$', notebook_api.get_external_statement, name='get_external_statement'),
+  re_path(r'^api/explain/?$', notebook_api.explain, name='explain'),
+  re_path(r'^api/format/?$', notebook_api.format, name='format'),
+  re_path(r'^api/get_external_statement/?$', notebook_api.get_external_statement, name='get_external_statement'),
 
-  url(r'^api/get_history/?', notebook_api.get_history, name='get_history'),
-  url(r'^api/clear_history/?', notebook_api.clear_history, name='clear_history'),
+  re_path(r'^api/get_history/?', notebook_api.get_history, name='get_history'),
+  re_path(r'^api/clear_history/?', notebook_api.clear_history, name='clear_history'),
 
-  url(r'^api/notebook/save/?$', notebook_api.save_notebook, name='save_notebook'),
-  url(r'^api/notebook/open/?$', notebook_api.open_notebook, name='open_notebook'),
-  url(r'^api/notebook/close/?$', notebook_api.close_notebook, name='close_notebook'),
+  re_path(r'^api/notebook/save/?$', notebook_api.save_notebook, name='save_notebook'),
+  re_path(r'^api/notebook/open/?$', notebook_api.open_notebook, name='open_notebook'),
+  re_path(r'^api/notebook/close/?$', notebook_api.close_notebook, name='close_notebook'),
 
-  url(r'^api/notebook/export_result/?$', notebook_api.export_result, name='export_result'),
+  re_path(r'^api/notebook/export_result/?$', notebook_api.export_result, name='export_result'),
 
-  url(r'^api/optimizer/statement/risk/?$', notebook_api.statement_risk, name='statement_risk'),
-  url(r'^api/optimizer/statement/compatibility/?$', notebook_api.statement_compatibility, name='statement_compatibility'),
-  url(r'^api/optimizer/statement/similarity/?$', notebook_api.statement_similarity, name='statement_similarity'),
+  re_path(r'^api/optimizer/statement/risk/?$', notebook_api.statement_risk, name='statement_risk'),
+  re_path(r'^api/optimizer/statement/compatibility/?$', notebook_api.statement_compatibility, name='statement_compatibility'),
+  re_path(r'^api/optimizer/statement/similarity/?$', notebook_api.statement_similarity, name='statement_similarity'),
 ]
 
 # Assist API
 urlpatterns += [
   # HS2, RDBMS, JDBC
-  url(r'^api/autocomplete/?$', notebook_api.autocomplete, name='api_autocomplete_databases'),
-  url(r'^api/autocomplete/(?P<database>[^/?]*)/?$', notebook_api.autocomplete, name='api_autocomplete_tables'),
-  url(r'^api/autocomplete/(?P<database>[^/?]*)/(?P<table>[\w_\-]+)/?$', notebook_api.autocomplete, name='api_autocomplete_columns'),
-  url(
+  re_path(r'^api/autocomplete/?$', notebook_api.autocomplete, name='api_autocomplete_databases'),
+  re_path(r'^api/autocomplete/(?P<database>[^/?]*)/?$', notebook_api.autocomplete, name='api_autocomplete_tables'),
+  re_path(r'^api/autocomplete/(?P<database>[^/?]*)/(?P<table>[\w_\-]+)/?$', notebook_api.autocomplete, name='api_autocomplete_columns'),
+  re_path(
     r'^api/autocomplete/(?P<database>[^/?]*)/(?P<table>[\w_\-]+)/(?P<column>\w+)/?$',
     notebook_api.autocomplete,
     name='api_autocomplete_column'
   ),
-  url(
+  re_path(
     r'^api/autocomplete/(?P<database>[^/?]*)/(?P<table>[\w_\-]+)/(?P<column>\w+)/(?P<nested>.+)/?$',
     notebook_api.autocomplete,
     name='api_autocomplete_nested'
   ),
-  url(r'^api/sample/(?P<database>[^/?]*)/(?P<table>[\w_\-]+)/?$', notebook_api.get_sample_data, name='api_sample_data'),
-  url(
+  re_path(r'^api/sample/(?P<database>[^/?]*)/(?P<table>[\w_\-]+)/?$', notebook_api.get_sample_data, name='api_sample_data'),
+  re_path(
     r'^api/sample/(?P<database>[^/?]*)/(?P<table>[\w_\-]+)/(?P<column>\w+)/?$',
     notebook_api.get_sample_data,
     name='api_sample_data_column'
   ),
 
   # SQLite
-  url(r'^api/autocomplete//?(?P<server>[\w_\-/]+)/(?P<database>[^/?]*)/?$', notebook_api.autocomplete, name='api_autocomplete_tables'),
-  url(
+  re_path(r'^api/autocomplete//?(?P<server>[\w_\-/]+)/(?P<database>[^/?]*)/?$', notebook_api.autocomplete, name='api_autocomplete_tables'),
+  re_path(
     r'^api/autocomplete//?(?P<server>[\w_\-/]+)/(?P<database>[^/?]*)/(?P<table>\w+)/?$',
     notebook_api.autocomplete,
     name='api_autocomplete_columns'
   ),
-  url(
+  re_path(
     r'^api/autocomplete//?(?P<server>[\w_\-/]+)/(?P<database>[^/?]*)/(?P<table>\w+)/(?P<column>\w+)/?$',
     notebook_api.autocomplete,
     name='api_autocomplete_column'
   ),
-  url(r'^api/sample/(?P<server>[\w_\-/]+)/(?P<database>[^/?]*)/(?P<table>\w+)/?$', notebook_api.get_sample_data, name='api_sample_data'),
-  url(
+  re_path(r'^api/sample/(?P<server>[\w_\-/]+)/(?P<database>[^/?]*)/(?P<table>\w+)/?$', notebook_api.get_sample_data, name='api_sample_data'),
+  re_path(
     r'^api/sample/(?P<server>[\w_\-/]+)/(?P<database>[^/?]*)/(?P<table>\w+)/(?P<column>\w+)/?$',
     notebook_api.get_sample_data,
     name='api_sample_data_column'
@@ -120,7 +120,7 @@ urlpatterns += [
 
 # Table API
 urlpatterns += [
-  url(r'^api/describe/(?P<database>[^/]*)/?$', notebook_api.describe, name='api_describe_database'),
-  url(r'^api/describe/(?P<database>[^/]*)/(?P<table>[\w_\-]+)/?$', notebook_api.describe, name='api_describe_table'),
-  url(r'^api/describe/(?P<database>[^/]*)/(?P<table>\w+)/stats(?:/(?P<column>\w+))?/?$', notebook_api.describe, name='api_describe_column'),
+  re_path(r'^api/describe/(?P<database>[^/]*)/?$', notebook_api.describe, name='api_describe_database'),
+  re_path(r'^api/describe/(?P<database>[^/]*)/(?P<table>[\w_\-]+)/?$', notebook_api.describe, name='api_describe_table'),
+  re_path(r'^api/describe/(?P<database>[^/]*)/(?P<table>\w+)/stats(?:/(?P<column>\w+))?/?$', notebook_api.describe, name='api_describe_column'),
 ]

--- a/desktop/libs/notebook/src/notebook/urls.py
+++ b/desktop/libs/notebook/src/notebook/urls.py
@@ -81,17 +81,41 @@ urlpatterns += [
   url(r'^api/autocomplete/?$', notebook_api.autocomplete, name='api_autocomplete_databases'),
   url(r'^api/autocomplete/(?P<database>[^/?]*)/?$', notebook_api.autocomplete, name='api_autocomplete_tables'),
   url(r'^api/autocomplete/(?P<database>[^/?]*)/(?P<table>[\w_\-]+)/?$', notebook_api.autocomplete, name='api_autocomplete_columns'),
-  url(r'^api/autocomplete/(?P<database>[^/?]*)/(?P<table>[\w_\-]+)/(?P<column>\w+)/?$', notebook_api.autocomplete, name='api_autocomplete_column'),
-  url(r'^api/autocomplete/(?P<database>[^/?]*)/(?P<table>[\w_\-]+)/(?P<column>\w+)/(?P<nested>.+)/?$', notebook_api.autocomplete, name='api_autocomplete_nested'),
+  url(
+    r'^api/autocomplete/(?P<database>[^/?]*)/(?P<table>[\w_\-]+)/(?P<column>\w+)/?$',
+    notebook_api.autocomplete,
+    name='api_autocomplete_column'
+  ),
+  url(
+    r'^api/autocomplete/(?P<database>[^/?]*)/(?P<table>[\w_\-]+)/(?P<column>\w+)/(?P<nested>.+)/?$',
+    notebook_api.autocomplete,
+    name='api_autocomplete_nested'
+  ),
   url(r'^api/sample/(?P<database>[^/?]*)/(?P<table>[\w_\-]+)/?$', notebook_api.get_sample_data, name='api_sample_data'),
-  url(r'^api/sample/(?P<database>[^/?]*)/(?P<table>[\w_\-]+)/(?P<column>\w+)/?$', notebook_api.get_sample_data, name='api_sample_data_column'),
+  url(
+    r'^api/sample/(?P<database>[^/?]*)/(?P<table>[\w_\-]+)/(?P<column>\w+)/?$',
+    notebook_api.get_sample_data,
+    name='api_sample_data_column'
+  ),
 
   # SQLite
   url(r'^api/autocomplete//?(?P<server>[\w_\-/]+)/(?P<database>[^/?]*)/?$', notebook_api.autocomplete, name='api_autocomplete_tables'),
-  url(r'^api/autocomplete//?(?P<server>[\w_\-/]+)/(?P<database>[^/?]*)/(?P<table>\w+)/?$', notebook_api.autocomplete, name='api_autocomplete_columns'),
-  url(r'^api/autocomplete//?(?P<server>[\w_\-/]+)/(?P<database>[^/?]*)/(?P<table>\w+)/(?P<column>\w+)/?$', notebook_api.autocomplete, name='api_autocomplete_column'),
+  url(
+    r'^api/autocomplete//?(?P<server>[\w_\-/]+)/(?P<database>[^/?]*)/(?P<table>\w+)/?$',
+    notebook_api.autocomplete,
+    name='api_autocomplete_columns'
+  ),
+  url(
+    r'^api/autocomplete//?(?P<server>[\w_\-/]+)/(?P<database>[^/?]*)/(?P<table>\w+)/(?P<column>\w+)/?$',
+    notebook_api.autocomplete,
+    name='api_autocomplete_column'
+  ),
   url(r'^api/sample/(?P<server>[\w_\-/]+)/(?P<database>[^/?]*)/(?P<table>\w+)/?$', notebook_api.get_sample_data, name='api_sample_data'),
-  url(r'^api/sample/(?P<server>[\w_\-/]+)/(?P<database>[^/?]*)/(?P<table>\w+)/(?P<column>\w+)/?$', notebook_api.get_sample_data, name='api_sample_data_column'),
+  url(
+    r'^api/sample/(?P<server>[\w_\-/]+)/(?P<database>[^/?]*)/(?P<table>\w+)/(?P<column>\w+)/?$',
+    notebook_api.get_sample_data,
+    name='api_sample_data_column'
+  ),
 ]
 
 # Table API

--- a/desktop/libs/notebook/src/notebook/urls.py
+++ b/desktop/libs/notebook/src/notebook/urls.py
@@ -15,11 +15,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+import sys
 
 from notebook import views as notebook_views
 from notebook import api as notebook_api
 
+if sys.version_info[0] < 3:
+  from django.conf.urls import url
+else:
+  from django.urls import re_path as url
 
 # Views
 urlpatterns = [


### PR DESCRIPTION
## What changes were proposed in this pull request?

- from django.conf.urls import include, url -> 

  if sys.version_info[0] < 3:
    from django.conf.urls import include, url
  else:
    from django.urls import include, re_path as url 

## How was this patch tested?

- https://docs.djangoproject.com/en/3.1/releases/2.0/#what-s-new-in-django-2-0