### PR TITLE
Table creation in Hive or Impala fails with UnicodeDecodeError: 'asci…

### DIFF
--- a/apps/beeswax/gen-py/TCLIService/ttypes.py
+++ b/apps/beeswax/gen-py/TCLIService/ttypes.py
@@ -17,958 +17,950 @@ all_structs = []
 
 
 class TProtocolVersion(object):
-    HIVE_CLI_SERVICE_PROTOCOL_V1 = 0
-    HIVE_CLI_SERVICE_PROTOCOL_V2 = 1
-    HIVE_CLI_SERVICE_PROTOCOL_V3 = 2
-    HIVE_CLI_SERVICE_PROTOCOL_V4 = 3
-    HIVE_CLI_SERVICE_PROTOCOL_V5 = 4
-    HIVE_CLI_SERVICE_PROTOCOL_V6 = 5
-    HIVE_CLI_SERVICE_PROTOCOL_V7 = 6
-    HIVE_CLI_SERVICE_PROTOCOL_V8 = 7
-    HIVE_CLI_SERVICE_PROTOCOL_V9 = 8
-    HIVE_CLI_SERVICE_PROTOCOL_V10 = 9
-    HIVE_CLI_SERVICE_PROTOCOL_V11 = 10
+  HIVE_CLI_SERVICE_PROTOCOL_V1 = 0
+  HIVE_CLI_SERVICE_PROTOCOL_V2 = 1
+  HIVE_CLI_SERVICE_PROTOCOL_V3 = 2
+  HIVE_CLI_SERVICE_PROTOCOL_V4 = 3
+  HIVE_CLI_SERVICE_PROTOCOL_V5 = 4
+  HIVE_CLI_SERVICE_PROTOCOL_V6 = 5
+  HIVE_CLI_SERVICE_PROTOCOL_V7 = 6
+  HIVE_CLI_SERVICE_PROTOCOL_V8 = 7
+  HIVE_CLI_SERVICE_PROTOCOL_V9 = 8
+  HIVE_CLI_SERVICE_PROTOCOL_V10 = 9
+  HIVE_CLI_SERVICE_PROTOCOL_V11 = 10
 
-    _VALUES_TO_NAMES = {
-        0: "HIVE_CLI_SERVICE_PROTOCOL_V1",
-        1: "HIVE_CLI_SERVICE_PROTOCOL_V2",
-        2: "HIVE_CLI_SERVICE_PROTOCOL_V3",
-        3: "HIVE_CLI_SERVICE_PROTOCOL_V4",
-        4: "HIVE_CLI_SERVICE_PROTOCOL_V5",
-        5: "HIVE_CLI_SERVICE_PROTOCOL_V6",
-        6: "HIVE_CLI_SERVICE_PROTOCOL_V7",
-        7: "HIVE_CLI_SERVICE_PROTOCOL_V8",
-        8: "HIVE_CLI_SERVICE_PROTOCOL_V9",
-        9: "HIVE_CLI_SERVICE_PROTOCOL_V10",
-        10: "HIVE_CLI_SERVICE_PROTOCOL_V11",
-    }
+  _VALUES_TO_NAMES = {
+    0: "HIVE_CLI_SERVICE_PROTOCOL_V1",
+    1: "HIVE_CLI_SERVICE_PROTOCOL_V2",
+    2: "HIVE_CLI_SERVICE_PROTOCOL_V3",
+    3: "HIVE_CLI_SERVICE_PROTOCOL_V4",
+    4: "HIVE_CLI_SERVICE_PROTOCOL_V5",
+    5: "HIVE_CLI_SERVICE_PROTOCOL_V6",
+    6: "HIVE_CLI_SERVICE_PROTOCOL_V7",
+    7: "HIVE_CLI_SERVICE_PROTOCOL_V8",
+    8: "HIVE_CLI_SERVICE_PROTOCOL_V9",
+    9: "HIVE_CLI_SERVICE_PROTOCOL_V10",
+    10: "HIVE_CLI_SERVICE_PROTOCOL_V11",
+  }
 
-    _NAMES_TO_VALUES = {
-        "HIVE_CLI_SERVICE_PROTOCOL_V1": 0,
-        "HIVE_CLI_SERVICE_PROTOCOL_V2": 1,
-        "HIVE_CLI_SERVICE_PROTOCOL_V3": 2,
-        "HIVE_CLI_SERVICE_PROTOCOL_V4": 3,
-        "HIVE_CLI_SERVICE_PROTOCOL_V5": 4,
-        "HIVE_CLI_SERVICE_PROTOCOL_V6": 5,
-        "HIVE_CLI_SERVICE_PROTOCOL_V7": 6,
-        "HIVE_CLI_SERVICE_PROTOCOL_V8": 7,
-        "HIVE_CLI_SERVICE_PROTOCOL_V9": 8,
-        "HIVE_CLI_SERVICE_PROTOCOL_V10": 9,
-        "HIVE_CLI_SERVICE_PROTOCOL_V11": 10,
-    }
+  _NAMES_TO_VALUES = {
+    "HIVE_CLI_SERVICE_PROTOCOL_V1": 0,
+    "HIVE_CLI_SERVICE_PROTOCOL_V2": 1,
+    "HIVE_CLI_SERVICE_PROTOCOL_V3": 2,
+    "HIVE_CLI_SERVICE_PROTOCOL_V4": 3,
+    "HIVE_CLI_SERVICE_PROTOCOL_V5": 4,
+    "HIVE_CLI_SERVICE_PROTOCOL_V6": 5,
+    "HIVE_CLI_SERVICE_PROTOCOL_V7": 6,
+    "HIVE_CLI_SERVICE_PROTOCOL_V8": 7,
+    "HIVE_CLI_SERVICE_PROTOCOL_V9": 8,
+    "HIVE_CLI_SERVICE_PROTOCOL_V10": 9,
+    "HIVE_CLI_SERVICE_PROTOCOL_V11": 10,
+  }
 
 
 class TTypeId(object):
-    BOOLEAN_TYPE = 0
-    TINYINT_TYPE = 1
-    SMALLINT_TYPE = 2
-    INT_TYPE = 3
-    BIGINT_TYPE = 4
-    FLOAT_TYPE = 5
-    DOUBLE_TYPE = 6
-    STRING_TYPE = 7
-    TIMESTAMP_TYPE = 8
-    BINARY_TYPE = 9
-    ARRAY_TYPE = 10
-    MAP_TYPE = 11
-    STRUCT_TYPE = 12
-    UNION_TYPE = 13
-    USER_DEFINED_TYPE = 14
-    DECIMAL_TYPE = 15
-    NULL_TYPE = 16
-    DATE_TYPE = 17
-    VARCHAR_TYPE = 18
-    CHAR_TYPE = 19
-    INTERVAL_YEAR_MONTH_TYPE = 20
-    INTERVAL_DAY_TIME_TYPE = 21
-    TIMESTAMPLOCALTZ_TYPE = 22
+  BOOLEAN_TYPE = 0
+  TINYINT_TYPE = 1
+  SMALLINT_TYPE = 2
+  INT_TYPE = 3
+  BIGINT_TYPE = 4
+  FLOAT_TYPE = 5
+  DOUBLE_TYPE = 6
+  STRING_TYPE = 7
+  TIMESTAMP_TYPE = 8
+  BINARY_TYPE = 9
+  ARRAY_TYPE = 10
+  MAP_TYPE = 11
+  STRUCT_TYPE = 12
+  UNION_TYPE = 13
+  USER_DEFINED_TYPE = 14
+  DECIMAL_TYPE = 15
+  NULL_TYPE = 16
+  DATE_TYPE = 17
+  VARCHAR_TYPE = 18
+  CHAR_TYPE = 19
+  INTERVAL_YEAR_MONTH_TYPE = 20
+  INTERVAL_DAY_TIME_TYPE = 21
+  TIMESTAMPLOCALTZ_TYPE = 22
 
-    _VALUES_TO_NAMES = {
-        0: "BOOLEAN_TYPE",
-        1: "TINYINT_TYPE",
-        2: "SMALLINT_TYPE",
-        3: "INT_TYPE",
-        4: "BIGINT_TYPE",
-        5: "FLOAT_TYPE",
-        6: "DOUBLE_TYPE",
-        7: "STRING_TYPE",
-        8: "TIMESTAMP_TYPE",
-        9: "BINARY_TYPE",
-        10: "ARRAY_TYPE",
-        11: "MAP_TYPE",
-        12: "STRUCT_TYPE",
-        13: "UNION_TYPE",
-        14: "USER_DEFINED_TYPE",
-        15: "DECIMAL_TYPE",
-        16: "NULL_TYPE",
-        17: "DATE_TYPE",
-        18: "VARCHAR_TYPE",
-        19: "CHAR_TYPE",
-        20: "INTERVAL_YEAR_MONTH_TYPE",
-        21: "INTERVAL_DAY_TIME_TYPE",
-        22: "TIMESTAMPLOCALTZ_TYPE",
-    }
+  _VALUES_TO_NAMES = {
+    0: "BOOLEAN_TYPE",
+    1: "TINYINT_TYPE",
+    2: "SMALLINT_TYPE",
+    3: "INT_TYPE",
+    4: "BIGINT_TYPE",
+    5: "FLOAT_TYPE",
+    6: "DOUBLE_TYPE",
+    7: "STRING_TYPE",
+    8: "TIMESTAMP_TYPE",
+    9: "BINARY_TYPE",
+    10: "ARRAY_TYPE",
+    11: "MAP_TYPE",
+    12: "STRUCT_TYPE",
+    13: "UNION_TYPE",
+    14: "USER_DEFINED_TYPE",
+    15: "DECIMAL_TYPE",
+    16: "NULL_TYPE",
+    17: "DATE_TYPE",
+    18: "VARCHAR_TYPE",
+    19: "CHAR_TYPE",
+    20: "INTERVAL_YEAR_MONTH_TYPE",
+    21: "INTERVAL_DAY_TIME_TYPE",
+    22: "TIMESTAMPLOCALTZ_TYPE",
+  }
 
-    _NAMES_TO_VALUES = {
-        "BOOLEAN_TYPE": 0,
-        "TINYINT_TYPE": 1,
-        "SMALLINT_TYPE": 2,
-        "INT_TYPE": 3,
-        "BIGINT_TYPE": 4,
-        "FLOAT_TYPE": 5,
-        "DOUBLE_TYPE": 6,
-        "STRING_TYPE": 7,
-        "TIMESTAMP_TYPE": 8,
-        "BINARY_TYPE": 9,
-        "ARRAY_TYPE": 10,
-        "MAP_TYPE": 11,
-        "STRUCT_TYPE": 12,
-        "UNION_TYPE": 13,
-        "USER_DEFINED_TYPE": 14,
-        "DECIMAL_TYPE": 15,
-        "NULL_TYPE": 16,
-        "DATE_TYPE": 17,
-        "VARCHAR_TYPE": 18,
-        "CHAR_TYPE": 19,
-        "INTERVAL_YEAR_MONTH_TYPE": 20,
-        "INTERVAL_DAY_TIME_TYPE": 21,
-        "TIMESTAMPLOCALTZ_TYPE": 22,
-    }
+  _NAMES_TO_VALUES = {
+    "BOOLEAN_TYPE": 0,
+    "TINYINT_TYPE": 1,
+    "SMALLINT_TYPE": 2,
+    "INT_TYPE": 3,
+    "BIGINT_TYPE": 4,
+    "FLOAT_TYPE": 5,
+    "DOUBLE_TYPE": 6,
+    "STRING_TYPE": 7,
+    "TIMESTAMP_TYPE": 8,
+    "BINARY_TYPE": 9,
+    "ARRAY_TYPE": 10,
+    "MAP_TYPE": 11,
+    "STRUCT_TYPE": 12,
+    "UNION_TYPE": 13,
+    "USER_DEFINED_TYPE": 14,
+    "DECIMAL_TYPE": 15,
+    "NULL_TYPE": 16,
+    "DATE_TYPE": 17,
+    "VARCHAR_TYPE": 18,
+    "CHAR_TYPE": 19,
+    "INTERVAL_YEAR_MONTH_TYPE": 20,
+    "INTERVAL_DAY_TIME_TYPE": 21,
+    "TIMESTAMPLOCALTZ_TYPE": 22,
+  }
 
 
 class TStatusCode(object):
-    SUCCESS_STATUS = 0
-    SUCCESS_WITH_INFO_STATUS = 1
-    STILL_EXECUTING_STATUS = 2
-    ERROR_STATUS = 3
-    INVALID_HANDLE_STATUS = 4
+  SUCCESS_STATUS = 0
+  SUCCESS_WITH_INFO_STATUS = 1
+  STILL_EXECUTING_STATUS = 2
+  ERROR_STATUS = 3
+  INVALID_HANDLE_STATUS = 4
 
-    _VALUES_TO_NAMES = {
-        0: "SUCCESS_STATUS",
-        1: "SUCCESS_WITH_INFO_STATUS",
-        2: "STILL_EXECUTING_STATUS",
-        3: "ERROR_STATUS",
-        4: "INVALID_HANDLE_STATUS",
-    }
+  _VALUES_TO_NAMES = {
+    0: "SUCCESS_STATUS",
+    1: "SUCCESS_WITH_INFO_STATUS",
+    2: "STILL_EXECUTING_STATUS",
+    3: "ERROR_STATUS",
+    4: "INVALID_HANDLE_STATUS",
+  }
 
-    _NAMES_TO_VALUES = {
-        "SUCCESS_STATUS": 0,
-        "SUCCESS_WITH_INFO_STATUS": 1,
-        "STILL_EXECUTING_STATUS": 2,
-        "ERROR_STATUS": 3,
-        "INVALID_HANDLE_STATUS": 4,
-    }
+  _NAMES_TO_VALUES = {
+    "SUCCESS_STATUS": 0,
+    "SUCCESS_WITH_INFO_STATUS": 1,
+    "STILL_EXECUTING_STATUS": 2,
+    "ERROR_STATUS": 3,
+    "INVALID_HANDLE_STATUS": 4,
+  }
 
 
 class TOperationState(object):
-    INITIALIZED_STATE = 0
-    RUNNING_STATE = 1
-    FINISHED_STATE = 2
-    CANCELED_STATE = 3
-    CLOSED_STATE = 4
-    ERROR_STATE = 5
-    UKNOWN_STATE = 6
-    PENDING_STATE = 7
-    TIMEDOUT_STATE = 8
+  INITIALIZED_STATE = 0
+  RUNNING_STATE = 1
+  FINISHED_STATE = 2
+  CANCELED_STATE = 3
+  CLOSED_STATE = 4
+  ERROR_STATE = 5
+  UKNOWN_STATE = 6
+  PENDING_STATE = 7
+  TIMEDOUT_STATE = 8
 
-    _VALUES_TO_NAMES = {
-        0: "INITIALIZED_STATE",
-        1: "RUNNING_STATE",
-        2: "FINISHED_STATE",
-        3: "CANCELED_STATE",
-        4: "CLOSED_STATE",
-        5: "ERROR_STATE",
-        6: "UKNOWN_STATE",
-        7: "PENDING_STATE",
-        8: "TIMEDOUT_STATE",
-    }
+  _VALUES_TO_NAMES = {
+    0: "INITIALIZED_STATE",
+    1: "RUNNING_STATE",
+    2: "FINISHED_STATE",
+    3: "CANCELED_STATE",
+    4: "CLOSED_STATE",
+    5: "ERROR_STATE",
+    6: "UKNOWN_STATE",
+    7: "PENDING_STATE",
+    8: "TIMEDOUT_STATE",
+  }
 
-    _NAMES_TO_VALUES = {
-        "INITIALIZED_STATE": 0,
-        "RUNNING_STATE": 1,
-        "FINISHED_STATE": 2,
-        "CANCELED_STATE": 3,
-        "CLOSED_STATE": 4,
-        "ERROR_STATE": 5,
-        "UKNOWN_STATE": 6,
-        "PENDING_STATE": 7,
-        "TIMEDOUT_STATE": 8,
-    }
+  _NAMES_TO_VALUES = {
+    "INITIALIZED_STATE": 0,
+    "RUNNING_STATE": 1,
+    "FINISHED_STATE": 2,
+    "CANCELED_STATE": 3,
+    "CLOSED_STATE": 4,
+    "ERROR_STATE": 5,
+    "UKNOWN_STATE": 6,
+    "PENDING_STATE": 7,
+    "TIMEDOUT_STATE": 8,
+  }
 
 
 class TOperationType(object):
-    EXECUTE_STATEMENT = 0
-    GET_TYPE_INFO = 1
-    GET_CATALOGS = 2
-    GET_SCHEMAS = 3
-    GET_TABLES = 4
-    GET_TABLE_TYPES = 5
-    GET_COLUMNS = 6
-    GET_FUNCTIONS = 7
-    UNKNOWN = 8
+  EXECUTE_STATEMENT = 0
+  GET_TYPE_INFO = 1
+  GET_CATALOGS = 2
+  GET_SCHEMAS = 3
+  GET_TABLES = 4
+  GET_TABLE_TYPES = 5
+  GET_COLUMNS = 6
+  GET_FUNCTIONS = 7
+  UNKNOWN = 8
 
-    _VALUES_TO_NAMES = {
-        0: "EXECUTE_STATEMENT",
-        1: "GET_TYPE_INFO",
-        2: "GET_CATALOGS",
-        3: "GET_SCHEMAS",
-        4: "GET_TABLES",
-        5: "GET_TABLE_TYPES",
-        6: "GET_COLUMNS",
-        7: "GET_FUNCTIONS",
-        8: "UNKNOWN",
-    }
+  _VALUES_TO_NAMES = {
+    0: "EXECUTE_STATEMENT",
+    1: "GET_TYPE_INFO",
+    2: "GET_CATALOGS",
+    3: "GET_SCHEMAS",
+    4: "GET_TABLES",
+    5: "GET_TABLE_TYPES",
+    6: "GET_COLUMNS",
+    7: "GET_FUNCTIONS",
+    8: "UNKNOWN",
+  }
 
-    _NAMES_TO_VALUES = {
-        "EXECUTE_STATEMENT": 0,
-        "GET_TYPE_INFO": 1,
-        "GET_CATALOGS": 2,
-        "GET_SCHEMAS": 3,
-        "GET_TABLES": 4,
-        "GET_TABLE_TYPES": 5,
-        "GET_COLUMNS": 6,
-        "GET_FUNCTIONS": 7,
-        "UNKNOWN": 8,
-    }
+  _NAMES_TO_VALUES = {
+    "EXECUTE_STATEMENT": 0,
+    "GET_TYPE_INFO": 1,
+    "GET_CATALOGS": 2,
+    "GET_SCHEMAS": 3,
+    "GET_TABLES": 4,
+    "GET_TABLE_TYPES": 5,
+    "GET_COLUMNS": 6,
+    "GET_FUNCTIONS": 7,
+    "UNKNOWN": 8,
+  }
 
 
 class TGetInfoType(object):
-    CLI_MAX_DRIVER_CONNECTIONS = 0
-    CLI_MAX_CONCURRENT_ACTIVITIES = 1
-    CLI_DATA_SOURCE_NAME = 2
-    CLI_FETCH_DIRECTION = 8
-    CLI_SERVER_NAME = 13
-    CLI_SEARCH_PATTERN_ESCAPE = 14
-    CLI_DBMS_NAME = 17
-    CLI_DBMS_VER = 18
-    CLI_ACCESSIBLE_TABLES = 19
-    CLI_ACCESSIBLE_PROCEDURES = 20
-    CLI_CURSOR_COMMIT_BEHAVIOR = 23
-    CLI_DATA_SOURCE_READ_ONLY = 25
-    CLI_DEFAULT_TXN_ISOLATION = 26
-    CLI_IDENTIFIER_CASE = 28
-    CLI_IDENTIFIER_QUOTE_CHAR = 29
-    CLI_MAX_COLUMN_NAME_LEN = 30
-    CLI_MAX_CURSOR_NAME_LEN = 31
-    CLI_MAX_SCHEMA_NAME_LEN = 32
-    CLI_MAX_CATALOG_NAME_LEN = 34
-    CLI_MAX_TABLE_NAME_LEN = 35
-    CLI_SCROLL_CONCURRENCY = 43
-    CLI_TXN_CAPABLE = 46
-    CLI_USER_NAME = 47
-    CLI_TXN_ISOLATION_OPTION = 72
-    CLI_INTEGRITY = 73
-    CLI_GETDATA_EXTENSIONS = 81
-    CLI_NULL_COLLATION = 85
-    CLI_ALTER_TABLE = 86
-    CLI_ORDER_BY_COLUMNS_IN_SELECT = 90
-    CLI_SPECIAL_CHARACTERS = 94
-    CLI_MAX_COLUMNS_IN_GROUP_BY = 97
-    CLI_MAX_COLUMNS_IN_INDEX = 98
-    CLI_MAX_COLUMNS_IN_ORDER_BY = 99
-    CLI_MAX_COLUMNS_IN_SELECT = 100
-    CLI_MAX_COLUMNS_IN_TABLE = 101
-    CLI_MAX_INDEX_SIZE = 102
-    CLI_MAX_ROW_SIZE = 104
-    CLI_MAX_STATEMENT_LEN = 105
-    CLI_MAX_TABLES_IN_SELECT = 106
-    CLI_MAX_USER_NAME_LEN = 107
-    CLI_OJ_CAPABILITIES = 115
-    CLI_XOPEN_CLI_YEAR = 10000
-    CLI_CURSOR_SENSITIVITY = 10001
-    CLI_DESCRIBE_PARAMETER = 10002
-    CLI_CATALOG_NAME = 10003
-    CLI_COLLATION_SEQ = 10004
-    CLI_MAX_IDENTIFIER_LEN = 10005
-    CLI_ODBC_KEYWORDS = 10006
+  CLI_MAX_DRIVER_CONNECTIONS = 0
+  CLI_MAX_CONCURRENT_ACTIVITIES = 1
+  CLI_DATA_SOURCE_NAME = 2
+  CLI_FETCH_DIRECTION = 8
+  CLI_SERVER_NAME = 13
+  CLI_SEARCH_PATTERN_ESCAPE = 14
+  CLI_DBMS_NAME = 17
+  CLI_DBMS_VER = 18
+  CLI_ACCESSIBLE_TABLES = 19
+  CLI_ACCESSIBLE_PROCEDURES = 20
+  CLI_CURSOR_COMMIT_BEHAVIOR = 23
+  CLI_DATA_SOURCE_READ_ONLY = 25
+  CLI_DEFAULT_TXN_ISOLATION = 26
+  CLI_IDENTIFIER_CASE = 28
+  CLI_IDENTIFIER_QUOTE_CHAR = 29
+  CLI_MAX_COLUMN_NAME_LEN = 30
+  CLI_MAX_CURSOR_NAME_LEN = 31
+  CLI_MAX_SCHEMA_NAME_LEN = 32
+  CLI_MAX_CATALOG_NAME_LEN = 34
+  CLI_MAX_TABLE_NAME_LEN = 35
+  CLI_SCROLL_CONCURRENCY = 43
+  CLI_TXN_CAPABLE = 46
+  CLI_USER_NAME = 47
+  CLI_TXN_ISOLATION_OPTION = 72
+  CLI_INTEGRITY = 73
+  CLI_GETDATA_EXTENSIONS = 81
+  CLI_NULL_COLLATION = 85
+  CLI_ALTER_TABLE = 86
+  CLI_ORDER_BY_COLUMNS_IN_SELECT = 90
+  CLI_SPECIAL_CHARACTERS = 94
+  CLI_MAX_COLUMNS_IN_GROUP_BY = 97
+  CLI_MAX_COLUMNS_IN_INDEX = 98
+  CLI_MAX_COLUMNS_IN_ORDER_BY = 99
+  CLI_MAX_COLUMNS_IN_SELECT = 100
+  CLI_MAX_COLUMNS_IN_TABLE = 101
+  CLI_MAX_INDEX_SIZE = 102
+  CLI_MAX_ROW_SIZE = 104
+  CLI_MAX_STATEMENT_LEN = 105
+  CLI_MAX_TABLES_IN_SELECT = 106
+  CLI_MAX_USER_NAME_LEN = 107
+  CLI_OJ_CAPABILITIES = 115
+  CLI_XOPEN_CLI_YEAR = 10000
+  CLI_CURSOR_SENSITIVITY = 10001
+  CLI_DESCRIBE_PARAMETER = 10002
+  CLI_CATALOG_NAME = 10003
+  CLI_COLLATION_SEQ = 10004
+  CLI_MAX_IDENTIFIER_LEN = 10005
+  CLI_ODBC_KEYWORDS = 10006
 
-    _VALUES_TO_NAMES = {
-        0: "CLI_MAX_DRIVER_CONNECTIONS",
-        1: "CLI_MAX_CONCURRENT_ACTIVITIES",
-        2: "CLI_DATA_SOURCE_NAME",
-        8: "CLI_FETCH_DIRECTION",
-        13: "CLI_SERVER_NAME",
-        14: "CLI_SEARCH_PATTERN_ESCAPE",
-        17: "CLI_DBMS_NAME",
-        18: "CLI_DBMS_VER",
-        19: "CLI_ACCESSIBLE_TABLES",
-        20: "CLI_ACCESSIBLE_PROCEDURES",
-        23: "CLI_CURSOR_COMMIT_BEHAVIOR",
-        25: "CLI_DATA_SOURCE_READ_ONLY",
-        26: "CLI_DEFAULT_TXN_ISOLATION",
-        28: "CLI_IDENTIFIER_CASE",
-        29: "CLI_IDENTIFIER_QUOTE_CHAR",
-        30: "CLI_MAX_COLUMN_NAME_LEN",
-        31: "CLI_MAX_CURSOR_NAME_LEN",
-        32: "CLI_MAX_SCHEMA_NAME_LEN",
-        34: "CLI_MAX_CATALOG_NAME_LEN",
-        35: "CLI_MAX_TABLE_NAME_LEN",
-        43: "CLI_SCROLL_CONCURRENCY",
-        46: "CLI_TXN_CAPABLE",
-        47: "CLI_USER_NAME",
-        72: "CLI_TXN_ISOLATION_OPTION",
-        73: "CLI_INTEGRITY",
-        81: "CLI_GETDATA_EXTENSIONS",
-        85: "CLI_NULL_COLLATION",
-        86: "CLI_ALTER_TABLE",
-        90: "CLI_ORDER_BY_COLUMNS_IN_SELECT",
-        94: "CLI_SPECIAL_CHARACTERS",
-        97: "CLI_MAX_COLUMNS_IN_GROUP_BY",
-        98: "CLI_MAX_COLUMNS_IN_INDEX",
-        99: "CLI_MAX_COLUMNS_IN_ORDER_BY",
-        100: "CLI_MAX_COLUMNS_IN_SELECT",
-        101: "CLI_MAX_COLUMNS_IN_TABLE",
-        102: "CLI_MAX_INDEX_SIZE",
-        104: "CLI_MAX_ROW_SIZE",
-        105: "CLI_MAX_STATEMENT_LEN",
-        106: "CLI_MAX_TABLES_IN_SELECT",
-        107: "CLI_MAX_USER_NAME_LEN",
-        115: "CLI_OJ_CAPABILITIES",
-        10000: "CLI_XOPEN_CLI_YEAR",
-        10001: "CLI_CURSOR_SENSITIVITY",
-        10002: "CLI_DESCRIBE_PARAMETER",
-        10003: "CLI_CATALOG_NAME",
-        10004: "CLI_COLLATION_SEQ",
-        10005: "CLI_MAX_IDENTIFIER_LEN",
-        10006: "CLI_ODBC_KEYWORDS",
-    }
+  _VALUES_TO_NAMES = {
+    0: "CLI_MAX_DRIVER_CONNECTIONS",
+    1: "CLI_MAX_CONCURRENT_ACTIVITIES",
+    2: "CLI_DATA_SOURCE_NAME",
+    8: "CLI_FETCH_DIRECTION",
+    13: "CLI_SERVER_NAME",
+    14: "CLI_SEARCH_PATTERN_ESCAPE",
+    17: "CLI_DBMS_NAME",
+    18: "CLI_DBMS_VER",
+    19: "CLI_ACCESSIBLE_TABLES",
+    20: "CLI_ACCESSIBLE_PROCEDURES",
+    23: "CLI_CURSOR_COMMIT_BEHAVIOR",
+    25: "CLI_DATA_SOURCE_READ_ONLY",
+    26: "CLI_DEFAULT_TXN_ISOLATION",
+    28: "CLI_IDENTIFIER_CASE",
+    29: "CLI_IDENTIFIER_QUOTE_CHAR",
+    30: "CLI_MAX_COLUMN_NAME_LEN",
+    31: "CLI_MAX_CURSOR_NAME_LEN",
+    32: "CLI_MAX_SCHEMA_NAME_LEN",
+    34: "CLI_MAX_CATALOG_NAME_LEN",
+    35: "CLI_MAX_TABLE_NAME_LEN",
+    43: "CLI_SCROLL_CONCURRENCY",
+    46: "CLI_TXN_CAPABLE",
+    47: "CLI_USER_NAME",
+    72: "CLI_TXN_ISOLATION_OPTION",
+    73: "CLI_INTEGRITY",
+    81: "CLI_GETDATA_EXTENSIONS",
+    85: "CLI_NULL_COLLATION",
+    86: "CLI_ALTER_TABLE",
+    90: "CLI_ORDER_BY_COLUMNS_IN_SELECT",
+    94: "CLI_SPECIAL_CHARACTERS",
+    97: "CLI_MAX_COLUMNS_IN_GROUP_BY",
+    98: "CLI_MAX_COLUMNS_IN_INDEX",
+    99: "CLI_MAX_COLUMNS_IN_ORDER_BY",
+    100: "CLI_MAX_COLUMNS_IN_SELECT",
+    101: "CLI_MAX_COLUMNS_IN_TABLE",
+    102: "CLI_MAX_INDEX_SIZE",
+    104: "CLI_MAX_ROW_SIZE",
+    105: "CLI_MAX_STATEMENT_LEN",
+    106: "CLI_MAX_TABLES_IN_SELECT",
+    107: "CLI_MAX_USER_NAME_LEN",
+    115: "CLI_OJ_CAPABILITIES",
+    10000: "CLI_XOPEN_CLI_YEAR",
+    10001: "CLI_CURSOR_SENSITIVITY",
+    10002: "CLI_DESCRIBE_PARAMETER",
+    10003: "CLI_CATALOG_NAME",
+    10004: "CLI_COLLATION_SEQ",
+    10005: "CLI_MAX_IDENTIFIER_LEN",
+    10006: "CLI_ODBC_KEYWORDS",
+  }
 
-    _NAMES_TO_VALUES = {
-        "CLI_MAX_DRIVER_CONNECTIONS": 0,
-        "CLI_MAX_CONCURRENT_ACTIVITIES": 1,
-        "CLI_DATA_SOURCE_NAME": 2,
-        "CLI_FETCH_DIRECTION": 8,
-        "CLI_SERVER_NAME": 13,
-        "CLI_SEARCH_PATTERN_ESCAPE": 14,
-        "CLI_DBMS_NAME": 17,
-        "CLI_DBMS_VER": 18,
-        "CLI_ACCESSIBLE_TABLES": 19,
-        "CLI_ACCESSIBLE_PROCEDURES": 20,
-        "CLI_CURSOR_COMMIT_BEHAVIOR": 23,
-        "CLI_DATA_SOURCE_READ_ONLY": 25,
-        "CLI_DEFAULT_TXN_ISOLATION": 26,
-        "CLI_IDENTIFIER_CASE": 28,
-        "CLI_IDENTIFIER_QUOTE_CHAR": 29,
-        "CLI_MAX_COLUMN_NAME_LEN": 30,
-        "CLI_MAX_CURSOR_NAME_LEN": 31,
-        "CLI_MAX_SCHEMA_NAME_LEN": 32,
-        "CLI_MAX_CATALOG_NAME_LEN": 34,
-        "CLI_MAX_TABLE_NAME_LEN": 35,
-        "CLI_SCROLL_CONCURRENCY": 43,
-        "CLI_TXN_CAPABLE": 46,
-        "CLI_USER_NAME": 47,
-        "CLI_TXN_ISOLATION_OPTION": 72,
-        "CLI_INTEGRITY": 73,
-        "CLI_GETDATA_EXTENSIONS": 81,
-        "CLI_NULL_COLLATION": 85,
-        "CLI_ALTER_TABLE": 86,
-        "CLI_ORDER_BY_COLUMNS_IN_SELECT": 90,
-        "CLI_SPECIAL_CHARACTERS": 94,
-        "CLI_MAX_COLUMNS_IN_GROUP_BY": 97,
-        "CLI_MAX_COLUMNS_IN_INDEX": 98,
-        "CLI_MAX_COLUMNS_IN_ORDER_BY": 99,
-        "CLI_MAX_COLUMNS_IN_SELECT": 100,
-        "CLI_MAX_COLUMNS_IN_TABLE": 101,
-        "CLI_MAX_INDEX_SIZE": 102,
-        "CLI_MAX_ROW_SIZE": 104,
-        "CLI_MAX_STATEMENT_LEN": 105,
-        "CLI_MAX_TABLES_IN_SELECT": 106,
-        "CLI_MAX_USER_NAME_LEN": 107,
-        "CLI_OJ_CAPABILITIES": 115,
-        "CLI_XOPEN_CLI_YEAR": 10000,
-        "CLI_CURSOR_SENSITIVITY": 10001,
-        "CLI_DESCRIBE_PARAMETER": 10002,
-        "CLI_CATALOG_NAME": 10003,
-        "CLI_COLLATION_SEQ": 10004,
-        "CLI_MAX_IDENTIFIER_LEN": 10005,
-        "CLI_ODBC_KEYWORDS": 10006,
-    }
+  _NAMES_TO_VALUES = {
+    "CLI_MAX_DRIVER_CONNECTIONS": 0,
+    "CLI_MAX_CONCURRENT_ACTIVITIES": 1,
+    "CLI_DATA_SOURCE_NAME": 2,
+    "CLI_FETCH_DIRECTION": 8,
+    "CLI_SERVER_NAME": 13,
+    "CLI_SEARCH_PATTERN_ESCAPE": 14,
+    "CLI_DBMS_NAME": 17,
+    "CLI_DBMS_VER": 18,
+    "CLI_ACCESSIBLE_TABLES": 19,
+    "CLI_ACCESSIBLE_PROCEDURES": 20,
+    "CLI_CURSOR_COMMIT_BEHAVIOR": 23,
+    "CLI_DATA_SOURCE_READ_ONLY": 25,
+    "CLI_DEFAULT_TXN_ISOLATION": 26,
+    "CLI_IDENTIFIER_CASE": 28,
+    "CLI_IDENTIFIER_QUOTE_CHAR": 29,
+    "CLI_MAX_COLUMN_NAME_LEN": 30,
+    "CLI_MAX_CURSOR_NAME_LEN": 31,
+    "CLI_MAX_SCHEMA_NAME_LEN": 32,
+    "CLI_MAX_CATALOG_NAME_LEN": 34,
+    "CLI_MAX_TABLE_NAME_LEN": 35,
+    "CLI_SCROLL_CONCURRENCY": 43,
+    "CLI_TXN_CAPABLE": 46,
+    "CLI_USER_NAME": 47,
+    "CLI_TXN_ISOLATION_OPTION": 72,
+    "CLI_INTEGRITY": 73,
+    "CLI_GETDATA_EXTENSIONS": 81,
+    "CLI_NULL_COLLATION": 85,
+    "CLI_ALTER_TABLE": 86,
+    "CLI_ORDER_BY_COLUMNS_IN_SELECT": 90,
+    "CLI_SPECIAL_CHARACTERS": 94,
+    "CLI_MAX_COLUMNS_IN_GROUP_BY": 97,
+    "CLI_MAX_COLUMNS_IN_INDEX": 98,
+    "CLI_MAX_COLUMNS_IN_ORDER_BY": 99,
+    "CLI_MAX_COLUMNS_IN_SELECT": 100,
+    "CLI_MAX_COLUMNS_IN_TABLE": 101,
+    "CLI_MAX_INDEX_SIZE": 102,
+    "CLI_MAX_ROW_SIZE": 104,
+    "CLI_MAX_STATEMENT_LEN": 105,
+    "CLI_MAX_TABLES_IN_SELECT": 106,
+    "CLI_MAX_USER_NAME_LEN": 107,
+    "CLI_OJ_CAPABILITIES": 115,
+    "CLI_XOPEN_CLI_YEAR": 10000,
+    "CLI_CURSOR_SENSITIVITY": 10001,
+    "CLI_DESCRIBE_PARAMETER": 10002,
+    "CLI_CATALOG_NAME": 10003,
+    "CLI_COLLATION_SEQ": 10004,
+    "CLI_MAX_IDENTIFIER_LEN": 10005,
+    "CLI_ODBC_KEYWORDS": 10006,
+  }
 
 
 class TFetchOrientation(object):
-    FETCH_NEXT = 0
-    FETCH_PRIOR = 1
-    FETCH_RELATIVE = 2
-    FETCH_ABSOLUTE = 3
-    FETCH_FIRST = 4
-    FETCH_LAST = 5
+  FETCH_NEXT = 0
+  FETCH_PRIOR = 1
+  FETCH_RELATIVE = 2
+  FETCH_ABSOLUTE = 3
+  FETCH_FIRST = 4
+  FETCH_LAST = 5
 
-    _VALUES_TO_NAMES = {
-        0: "FETCH_NEXT",
-        1: "FETCH_PRIOR",
-        2: "FETCH_RELATIVE",
-        3: "FETCH_ABSOLUTE",
-        4: "FETCH_FIRST",
-        5: "FETCH_LAST",
-    }
+  _VALUES_TO_NAMES = {
+    0: "FETCH_NEXT",
+    1: "FETCH_PRIOR",
+    2: "FETCH_RELATIVE",
+    3: "FETCH_ABSOLUTE",
+    4: "FETCH_FIRST",
+    5: "FETCH_LAST",
+  }
 
-    _NAMES_TO_VALUES = {
-        "FETCH_NEXT": 0,
-        "FETCH_PRIOR": 1,
-        "FETCH_RELATIVE": 2,
-        "FETCH_ABSOLUTE": 3,
-        "FETCH_FIRST": 4,
-        "FETCH_LAST": 5,
-    }
+  _NAMES_TO_VALUES = {
+    "FETCH_NEXT": 0,
+    "FETCH_PRIOR": 1,
+    "FETCH_RELATIVE": 2,
+    "FETCH_ABSOLUTE": 3,
+    "FETCH_FIRST": 4,
+    "FETCH_LAST": 5,
+  }
 
 
 class TJobExecutionStatus(object):
-    IN_PROGRESS = 0
-    COMPLETE = 1
-    NOT_AVAILABLE = 2
+  IN_PROGRESS = 0
+  COMPLETE = 1
+  NOT_AVAILABLE = 2
 
-    _VALUES_TO_NAMES = {
-        0: "IN_PROGRESS",
-        1: "COMPLETE",
-        2: "NOT_AVAILABLE",
-    }
+  _VALUES_TO_NAMES = {
+    0: "IN_PROGRESS",
+    1: "COMPLETE",
+    2: "NOT_AVAILABLE",
+  }
 
-    _NAMES_TO_VALUES = {
-        "IN_PROGRESS": 0,
-        "COMPLETE": 1,
-        "NOT_AVAILABLE": 2,
-    }
+  _NAMES_TO_VALUES = {
+    "IN_PROGRESS": 0,
+    "COMPLETE": 1,
+    "NOT_AVAILABLE": 2,
+  }
 
 
 class TTypeQualifierValue(object):
-    """
+  """
     Attributes:
      - i32Value
      - stringValue
 
     """
 
+  def __init__(self, i32Value=None, stringValue=None, ):
+    self.i32Value = i32Value
+    self.stringValue = stringValue
 
-    def __init__(self, i32Value=None, stringValue=None,):
-        self.i32Value = i32Value
-        self.stringValue = stringValue
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.I32:
+          self.i32Value = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.stringValue = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.I32:
-                    self.i32Value = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.stringValue = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TTypeQualifierValue')
+    if self.i32Value is not None:
+      oprot.writeFieldBegin('i32Value', TType.I32, 1)
+      oprot.writeI32(self.i32Value)
+      oprot.writeFieldEnd()
+    if self.stringValue is not None:
+      oprot.writeFieldBegin('stringValue', TType.STRING, 2)
+      oprot.writeString(self.stringValue)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TTypeQualifierValue')
-        if self.i32Value is not None:
-            oprot.writeFieldBegin('i32Value', TType.I32, 1)
-            oprot.writeI32(self.i32Value)
-            oprot.writeFieldEnd()
-        if self.stringValue is not None:
-            oprot.writeFieldBegin('stringValue', TType.STRING, 2)
-            oprot.writeString(self.stringValue.encode('utf-8') if sys.version_info[0] == 2 else self.stringValue)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    return
 
-    def validate(self):
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TTypeQualifiers(object):
-    """
+  """
     Attributes:
      - qualifiers
 
     """
 
+  def __init__(self, qualifiers=None, ):
+    self.qualifiers = qualifiers
 
-    def __init__(self, qualifiers=None,):
-        self.qualifiers = qualifiers
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.MAP:
+          self.qualifiers = {}
+          (_ktype1, _vtype2, _size0) = iprot.readMapBegin()
+          for _i4 in range(_size0):
+            _key5 = iprot.readString()
+            _val6 = TTypeQualifierValue()
+            _val6.read(iprot)
+            self.qualifiers[_key5] = _val6
+          iprot.readMapEnd()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.MAP:
-                    self.qualifiers = {}
-                    (_ktype1, _vtype2, _size0) = iprot.readMapBegin()
-                    for _i4 in range(_size0):
-                        _key5 = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                        _val6 = TTypeQualifierValue()
-                        _val6.read(iprot)
-                        self.qualifiers[_key5] = _val6
-                    iprot.readMapEnd()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TTypeQualifiers')
+    if self.qualifiers is not None:
+      oprot.writeFieldBegin('qualifiers', TType.MAP, 1)
+      oprot.writeMapBegin(TType.STRING, TType.STRUCT, len(self.qualifiers))
+      for kiter7, viter8 in self.qualifiers.items():
+        oprot.writeString(kiter7)
+        viter8.write(oprot)
+      oprot.writeMapEnd()
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TTypeQualifiers')
-        if self.qualifiers is not None:
-            oprot.writeFieldBegin('qualifiers', TType.MAP, 1)
-            oprot.writeMapBegin(TType.STRING, TType.STRUCT, len(self.qualifiers))
-            for kiter7, viter8 in self.qualifiers.items():
-                oprot.writeString(kiter7.encode('utf-8') if sys.version_info[0] == 2 else kiter7)
-                viter8.write(oprot)
-            oprot.writeMapEnd()
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.qualifiers is None:
+      raise TProtocolException(message='Required field qualifiers is unset!')
+    return
 
-    def validate(self):
-        if self.qualifiers is None:
-            raise TProtocolException(message='Required field qualifiers is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TPrimitiveTypeEntry(object):
-    """
+  """
     Attributes:
      - type
      - typeQualifiers
 
     """
 
+  def __init__(self, type=None, typeQualifiers=None, ):
+    self.type = type
+    self.typeQualifiers = typeQualifiers
 
-    def __init__(self, type=None, typeQualifiers=None,):
-        self.type = type
-        self.typeQualifiers = typeQualifiers
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.I32:
+          self.type = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.typeQualifiers = TTypeQualifiers()
+          self.typeQualifiers.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.I32:
-                    self.type = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRUCT:
-                    self.typeQualifiers = TTypeQualifiers()
-                    self.typeQualifiers.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TPrimitiveTypeEntry')
+    if self.type is not None:
+      oprot.writeFieldBegin('type', TType.I32, 1)
+      oprot.writeI32(self.type)
+      oprot.writeFieldEnd()
+    if self.typeQualifiers is not None:
+      oprot.writeFieldBegin('typeQualifiers', TType.STRUCT, 2)
+      self.typeQualifiers.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TPrimitiveTypeEntry')
-        if self.type is not None:
-            oprot.writeFieldBegin('type', TType.I32, 1)
-            oprot.writeI32(self.type)
-            oprot.writeFieldEnd()
-        if self.typeQualifiers is not None:
-            oprot.writeFieldBegin('typeQualifiers', TType.STRUCT, 2)
-            self.typeQualifiers.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.type is None:
+      raise TProtocolException(message='Required field type is unset!')
+    return
 
-    def validate(self):
-        if self.type is None:
-            raise TProtocolException(message='Required field type is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TArrayTypeEntry(object):
-    """
+  """
     Attributes:
      - objectTypePtr
 
     """
 
+  def __init__(self, objectTypePtr=None, ):
+    self.objectTypePtr = objectTypePtr
 
-    def __init__(self, objectTypePtr=None,):
-        self.objectTypePtr = objectTypePtr
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.I32:
+          self.objectTypePtr = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.I32:
-                    self.objectTypePtr = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TArrayTypeEntry')
+    if self.objectTypePtr is not None:
+      oprot.writeFieldBegin('objectTypePtr', TType.I32, 1)
+      oprot.writeI32(self.objectTypePtr)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TArrayTypeEntry')
-        if self.objectTypePtr is not None:
-            oprot.writeFieldBegin('objectTypePtr', TType.I32, 1)
-            oprot.writeI32(self.objectTypePtr)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.objectTypePtr is None:
+      raise TProtocolException(message='Required field objectTypePtr is unset!')
+    return
 
-    def validate(self):
-        if self.objectTypePtr is None:
-            raise TProtocolException(message='Required field objectTypePtr is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TMapTypeEntry(object):
-    """
+  """
     Attributes:
      - keyTypePtr
      - valueTypePtr
 
     """
 
+  def __init__(self, keyTypePtr=None, valueTypePtr=None, ):
+    self.keyTypePtr = keyTypePtr
+    self.valueTypePtr = valueTypePtr
 
-    def __init__(self, keyTypePtr=None, valueTypePtr=None,):
-        self.keyTypePtr = keyTypePtr
-        self.valueTypePtr = valueTypePtr
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.I32:
+          self.keyTypePtr = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.I32:
+          self.valueTypePtr = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.I32:
-                    self.keyTypePtr = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.I32:
-                    self.valueTypePtr = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TMapTypeEntry')
+    if self.keyTypePtr is not None:
+      oprot.writeFieldBegin('keyTypePtr', TType.I32, 1)
+      oprot.writeI32(self.keyTypePtr)
+      oprot.writeFieldEnd()
+    if self.valueTypePtr is not None:
+      oprot.writeFieldBegin('valueTypePtr', TType.I32, 2)
+      oprot.writeI32(self.valueTypePtr)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TMapTypeEntry')
-        if self.keyTypePtr is not None:
-            oprot.writeFieldBegin('keyTypePtr', TType.I32, 1)
-            oprot.writeI32(self.keyTypePtr)
-            oprot.writeFieldEnd()
-        if self.valueTypePtr is not None:
-            oprot.writeFieldBegin('valueTypePtr', TType.I32, 2)
-            oprot.writeI32(self.valueTypePtr)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.keyTypePtr is None:
+      raise TProtocolException(message='Required field keyTypePtr is unset!')
+    if self.valueTypePtr is None:
+      raise TProtocolException(message='Required field valueTypePtr is unset!')
+    return
 
-    def validate(self):
-        if self.keyTypePtr is None:
-            raise TProtocolException(message='Required field keyTypePtr is unset!')
-        if self.valueTypePtr is None:
-            raise TProtocolException(message='Required field valueTypePtr is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TStructTypeEntry(object):
-    """
+  """
     Attributes:
      - nameToTypePtr
 
     """
 
+  def __init__(self, nameToTypePtr=None, ):
+    self.nameToTypePtr = nameToTypePtr
 
-    def __init__(self, nameToTypePtr=None,):
-        self.nameToTypePtr = nameToTypePtr
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.MAP:
+          self.nameToTypePtr = {}
+          (_ktype10, _vtype11, _size9) = iprot.readMapBegin()
+          for _i13 in range(_size9):
+            _key14 = iprot.readString()
+            _val15 = iprot.readI32()
+            self.nameToTypePtr[_key14] = _val15
+          iprot.readMapEnd()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.MAP:
-                    self.nameToTypePtr = {}
-                    (_ktype10, _vtype11, _size9) = iprot.readMapBegin()
-                    for _i13 in range(_size9):
-                        _key14 = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                        _val15 = iprot.readI32()
-                        self.nameToTypePtr[_key14] = _val15
-                    iprot.readMapEnd()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TStructTypeEntry')
+    if self.nameToTypePtr is not None:
+      oprot.writeFieldBegin('nameToTypePtr', TType.MAP, 1)
+      oprot.writeMapBegin(TType.STRING, TType.I32, len(self.nameToTypePtr))
+      for kiter16, viter17 in self.nameToTypePtr.items():
+        oprot.writeString(kiter16)
+        oprot.writeI32(viter17)
+      oprot.writeMapEnd()
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TStructTypeEntry')
-        if self.nameToTypePtr is not None:
-            oprot.writeFieldBegin('nameToTypePtr', TType.MAP, 1)
-            oprot.writeMapBegin(TType.STRING, TType.I32, len(self.nameToTypePtr))
-            for kiter16, viter17 in self.nameToTypePtr.items():
-                oprot.writeString(kiter16.encode('utf-8') if sys.version_info[0] == 2 else kiter16)
-                oprot.writeI32(viter17)
-            oprot.writeMapEnd()
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.nameToTypePtr is None:
+      raise TProtocolException(message='Required field nameToTypePtr is unset!')
+    return
 
-    def validate(self):
-        if self.nameToTypePtr is None:
-            raise TProtocolException(message='Required field nameToTypePtr is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TUnionTypeEntry(object):
-    """
+  """
     Attributes:
      - nameToTypePtr
 
     """
 
+  def __init__(self, nameToTypePtr=None, ):
+    self.nameToTypePtr = nameToTypePtr
 
-    def __init__(self, nameToTypePtr=None,):
-        self.nameToTypePtr = nameToTypePtr
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.MAP:
+          self.nameToTypePtr = {}
+          (_ktype19, _vtype20, _size18) = iprot.readMapBegin()
+          for _i22 in range(_size18):
+            _key23 = iprot.readString()
+            _val24 = iprot.readI32()
+            self.nameToTypePtr[_key23] = _val24
+          iprot.readMapEnd()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.MAP:
-                    self.nameToTypePtr = {}
-                    (_ktype19, _vtype20, _size18) = iprot.readMapBegin()
-                    for _i22 in range(_size18):
-                        _key23 = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                        _val24 = iprot.readI32()
-                        self.nameToTypePtr[_key23] = _val24
-                    iprot.readMapEnd()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TUnionTypeEntry')
+    if self.nameToTypePtr is not None:
+      oprot.writeFieldBegin('nameToTypePtr', TType.MAP, 1)
+      oprot.writeMapBegin(TType.STRING, TType.I32, len(self.nameToTypePtr))
+      for kiter25, viter26 in self.nameToTypePtr.items():
+        oprot.writeString(kiter25)
+        oprot.writeI32(viter26)
+      oprot.writeMapEnd()
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TUnionTypeEntry')
-        if self.nameToTypePtr is not None:
-            oprot.writeFieldBegin('nameToTypePtr', TType.MAP, 1)
-            oprot.writeMapBegin(TType.STRING, TType.I32, len(self.nameToTypePtr))
-            for kiter25, viter26 in self.nameToTypePtr.items():
-                oprot.writeString(kiter25.encode('utf-8') if sys.version_info[0] == 2 else kiter25)
-                oprot.writeI32(viter26)
-            oprot.writeMapEnd()
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.nameToTypePtr is None:
+      raise TProtocolException(message='Required field nameToTypePtr is unset!')
+    return
 
-    def validate(self):
-        if self.nameToTypePtr is None:
-            raise TProtocolException(message='Required field nameToTypePtr is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TUserDefinedTypeEntry(object):
-    """
+  """
     Attributes:
      - typeClassName
 
     """
 
+  def __init__(self, typeClassName=None, ):
+    self.typeClassName = typeClassName
 
-    def __init__(self, typeClassName=None,):
-        self.typeClassName = typeClassName
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRING:
+          self.typeClassName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRING:
-                    self.typeClassName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TUserDefinedTypeEntry')
+    if self.typeClassName is not None:
+      oprot.writeFieldBegin('typeClassName', TType.STRING, 1)
+      oprot.writeString(self.typeClassName)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TUserDefinedTypeEntry')
-        if self.typeClassName is not None:
-            oprot.writeFieldBegin('typeClassName', TType.STRING, 1)
-            oprot.writeString(self.typeClassName.encode('utf-8') if sys.version_info[0] == 2 else self.typeClassName)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.typeClassName is None:
+      raise TProtocolException(message='Required field typeClassName is unset!')
+    return
 
-    def validate(self):
-        if self.typeClassName is None:
-            raise TProtocolException(message='Required field typeClassName is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TTypeEntry(object):
-    """
+  """
     Attributes:
      - primitiveEntry
      - arrayEntry
@@ -979,182 +971,180 @@ class TTypeEntry(object):
 
     """
 
+  def __init__(self, primitiveEntry=None, arrayEntry=None, mapEntry=None, structEntry=None, unionEntry=None, userDefinedTypeEntry=None, ):
+    self.primitiveEntry = primitiveEntry
+    self.arrayEntry = arrayEntry
+    self.mapEntry = mapEntry
+    self.structEntry = structEntry
+    self.unionEntry = unionEntry
+    self.userDefinedTypeEntry = userDefinedTypeEntry
 
-    def __init__(self, primitiveEntry=None, arrayEntry=None, mapEntry=None, structEntry=None, unionEntry=None, userDefinedTypeEntry=None,):
-        self.primitiveEntry = primitiveEntry
-        self.arrayEntry = arrayEntry
-        self.mapEntry = mapEntry
-        self.structEntry = structEntry
-        self.unionEntry = unionEntry
-        self.userDefinedTypeEntry = userDefinedTypeEntry
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.primitiveEntry = TPrimitiveTypeEntry()
+          self.primitiveEntry.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.arrayEntry = TArrayTypeEntry()
+          self.arrayEntry.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRUCT:
+          self.mapEntry = TMapTypeEntry()
+          self.mapEntry.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.STRUCT:
+          self.structEntry = TStructTypeEntry()
+          self.structEntry.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 5:
+        if ftype == TType.STRUCT:
+          self.unionEntry = TUnionTypeEntry()
+          self.unionEntry.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 6:
+        if ftype == TType.STRUCT:
+          self.userDefinedTypeEntry = TUserDefinedTypeEntry()
+          self.userDefinedTypeEntry.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.primitiveEntry = TPrimitiveTypeEntry()
-                    self.primitiveEntry.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRUCT:
-                    self.arrayEntry = TArrayTypeEntry()
-                    self.arrayEntry.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.STRUCT:
-                    self.mapEntry = TMapTypeEntry()
-                    self.mapEntry.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.STRUCT:
-                    self.structEntry = TStructTypeEntry()
-                    self.structEntry.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 5:
-                if ftype == TType.STRUCT:
-                    self.unionEntry = TUnionTypeEntry()
-                    self.unionEntry.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 6:
-                if ftype == TType.STRUCT:
-                    self.userDefinedTypeEntry = TUserDefinedTypeEntry()
-                    self.userDefinedTypeEntry.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TTypeEntry')
+    if self.primitiveEntry is not None:
+      oprot.writeFieldBegin('primitiveEntry', TType.STRUCT, 1)
+      self.primitiveEntry.write(oprot)
+      oprot.writeFieldEnd()
+    if self.arrayEntry is not None:
+      oprot.writeFieldBegin('arrayEntry', TType.STRUCT, 2)
+      self.arrayEntry.write(oprot)
+      oprot.writeFieldEnd()
+    if self.mapEntry is not None:
+      oprot.writeFieldBegin('mapEntry', TType.STRUCT, 3)
+      self.mapEntry.write(oprot)
+      oprot.writeFieldEnd()
+    if self.structEntry is not None:
+      oprot.writeFieldBegin('structEntry', TType.STRUCT, 4)
+      self.structEntry.write(oprot)
+      oprot.writeFieldEnd()
+    if self.unionEntry is not None:
+      oprot.writeFieldBegin('unionEntry', TType.STRUCT, 5)
+      self.unionEntry.write(oprot)
+      oprot.writeFieldEnd()
+    if self.userDefinedTypeEntry is not None:
+      oprot.writeFieldBegin('userDefinedTypeEntry', TType.STRUCT, 6)
+      self.userDefinedTypeEntry.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TTypeEntry')
-        if self.primitiveEntry is not None:
-            oprot.writeFieldBegin('primitiveEntry', TType.STRUCT, 1)
-            self.primitiveEntry.write(oprot)
-            oprot.writeFieldEnd()
-        if self.arrayEntry is not None:
-            oprot.writeFieldBegin('arrayEntry', TType.STRUCT, 2)
-            self.arrayEntry.write(oprot)
-            oprot.writeFieldEnd()
-        if self.mapEntry is not None:
-            oprot.writeFieldBegin('mapEntry', TType.STRUCT, 3)
-            self.mapEntry.write(oprot)
-            oprot.writeFieldEnd()
-        if self.structEntry is not None:
-            oprot.writeFieldBegin('structEntry', TType.STRUCT, 4)
-            self.structEntry.write(oprot)
-            oprot.writeFieldEnd()
-        if self.unionEntry is not None:
-            oprot.writeFieldBegin('unionEntry', TType.STRUCT, 5)
-            self.unionEntry.write(oprot)
-            oprot.writeFieldEnd()
-        if self.userDefinedTypeEntry is not None:
-            oprot.writeFieldBegin('userDefinedTypeEntry', TType.STRUCT, 6)
-            self.userDefinedTypeEntry.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    return
 
-    def validate(self):
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TTypeDesc(object):
-    """
+  """
     Attributes:
      - types
 
     """
 
+  def __init__(self, types=None, ):
+    self.types = types
 
-    def __init__(self, types=None,):
-        self.types = types
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.LIST:
+          self.types = []
+          (_etype30, _size27) = iprot.readListBegin()
+          for _i31 in range(_size27):
+            _elem32 = TTypeEntry()
+            _elem32.read(iprot)
+            self.types.append(_elem32)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.LIST:
-                    self.types = []
-                    (_etype30, _size27) = iprot.readListBegin()
-                    for _i31 in range(_size27):
-                        _elem32 = TTypeEntry()
-                        _elem32.read(iprot)
-                        self.types.append(_elem32)
-                    iprot.readListEnd()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TTypeDesc')
+    if self.types is not None:
+      oprot.writeFieldBegin('types', TType.LIST, 1)
+      oprot.writeListBegin(TType.STRUCT, len(self.types))
+      for iter33 in self.types:
+        iter33.write(oprot)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TTypeDesc')
-        if self.types is not None:
-            oprot.writeFieldBegin('types', TType.LIST, 1)
-            oprot.writeListBegin(TType.STRUCT, len(self.types))
-            for iter33 in self.types:
-                iter33.write(oprot)
-            oprot.writeListEnd()
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.types is None:
+      raise TProtocolException(message='Required field types is unset!')
+    return
 
-    def validate(self):
-        if self.types is None:
-            raise TProtocolException(message='Required field types is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TColumnDesc(object):
-    """
+  """
     Attributes:
      - columnName
      - typeDesc
@@ -1163,562 +1153,553 @@ class TColumnDesc(object):
 
     """
 
+  def __init__(self, columnName=None, typeDesc=None, position=None, comment=None, ):
+    self.columnName = columnName
+    self.typeDesc = typeDesc
+    self.position = position
+    self.comment = comment
 
-    def __init__(self, columnName=None, typeDesc=None, position=None, comment=None,):
-        self.columnName = columnName
-        self.typeDesc = typeDesc
-        self.position = position
-        self.comment = comment
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRING:
+          self.columnName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.typeDesc = TTypeDesc()
+          self.typeDesc.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.I32:
+          self.position = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.STRING:
+          self.comment = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRING:
-                    self.columnName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRUCT:
-                    self.typeDesc = TTypeDesc()
-                    self.typeDesc.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.I32:
-                    self.position = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.STRING:
-                    self.comment = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TColumnDesc')
+    if self.columnName is not None:
+      oprot.writeFieldBegin('columnName', TType.STRING, 1)
+      oprot.writeString(self.columnName)
+      oprot.writeFieldEnd()
+    if self.typeDesc is not None:
+      oprot.writeFieldBegin('typeDesc', TType.STRUCT, 2)
+      self.typeDesc.write(oprot)
+      oprot.writeFieldEnd()
+    if self.position is not None:
+      oprot.writeFieldBegin('position', TType.I32, 3)
+      oprot.writeI32(self.position)
+      oprot.writeFieldEnd()
+    if self.comment is not None:
+      oprot.writeFieldBegin('comment', TType.STRING, 4)
+      oprot.writeString(self.comment)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TColumnDesc')
-        if self.columnName is not None:
-            oprot.writeFieldBegin('columnName', TType.STRING, 1)
-            oprot.writeString(self.columnName.encode('utf-8') if sys.version_info[0] == 2 else self.columnName)
-            oprot.writeFieldEnd()
-        if self.typeDesc is not None:
-            oprot.writeFieldBegin('typeDesc', TType.STRUCT, 2)
-            self.typeDesc.write(oprot)
-            oprot.writeFieldEnd()
-        if self.position is not None:
-            oprot.writeFieldBegin('position', TType.I32, 3)
-            oprot.writeI32(self.position)
-            oprot.writeFieldEnd()
-        if self.comment is not None:
-            oprot.writeFieldBegin('comment', TType.STRING, 4)
-            oprot.writeString(self.comment.encode('utf-8') if sys.version_info[0] == 2 else self.comment)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.columnName is None:
+      raise TProtocolException(message='Required field columnName is unset!')
+    if self.typeDesc is None:
+      raise TProtocolException(message='Required field typeDesc is unset!')
+    if self.position is None:
+      raise TProtocolException(message='Required field position is unset!')
+    return
 
-    def validate(self):
-        if self.columnName is None:
-            raise TProtocolException(message='Required field columnName is unset!')
-        if self.typeDesc is None:
-            raise TProtocolException(message='Required field typeDesc is unset!')
-        if self.position is None:
-            raise TProtocolException(message='Required field position is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TTableSchema(object):
-    """
+  """
     Attributes:
      - columns
 
     """
 
+  def __init__(self, columns=None, ):
+    self.columns = columns
 
-    def __init__(self, columns=None,):
-        self.columns = columns
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.LIST:
+          self.columns = []
+          (_etype37, _size34) = iprot.readListBegin()
+          for _i38 in range(_size34):
+            _elem39 = TColumnDesc()
+            _elem39.read(iprot)
+            self.columns.append(_elem39)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.LIST:
-                    self.columns = []
-                    (_etype37, _size34) = iprot.readListBegin()
-                    for _i38 in range(_size34):
-                        _elem39 = TColumnDesc()
-                        _elem39.read(iprot)
-                        self.columns.append(_elem39)
-                    iprot.readListEnd()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TTableSchema')
+    if self.columns is not None:
+      oprot.writeFieldBegin('columns', TType.LIST, 1)
+      oprot.writeListBegin(TType.STRUCT, len(self.columns))
+      for iter40 in self.columns:
+        iter40.write(oprot)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TTableSchema')
-        if self.columns is not None:
-            oprot.writeFieldBegin('columns', TType.LIST, 1)
-            oprot.writeListBegin(TType.STRUCT, len(self.columns))
-            for iter40 in self.columns:
-                iter40.write(oprot)
-            oprot.writeListEnd()
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.columns is None:
+      raise TProtocolException(message='Required field columns is unset!')
+    return
 
-    def validate(self):
-        if self.columns is None:
-            raise TProtocolException(message='Required field columns is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TBoolValue(object):
-    """
+  """
     Attributes:
      - value
 
     """
 
+  def __init__(self, value=None, ):
+    self.value = value
 
-    def __init__(self, value=None,):
-        self.value = value
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.BOOL:
+          self.value = iprot.readBool()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.BOOL:
-                    self.value = iprot.readBool()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TBoolValue')
+    if self.value is not None:
+      oprot.writeFieldBegin('value', TType.BOOL, 1)
+      oprot.writeBool(self.value)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TBoolValue')
-        if self.value is not None:
-            oprot.writeFieldBegin('value', TType.BOOL, 1)
-            oprot.writeBool(self.value)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    return
 
-    def validate(self):
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TByteValue(object):
-    """
+  """
     Attributes:
      - value
 
     """
 
+  def __init__(self, value=None, ):
+    self.value = value
 
-    def __init__(self, value=None,):
-        self.value = value
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.BYTE:
+          self.value = iprot.readByte()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.BYTE:
-                    self.value = iprot.readByte()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TByteValue')
+    if self.value is not None:
+      oprot.writeFieldBegin('value', TType.BYTE, 1)
+      oprot.writeByte(self.value)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TByteValue')
-        if self.value is not None:
-            oprot.writeFieldBegin('value', TType.BYTE, 1)
-            oprot.writeByte(self.value)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    return
 
-    def validate(self):
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TI16Value(object):
-    """
+  """
     Attributes:
      - value
 
     """
 
+  def __init__(self, value=None, ):
+    self.value = value
 
-    def __init__(self, value=None,):
-        self.value = value
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.I16:
+          self.value = iprot.readI16()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.I16:
-                    self.value = iprot.readI16()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TI16Value')
+    if self.value is not None:
+      oprot.writeFieldBegin('value', TType.I16, 1)
+      oprot.writeI16(self.value)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TI16Value')
-        if self.value is not None:
-            oprot.writeFieldBegin('value', TType.I16, 1)
-            oprot.writeI16(self.value)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    return
 
-    def validate(self):
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TI32Value(object):
-    """
+  """
     Attributes:
      - value
 
     """
 
+  def __init__(self, value=None, ):
+    self.value = value
 
-    def __init__(self, value=None,):
-        self.value = value
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.I32:
+          self.value = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.I32:
-                    self.value = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TI32Value')
+    if self.value is not None:
+      oprot.writeFieldBegin('value', TType.I32, 1)
+      oprot.writeI32(self.value)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TI32Value')
-        if self.value is not None:
-            oprot.writeFieldBegin('value', TType.I32, 1)
-            oprot.writeI32(self.value)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    return
 
-    def validate(self):
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TI64Value(object):
-    """
+  """
     Attributes:
      - value
 
     """
 
+  def __init__(self, value=None, ):
+    self.value = value
 
-    def __init__(self, value=None,):
-        self.value = value
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.I64:
+          self.value = iprot.readI64()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.I64:
-                    self.value = iprot.readI64()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TI64Value')
+    if self.value is not None:
+      oprot.writeFieldBegin('value', TType.I64, 1)
+      oprot.writeI64(self.value)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TI64Value')
-        if self.value is not None:
-            oprot.writeFieldBegin('value', TType.I64, 1)
-            oprot.writeI64(self.value)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    return
 
-    def validate(self):
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TDoubleValue(object):
-    """
+  """
     Attributes:
      - value
 
     """
 
+  def __init__(self, value=None, ):
+    self.value = value
 
-    def __init__(self, value=None,):
-        self.value = value
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.DOUBLE:
+          self.value = iprot.readDouble()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.DOUBLE:
-                    self.value = iprot.readDouble()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TDoubleValue')
+    if self.value is not None:
+      oprot.writeFieldBegin('value', TType.DOUBLE, 1)
+      oprot.writeDouble(self.value)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TDoubleValue')
-        if self.value is not None:
-            oprot.writeFieldBegin('value', TType.DOUBLE, 1)
-            oprot.writeDouble(self.value)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    return
 
-    def validate(self):
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TStringValue(object):
-    """
+  """
     Attributes:
      - value
 
     """
 
+  def __init__(self, value=None, ):
+    self.value = value
 
-    def __init__(self, value=None,):
-        self.value = value
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRING:
+          self.value = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRING:
-                    self.value = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TStringValue')
+    if self.value is not None:
+      oprot.writeFieldBegin('value', TType.STRING, 1)
+      oprot.writeString(self.value)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TStringValue')
-        if self.value is not None:
-            oprot.writeFieldBegin('value', TType.STRING, 1)
-            oprot.writeString(self.value.encode('utf-8') if sys.version_info[0] == 2 else self.value)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    return
 
-    def validate(self):
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TColumnValue(object):
-    """
+  """
     Attributes:
      - boolVal
      - byteVal
@@ -1730,833 +1711,823 @@ class TColumnValue(object):
 
     """
 
+  def __init__(self, boolVal=None, byteVal=None, i16Val=None, i32Val=None, i64Val=None, doubleVal=None, stringVal=None, ):
+    self.boolVal = boolVal
+    self.byteVal = byteVal
+    self.i16Val = i16Val
+    self.i32Val = i32Val
+    self.i64Val = i64Val
+    self.doubleVal = doubleVal
+    self.stringVal = stringVal
 
-    def __init__(self, boolVal=None, byteVal=None, i16Val=None, i32Val=None, i64Val=None, doubleVal=None, stringVal=None,):
-        self.boolVal = boolVal
-        self.byteVal = byteVal
-        self.i16Val = i16Val
-        self.i32Val = i32Val
-        self.i64Val = i64Val
-        self.doubleVal = doubleVal
-        self.stringVal = stringVal
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.boolVal = TBoolValue()
+          self.boolVal.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.byteVal = TByteValue()
+          self.byteVal.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRUCT:
+          self.i16Val = TI16Value()
+          self.i16Val.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.STRUCT:
+          self.i32Val = TI32Value()
+          self.i32Val.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 5:
+        if ftype == TType.STRUCT:
+          self.i64Val = TI64Value()
+          self.i64Val.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 6:
+        if ftype == TType.STRUCT:
+          self.doubleVal = TDoubleValue()
+          self.doubleVal.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 7:
+        if ftype == TType.STRUCT:
+          self.stringVal = TStringValue()
+          self.stringVal.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.boolVal = TBoolValue()
-                    self.boolVal.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRUCT:
-                    self.byteVal = TByteValue()
-                    self.byteVal.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.STRUCT:
-                    self.i16Val = TI16Value()
-                    self.i16Val.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.STRUCT:
-                    self.i32Val = TI32Value()
-                    self.i32Val.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 5:
-                if ftype == TType.STRUCT:
-                    self.i64Val = TI64Value()
-                    self.i64Val.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 6:
-                if ftype == TType.STRUCT:
-                    self.doubleVal = TDoubleValue()
-                    self.doubleVal.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 7:
-                if ftype == TType.STRUCT:
-                    self.stringVal = TStringValue()
-                    self.stringVal.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TColumnValue')
+    if self.boolVal is not None:
+      oprot.writeFieldBegin('boolVal', TType.STRUCT, 1)
+      self.boolVal.write(oprot)
+      oprot.writeFieldEnd()
+    if self.byteVal is not None:
+      oprot.writeFieldBegin('byteVal', TType.STRUCT, 2)
+      self.byteVal.write(oprot)
+      oprot.writeFieldEnd()
+    if self.i16Val is not None:
+      oprot.writeFieldBegin('i16Val', TType.STRUCT, 3)
+      self.i16Val.write(oprot)
+      oprot.writeFieldEnd()
+    if self.i32Val is not None:
+      oprot.writeFieldBegin('i32Val', TType.STRUCT, 4)
+      self.i32Val.write(oprot)
+      oprot.writeFieldEnd()
+    if self.i64Val is not None:
+      oprot.writeFieldBegin('i64Val', TType.STRUCT, 5)
+      self.i64Val.write(oprot)
+      oprot.writeFieldEnd()
+    if self.doubleVal is not None:
+      oprot.writeFieldBegin('doubleVal', TType.STRUCT, 6)
+      self.doubleVal.write(oprot)
+      oprot.writeFieldEnd()
+    if self.stringVal is not None:
+      oprot.writeFieldBegin('stringVal', TType.STRUCT, 7)
+      self.stringVal.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TColumnValue')
-        if self.boolVal is not None:
-            oprot.writeFieldBegin('boolVal', TType.STRUCT, 1)
-            self.boolVal.write(oprot)
-            oprot.writeFieldEnd()
-        if self.byteVal is not None:
-            oprot.writeFieldBegin('byteVal', TType.STRUCT, 2)
-            self.byteVal.write(oprot)
-            oprot.writeFieldEnd()
-        if self.i16Val is not None:
-            oprot.writeFieldBegin('i16Val', TType.STRUCT, 3)
-            self.i16Val.write(oprot)
-            oprot.writeFieldEnd()
-        if self.i32Val is not None:
-            oprot.writeFieldBegin('i32Val', TType.STRUCT, 4)
-            self.i32Val.write(oprot)
-            oprot.writeFieldEnd()
-        if self.i64Val is not None:
-            oprot.writeFieldBegin('i64Val', TType.STRUCT, 5)
-            self.i64Val.write(oprot)
-            oprot.writeFieldEnd()
-        if self.doubleVal is not None:
-            oprot.writeFieldBegin('doubleVal', TType.STRUCT, 6)
-            self.doubleVal.write(oprot)
-            oprot.writeFieldEnd()
-        if self.stringVal is not None:
-            oprot.writeFieldBegin('stringVal', TType.STRUCT, 7)
-            self.stringVal.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    return
 
-    def validate(self):
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TRow(object):
-    """
+  """
     Attributes:
      - colVals
 
     """
 
+  def __init__(self, colVals=None, ):
+    self.colVals = colVals
 
-    def __init__(self, colVals=None,):
-        self.colVals = colVals
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.LIST:
+          self.colVals = []
+          (_etype44, _size41) = iprot.readListBegin()
+          for _i45 in range(_size41):
+            _elem46 = TColumnValue()
+            _elem46.read(iprot)
+            self.colVals.append(_elem46)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.LIST:
-                    self.colVals = []
-                    (_etype44, _size41) = iprot.readListBegin()
-                    for _i45 in range(_size41):
-                        _elem46 = TColumnValue()
-                        _elem46.read(iprot)
-                        self.colVals.append(_elem46)
-                    iprot.readListEnd()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TRow')
+    if self.colVals is not None:
+      oprot.writeFieldBegin('colVals', TType.LIST, 1)
+      oprot.writeListBegin(TType.STRUCT, len(self.colVals))
+      for iter47 in self.colVals:
+        iter47.write(oprot)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TRow')
-        if self.colVals is not None:
-            oprot.writeFieldBegin('colVals', TType.LIST, 1)
-            oprot.writeListBegin(TType.STRUCT, len(self.colVals))
-            for iter47 in self.colVals:
-                iter47.write(oprot)
-            oprot.writeListEnd()
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.colVals is None:
+      raise TProtocolException(message='Required field colVals is unset!')
+    return
 
-    def validate(self):
-        if self.colVals is None:
-            raise TProtocolException(message='Required field colVals is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TBoolColumn(object):
-    """
+  """
     Attributes:
      - values
      - nulls
 
     """
 
+  def __init__(self, values=None, nulls=None, ):
+    self.values = values
+    self.nulls = nulls
 
-    def __init__(self, values=None, nulls=None,):
-        self.values = values
-        self.nulls = nulls
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.LIST:
+          self.values = []
+          (_etype51, _size48) = iprot.readListBegin()
+          for _i52 in range(_size48):
+            _elem53 = iprot.readBool()
+            self.values.append(_elem53)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.nulls = iprot.readBinary()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.LIST:
-                    self.values = []
-                    (_etype51, _size48) = iprot.readListBegin()
-                    for _i52 in range(_size48):
-                        _elem53 = iprot.readBool()
-                        self.values.append(_elem53)
-                    iprot.readListEnd()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.nulls = iprot.readBinary()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TBoolColumn')
+    if self.values is not None:
+      oprot.writeFieldBegin('values', TType.LIST, 1)
+      oprot.writeListBegin(TType.BOOL, len(self.values))
+      for iter54 in self.values:
+        oprot.writeBool(iter54)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    if self.nulls is not None:
+      oprot.writeFieldBegin('nulls', TType.STRING, 2)
+      oprot.writeBinary(self.nulls)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TBoolColumn')
-        if self.values is not None:
-            oprot.writeFieldBegin('values', TType.LIST, 1)
-            oprot.writeListBegin(TType.BOOL, len(self.values))
-            for iter54 in self.values:
-                oprot.writeBool(iter54)
-            oprot.writeListEnd()
-            oprot.writeFieldEnd()
-        if self.nulls is not None:
-            oprot.writeFieldBegin('nulls', TType.STRING, 2)
-            oprot.writeBinary(self.nulls)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.values is None:
+      raise TProtocolException(message='Required field values is unset!')
+    if self.nulls is None:
+      raise TProtocolException(message='Required field nulls is unset!')
+    return
 
-    def validate(self):
-        if self.values is None:
-            raise TProtocolException(message='Required field values is unset!')
-        if self.nulls is None:
-            raise TProtocolException(message='Required field nulls is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TByteColumn(object):
-    """
+  """
     Attributes:
      - values
      - nulls
 
     """
 
+  def __init__(self, values=None, nulls=None, ):
+    self.values = values
+    self.nulls = nulls
 
-    def __init__(self, values=None, nulls=None,):
-        self.values = values
-        self.nulls = nulls
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.LIST:
+          self.values = []
+          (_etype58, _size55) = iprot.readListBegin()
+          for _i59 in range(_size55):
+            _elem60 = iprot.readByte()
+            self.values.append(_elem60)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.nulls = iprot.readBinary()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.LIST:
-                    self.values = []
-                    (_etype58, _size55) = iprot.readListBegin()
-                    for _i59 in range(_size55):
-                        _elem60 = iprot.readByte()
-                        self.values.append(_elem60)
-                    iprot.readListEnd()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.nulls = iprot.readBinary()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TByteColumn')
+    if self.values is not None:
+      oprot.writeFieldBegin('values', TType.LIST, 1)
+      oprot.writeListBegin(TType.BYTE, len(self.values))
+      for iter61 in self.values:
+        oprot.writeByte(iter61)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    if self.nulls is not None:
+      oprot.writeFieldBegin('nulls', TType.STRING, 2)
+      oprot.writeBinary(self.nulls)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TByteColumn')
-        if self.values is not None:
-            oprot.writeFieldBegin('values', TType.LIST, 1)
-            oprot.writeListBegin(TType.BYTE, len(self.values))
-            for iter61 in self.values:
-                oprot.writeByte(iter61)
-            oprot.writeListEnd()
-            oprot.writeFieldEnd()
-        if self.nulls is not None:
-            oprot.writeFieldBegin('nulls', TType.STRING, 2)
-            oprot.writeBinary(self.nulls)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.values is None:
+      raise TProtocolException(message='Required field values is unset!')
+    if self.nulls is None:
+      raise TProtocolException(message='Required field nulls is unset!')
+    return
 
-    def validate(self):
-        if self.values is None:
-            raise TProtocolException(message='Required field values is unset!')
-        if self.nulls is None:
-            raise TProtocolException(message='Required field nulls is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TI16Column(object):
-    """
+  """
     Attributes:
      - values
      - nulls
 
     """
 
+  def __init__(self, values=None, nulls=None, ):
+    self.values = values
+    self.nulls = nulls
 
-    def __init__(self, values=None, nulls=None,):
-        self.values = values
-        self.nulls = nulls
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.LIST:
+          self.values = []
+          (_etype65, _size62) = iprot.readListBegin()
+          for _i66 in range(_size62):
+            _elem67 = iprot.readI16()
+            self.values.append(_elem67)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.nulls = iprot.readBinary()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.LIST:
-                    self.values = []
-                    (_etype65, _size62) = iprot.readListBegin()
-                    for _i66 in range(_size62):
-                        _elem67 = iprot.readI16()
-                        self.values.append(_elem67)
-                    iprot.readListEnd()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.nulls = iprot.readBinary()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TI16Column')
+    if self.values is not None:
+      oprot.writeFieldBegin('values', TType.LIST, 1)
+      oprot.writeListBegin(TType.I16, len(self.values))
+      for iter68 in self.values:
+        oprot.writeI16(iter68)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    if self.nulls is not None:
+      oprot.writeFieldBegin('nulls', TType.STRING, 2)
+      oprot.writeBinary(self.nulls)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TI16Column')
-        if self.values is not None:
-            oprot.writeFieldBegin('values', TType.LIST, 1)
-            oprot.writeListBegin(TType.I16, len(self.values))
-            for iter68 in self.values:
-                oprot.writeI16(iter68)
-            oprot.writeListEnd()
-            oprot.writeFieldEnd()
-        if self.nulls is not None:
-            oprot.writeFieldBegin('nulls', TType.STRING, 2)
-            oprot.writeBinary(self.nulls)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.values is None:
+      raise TProtocolException(message='Required field values is unset!')
+    if self.nulls is None:
+      raise TProtocolException(message='Required field nulls is unset!')
+    return
 
-    def validate(self):
-        if self.values is None:
-            raise TProtocolException(message='Required field values is unset!')
-        if self.nulls is None:
-            raise TProtocolException(message='Required field nulls is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TI32Column(object):
-    """
+  """
     Attributes:
      - values
      - nulls
 
     """
 
+  def __init__(self, values=None, nulls=None, ):
+    self.values = values
+    self.nulls = nulls
 
-    def __init__(self, values=None, nulls=None,):
-        self.values = values
-        self.nulls = nulls
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.LIST:
+          self.values = []
+          (_etype72, _size69) = iprot.readListBegin()
+          for _i73 in range(_size69):
+            _elem74 = iprot.readI32()
+            self.values.append(_elem74)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.nulls = iprot.readBinary()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.LIST:
-                    self.values = []
-                    (_etype72, _size69) = iprot.readListBegin()
-                    for _i73 in range(_size69):
-                        _elem74 = iprot.readI32()
-                        self.values.append(_elem74)
-                    iprot.readListEnd()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.nulls = iprot.readBinary()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TI32Column')
+    if self.values is not None:
+      oprot.writeFieldBegin('values', TType.LIST, 1)
+      oprot.writeListBegin(TType.I32, len(self.values))
+      for iter75 in self.values:
+        oprot.writeI32(iter75)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    if self.nulls is not None:
+      oprot.writeFieldBegin('nulls', TType.STRING, 2)
+      oprot.writeBinary(self.nulls)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TI32Column')
-        if self.values is not None:
-            oprot.writeFieldBegin('values', TType.LIST, 1)
-            oprot.writeListBegin(TType.I32, len(self.values))
-            for iter75 in self.values:
-                oprot.writeI32(iter75)
-            oprot.writeListEnd()
-            oprot.writeFieldEnd()
-        if self.nulls is not None:
-            oprot.writeFieldBegin('nulls', TType.STRING, 2)
-            oprot.writeBinary(self.nulls)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.values is None:
+      raise TProtocolException(message='Required field values is unset!')
+    if self.nulls is None:
+      raise TProtocolException(message='Required field nulls is unset!')
+    return
 
-    def validate(self):
-        if self.values is None:
-            raise TProtocolException(message='Required field values is unset!')
-        if self.nulls is None:
-            raise TProtocolException(message='Required field nulls is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TI64Column(object):
-    """
+  """
     Attributes:
      - values
      - nulls
 
     """
 
+  def __init__(self, values=None, nulls=None, ):
+    self.values = values
+    self.nulls = nulls
 
-    def __init__(self, values=None, nulls=None,):
-        self.values = values
-        self.nulls = nulls
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.LIST:
+          self.values = []
+          (_etype79, _size76) = iprot.readListBegin()
+          for _i80 in range(_size76):
+            _elem81 = iprot.readI64()
+            self.values.append(_elem81)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.nulls = iprot.readBinary()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.LIST:
-                    self.values = []
-                    (_etype79, _size76) = iprot.readListBegin()
-                    for _i80 in range(_size76):
-                        _elem81 = iprot.readI64()
-                        self.values.append(_elem81)
-                    iprot.readListEnd()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.nulls = iprot.readBinary()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TI64Column')
+    if self.values is not None:
+      oprot.writeFieldBegin('values', TType.LIST, 1)
+      oprot.writeListBegin(TType.I64, len(self.values))
+      for iter82 in self.values:
+        oprot.writeI64(iter82)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    if self.nulls is not None:
+      oprot.writeFieldBegin('nulls', TType.STRING, 2)
+      oprot.writeBinary(self.nulls)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TI64Column')
-        if self.values is not None:
-            oprot.writeFieldBegin('values', TType.LIST, 1)
-            oprot.writeListBegin(TType.I64, len(self.values))
-            for iter82 in self.values:
-                oprot.writeI64(iter82)
-            oprot.writeListEnd()
-            oprot.writeFieldEnd()
-        if self.nulls is not None:
-            oprot.writeFieldBegin('nulls', TType.STRING, 2)
-            oprot.writeBinary(self.nulls)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.values is None:
+      raise TProtocolException(message='Required field values is unset!')
+    if self.nulls is None:
+      raise TProtocolException(message='Required field nulls is unset!')
+    return
 
-    def validate(self):
-        if self.values is None:
-            raise TProtocolException(message='Required field values is unset!')
-        if self.nulls is None:
-            raise TProtocolException(message='Required field nulls is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TDoubleColumn(object):
-    """
+  """
     Attributes:
      - values
      - nulls
 
     """
 
+  def __init__(self, values=None, nulls=None, ):
+    self.values = values
+    self.nulls = nulls
 
-    def __init__(self, values=None, nulls=None,):
-        self.values = values
-        self.nulls = nulls
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.LIST:
+          self.values = []
+          (_etype86, _size83) = iprot.readListBegin()
+          for _i87 in range(_size83):
+            _elem88 = iprot.readDouble()
+            self.values.append(_elem88)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.nulls = iprot.readBinary()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.LIST:
-                    self.values = []
-                    (_etype86, _size83) = iprot.readListBegin()
-                    for _i87 in range(_size83):
-                        _elem88 = iprot.readDouble()
-                        self.values.append(_elem88)
-                    iprot.readListEnd()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.nulls = iprot.readBinary()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TDoubleColumn')
+    if self.values is not None:
+      oprot.writeFieldBegin('values', TType.LIST, 1)
+      oprot.writeListBegin(TType.DOUBLE, len(self.values))
+      for iter89 in self.values:
+        oprot.writeDouble(iter89)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    if self.nulls is not None:
+      oprot.writeFieldBegin('nulls', TType.STRING, 2)
+      oprot.writeBinary(self.nulls)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TDoubleColumn')
-        if self.values is not None:
-            oprot.writeFieldBegin('values', TType.LIST, 1)
-            oprot.writeListBegin(TType.DOUBLE, len(self.values))
-            for iter89 in self.values:
-                oprot.writeDouble(iter89)
-            oprot.writeListEnd()
-            oprot.writeFieldEnd()
-        if self.nulls is not None:
-            oprot.writeFieldBegin('nulls', TType.STRING, 2)
-            oprot.writeBinary(self.nulls)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.values is None:
+      raise TProtocolException(message='Required field values is unset!')
+    if self.nulls is None:
+      raise TProtocolException(message='Required field nulls is unset!')
+    return
 
-    def validate(self):
-        if self.values is None:
-            raise TProtocolException(message='Required field values is unset!')
-        if self.nulls is None:
-            raise TProtocolException(message='Required field nulls is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TStringColumn(object):
-    """
+  """
     Attributes:
      - values
      - nulls
 
     """
 
+  def __init__(self, values=None, nulls=None, ):
+    self.values = values
+    self.nulls = nulls
 
-    def __init__(self, values=None, nulls=None,):
-        self.values = values
-        self.nulls = nulls
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.LIST:
+          self.values = []
+          (_etype93, _size90) = iprot.readListBegin()
+          for _i94 in range(_size90):
+            _elem95 = iprot.readString()
+            self.values.append(_elem95)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.nulls = iprot.readBinary()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.LIST:
-                    self.values = []
-                    (_etype93, _size90) = iprot.readListBegin()
-                    for _i94 in range(_size90):
-                        _elem95 = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                        self.values.append(_elem95)
-                    iprot.readListEnd()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.nulls = iprot.readBinary()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TStringColumn')
+    if self.values is not None:
+      oprot.writeFieldBegin('values', TType.LIST, 1)
+      oprot.writeListBegin(TType.STRING, len(self.values))
+      for iter96 in self.values:
+        oprot.writeString(iter96)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    if self.nulls is not None:
+      oprot.writeFieldBegin('nulls', TType.STRING, 2)
+      oprot.writeBinary(self.nulls)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TStringColumn')
-        if self.values is not None:
-            oprot.writeFieldBegin('values', TType.LIST, 1)
-            oprot.writeListBegin(TType.STRING, len(self.values))
-            for iter96 in self.values:
-                oprot.writeString(iter96.encode('utf-8') if sys.version_info[0] == 2 else iter96)
-            oprot.writeListEnd()
-            oprot.writeFieldEnd()
-        if self.nulls is not None:
-            oprot.writeFieldBegin('nulls', TType.STRING, 2)
-            oprot.writeBinary(self.nulls)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.values is None:
+      raise TProtocolException(message='Required field values is unset!')
+    if self.nulls is None:
+      raise TProtocolException(message='Required field nulls is unset!')
+    return
 
-    def validate(self):
-        if self.values is None:
-            raise TProtocolException(message='Required field values is unset!')
-        if self.nulls is None:
-            raise TProtocolException(message='Required field nulls is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TBinaryColumn(object):
-    """
+  """
     Attributes:
      - values
      - nulls
 
     """
 
+  def __init__(self, values=None, nulls=None, ):
+    self.values = values
+    self.nulls = nulls
 
-    def __init__(self, values=None, nulls=None,):
-        self.values = values
-        self.nulls = nulls
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.LIST:
+          self.values = []
+          (_etype100, _size97) = iprot.readListBegin()
+          for _i101 in range(_size97):
+            _elem102 = iprot.readBinary()
+            self.values.append(_elem102)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.nulls = iprot.readBinary()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.LIST:
-                    self.values = []
-                    (_etype100, _size97) = iprot.readListBegin()
-                    for _i101 in range(_size97):
-                        _elem102 = iprot.readBinary()
-                        self.values.append(_elem102)
-                    iprot.readListEnd()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.nulls = iprot.readBinary()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TBinaryColumn')
+    if self.values is not None:
+      oprot.writeFieldBegin('values', TType.LIST, 1)
+      oprot.writeListBegin(TType.STRING, len(self.values))
+      for iter103 in self.values:
+        oprot.writeBinary(iter103)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    if self.nulls is not None:
+      oprot.writeFieldBegin('nulls', TType.STRING, 2)
+      oprot.writeBinary(self.nulls)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TBinaryColumn')
-        if self.values is not None:
-            oprot.writeFieldBegin('values', TType.LIST, 1)
-            oprot.writeListBegin(TType.STRING, len(self.values))
-            for iter103 in self.values:
-                oprot.writeBinary(iter103)
-            oprot.writeListEnd()
-            oprot.writeFieldEnd()
-        if self.nulls is not None:
-            oprot.writeFieldBegin('nulls', TType.STRING, 2)
-            oprot.writeBinary(self.nulls)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.values is None:
+      raise TProtocolException(message='Required field values is unset!')
+    if self.nulls is None:
+      raise TProtocolException(message='Required field nulls is unset!')
+    return
 
-    def validate(self):
-        if self.values is None:
-            raise TProtocolException(message='Required field values is unset!')
-        if self.nulls is None:
-            raise TProtocolException(message='Required field nulls is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TColumn(object):
-    """
+  """
     Attributes:
      - boolVal
      - byteVal
@@ -2569,136 +2540,135 @@ class TColumn(object):
 
     """
 
+  def __init__(self, boolVal=None, byteVal=None, i16Val=None, i32Val=None, i64Val=None, doubleVal=None, stringVal=None, binaryVal=None, ):
+    self.boolVal = boolVal
+    self.byteVal = byteVal
+    self.i16Val = i16Val
+    self.i32Val = i32Val
+    self.i64Val = i64Val
+    self.doubleVal = doubleVal
+    self.stringVal = stringVal
+    self.binaryVal = binaryVal
 
-    def __init__(self, boolVal=None, byteVal=None, i16Val=None, i32Val=None, i64Val=None, doubleVal=None, stringVal=None, binaryVal=None,):
-        self.boolVal = boolVal
-        self.byteVal = byteVal
-        self.i16Val = i16Val
-        self.i32Val = i32Val
-        self.i64Val = i64Val
-        self.doubleVal = doubleVal
-        self.stringVal = stringVal
-        self.binaryVal = binaryVal
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.boolVal = TBoolColumn()
+          self.boolVal.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.byteVal = TByteColumn()
+          self.byteVal.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRUCT:
+          self.i16Val = TI16Column()
+          self.i16Val.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.STRUCT:
+          self.i32Val = TI32Column()
+          self.i32Val.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 5:
+        if ftype == TType.STRUCT:
+          self.i64Val = TI64Column()
+          self.i64Val.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 6:
+        if ftype == TType.STRUCT:
+          self.doubleVal = TDoubleColumn()
+          self.doubleVal.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 7:
+        if ftype == TType.STRUCT:
+          self.stringVal = TStringColumn()
+          self.stringVal.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 8:
+        if ftype == TType.STRUCT:
+          self.binaryVal = TBinaryColumn()
+          self.binaryVal.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.boolVal = TBoolColumn()
-                    self.boolVal.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRUCT:
-                    self.byteVal = TByteColumn()
-                    self.byteVal.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.STRUCT:
-                    self.i16Val = TI16Column()
-                    self.i16Val.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.STRUCT:
-                    self.i32Val = TI32Column()
-                    self.i32Val.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 5:
-                if ftype == TType.STRUCT:
-                    self.i64Val = TI64Column()
-                    self.i64Val.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 6:
-                if ftype == TType.STRUCT:
-                    self.doubleVal = TDoubleColumn()
-                    self.doubleVal.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 7:
-                if ftype == TType.STRUCT:
-                    self.stringVal = TStringColumn()
-                    self.stringVal.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 8:
-                if ftype == TType.STRUCT:
-                    self.binaryVal = TBinaryColumn()
-                    self.binaryVal.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TColumn')
+    if self.boolVal is not None:
+      oprot.writeFieldBegin('boolVal', TType.STRUCT, 1)
+      self.boolVal.write(oprot)
+      oprot.writeFieldEnd()
+    if self.byteVal is not None:
+      oprot.writeFieldBegin('byteVal', TType.STRUCT, 2)
+      self.byteVal.write(oprot)
+      oprot.writeFieldEnd()
+    if self.i16Val is not None:
+      oprot.writeFieldBegin('i16Val', TType.STRUCT, 3)
+      self.i16Val.write(oprot)
+      oprot.writeFieldEnd()
+    if self.i32Val is not None:
+      oprot.writeFieldBegin('i32Val', TType.STRUCT, 4)
+      self.i32Val.write(oprot)
+      oprot.writeFieldEnd()
+    if self.i64Val is not None:
+      oprot.writeFieldBegin('i64Val', TType.STRUCT, 5)
+      self.i64Val.write(oprot)
+      oprot.writeFieldEnd()
+    if self.doubleVal is not None:
+      oprot.writeFieldBegin('doubleVal', TType.STRUCT, 6)
+      self.doubleVal.write(oprot)
+      oprot.writeFieldEnd()
+    if self.stringVal is not None:
+      oprot.writeFieldBegin('stringVal', TType.STRUCT, 7)
+      self.stringVal.write(oprot)
+      oprot.writeFieldEnd()
+    if self.binaryVal is not None:
+      oprot.writeFieldBegin('binaryVal', TType.STRUCT, 8)
+      self.binaryVal.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TColumn')
-        if self.boolVal is not None:
-            oprot.writeFieldBegin('boolVal', TType.STRUCT, 1)
-            self.boolVal.write(oprot)
-            oprot.writeFieldEnd()
-        if self.byteVal is not None:
-            oprot.writeFieldBegin('byteVal', TType.STRUCT, 2)
-            self.byteVal.write(oprot)
-            oprot.writeFieldEnd()
-        if self.i16Val is not None:
-            oprot.writeFieldBegin('i16Val', TType.STRUCT, 3)
-            self.i16Val.write(oprot)
-            oprot.writeFieldEnd()
-        if self.i32Val is not None:
-            oprot.writeFieldBegin('i32Val', TType.STRUCT, 4)
-            self.i32Val.write(oprot)
-            oprot.writeFieldEnd()
-        if self.i64Val is not None:
-            oprot.writeFieldBegin('i64Val', TType.STRUCT, 5)
-            self.i64Val.write(oprot)
-            oprot.writeFieldEnd()
-        if self.doubleVal is not None:
-            oprot.writeFieldBegin('doubleVal', TType.STRUCT, 6)
-            self.doubleVal.write(oprot)
-            oprot.writeFieldEnd()
-        if self.stringVal is not None:
-            oprot.writeFieldBegin('stringVal', TType.STRUCT, 7)
-            self.stringVal.write(oprot)
-            oprot.writeFieldEnd()
-        if self.binaryVal is not None:
-            oprot.writeFieldBegin('binaryVal', TType.STRUCT, 8)
-            self.binaryVal.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    return
 
-    def validate(self):
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TRowSet(object):
-    """
+  """
     Attributes:
      - startRowOffset
      - rows
@@ -2708,120 +2678,119 @@ class TRowSet(object):
 
     """
 
+  def __init__(self, startRowOffset=None, rows=None, columns=None, binaryColumns=None, columnCount=None, ):
+    self.startRowOffset = startRowOffset
+    self.rows = rows
+    self.columns = columns
+    self.binaryColumns = binaryColumns
+    self.columnCount = columnCount
 
-    def __init__(self, startRowOffset=None, rows=None, columns=None, binaryColumns=None, columnCount=None,):
-        self.startRowOffset = startRowOffset
-        self.rows = rows
-        self.columns = columns
-        self.binaryColumns = binaryColumns
-        self.columnCount = columnCount
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.I64:
+          self.startRowOffset = iprot.readI64()
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.LIST:
+          self.rows = []
+          (_etype107, _size104) = iprot.readListBegin()
+          for _i108 in range(_size104):
+            _elem109 = TRow()
+            _elem109.read(iprot)
+            self.rows.append(_elem109)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.LIST:
+          self.columns = []
+          (_etype113, _size110) = iprot.readListBegin()
+          for _i114 in range(_size110):
+            _elem115 = TColumn()
+            _elem115.read(iprot)
+            self.columns.append(_elem115)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.STRING:
+          self.binaryColumns = iprot.readBinary()
+        else:
+          iprot.skip(ftype)
+      elif fid == 5:
+        if ftype == TType.I32:
+          self.columnCount = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.I64:
-                    self.startRowOffset = iprot.readI64()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.LIST:
-                    self.rows = []
-                    (_etype107, _size104) = iprot.readListBegin()
-                    for _i108 in range(_size104):
-                        _elem109 = TRow()
-                        _elem109.read(iprot)
-                        self.rows.append(_elem109)
-                    iprot.readListEnd()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.LIST:
-                    self.columns = []
-                    (_etype113, _size110) = iprot.readListBegin()
-                    for _i114 in range(_size110):
-                        _elem115 = TColumn()
-                        _elem115.read(iprot)
-                        self.columns.append(_elem115)
-                    iprot.readListEnd()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.STRING:
-                    self.binaryColumns = iprot.readBinary()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 5:
-                if ftype == TType.I32:
-                    self.columnCount = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TRowSet')
+    if self.startRowOffset is not None:
+      oprot.writeFieldBegin('startRowOffset', TType.I64, 1)
+      oprot.writeI64(self.startRowOffset)
+      oprot.writeFieldEnd()
+    if self.rows is not None:
+      oprot.writeFieldBegin('rows', TType.LIST, 2)
+      oprot.writeListBegin(TType.STRUCT, len(self.rows))
+      for iter116 in self.rows:
+        iter116.write(oprot)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    if self.columns is not None:
+      oprot.writeFieldBegin('columns', TType.LIST, 3)
+      oprot.writeListBegin(TType.STRUCT, len(self.columns))
+      for iter117 in self.columns:
+        iter117.write(oprot)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    if self.binaryColumns is not None:
+      oprot.writeFieldBegin('binaryColumns', TType.STRING, 4)
+      oprot.writeBinary(self.binaryColumns)
+      oprot.writeFieldEnd()
+    if self.columnCount is not None:
+      oprot.writeFieldBegin('columnCount', TType.I32, 5)
+      oprot.writeI32(self.columnCount)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TRowSet')
-        if self.startRowOffset is not None:
-            oprot.writeFieldBegin('startRowOffset', TType.I64, 1)
-            oprot.writeI64(self.startRowOffset)
-            oprot.writeFieldEnd()
-        if self.rows is not None:
-            oprot.writeFieldBegin('rows', TType.LIST, 2)
-            oprot.writeListBegin(TType.STRUCT, len(self.rows))
-            for iter116 in self.rows:
-                iter116.write(oprot)
-            oprot.writeListEnd()
-            oprot.writeFieldEnd()
-        if self.columns is not None:
-            oprot.writeFieldBegin('columns', TType.LIST, 3)
-            oprot.writeListBegin(TType.STRUCT, len(self.columns))
-            for iter117 in self.columns:
-                iter117.write(oprot)
-            oprot.writeListEnd()
-            oprot.writeFieldEnd()
-        if self.binaryColumns is not None:
-            oprot.writeFieldBegin('binaryColumns', TType.STRING, 4)
-            oprot.writeBinary(self.binaryColumns)
-            oprot.writeFieldEnd()
-        if self.columnCount is not None:
-            oprot.writeFieldBegin('columnCount', TType.I32, 5)
-            oprot.writeI32(self.columnCount)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.startRowOffset is None:
+      raise TProtocolException(message='Required field startRowOffset is unset!')
+    if self.rows is None:
+      raise TProtocolException(message='Required field rows is unset!')
+    return
 
-    def validate(self):
-        if self.startRowOffset is None:
-            raise TProtocolException(message='Required field startRowOffset is unset!')
-        if self.rows is None:
-            raise TProtocolException(message='Required field rows is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TStatus(object):
-    """
+  """
     Attributes:
      - statusCode
      - infoMessages
@@ -2831,240 +2800,237 @@ class TStatus(object):
 
     """
 
+  def __init__(self, statusCode=None, infoMessages=None, sqlState=None, errorCode=None, errorMessage=None, ):
+    self.statusCode = statusCode
+    self.infoMessages = infoMessages
+    self.sqlState = sqlState
+    self.errorCode = errorCode
+    self.errorMessage = errorMessage
 
-    def __init__(self, statusCode=None, infoMessages=None, sqlState=None, errorCode=None, errorMessage=None,):
-        self.statusCode = statusCode
-        self.infoMessages = infoMessages
-        self.sqlState = sqlState
-        self.errorCode = errorCode
-        self.errorMessage = errorMessage
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.I32:
+          self.statusCode = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.LIST:
+          self.infoMessages = []
+          (_etype121, _size118) = iprot.readListBegin()
+          for _i122 in range(_size118):
+            _elem123 = iprot.readString()
+            self.infoMessages.append(_elem123)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRING:
+          self.sqlState = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.I32:
+          self.errorCode = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      elif fid == 5:
+        if ftype == TType.STRING:
+          self.errorMessage = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.I32:
-                    self.statusCode = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.LIST:
-                    self.infoMessages = []
-                    (_etype121, _size118) = iprot.readListBegin()
-                    for _i122 in range(_size118):
-                        _elem123 = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                        self.infoMessages.append(_elem123)
-                    iprot.readListEnd()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.STRING:
-                    self.sqlState = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.I32:
-                    self.errorCode = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 5:
-                if ftype == TType.STRING:
-                    self.errorMessage = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TStatus')
+    if self.statusCode is not None:
+      oprot.writeFieldBegin('statusCode', TType.I32, 1)
+      oprot.writeI32(self.statusCode)
+      oprot.writeFieldEnd()
+    if self.infoMessages is not None:
+      oprot.writeFieldBegin('infoMessages', TType.LIST, 2)
+      oprot.writeListBegin(TType.STRING, len(self.infoMessages))
+      for iter124 in self.infoMessages:
+        oprot.writeString(iter124)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    if self.sqlState is not None:
+      oprot.writeFieldBegin('sqlState', TType.STRING, 3)
+      oprot.writeString(self.sqlState)
+      oprot.writeFieldEnd()
+    if self.errorCode is not None:
+      oprot.writeFieldBegin('errorCode', TType.I32, 4)
+      oprot.writeI32(self.errorCode)
+      oprot.writeFieldEnd()
+    if self.errorMessage is not None:
+      oprot.writeFieldBegin('errorMessage', TType.STRING, 5)
+      oprot.writeString(self.errorMessage)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TStatus')
-        if self.statusCode is not None:
-            oprot.writeFieldBegin('statusCode', TType.I32, 1)
-            oprot.writeI32(self.statusCode)
-            oprot.writeFieldEnd()
-        if self.infoMessages is not None:
-            oprot.writeFieldBegin('infoMessages', TType.LIST, 2)
-            oprot.writeListBegin(TType.STRING, len(self.infoMessages))
-            for iter124 in self.infoMessages:
-                oprot.writeString(iter124.encode('utf-8') if sys.version_info[0] == 2 else iter124)
-            oprot.writeListEnd()
-            oprot.writeFieldEnd()
-        if self.sqlState is not None:
-            oprot.writeFieldBegin('sqlState', TType.STRING, 3)
-            oprot.writeString(self.sqlState.encode('utf-8') if sys.version_info[0] == 2 else self.sqlState)
-            oprot.writeFieldEnd()
-        if self.errorCode is not None:
-            oprot.writeFieldBegin('errorCode', TType.I32, 4)
-            oprot.writeI32(self.errorCode)
-            oprot.writeFieldEnd()
-        if self.errorMessage is not None:
-            oprot.writeFieldBegin('errorMessage', TType.STRING, 5)
-            oprot.writeString(self.errorMessage.encode('utf-8') if sys.version_info[0] == 2 else self.errorMessage)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.statusCode is None:
+      raise TProtocolException(message='Required field statusCode is unset!')
+    return
 
-    def validate(self):
-        if self.statusCode is None:
-            raise TProtocolException(message='Required field statusCode is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class THandleIdentifier(object):
-    """
+  """
     Attributes:
      - guid
      - secret
 
     """
 
+  def __init__(self, guid=None, secret=None, ):
+    self.guid = guid
+    self.secret = secret
 
-    def __init__(self, guid=None, secret=None,):
-        self.guid = guid
-        self.secret = secret
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRING:
+          self.guid = iprot.readBinary()
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.secret = iprot.readBinary()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRING:
-                    self.guid = iprot.readBinary()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.secret = iprot.readBinary()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('THandleIdentifier')
+    if self.guid is not None:
+      oprot.writeFieldBegin('guid', TType.STRING, 1)
+      oprot.writeBinary(self.guid)
+      oprot.writeFieldEnd()
+    if self.secret is not None:
+      oprot.writeFieldBegin('secret', TType.STRING, 2)
+      oprot.writeBinary(self.secret)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('THandleIdentifier')
-        if self.guid is not None:
-            oprot.writeFieldBegin('guid', TType.STRING, 1)
-            oprot.writeBinary(self.guid)
-            oprot.writeFieldEnd()
-        if self.secret is not None:
-            oprot.writeFieldBegin('secret', TType.STRING, 2)
-            oprot.writeBinary(self.secret)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.guid is None:
+      raise TProtocolException(message='Required field guid is unset!')
+    if self.secret is None:
+      raise TProtocolException(message='Required field secret is unset!')
+    return
 
-    def validate(self):
-        if self.guid is None:
-            raise TProtocolException(message='Required field guid is unset!')
-        if self.secret is None:
-            raise TProtocolException(message='Required field secret is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TSessionHandle(object):
-    """
+  """
     Attributes:
      - sessionId
 
     """
 
+  def __init__(self, sessionId=None, ):
+    self.sessionId = sessionId
 
-    def __init__(self, sessionId=None,):
-        self.sessionId = sessionId
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.sessionId = THandleIdentifier()
+          self.sessionId.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.sessionId = THandleIdentifier()
-                    self.sessionId.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TSessionHandle')
+    if self.sessionId is not None:
+      oprot.writeFieldBegin('sessionId', TType.STRUCT, 1)
+      self.sessionId.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TSessionHandle')
-        if self.sessionId is not None:
-            oprot.writeFieldBegin('sessionId', TType.STRUCT, 1)
-            self.sessionId.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.sessionId is None:
+      raise TProtocolException(message='Required field sessionId is unset!')
+    return
 
-    def validate(self):
-        if self.sessionId is None:
-            raise TProtocolException(message='Required field sessionId is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TOperationHandle(object):
-    """
+  """
     Attributes:
      - operationId
      - operationType
@@ -3073,95 +3039,94 @@ class TOperationHandle(object):
 
     """
 
+  def __init__(self, operationId=None, operationType=None, hasResultSet=None, modifiedRowCount=None, ):
+    self.operationId = operationId
+    self.operationType = operationType
+    self.hasResultSet = hasResultSet
+    self.modifiedRowCount = modifiedRowCount
 
-    def __init__(self, operationId=None, operationType=None, hasResultSet=None, modifiedRowCount=None,):
-        self.operationId = operationId
-        self.operationType = operationType
-        self.hasResultSet = hasResultSet
-        self.modifiedRowCount = modifiedRowCount
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.operationId = THandleIdentifier()
+          self.operationId.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.I32:
+          self.operationType = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.BOOL:
+          self.hasResultSet = iprot.readBool()
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.DOUBLE:
+          self.modifiedRowCount = iprot.readDouble()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.operationId = THandleIdentifier()
-                    self.operationId.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.I32:
-                    self.operationType = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.BOOL:
-                    self.hasResultSet = iprot.readBool()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.DOUBLE:
-                    self.modifiedRowCount = iprot.readDouble()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TOperationHandle')
+    if self.operationId is not None:
+      oprot.writeFieldBegin('operationId', TType.STRUCT, 1)
+      self.operationId.write(oprot)
+      oprot.writeFieldEnd()
+    if self.operationType is not None:
+      oprot.writeFieldBegin('operationType', TType.I32, 2)
+      oprot.writeI32(self.operationType)
+      oprot.writeFieldEnd()
+    if self.hasResultSet is not None:
+      oprot.writeFieldBegin('hasResultSet', TType.BOOL, 3)
+      oprot.writeBool(self.hasResultSet)
+      oprot.writeFieldEnd()
+    if self.modifiedRowCount is not None:
+      oprot.writeFieldBegin('modifiedRowCount', TType.DOUBLE, 4)
+      oprot.writeDouble(self.modifiedRowCount)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TOperationHandle')
-        if self.operationId is not None:
-            oprot.writeFieldBegin('operationId', TType.STRUCT, 1)
-            self.operationId.write(oprot)
-            oprot.writeFieldEnd()
-        if self.operationType is not None:
-            oprot.writeFieldBegin('operationType', TType.I32, 2)
-            oprot.writeI32(self.operationType)
-            oprot.writeFieldEnd()
-        if self.hasResultSet is not None:
-            oprot.writeFieldBegin('hasResultSet', TType.BOOL, 3)
-            oprot.writeBool(self.hasResultSet)
-            oprot.writeFieldEnd()
-        if self.modifiedRowCount is not None:
-            oprot.writeFieldBegin('modifiedRowCount', TType.DOUBLE, 4)
-            oprot.writeDouble(self.modifiedRowCount)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.operationId is None:
+      raise TProtocolException(message='Required field operationId is unset!')
+    if self.operationType is None:
+      raise TProtocolException(message='Required field operationType is unset!')
+    if self.hasResultSet is None:
+      raise TProtocolException(message='Required field hasResultSet is unset!')
+    return
 
-    def validate(self):
-        if self.operationId is None:
-            raise TProtocolException(message='Required field operationId is unset!')
-        if self.operationType is None:
-            raise TProtocolException(message='Required field operationType is unset!')
-        if self.hasResultSet is None:
-            raise TProtocolException(message='Required field hasResultSet is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TOpenSessionReq(object):
-    """
+  """
     Attributes:
      - client_protocol
      - username
@@ -3170,100 +3135,99 @@ class TOpenSessionReq(object):
 
     """
 
+  def __init__(self, client_protocol=9, username=None, password=None, configuration=None, ):
+    self.client_protocol = client_protocol
+    self.username = username
+    self.password = password
+    self.configuration = configuration
 
-    def __init__(self, client_protocol=9, username=None, password=None, configuration=None,):
-        self.client_protocol = client_protocol
-        self.username = username
-        self.password = password
-        self.configuration = configuration
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.I32:
+          self.client_protocol = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.username = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRING:
+          self.password = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.MAP:
+          self.configuration = {}
+          (_ktype126, _vtype127, _size125) = iprot.readMapBegin()
+          for _i129 in range(_size125):
+            _key130 = iprot.readString()
+            _val131 = iprot.readString()
+            self.configuration[_key130] = _val131
+          iprot.readMapEnd()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.I32:
-                    self.client_protocol = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.username = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.STRING:
-                    self.password = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.MAP:
-                    self.configuration = {}
-                    (_ktype126, _vtype127, _size125) = iprot.readMapBegin()
-                    for _i129 in range(_size125):
-                        _key130 = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                        _val131 = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                        self.configuration[_key130] = _val131
-                    iprot.readMapEnd()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TOpenSessionReq')
+    if self.client_protocol is not None:
+      oprot.writeFieldBegin('client_protocol', TType.I32, 1)
+      oprot.writeI32(self.client_protocol)
+      oprot.writeFieldEnd()
+    if self.username is not None:
+      oprot.writeFieldBegin('username', TType.STRING, 2)
+      oprot.writeString(self.username)
+      oprot.writeFieldEnd()
+    if self.password is not None:
+      oprot.writeFieldBegin('password', TType.STRING, 3)
+      oprot.writeString(self.password)
+      oprot.writeFieldEnd()
+    if self.configuration is not None:
+      oprot.writeFieldBegin('configuration', TType.MAP, 4)
+      oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.configuration))
+      for kiter132, viter133 in self.configuration.items():
+        oprot.writeString(kiter132)
+        oprot.writeString(viter133)
+      oprot.writeMapEnd()
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TOpenSessionReq')
-        if self.client_protocol is not None:
-            oprot.writeFieldBegin('client_protocol', TType.I32, 1)
-            oprot.writeI32(self.client_protocol)
-            oprot.writeFieldEnd()
-        if self.username is not None:
-            oprot.writeFieldBegin('username', TType.STRING, 2)
-            oprot.writeString(self.username.encode('utf-8') if sys.version_info[0] == 2 else self.username)
-            oprot.writeFieldEnd()
-        if self.password is not None:
-            oprot.writeFieldBegin('password', TType.STRING, 3)
-            oprot.writeString(self.password.encode('utf-8') if sys.version_info[0] == 2 else self.password)
-            oprot.writeFieldEnd()
-        if self.configuration is not None:
-            oprot.writeFieldBegin('configuration', TType.MAP, 4)
-            oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.configuration))
-            for kiter132, viter133 in self.configuration.items():
-                oprot.writeString(kiter132.encode('utf-8') if sys.version_info[0] == 2 else kiter132)
-                oprot.writeString(viter133.encode('utf-8') if sys.version_info[0] == 2 else viter133)
-            oprot.writeMapEnd()
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.client_protocol is None:
+      raise TProtocolException(message='Required field client_protocol is unset!')
+    return
 
-    def validate(self):
-        if self.client_protocol is None:
-            raise TProtocolException(message='Required field client_protocol is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TOpenSessionResp(object):
-    """
+  """
     Attributes:
      - status
      - serverProtocolVersion
@@ -3272,365 +3236,360 @@ class TOpenSessionResp(object):
 
     """
 
+  def __init__(self, status=None, serverProtocolVersion=9, sessionHandle=None, configuration=None, ):
+    self.status = status
+    self.serverProtocolVersion = serverProtocolVersion
+    self.sessionHandle = sessionHandle
+    self.configuration = configuration
 
-    def __init__(self, status=None, serverProtocolVersion=9, sessionHandle=None, configuration=None,):
-        self.status = status
-        self.serverProtocolVersion = serverProtocolVersion
-        self.sessionHandle = sessionHandle
-        self.configuration = configuration
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.I32:
+          self.serverProtocolVersion = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRUCT:
+          self.sessionHandle = TSessionHandle()
+          self.sessionHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.MAP:
+          self.configuration = {}
+          (_ktype135, _vtype136, _size134) = iprot.readMapBegin()
+          for _i138 in range(_size134):
+            _key139 = iprot.readString()
+            _val140 = iprot.readString()
+            self.configuration[_key139] = _val140
+          iprot.readMapEnd()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.I32:
-                    self.serverProtocolVersion = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.STRUCT:
-                    self.sessionHandle = TSessionHandle()
-                    self.sessionHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.MAP:
-                    self.configuration = {}
-                    (_ktype135, _vtype136, _size134) = iprot.readMapBegin()
-                    for _i138 in range(_size134):
-                        _key139 = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                        _val140 = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                        self.configuration[_key139] = _val140
-                    iprot.readMapEnd()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TOpenSessionResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    if self.serverProtocolVersion is not None:
+      oprot.writeFieldBegin('serverProtocolVersion', TType.I32, 2)
+      oprot.writeI32(self.serverProtocolVersion)
+      oprot.writeFieldEnd()
+    if self.sessionHandle is not None:
+      oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 3)
+      self.sessionHandle.write(oprot)
+      oprot.writeFieldEnd()
+    if self.configuration is not None:
+      oprot.writeFieldBegin('configuration', TType.MAP, 4)
+      oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.configuration))
+      for kiter141, viter142 in self.configuration.items():
+        oprot.writeString(kiter141)
+        oprot.writeString(viter142)
+      oprot.writeMapEnd()
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TOpenSessionResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        if self.serverProtocolVersion is not None:
-            oprot.writeFieldBegin('serverProtocolVersion', TType.I32, 2)
-            oprot.writeI32(self.serverProtocolVersion)
-            oprot.writeFieldEnd()
-        if self.sessionHandle is not None:
-            oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 3)
-            self.sessionHandle.write(oprot)
-            oprot.writeFieldEnd()
-        if self.configuration is not None:
-            oprot.writeFieldBegin('configuration', TType.MAP, 4)
-            oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.configuration))
-            for kiter141, viter142 in self.configuration.items():
-                oprot.writeString(kiter141.encode('utf-8') if sys.version_info[0] == 2 else kiter141)
-                oprot.writeString(viter142.encode('utf-8') if sys.version_info[0] == 2 else viter142)
-            oprot.writeMapEnd()
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    if self.serverProtocolVersion is None:
+      raise TProtocolException(message='Required field serverProtocolVersion is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        if self.serverProtocolVersion is None:
-            raise TProtocolException(message='Required field serverProtocolVersion is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TSetClientInfoReq(object):
-    """
+  """
     Attributes:
      - sessionHandle
      - configuration
 
     """
 
+  def __init__(self, sessionHandle=None, configuration=None, ):
+    self.sessionHandle = sessionHandle
+    self.configuration = configuration
 
-    def __init__(self, sessionHandle=None, configuration=None,):
-        self.sessionHandle = sessionHandle
-        self.configuration = configuration
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.sessionHandle = TSessionHandle()
+          self.sessionHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.MAP:
+          self.configuration = {}
+          (_ktype144, _vtype145, _size143) = iprot.readMapBegin()
+          for _i147 in range(_size143):
+            _key148 = iprot.readString()
+            _val149 = iprot.readString()
+            self.configuration[_key148] = _val149
+          iprot.readMapEnd()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.sessionHandle = TSessionHandle()
-                    self.sessionHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.MAP:
-                    self.configuration = {}
-                    (_ktype144, _vtype145, _size143) = iprot.readMapBegin()
-                    for _i147 in range(_size143):
-                        _key148 = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                        _val149 = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                        self.configuration[_key148] = _val149
-                    iprot.readMapEnd()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TSetClientInfoReq')
+    if self.sessionHandle is not None:
+      oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
+      self.sessionHandle.write(oprot)
+      oprot.writeFieldEnd()
+    if self.configuration is not None:
+      oprot.writeFieldBegin('configuration', TType.MAP, 2)
+      oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.configuration))
+      for kiter150, viter151 in self.configuration.items():
+        oprot.writeString(kiter150)
+        oprot.writeString(viter151)
+      oprot.writeMapEnd()
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TSetClientInfoReq')
-        if self.sessionHandle is not None:
-            oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
-            self.sessionHandle.write(oprot)
-            oprot.writeFieldEnd()
-        if self.configuration is not None:
-            oprot.writeFieldBegin('configuration', TType.MAP, 2)
-            oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.configuration))
-            for kiter150, viter151 in self.configuration.items():
-                oprot.writeString(kiter150.encode('utf-8') if sys.version_info[0] == 2 else kiter150)
-                oprot.writeString(viter151.encode('utf-8') if sys.version_info[0] == 2 else viter151)
-            oprot.writeMapEnd()
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.sessionHandle is None:
+      raise TProtocolException(message='Required field sessionHandle is unset!')
+    return
 
-    def validate(self):
-        if self.sessionHandle is None:
-            raise TProtocolException(message='Required field sessionHandle is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TSetClientInfoResp(object):
-    """
+  """
     Attributes:
      - status
 
     """
 
+  def __init__(self, status=None, ):
+    self.status = status
 
-    def __init__(self, status=None,):
-        self.status = status
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TSetClientInfoResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TSetClientInfoResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TCloseSessionReq(object):
-    """
+  """
     Attributes:
      - sessionHandle
 
     """
 
+  def __init__(self, sessionHandle=None, ):
+    self.sessionHandle = sessionHandle
 
-    def __init__(self, sessionHandle=None,):
-        self.sessionHandle = sessionHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.sessionHandle = TSessionHandle()
+          self.sessionHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.sessionHandle = TSessionHandle()
-                    self.sessionHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TCloseSessionReq')
+    if self.sessionHandle is not None:
+      oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
+      self.sessionHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TCloseSessionReq')
-        if self.sessionHandle is not None:
-            oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
-            self.sessionHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.sessionHandle is None:
+      raise TProtocolException(message='Required field sessionHandle is unset!')
+    return
 
-    def validate(self):
-        if self.sessionHandle is None:
-            raise TProtocolException(message='Required field sessionHandle is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TCloseSessionResp(object):
-    """
+  """
     Attributes:
      - status
 
     """
 
+  def __init__(self, status=None, ):
+    self.status = status
 
-    def __init__(self, status=None,):
-        self.status = status
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TCloseSessionResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TCloseSessionResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetInfoValue(object):
-    """
+  """
     Attributes:
      - stringValue
      - smallIntValue
@@ -3641,255 +3600,252 @@ class TGetInfoValue(object):
 
     """
 
+  def __init__(self, stringValue=None, smallIntValue=None, integerBitmask=None, integerFlag=None, binaryValue=None, lenValue=None, ):
+    self.stringValue = stringValue
+    self.smallIntValue = smallIntValue
+    self.integerBitmask = integerBitmask
+    self.integerFlag = integerFlag
+    self.binaryValue = binaryValue
+    self.lenValue = lenValue
 
-    def __init__(self, stringValue=None, smallIntValue=None, integerBitmask=None, integerFlag=None, binaryValue=None, lenValue=None,):
-        self.stringValue = stringValue
-        self.smallIntValue = smallIntValue
-        self.integerBitmask = integerBitmask
-        self.integerFlag = integerFlag
-        self.binaryValue = binaryValue
-        self.lenValue = lenValue
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRING:
+          self.stringValue = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.I16:
+          self.smallIntValue = iprot.readI16()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.I32:
+          self.integerBitmask = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.I32:
+          self.integerFlag = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      elif fid == 5:
+        if ftype == TType.I32:
+          self.binaryValue = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      elif fid == 6:
+        if ftype == TType.I64:
+          self.lenValue = iprot.readI64()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRING:
-                    self.stringValue = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.I16:
-                    self.smallIntValue = iprot.readI16()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.I32:
-                    self.integerBitmask = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.I32:
-                    self.integerFlag = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 5:
-                if ftype == TType.I32:
-                    self.binaryValue = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 6:
-                if ftype == TType.I64:
-                    self.lenValue = iprot.readI64()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetInfoValue')
+    if self.stringValue is not None:
+      oprot.writeFieldBegin('stringValue', TType.STRING, 1)
+      oprot.writeString(self.stringValue)
+      oprot.writeFieldEnd()
+    if self.smallIntValue is not None:
+      oprot.writeFieldBegin('smallIntValue', TType.I16, 2)
+      oprot.writeI16(self.smallIntValue)
+      oprot.writeFieldEnd()
+    if self.integerBitmask is not None:
+      oprot.writeFieldBegin('integerBitmask', TType.I32, 3)
+      oprot.writeI32(self.integerBitmask)
+      oprot.writeFieldEnd()
+    if self.integerFlag is not None:
+      oprot.writeFieldBegin('integerFlag', TType.I32, 4)
+      oprot.writeI32(self.integerFlag)
+      oprot.writeFieldEnd()
+    if self.binaryValue is not None:
+      oprot.writeFieldBegin('binaryValue', TType.I32, 5)
+      oprot.writeI32(self.binaryValue)
+      oprot.writeFieldEnd()
+    if self.lenValue is not None:
+      oprot.writeFieldBegin('lenValue', TType.I64, 6)
+      oprot.writeI64(self.lenValue)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetInfoValue')
-        if self.stringValue is not None:
-            oprot.writeFieldBegin('stringValue', TType.STRING, 1)
-            oprot.writeString(self.stringValue.encode('utf-8') if sys.version_info[0] == 2 else self.stringValue)
-            oprot.writeFieldEnd()
-        if self.smallIntValue is not None:
-            oprot.writeFieldBegin('smallIntValue', TType.I16, 2)
-            oprot.writeI16(self.smallIntValue)
-            oprot.writeFieldEnd()
-        if self.integerBitmask is not None:
-            oprot.writeFieldBegin('integerBitmask', TType.I32, 3)
-            oprot.writeI32(self.integerBitmask)
-            oprot.writeFieldEnd()
-        if self.integerFlag is not None:
-            oprot.writeFieldBegin('integerFlag', TType.I32, 4)
-            oprot.writeI32(self.integerFlag)
-            oprot.writeFieldEnd()
-        if self.binaryValue is not None:
-            oprot.writeFieldBegin('binaryValue', TType.I32, 5)
-            oprot.writeI32(self.binaryValue)
-            oprot.writeFieldEnd()
-        if self.lenValue is not None:
-            oprot.writeFieldBegin('lenValue', TType.I64, 6)
-            oprot.writeI64(self.lenValue)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    return
 
-    def validate(self):
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetInfoReq(object):
-    """
+  """
     Attributes:
      - sessionHandle
      - infoType
 
     """
 
+  def __init__(self, sessionHandle=None, infoType=None, ):
+    self.sessionHandle = sessionHandle
+    self.infoType = infoType
 
-    def __init__(self, sessionHandle=None, infoType=None,):
-        self.sessionHandle = sessionHandle
-        self.infoType = infoType
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.sessionHandle = TSessionHandle()
+          self.sessionHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.I32:
+          self.infoType = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.sessionHandle = TSessionHandle()
-                    self.sessionHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.I32:
-                    self.infoType = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetInfoReq')
+    if self.sessionHandle is not None:
+      oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
+      self.sessionHandle.write(oprot)
+      oprot.writeFieldEnd()
+    if self.infoType is not None:
+      oprot.writeFieldBegin('infoType', TType.I32, 2)
+      oprot.writeI32(self.infoType)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetInfoReq')
-        if self.sessionHandle is not None:
-            oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
-            self.sessionHandle.write(oprot)
-            oprot.writeFieldEnd()
-        if self.infoType is not None:
-            oprot.writeFieldBegin('infoType', TType.I32, 2)
-            oprot.writeI32(self.infoType)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.sessionHandle is None:
+      raise TProtocolException(message='Required field sessionHandle is unset!')
+    if self.infoType is None:
+      raise TProtocolException(message='Required field infoType is unset!')
+    return
 
-    def validate(self):
-        if self.sessionHandle is None:
-            raise TProtocolException(message='Required field sessionHandle is unset!')
-        if self.infoType is None:
-            raise TProtocolException(message='Required field infoType is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetInfoResp(object):
-    """
+  """
     Attributes:
      - status
      - infoValue
 
     """
 
+  def __init__(self, status=None, infoValue=None, ):
+    self.status = status
+    self.infoValue = infoValue
 
-    def __init__(self, status=None, infoValue=None,):
-        self.status = status
-        self.infoValue = infoValue
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.infoValue = TGetInfoValue()
+          self.infoValue.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRUCT:
-                    self.infoValue = TGetInfoValue()
-                    self.infoValue.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetInfoResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    if self.infoValue is not None:
+      oprot.writeFieldBegin('infoValue', TType.STRUCT, 2)
+      self.infoValue.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetInfoResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        if self.infoValue is not None:
-            oprot.writeFieldBegin('infoValue', TType.STRUCT, 2)
-            self.infoValue.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    if self.infoValue is None:
+      raise TProtocolException(message='Required field infoValue is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        if self.infoValue is None:
-            raise TProtocolException(message='Required field infoValue is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TExecuteStatementReq(object):
-    """
+  """
     Attributes:
      - sessionHandle
      - statement
@@ -3899,449 +3855,443 @@ class TExecuteStatementReq(object):
 
     """
 
+  def __init__(self, sessionHandle=None, statement=None, confOverlay=None, runAsync=False, queryTimeout=0, ):
+    self.sessionHandle = sessionHandle
+    self.statement = statement
+    self.confOverlay = confOverlay
+    self.runAsync = runAsync
+    self.queryTimeout = queryTimeout
 
-    def __init__(self, sessionHandle=None, statement=None, confOverlay=None, runAsync=False, queryTimeout=0,):
-        self.sessionHandle = sessionHandle
-        self.statement = statement
-        self.confOverlay = confOverlay
-        self.runAsync = runAsync
-        self.queryTimeout = queryTimeout
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.sessionHandle = TSessionHandle()
+          self.sessionHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.statement = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.MAP:
+          self.confOverlay = {}
+          (_ktype153, _vtype154, _size152) = iprot.readMapBegin()
+          for _i156 in range(_size152):
+            _key157 = iprot.readString()
+            _val158 = iprot.readString()
+            self.confOverlay[_key157] = _val158
+          iprot.readMapEnd()
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.BOOL:
+          self.runAsync = iprot.readBool()
+        else:
+          iprot.skip(ftype)
+      elif fid == 5:
+        if ftype == TType.I64:
+          self.queryTimeout = iprot.readI64()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.sessionHandle = TSessionHandle()
-                    self.sessionHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.statement = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.MAP:
-                    self.confOverlay = {}
-                    (_ktype153, _vtype154, _size152) = iprot.readMapBegin()
-                    for _i156 in range(_size152):
-                        _key157 = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                        _val158 = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                        self.confOverlay[_key157] = _val158
-                    iprot.readMapEnd()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.BOOL:
-                    self.runAsync = iprot.readBool()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 5:
-                if ftype == TType.I64:
-                    self.queryTimeout = iprot.readI64()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TExecuteStatementReq')
+    if self.sessionHandle is not None:
+      oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
+      self.sessionHandle.write(oprot)
+      oprot.writeFieldEnd()
+    if self.statement is not None:
+      oprot.writeFieldBegin('statement', TType.STRING, 2)
+      oprot.writeString(self.statement)
+      oprot.writeFieldEnd()
+    if self.confOverlay is not None:
+      oprot.writeFieldBegin('confOverlay', TType.MAP, 3)
+      oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.confOverlay))
+      for kiter159, viter160 in self.confOverlay.items():
+        oprot.writeString(kiter159)
+        oprot.writeString(viter160)
+      oprot.writeMapEnd()
+      oprot.writeFieldEnd()
+    if self.runAsync is not None:
+      oprot.writeFieldBegin('runAsync', TType.BOOL, 4)
+      oprot.writeBool(self.runAsync)
+      oprot.writeFieldEnd()
+    if self.queryTimeout is not None:
+      oprot.writeFieldBegin('queryTimeout', TType.I64, 5)
+      oprot.writeI64(self.queryTimeout)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TExecuteStatementReq')
-        if self.sessionHandle is not None:
-            oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
-            self.sessionHandle.write(oprot)
-            oprot.writeFieldEnd()
-        if self.statement is not None:
-            oprot.writeFieldBegin('statement', TType.STRING, 2)
-            oprot.writeString(self.statement.encode('utf-8') if sys.version_info[0] == 2 else self.statement)
-            oprot.writeFieldEnd()
-        if self.confOverlay is not None:
-            oprot.writeFieldBegin('confOverlay', TType.MAP, 3)
-            oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.confOverlay))
-            for kiter159, viter160 in self.confOverlay.items():
-                oprot.writeString(kiter159.encode('utf-8') if sys.version_info[0] == 2 else kiter159)
-                oprot.writeString(viter160.encode('utf-8') if sys.version_info[0] == 2 else viter160)
-            oprot.writeMapEnd()
-            oprot.writeFieldEnd()
-        if self.runAsync is not None:
-            oprot.writeFieldBegin('runAsync', TType.BOOL, 4)
-            oprot.writeBool(self.runAsync)
-            oprot.writeFieldEnd()
-        if self.queryTimeout is not None:
-            oprot.writeFieldBegin('queryTimeout', TType.I64, 5)
-            oprot.writeI64(self.queryTimeout)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.sessionHandle is None:
+      raise TProtocolException(message='Required field sessionHandle is unset!')
+    if self.statement is None:
+      raise TProtocolException(message='Required field statement is unset!')
+    return
 
-    def validate(self):
-        if self.sessionHandle is None:
-            raise TProtocolException(message='Required field sessionHandle is unset!')
-        if self.statement is None:
-            raise TProtocolException(message='Required field statement is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TExecuteStatementResp(object):
-    """
+  """
     Attributes:
      - status
      - operationHandle
 
     """
 
+  def __init__(self, status=None, operationHandle=None, ):
+    self.status = status
+    self.operationHandle = operationHandle
 
-    def __init__(self, status=None, operationHandle=None,):
-        self.status = status
-        self.operationHandle = operationHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.operationHandle = TOperationHandle()
+          self.operationHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRUCT:
-                    self.operationHandle = TOperationHandle()
-                    self.operationHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TExecuteStatementResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    if self.operationHandle is not None:
+      oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
+      self.operationHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TExecuteStatementResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        if self.operationHandle is not None:
-            oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
-            self.operationHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetTypeInfoReq(object):
-    """
+  """
     Attributes:
      - sessionHandle
 
     """
 
+  def __init__(self, sessionHandle=None, ):
+    self.sessionHandle = sessionHandle
 
-    def __init__(self, sessionHandle=None,):
-        self.sessionHandle = sessionHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.sessionHandle = TSessionHandle()
+          self.sessionHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.sessionHandle = TSessionHandle()
-                    self.sessionHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetTypeInfoReq')
+    if self.sessionHandle is not None:
+      oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
+      self.sessionHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetTypeInfoReq')
-        if self.sessionHandle is not None:
-            oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
-            self.sessionHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.sessionHandle is None:
+      raise TProtocolException(message='Required field sessionHandle is unset!')
+    return
 
-    def validate(self):
-        if self.sessionHandle is None:
-            raise TProtocolException(message='Required field sessionHandle is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetTypeInfoResp(object):
-    """
+  """
     Attributes:
      - status
      - operationHandle
 
     """
 
+  def __init__(self, status=None, operationHandle=None, ):
+    self.status = status
+    self.operationHandle = operationHandle
 
-    def __init__(self, status=None, operationHandle=None,):
-        self.status = status
-        self.operationHandle = operationHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.operationHandle = TOperationHandle()
+          self.operationHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRUCT:
-                    self.operationHandle = TOperationHandle()
-                    self.operationHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetTypeInfoResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    if self.operationHandle is not None:
+      oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
+      self.operationHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetTypeInfoResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        if self.operationHandle is not None:
-            oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
-            self.operationHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetCatalogsReq(object):
-    """
+  """
     Attributes:
      - sessionHandle
 
     """
 
+  def __init__(self, sessionHandle=None, ):
+    self.sessionHandle = sessionHandle
 
-    def __init__(self, sessionHandle=None,):
-        self.sessionHandle = sessionHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.sessionHandle = TSessionHandle()
+          self.sessionHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.sessionHandle = TSessionHandle()
-                    self.sessionHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetCatalogsReq')
+    if self.sessionHandle is not None:
+      oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
+      self.sessionHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetCatalogsReq')
-        if self.sessionHandle is not None:
-            oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
-            self.sessionHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.sessionHandle is None:
+      raise TProtocolException(message='Required field sessionHandle is unset!')
+    return
 
-    def validate(self):
-        if self.sessionHandle is None:
-            raise TProtocolException(message='Required field sessionHandle is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetCatalogsResp(object):
-    """
+  """
     Attributes:
      - status
      - operationHandle
 
     """
 
+  def __init__(self, status=None, operationHandle=None, ):
+    self.status = status
+    self.operationHandle = operationHandle
 
-    def __init__(self, status=None, operationHandle=None,):
-        self.status = status
-        self.operationHandle = operationHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.operationHandle = TOperationHandle()
+          self.operationHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRUCT:
-                    self.operationHandle = TOperationHandle()
-                    self.operationHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetCatalogsResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    if self.operationHandle is not None:
+      oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
+      self.operationHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetCatalogsResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        if self.operationHandle is not None:
-            oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
-            self.operationHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetSchemasReq(object):
-    """
+  """
     Attributes:
      - sessionHandle
      - catalogName
@@ -4349,153 +4299,151 @@ class TGetSchemasReq(object):
 
     """
 
+  def __init__(self, sessionHandle=None, catalogName=None, schemaName=None, ):
+    self.sessionHandle = sessionHandle
+    self.catalogName = catalogName
+    self.schemaName = schemaName
 
-    def __init__(self, sessionHandle=None, catalogName=None, schemaName=None,):
-        self.sessionHandle = sessionHandle
-        self.catalogName = catalogName
-        self.schemaName = schemaName
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.sessionHandle = TSessionHandle()
+          self.sessionHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.catalogName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRING:
+          self.schemaName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.sessionHandle = TSessionHandle()
-                    self.sessionHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.catalogName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.STRING:
-                    self.schemaName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetSchemasReq')
+    if self.sessionHandle is not None:
+      oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
+      self.sessionHandle.write(oprot)
+      oprot.writeFieldEnd()
+    if self.catalogName is not None:
+      oprot.writeFieldBegin('catalogName', TType.STRING, 2)
+      oprot.writeString(self.catalogName)
+      oprot.writeFieldEnd()
+    if self.schemaName is not None:
+      oprot.writeFieldBegin('schemaName', TType.STRING, 3)
+      oprot.writeString(self.schemaName)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetSchemasReq')
-        if self.sessionHandle is not None:
-            oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
-            self.sessionHandle.write(oprot)
-            oprot.writeFieldEnd()
-        if self.catalogName is not None:
-            oprot.writeFieldBegin('catalogName', TType.STRING, 2)
-            oprot.writeString(self.catalogName.encode('utf-8') if sys.version_info[0] == 2 else self.catalogName)
-            oprot.writeFieldEnd()
-        if self.schemaName is not None:
-            oprot.writeFieldBegin('schemaName', TType.STRING, 3)
-            oprot.writeString(self.schemaName.encode('utf-8') if sys.version_info[0] == 2 else self.schemaName)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.sessionHandle is None:
+      raise TProtocolException(message='Required field sessionHandle is unset!')
+    return
 
-    def validate(self):
-        if self.sessionHandle is None:
-            raise TProtocolException(message='Required field sessionHandle is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetSchemasResp(object):
-    """
+  """
     Attributes:
      - status
      - operationHandle
 
     """
 
+  def __init__(self, status=None, operationHandle=None, ):
+    self.status = status
+    self.operationHandle = operationHandle
 
-    def __init__(self, status=None, operationHandle=None,):
-        self.status = status
-        self.operationHandle = operationHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.operationHandle = TOperationHandle()
+          self.operationHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRUCT:
-                    self.operationHandle = TOperationHandle()
-                    self.operationHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetSchemasResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    if self.operationHandle is not None:
+      oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
+      self.operationHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetSchemasResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        if self.operationHandle is not None:
-            oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
-            self.operationHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetTablesReq(object):
-    """
+  """
     Attributes:
      - sessionHandle
      - catalogName
@@ -4505,313 +4453,309 @@ class TGetTablesReq(object):
 
     """
 
+  def __init__(self, sessionHandle=None, catalogName=None, schemaName=None, tableName=None, tableTypes=None, ):
+    self.sessionHandle = sessionHandle
+    self.catalogName = catalogName
+    self.schemaName = schemaName
+    self.tableName = tableName
+    self.tableTypes = tableTypes
 
-    def __init__(self, sessionHandle=None, catalogName=None, schemaName=None, tableName=None, tableTypes=None,):
-        self.sessionHandle = sessionHandle
-        self.catalogName = catalogName
-        self.schemaName = schemaName
-        self.tableName = tableName
-        self.tableTypes = tableTypes
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.sessionHandle = TSessionHandle()
+          self.sessionHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.catalogName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRING:
+          self.schemaName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.STRING:
+          self.tableName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 5:
+        if ftype == TType.LIST:
+          self.tableTypes = []
+          (_etype164, _size161) = iprot.readListBegin()
+          for _i165 in range(_size161):
+            _elem166 = iprot.readString()
+            self.tableTypes.append(_elem166)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.sessionHandle = TSessionHandle()
-                    self.sessionHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.catalogName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.STRING:
-                    self.schemaName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.STRING:
-                    self.tableName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 5:
-                if ftype == TType.LIST:
-                    self.tableTypes = []
-                    (_etype164, _size161) = iprot.readListBegin()
-                    for _i165 in range(_size161):
-                        _elem166 = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                        self.tableTypes.append(_elem166)
-                    iprot.readListEnd()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetTablesReq')
+    if self.sessionHandle is not None:
+      oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
+      self.sessionHandle.write(oprot)
+      oprot.writeFieldEnd()
+    if self.catalogName is not None:
+      oprot.writeFieldBegin('catalogName', TType.STRING, 2)
+      oprot.writeString(self.catalogName)
+      oprot.writeFieldEnd()
+    if self.schemaName is not None:
+      oprot.writeFieldBegin('schemaName', TType.STRING, 3)
+      oprot.writeString(self.schemaName)
+      oprot.writeFieldEnd()
+    if self.tableName is not None:
+      oprot.writeFieldBegin('tableName', TType.STRING, 4)
+      oprot.writeString(self.tableName)
+      oprot.writeFieldEnd()
+    if self.tableTypes is not None:
+      oprot.writeFieldBegin('tableTypes', TType.LIST, 5)
+      oprot.writeListBegin(TType.STRING, len(self.tableTypes))
+      for iter167 in self.tableTypes:
+        oprot.writeString(iter167)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetTablesReq')
-        if self.sessionHandle is not None:
-            oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
-            self.sessionHandle.write(oprot)
-            oprot.writeFieldEnd()
-        if self.catalogName is not None:
-            oprot.writeFieldBegin('catalogName', TType.STRING, 2)
-            oprot.writeString(self.catalogName.encode('utf-8') if sys.version_info[0] == 2 else self.catalogName)
-            oprot.writeFieldEnd()
-        if self.schemaName is not None:
-            oprot.writeFieldBegin('schemaName', TType.STRING, 3)
-            oprot.writeString(self.schemaName.encode('utf-8') if sys.version_info[0] == 2 else self.schemaName)
-            oprot.writeFieldEnd()
-        if self.tableName is not None:
-            oprot.writeFieldBegin('tableName', TType.STRING, 4)
-            oprot.writeString(self.tableName.encode('utf-8') if sys.version_info[0] == 2 else self.tableName)
-            oprot.writeFieldEnd()
-        if self.tableTypes is not None:
-            oprot.writeFieldBegin('tableTypes', TType.LIST, 5)
-            oprot.writeListBegin(TType.STRING, len(self.tableTypes))
-            for iter167 in self.tableTypes:
-                oprot.writeString(iter167.encode('utf-8') if sys.version_info[0] == 2 else iter167)
-            oprot.writeListEnd()
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.sessionHandle is None:
+      raise TProtocolException(message='Required field sessionHandle is unset!')
+    return
 
-    def validate(self):
-        if self.sessionHandle is None:
-            raise TProtocolException(message='Required field sessionHandle is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetTablesResp(object):
-    """
+  """
     Attributes:
      - status
      - operationHandle
 
     """
 
+  def __init__(self, status=None, operationHandle=None, ):
+    self.status = status
+    self.operationHandle = operationHandle
 
-    def __init__(self, status=None, operationHandle=None,):
-        self.status = status
-        self.operationHandle = operationHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.operationHandle = TOperationHandle()
+          self.operationHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRUCT:
-                    self.operationHandle = TOperationHandle()
-                    self.operationHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetTablesResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    if self.operationHandle is not None:
+      oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
+      self.operationHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetTablesResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        if self.operationHandle is not None:
-            oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
-            self.operationHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetTableTypesReq(object):
-    """
+  """
     Attributes:
      - sessionHandle
 
     """
 
+  def __init__(self, sessionHandle=None, ):
+    self.sessionHandle = sessionHandle
 
-    def __init__(self, sessionHandle=None,):
-        self.sessionHandle = sessionHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.sessionHandle = TSessionHandle()
+          self.sessionHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.sessionHandle = TSessionHandle()
-                    self.sessionHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetTableTypesReq')
+    if self.sessionHandle is not None:
+      oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
+      self.sessionHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetTableTypesReq')
-        if self.sessionHandle is not None:
-            oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
-            self.sessionHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.sessionHandle is None:
+      raise TProtocolException(message='Required field sessionHandle is unset!')
+    return
 
-    def validate(self):
-        if self.sessionHandle is None:
-            raise TProtocolException(message='Required field sessionHandle is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetTableTypesResp(object):
-    """
+  """
     Attributes:
      - status
      - operationHandle
 
     """
 
+  def __init__(self, status=None, operationHandle=None, ):
+    self.status = status
+    self.operationHandle = operationHandle
 
-    def __init__(self, status=None, operationHandle=None,):
-        self.status = status
-        self.operationHandle = operationHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.operationHandle = TOperationHandle()
+          self.operationHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRUCT:
-                    self.operationHandle = TOperationHandle()
-                    self.operationHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetTableTypesResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    if self.operationHandle is not None:
+      oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
+      self.operationHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetTableTypesResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        if self.operationHandle is not None:
-            oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
-            self.operationHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetColumnsReq(object):
-    """
+  """
     Attributes:
      - sessionHandle
      - catalogName
@@ -4821,173 +4765,171 @@ class TGetColumnsReq(object):
 
     """
 
+  def __init__(self, sessionHandle=None, catalogName=None, schemaName=None, tableName=None, columnName=None, ):
+    self.sessionHandle = sessionHandle
+    self.catalogName = catalogName
+    self.schemaName = schemaName
+    self.tableName = tableName
+    self.columnName = columnName
 
-    def __init__(self, sessionHandle=None, catalogName=None, schemaName=None, tableName=None, columnName=None,):
-        self.sessionHandle = sessionHandle
-        self.catalogName = catalogName
-        self.schemaName = schemaName
-        self.tableName = tableName
-        self.columnName = columnName
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.sessionHandle = TSessionHandle()
+          self.sessionHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.catalogName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRING:
+          self.schemaName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.STRING:
+          self.tableName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 5:
+        if ftype == TType.STRING:
+          self.columnName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.sessionHandle = TSessionHandle()
-                    self.sessionHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.catalogName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.STRING:
-                    self.schemaName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.STRING:
-                    self.tableName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 5:
-                if ftype == TType.STRING:
-                    self.columnName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetColumnsReq')
+    if self.sessionHandle is not None:
+      oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
+      self.sessionHandle.write(oprot)
+      oprot.writeFieldEnd()
+    if self.catalogName is not None:
+      oprot.writeFieldBegin('catalogName', TType.STRING, 2)
+      oprot.writeString(self.catalogName)
+      oprot.writeFieldEnd()
+    if self.schemaName is not None:
+      oprot.writeFieldBegin('schemaName', TType.STRING, 3)
+      oprot.writeString(self.schemaName)
+      oprot.writeFieldEnd()
+    if self.tableName is not None:
+      oprot.writeFieldBegin('tableName', TType.STRING, 4)
+      oprot.writeString(self.tableName)
+      oprot.writeFieldEnd()
+    if self.columnName is not None:
+      oprot.writeFieldBegin('columnName', TType.STRING, 5)
+      oprot.writeString(self.columnName)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetColumnsReq')
-        if self.sessionHandle is not None:
-            oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
-            self.sessionHandle.write(oprot)
-            oprot.writeFieldEnd()
-        if self.catalogName is not None:
-            oprot.writeFieldBegin('catalogName', TType.STRING, 2)
-            oprot.writeString(self.catalogName.encode('utf-8') if sys.version_info[0] == 2 else self.catalogName)
-            oprot.writeFieldEnd()
-        if self.schemaName is not None:
-            oprot.writeFieldBegin('schemaName', TType.STRING, 3)
-            oprot.writeString(self.schemaName.encode('utf-8') if sys.version_info[0] == 2 else self.schemaName)
-            oprot.writeFieldEnd()
-        if self.tableName is not None:
-            oprot.writeFieldBegin('tableName', TType.STRING, 4)
-            oprot.writeString(self.tableName.encode('utf-8') if sys.version_info[0] == 2 else self.tableName)
-            oprot.writeFieldEnd()
-        if self.columnName is not None:
-            oprot.writeFieldBegin('columnName', TType.STRING, 5)
-            oprot.writeString(self.columnName.encode('utf-8') if sys.version_info[0] == 2 else self.columnName)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.sessionHandle is None:
+      raise TProtocolException(message='Required field sessionHandle is unset!')
+    return
 
-    def validate(self):
-        if self.sessionHandle is None:
-            raise TProtocolException(message='Required field sessionHandle is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetColumnsResp(object):
-    """
+  """
     Attributes:
      - status
      - operationHandle
 
     """
 
+  def __init__(self, status=None, operationHandle=None, ):
+    self.status = status
+    self.operationHandle = operationHandle
 
-    def __init__(self, status=None, operationHandle=None,):
-        self.status = status
-        self.operationHandle = operationHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.operationHandle = TOperationHandle()
+          self.operationHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRUCT:
-                    self.operationHandle = TOperationHandle()
-                    self.operationHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetColumnsResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    if self.operationHandle is not None:
+      oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
+      self.operationHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetColumnsResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        if self.operationHandle is not None:
-            oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
-            self.operationHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetFunctionsReq(object):
-    """
+  """
     Attributes:
      - sessionHandle
      - catalogName
@@ -4996,165 +4938,163 @@ class TGetFunctionsReq(object):
 
     """
 
+  def __init__(self, sessionHandle=None, catalogName=None, schemaName=None, functionName=None, ):
+    self.sessionHandle = sessionHandle
+    self.catalogName = catalogName
+    self.schemaName = schemaName
+    self.functionName = functionName
 
-    def __init__(self, sessionHandle=None, catalogName=None, schemaName=None, functionName=None,):
-        self.sessionHandle = sessionHandle
-        self.catalogName = catalogName
-        self.schemaName = schemaName
-        self.functionName = functionName
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.sessionHandle = TSessionHandle()
+          self.sessionHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.catalogName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRING:
+          self.schemaName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.STRING:
+          self.functionName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.sessionHandle = TSessionHandle()
-                    self.sessionHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.catalogName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.STRING:
-                    self.schemaName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.STRING:
-                    self.functionName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetFunctionsReq')
+    if self.sessionHandle is not None:
+      oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
+      self.sessionHandle.write(oprot)
+      oprot.writeFieldEnd()
+    if self.catalogName is not None:
+      oprot.writeFieldBegin('catalogName', TType.STRING, 2)
+      oprot.writeString(self.catalogName)
+      oprot.writeFieldEnd()
+    if self.schemaName is not None:
+      oprot.writeFieldBegin('schemaName', TType.STRING, 3)
+      oprot.writeString(self.schemaName)
+      oprot.writeFieldEnd()
+    if self.functionName is not None:
+      oprot.writeFieldBegin('functionName', TType.STRING, 4)
+      oprot.writeString(self.functionName)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetFunctionsReq')
-        if self.sessionHandle is not None:
-            oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
-            self.sessionHandle.write(oprot)
-            oprot.writeFieldEnd()
-        if self.catalogName is not None:
-            oprot.writeFieldBegin('catalogName', TType.STRING, 2)
-            oprot.writeString(self.catalogName.encode('utf-8') if sys.version_info[0] == 2 else self.catalogName)
-            oprot.writeFieldEnd()
-        if self.schemaName is not None:
-            oprot.writeFieldBegin('schemaName', TType.STRING, 3)
-            oprot.writeString(self.schemaName.encode('utf-8') if sys.version_info[0] == 2 else self.schemaName)
-            oprot.writeFieldEnd()
-        if self.functionName is not None:
-            oprot.writeFieldBegin('functionName', TType.STRING, 4)
-            oprot.writeString(self.functionName.encode('utf-8') if sys.version_info[0] == 2 else self.functionName)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.sessionHandle is None:
+      raise TProtocolException(message='Required field sessionHandle is unset!')
+    if self.functionName is None:
+      raise TProtocolException(message='Required field functionName is unset!')
+    return
 
-    def validate(self):
-        if self.sessionHandle is None:
-            raise TProtocolException(message='Required field sessionHandle is unset!')
-        if self.functionName is None:
-            raise TProtocolException(message='Required field functionName is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetFunctionsResp(object):
-    """
+  """
     Attributes:
      - status
      - operationHandle
 
     """
 
+  def __init__(self, status=None, operationHandle=None, ):
+    self.status = status
+    self.operationHandle = operationHandle
 
-    def __init__(self, status=None, operationHandle=None,):
-        self.status = status
-        self.operationHandle = operationHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.operationHandle = TOperationHandle()
+          self.operationHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRUCT:
-                    self.operationHandle = TOperationHandle()
-                    self.operationHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetFunctionsResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    if self.operationHandle is not None:
+      oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
+      self.operationHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetFunctionsResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        if self.operationHandle is not None:
-            oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
-            self.operationHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetPrimaryKeysReq(object):
-    """
+  """
     Attributes:
      - sessionHandle
      - catalogName
@@ -5163,163 +5103,161 @@ class TGetPrimaryKeysReq(object):
 
     """
 
+  def __init__(self, sessionHandle=None, catalogName=None, schemaName=None, tableName=None, ):
+    self.sessionHandle = sessionHandle
+    self.catalogName = catalogName
+    self.schemaName = schemaName
+    self.tableName = tableName
 
-    def __init__(self, sessionHandle=None, catalogName=None, schemaName=None, tableName=None,):
-        self.sessionHandle = sessionHandle
-        self.catalogName = catalogName
-        self.schemaName = schemaName
-        self.tableName = tableName
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.sessionHandle = TSessionHandle()
+          self.sessionHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.catalogName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRING:
+          self.schemaName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.STRING:
+          self.tableName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.sessionHandle = TSessionHandle()
-                    self.sessionHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.catalogName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.STRING:
-                    self.schemaName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.STRING:
-                    self.tableName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetPrimaryKeysReq')
+    if self.sessionHandle is not None:
+      oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
+      self.sessionHandle.write(oprot)
+      oprot.writeFieldEnd()
+    if self.catalogName is not None:
+      oprot.writeFieldBegin('catalogName', TType.STRING, 2)
+      oprot.writeString(self.catalogName)
+      oprot.writeFieldEnd()
+    if self.schemaName is not None:
+      oprot.writeFieldBegin('schemaName', TType.STRING, 3)
+      oprot.writeString(self.schemaName)
+      oprot.writeFieldEnd()
+    if self.tableName is not None:
+      oprot.writeFieldBegin('tableName', TType.STRING, 4)
+      oprot.writeString(self.tableName)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetPrimaryKeysReq')
-        if self.sessionHandle is not None:
-            oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
-            self.sessionHandle.write(oprot)
-            oprot.writeFieldEnd()
-        if self.catalogName is not None:
-            oprot.writeFieldBegin('catalogName', TType.STRING, 2)
-            oprot.writeString(self.catalogName.encode('utf-8') if sys.version_info[0] == 2 else self.catalogName)
-            oprot.writeFieldEnd()
-        if self.schemaName is not None:
-            oprot.writeFieldBegin('schemaName', TType.STRING, 3)
-            oprot.writeString(self.schemaName.encode('utf-8') if sys.version_info[0] == 2 else self.schemaName)
-            oprot.writeFieldEnd()
-        if self.tableName is not None:
-            oprot.writeFieldBegin('tableName', TType.STRING, 4)
-            oprot.writeString(self.tableName.encode('utf-8') if sys.version_info[0] == 2 else self.tableName)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.sessionHandle is None:
+      raise TProtocolException(message='Required field sessionHandle is unset!')
+    return
 
-    def validate(self):
-        if self.sessionHandle is None:
-            raise TProtocolException(message='Required field sessionHandle is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetPrimaryKeysResp(object):
-    """
+  """
     Attributes:
      - status
      - operationHandle
 
     """
 
+  def __init__(self, status=None, operationHandle=None, ):
+    self.status = status
+    self.operationHandle = operationHandle
 
-    def __init__(self, status=None, operationHandle=None,):
-        self.status = status
-        self.operationHandle = operationHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.operationHandle = TOperationHandle()
+          self.operationHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRUCT:
-                    self.operationHandle = TOperationHandle()
-                    self.operationHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetPrimaryKeysResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    if self.operationHandle is not None:
+      oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
+      self.operationHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetPrimaryKeysResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        if self.operationHandle is not None:
-            oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
-            self.operationHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetCrossReferenceReq(object):
-    """
+  """
     Attributes:
      - sessionHandle
      - parentCatalogName
@@ -5331,264 +5269,262 @@ class TGetCrossReferenceReq(object):
 
     """
 
+  def __init__(self, sessionHandle=None, parentCatalogName=None, parentSchemaName=None, parentTableName=None, foreignCatalogName=None, foreignSchemaName=None,
+    foreignTableName=None, ):
+    self.sessionHandle = sessionHandle
+    self.parentCatalogName = parentCatalogName
+    self.parentSchemaName = parentSchemaName
+    self.parentTableName = parentTableName
+    self.foreignCatalogName = foreignCatalogName
+    self.foreignSchemaName = foreignSchemaName
+    self.foreignTableName = foreignTableName
 
-    def __init__(self, sessionHandle=None, parentCatalogName=None, parentSchemaName=None, parentTableName=None, foreignCatalogName=None, foreignSchemaName=None, foreignTableName=None,):
-        self.sessionHandle = sessionHandle
-        self.parentCatalogName = parentCatalogName
-        self.parentSchemaName = parentSchemaName
-        self.parentTableName = parentTableName
-        self.foreignCatalogName = foreignCatalogName
-        self.foreignSchemaName = foreignSchemaName
-        self.foreignTableName = foreignTableName
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.sessionHandle = TSessionHandle()
+          self.sessionHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.parentCatalogName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRING:
+          self.parentSchemaName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.STRING:
+          self.parentTableName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 5:
+        if ftype == TType.STRING:
+          self.foreignCatalogName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 6:
+        if ftype == TType.STRING:
+          self.foreignSchemaName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 7:
+        if ftype == TType.STRING:
+          self.foreignTableName = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.sessionHandle = TSessionHandle()
-                    self.sessionHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.parentCatalogName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.STRING:
-                    self.parentSchemaName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.STRING:
-                    self.parentTableName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 5:
-                if ftype == TType.STRING:
-                    self.foreignCatalogName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 6:
-                if ftype == TType.STRING:
-                    self.foreignSchemaName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 7:
-                if ftype == TType.STRING:
-                    self.foreignTableName = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetCrossReferenceReq')
+    if self.sessionHandle is not None:
+      oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
+      self.sessionHandle.write(oprot)
+      oprot.writeFieldEnd()
+    if self.parentCatalogName is not None:
+      oprot.writeFieldBegin('parentCatalogName', TType.STRING, 2)
+      oprot.writeString(self.parentCatalogName)
+      oprot.writeFieldEnd()
+    if self.parentSchemaName is not None:
+      oprot.writeFieldBegin('parentSchemaName', TType.STRING, 3)
+      oprot.writeString(self.parentSchemaName)
+      oprot.writeFieldEnd()
+    if self.parentTableName is not None:
+      oprot.writeFieldBegin('parentTableName', TType.STRING, 4)
+      oprot.writeString(self.parentTableName)
+      oprot.writeFieldEnd()
+    if self.foreignCatalogName is not None:
+      oprot.writeFieldBegin('foreignCatalogName', TType.STRING, 5)
+      oprot.writeString(self.foreignCatalogName)
+      oprot.writeFieldEnd()
+    if self.foreignSchemaName is not None:
+      oprot.writeFieldBegin('foreignSchemaName', TType.STRING, 6)
+      oprot.writeString(self.foreignSchemaName)
+      oprot.writeFieldEnd()
+    if self.foreignTableName is not None:
+      oprot.writeFieldBegin('foreignTableName', TType.STRING, 7)
+      oprot.writeString(self.foreignTableName)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetCrossReferenceReq')
-        if self.sessionHandle is not None:
-            oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
-            self.sessionHandle.write(oprot)
-            oprot.writeFieldEnd()
-        if self.parentCatalogName is not None:
-            oprot.writeFieldBegin('parentCatalogName', TType.STRING, 2)
-            oprot.writeString(self.parentCatalogName.encode('utf-8') if sys.version_info[0] == 2 else self.parentCatalogName)
-            oprot.writeFieldEnd()
-        if self.parentSchemaName is not None:
-            oprot.writeFieldBegin('parentSchemaName', TType.STRING, 3)
-            oprot.writeString(self.parentSchemaName.encode('utf-8') if sys.version_info[0] == 2 else self.parentSchemaName)
-            oprot.writeFieldEnd()
-        if self.parentTableName is not None:
-            oprot.writeFieldBegin('parentTableName', TType.STRING, 4)
-            oprot.writeString(self.parentTableName.encode('utf-8') if sys.version_info[0] == 2 else self.parentTableName)
-            oprot.writeFieldEnd()
-        if self.foreignCatalogName is not None:
-            oprot.writeFieldBegin('foreignCatalogName', TType.STRING, 5)
-            oprot.writeString(self.foreignCatalogName.encode('utf-8') if sys.version_info[0] == 2 else self.foreignCatalogName)
-            oprot.writeFieldEnd()
-        if self.foreignSchemaName is not None:
-            oprot.writeFieldBegin('foreignSchemaName', TType.STRING, 6)
-            oprot.writeString(self.foreignSchemaName.encode('utf-8') if sys.version_info[0] == 2 else self.foreignSchemaName)
-            oprot.writeFieldEnd()
-        if self.foreignTableName is not None:
-            oprot.writeFieldBegin('foreignTableName', TType.STRING, 7)
-            oprot.writeString(self.foreignTableName.encode('utf-8') if sys.version_info[0] == 2 else self.foreignTableName)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.sessionHandle is None:
+      raise TProtocolException(message='Required field sessionHandle is unset!')
+    return
 
-    def validate(self):
-        if self.sessionHandle is None:
-            raise TProtocolException(message='Required field sessionHandle is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetCrossReferenceResp(object):
-    """
+  """
     Attributes:
      - status
      - operationHandle
 
     """
 
+  def __init__(self, status=None, operationHandle=None, ):
+    self.status = status
+    self.operationHandle = operationHandle
 
-    def __init__(self, status=None, operationHandle=None,):
-        self.status = status
-        self.operationHandle = operationHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.operationHandle = TOperationHandle()
+          self.operationHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRUCT:
-                    self.operationHandle = TOperationHandle()
-                    self.operationHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetCrossReferenceResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    if self.operationHandle is not None:
+      oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
+      self.operationHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetCrossReferenceResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        if self.operationHandle is not None:
-            oprot.writeFieldBegin('operationHandle', TType.STRUCT, 2)
-            self.operationHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetOperationStatusReq(object):
-    """
+  """
     Attributes:
      - operationHandle
      - getProgressUpdate
 
     """
 
+  def __init__(self, operationHandle=None, getProgressUpdate=None, ):
+    self.operationHandle = operationHandle
+    self.getProgressUpdate = getProgressUpdate
 
-    def __init__(self, operationHandle=None, getProgressUpdate=None,):
-        self.operationHandle = operationHandle
-        self.getProgressUpdate = getProgressUpdate
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.operationHandle = TOperationHandle()
+          self.operationHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.BOOL:
+          self.getProgressUpdate = iprot.readBool()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.operationHandle = TOperationHandle()
-                    self.operationHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.BOOL:
-                    self.getProgressUpdate = iprot.readBool()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetOperationStatusReq')
+    if self.operationHandle is not None:
+      oprot.writeFieldBegin('operationHandle', TType.STRUCT, 1)
+      self.operationHandle.write(oprot)
+      oprot.writeFieldEnd()
+    if self.getProgressUpdate is not None:
+      oprot.writeFieldBegin('getProgressUpdate', TType.BOOL, 2)
+      oprot.writeBool(self.getProgressUpdate)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetOperationStatusReq')
-        if self.operationHandle is not None:
-            oprot.writeFieldBegin('operationHandle', TType.STRUCT, 1)
-            self.operationHandle.write(oprot)
-            oprot.writeFieldEnd()
-        if self.getProgressUpdate is not None:
-            oprot.writeFieldBegin('getProgressUpdate', TType.BOOL, 2)
-            oprot.writeBool(self.getProgressUpdate)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.operationHandle is None:
+      raise TProtocolException(message='Required field operationHandle is unset!')
+    return
 
-    def validate(self):
-        if self.operationHandle is None:
-            raise TProtocolException(message='Required field operationHandle is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TProgressUpdateResp(object):
-    """
+  """
     Attributes:
      - headerNames
      - rows
@@ -5599,144 +5535,143 @@ class TProgressUpdateResp(object):
 
     """
 
+  def __init__(self, headerNames=None, rows=None, progressedPercentage=None, status=None, footerSummary=None, startTime=None, ):
+    self.headerNames = headerNames
+    self.rows = rows
+    self.progressedPercentage = progressedPercentage
+    self.status = status
+    self.footerSummary = footerSummary
+    self.startTime = startTime
 
-    def __init__(self, headerNames=None, rows=None, progressedPercentage=None, status=None, footerSummary=None, startTime=None,):
-        self.headerNames = headerNames
-        self.rows = rows
-        self.progressedPercentage = progressedPercentage
-        self.status = status
-        self.footerSummary = footerSummary
-        self.startTime = startTime
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.LIST:
+          self.headerNames = []
+          (_etype171, _size168) = iprot.readListBegin()
+          for _i172 in range(_size168):
+            _elem173 = iprot.readString()
+            self.headerNames.append(_elem173)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.LIST:
+          self.rows = []
+          (_etype177, _size174) = iprot.readListBegin()
+          for _i178 in range(_size174):
+            _elem179 = []
+            (_etype183, _size180) = iprot.readListBegin()
+            for _i184 in range(_size180):
+              _elem185 = iprot.readString()
+              _elem179.append(_elem185)
+            iprot.readListEnd()
+            self.rows.append(_elem179)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.DOUBLE:
+          self.progressedPercentage = iprot.readDouble()
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.I32:
+          self.status = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      elif fid == 5:
+        if ftype == TType.STRING:
+          self.footerSummary = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 6:
+        if ftype == TType.I64:
+          self.startTime = iprot.readI64()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.LIST:
-                    self.headerNames = []
-                    (_etype171, _size168) = iprot.readListBegin()
-                    for _i172 in range(_size168):
-                        _elem173 = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                        self.headerNames.append(_elem173)
-                    iprot.readListEnd()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.LIST:
-                    self.rows = []
-                    (_etype177, _size174) = iprot.readListBegin()
-                    for _i178 in range(_size174):
-                        _elem179 = []
-                        (_etype183, _size180) = iprot.readListBegin()
-                        for _i184 in range(_size180):
-                            _elem185 = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                            _elem179.append(_elem185)
-                        iprot.readListEnd()
-                        self.rows.append(_elem179)
-                    iprot.readListEnd()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.DOUBLE:
-                    self.progressedPercentage = iprot.readDouble()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.I32:
-                    self.status = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 5:
-                if ftype == TType.STRING:
-                    self.footerSummary = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 6:
-                if ftype == TType.I64:
-                    self.startTime = iprot.readI64()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TProgressUpdateResp')
+    if self.headerNames is not None:
+      oprot.writeFieldBegin('headerNames', TType.LIST, 1)
+      oprot.writeListBegin(TType.STRING, len(self.headerNames))
+      for iter186 in self.headerNames:
+        oprot.writeString(iter186)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    if self.rows is not None:
+      oprot.writeFieldBegin('rows', TType.LIST, 2)
+      oprot.writeListBegin(TType.LIST, len(self.rows))
+      for iter187 in self.rows:
+        oprot.writeListBegin(TType.STRING, len(iter187))
+        for iter188 in iter187:
+          oprot.writeString(iter188)
+        oprot.writeListEnd()
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    if self.progressedPercentage is not None:
+      oprot.writeFieldBegin('progressedPercentage', TType.DOUBLE, 3)
+      oprot.writeDouble(self.progressedPercentage)
+      oprot.writeFieldEnd()
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.I32, 4)
+      oprot.writeI32(self.status)
+      oprot.writeFieldEnd()
+    if self.footerSummary is not None:
+      oprot.writeFieldBegin('footerSummary', TType.STRING, 5)
+      oprot.writeString(self.footerSummary)
+      oprot.writeFieldEnd()
+    if self.startTime is not None:
+      oprot.writeFieldBegin('startTime', TType.I64, 6)
+      oprot.writeI64(self.startTime)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TProgressUpdateResp')
-        if self.headerNames is not None:
-            oprot.writeFieldBegin('headerNames', TType.LIST, 1)
-            oprot.writeListBegin(TType.STRING, len(self.headerNames))
-            for iter186 in self.headerNames:
-                oprot.writeString(iter186.encode('utf-8') if sys.version_info[0] == 2 else iter186)
-            oprot.writeListEnd()
-            oprot.writeFieldEnd()
-        if self.rows is not None:
-            oprot.writeFieldBegin('rows', TType.LIST, 2)
-            oprot.writeListBegin(TType.LIST, len(self.rows))
-            for iter187 in self.rows:
-                oprot.writeListBegin(TType.STRING, len(iter187))
-                for iter188 in iter187:
-                    oprot.writeString(iter188.encode('utf-8') if sys.version_info[0] == 2 else iter188)
-                oprot.writeListEnd()
-            oprot.writeListEnd()
-            oprot.writeFieldEnd()
-        if self.progressedPercentage is not None:
-            oprot.writeFieldBegin('progressedPercentage', TType.DOUBLE, 3)
-            oprot.writeDouble(self.progressedPercentage)
-            oprot.writeFieldEnd()
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.I32, 4)
-            oprot.writeI32(self.status)
-            oprot.writeFieldEnd()
-        if self.footerSummary is not None:
-            oprot.writeFieldBegin('footerSummary', TType.STRING, 5)
-            oprot.writeString(self.footerSummary.encode('utf-8') if sys.version_info[0] == 2 else self.footerSummary)
-            oprot.writeFieldEnd()
-        if self.startTime is not None:
-            oprot.writeFieldBegin('startTime', TType.I64, 6)
-            oprot.writeI64(self.startTime)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.headerNames is None:
+      raise TProtocolException(message='Required field headerNames is unset!')
+    if self.rows is None:
+      raise TProtocolException(message='Required field rows is unset!')
+    if self.progressedPercentage is None:
+      raise TProtocolException(message='Required field progressedPercentage is unset!')
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    if self.footerSummary is None:
+      raise TProtocolException(message='Required field footerSummary is unset!')
+    if self.startTime is None:
+      raise TProtocolException(message='Required field startTime is unset!')
+    return
 
-    def validate(self):
-        if self.headerNames is None:
-            raise TProtocolException(message='Required field headerNames is unset!')
-        if self.rows is None:
-            raise TProtocolException(message='Required field rows is unset!')
-        if self.progressedPercentage is None:
-            raise TProtocolException(message='Required field progressedPercentage is unset!')
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        if self.footerSummary is None:
-            raise TProtocolException(message='Required field footerSummary is unset!')
-        if self.startTime is None:
-            raise TProtocolException(message='Required field startTime is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetOperationStatusResp(object):
-    """
+  """
     Attributes:
      - status
      - operationState
@@ -5752,534 +5687,528 @@ class TGetOperationStatusResp(object):
 
     """
 
+  def __init__(self, status=None, operationState=None, sqlState=None, errorCode=None, errorMessage=None, taskStatus=None, operationStarted=None, operationCompleted=None,
+    hasResultSet=None, progressUpdateResponse=None, numModifiedRows=None, ):
+    self.status = status
+    self.operationState = operationState
+    self.sqlState = sqlState
+    self.errorCode = errorCode
+    self.errorMessage = errorMessage
+    self.taskStatus = taskStatus
+    self.operationStarted = operationStarted
+    self.operationCompleted = operationCompleted
+    self.hasResultSet = hasResultSet
+    self.progressUpdateResponse = progressUpdateResponse
+    self.numModifiedRows = numModifiedRows
 
-    def __init__(self, status=None, operationState=None, sqlState=None, errorCode=None, errorMessage=None, taskStatus=None, operationStarted=None, operationCompleted=None, hasResultSet=None, progressUpdateResponse=None, numModifiedRows=None,):
-        self.status = status
-        self.operationState = operationState
-        self.sqlState = sqlState
-        self.errorCode = errorCode
-        self.errorMessage = errorMessage
-        self.taskStatus = taskStatus
-        self.operationStarted = operationStarted
-        self.operationCompleted = operationCompleted
-        self.hasResultSet = hasResultSet
-        self.progressUpdateResponse = progressUpdateResponse
-        self.numModifiedRows = numModifiedRows
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.I32:
+          self.operationState = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRING:
+          self.sqlState = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.I32:
+          self.errorCode = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      elif fid == 5:
+        if ftype == TType.STRING:
+          self.errorMessage = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 6:
+        if ftype == TType.STRING:
+          self.taskStatus = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 7:
+        if ftype == TType.I64:
+          self.operationStarted = iprot.readI64()
+        else:
+          iprot.skip(ftype)
+      elif fid == 8:
+        if ftype == TType.I64:
+          self.operationCompleted = iprot.readI64()
+        else:
+          iprot.skip(ftype)
+      elif fid == 9:
+        if ftype == TType.BOOL:
+          self.hasResultSet = iprot.readBool()
+        else:
+          iprot.skip(ftype)
+      elif fid == 10:
+        if ftype == TType.STRUCT:
+          self.progressUpdateResponse = TProgressUpdateResp()
+          self.progressUpdateResponse.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 11:
+        if ftype == TType.I64:
+          self.numModifiedRows = iprot.readI64()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.I32:
-                    self.operationState = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.STRING:
-                    self.sqlState = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.I32:
-                    self.errorCode = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 5:
-                if ftype == TType.STRING:
-                    self.errorMessage = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 6:
-                if ftype == TType.STRING:
-                    self.taskStatus = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 7:
-                if ftype == TType.I64:
-                    self.operationStarted = iprot.readI64()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 8:
-                if ftype == TType.I64:
-                    self.operationCompleted = iprot.readI64()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 9:
-                if ftype == TType.BOOL:
-                    self.hasResultSet = iprot.readBool()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 10:
-                if ftype == TType.STRUCT:
-                    self.progressUpdateResponse = TProgressUpdateResp()
-                    self.progressUpdateResponse.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 11:
-                if ftype == TType.I64:
-                    self.numModifiedRows = iprot.readI64()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetOperationStatusResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    if self.operationState is not None:
+      oprot.writeFieldBegin('operationState', TType.I32, 2)
+      oprot.writeI32(self.operationState)
+      oprot.writeFieldEnd()
+    if self.sqlState is not None:
+      oprot.writeFieldBegin('sqlState', TType.STRING, 3)
+      oprot.writeString(self.sqlState)
+      oprot.writeFieldEnd()
+    if self.errorCode is not None:
+      oprot.writeFieldBegin('errorCode', TType.I32, 4)
+      oprot.writeI32(self.errorCode)
+      oprot.writeFieldEnd()
+    if self.errorMessage is not None:
+      oprot.writeFieldBegin('errorMessage', TType.STRING, 5)
+      oprot.writeString(self.errorMessage)
+      oprot.writeFieldEnd()
+    if self.taskStatus is not None:
+      oprot.writeFieldBegin('taskStatus', TType.STRING, 6)
+      oprot.writeString(self.taskStatus)
+      oprot.writeFieldEnd()
+    if self.operationStarted is not None:
+      oprot.writeFieldBegin('operationStarted', TType.I64, 7)
+      oprot.writeI64(self.operationStarted)
+      oprot.writeFieldEnd()
+    if self.operationCompleted is not None:
+      oprot.writeFieldBegin('operationCompleted', TType.I64, 8)
+      oprot.writeI64(self.operationCompleted)
+      oprot.writeFieldEnd()
+    if self.hasResultSet is not None:
+      oprot.writeFieldBegin('hasResultSet', TType.BOOL, 9)
+      oprot.writeBool(self.hasResultSet)
+      oprot.writeFieldEnd()
+    if self.progressUpdateResponse is not None:
+      oprot.writeFieldBegin('progressUpdateResponse', TType.STRUCT, 10)
+      self.progressUpdateResponse.write(oprot)
+      oprot.writeFieldEnd()
+    if self.numModifiedRows is not None:
+      oprot.writeFieldBegin('numModifiedRows', TType.I64, 11)
+      oprot.writeI64(self.numModifiedRows)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetOperationStatusResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        if self.operationState is not None:
-            oprot.writeFieldBegin('operationState', TType.I32, 2)
-            oprot.writeI32(self.operationState)
-            oprot.writeFieldEnd()
-        if self.sqlState is not None:
-            oprot.writeFieldBegin('sqlState', TType.STRING, 3)
-            oprot.writeString(self.sqlState.encode('utf-8') if sys.version_info[0] == 2 else self.sqlState)
-            oprot.writeFieldEnd()
-        if self.errorCode is not None:
-            oprot.writeFieldBegin('errorCode', TType.I32, 4)
-            oprot.writeI32(self.errorCode)
-            oprot.writeFieldEnd()
-        if self.errorMessage is not None:
-            oprot.writeFieldBegin('errorMessage', TType.STRING, 5)
-            oprot.writeString(self.errorMessage.encode('utf-8') if sys.version_info[0] == 2 else self.errorMessage)
-            oprot.writeFieldEnd()
-        if self.taskStatus is not None:
-            oprot.writeFieldBegin('taskStatus', TType.STRING, 6)
-            oprot.writeString(self.taskStatus.encode('utf-8') if sys.version_info[0] == 2 else self.taskStatus)
-            oprot.writeFieldEnd()
-        if self.operationStarted is not None:
-            oprot.writeFieldBegin('operationStarted', TType.I64, 7)
-            oprot.writeI64(self.operationStarted)
-            oprot.writeFieldEnd()
-        if self.operationCompleted is not None:
-            oprot.writeFieldBegin('operationCompleted', TType.I64, 8)
-            oprot.writeI64(self.operationCompleted)
-            oprot.writeFieldEnd()
-        if self.hasResultSet is not None:
-            oprot.writeFieldBegin('hasResultSet', TType.BOOL, 9)
-            oprot.writeBool(self.hasResultSet)
-            oprot.writeFieldEnd()
-        if self.progressUpdateResponse is not None:
-            oprot.writeFieldBegin('progressUpdateResponse', TType.STRUCT, 10)
-            self.progressUpdateResponse.write(oprot)
-            oprot.writeFieldEnd()
-        if self.numModifiedRows is not None:
-            oprot.writeFieldBegin('numModifiedRows', TType.I64, 11)
-            oprot.writeI64(self.numModifiedRows)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TCancelOperationReq(object):
-    """
+  """
     Attributes:
      - operationHandle
 
     """
 
+  def __init__(self, operationHandle=None, ):
+    self.operationHandle = operationHandle
 
-    def __init__(self, operationHandle=None,):
-        self.operationHandle = operationHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.operationHandle = TOperationHandle()
+          self.operationHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.operationHandle = TOperationHandle()
-                    self.operationHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TCancelOperationReq')
+    if self.operationHandle is not None:
+      oprot.writeFieldBegin('operationHandle', TType.STRUCT, 1)
+      self.operationHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TCancelOperationReq')
-        if self.operationHandle is not None:
-            oprot.writeFieldBegin('operationHandle', TType.STRUCT, 1)
-            self.operationHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.operationHandle is None:
+      raise TProtocolException(message='Required field operationHandle is unset!')
+    return
 
-    def validate(self):
-        if self.operationHandle is None:
-            raise TProtocolException(message='Required field operationHandle is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TCancelOperationResp(object):
-    """
+  """
     Attributes:
      - status
 
     """
 
+  def __init__(self, status=None, ):
+    self.status = status
 
-    def __init__(self, status=None,):
-        self.status = status
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TCancelOperationResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TCancelOperationResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TCloseOperationReq(object):
-    """
+  """
     Attributes:
      - operationHandle
 
     """
 
+  def __init__(self, operationHandle=None, ):
+    self.operationHandle = operationHandle
 
-    def __init__(self, operationHandle=None,):
-        self.operationHandle = operationHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.operationHandle = TOperationHandle()
+          self.operationHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.operationHandle = TOperationHandle()
-                    self.operationHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TCloseOperationReq')
+    if self.operationHandle is not None:
+      oprot.writeFieldBegin('operationHandle', TType.STRUCT, 1)
+      self.operationHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TCloseOperationReq')
-        if self.operationHandle is not None:
-            oprot.writeFieldBegin('operationHandle', TType.STRUCT, 1)
-            self.operationHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.operationHandle is None:
+      raise TProtocolException(message='Required field operationHandle is unset!')
+    return
 
-    def validate(self):
-        if self.operationHandle is None:
-            raise TProtocolException(message='Required field operationHandle is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TCloseOperationResp(object):
-    """
+  """
     Attributes:
      - status
 
     """
 
+  def __init__(self, status=None, ):
+    self.status = status
 
-    def __init__(self, status=None,):
-        self.status = status
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TCloseOperationResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TCloseOperationResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetResultSetMetadataReq(object):
-    """
+  """
     Attributes:
      - operationHandle
 
     """
 
+  def __init__(self, operationHandle=None, ):
+    self.operationHandle = operationHandle
 
-    def __init__(self, operationHandle=None,):
-        self.operationHandle = operationHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.operationHandle = TOperationHandle()
+          self.operationHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.operationHandle = TOperationHandle()
-                    self.operationHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetResultSetMetadataReq')
+    if self.operationHandle is not None:
+      oprot.writeFieldBegin('operationHandle', TType.STRUCT, 1)
+      self.operationHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetResultSetMetadataReq')
-        if self.operationHandle is not None:
-            oprot.writeFieldBegin('operationHandle', TType.STRUCT, 1)
-            self.operationHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.operationHandle is None:
+      raise TProtocolException(message='Required field operationHandle is unset!')
+    return
 
-    def validate(self):
-        if self.operationHandle is None:
-            raise TProtocolException(message='Required field operationHandle is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetResultSetMetadataResp(object):
-    """
+  """
     Attributes:
      - status
      - schema
 
     """
 
+  def __init__(self, status=None, schema=None, ):
+    self.status = status
+    self.schema = schema
 
-    def __init__(self, status=None, schema=None,):
-        self.status = status
-        self.schema = schema
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.schema = TTableSchema()
+          self.schema.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRUCT:
-                    self.schema = TTableSchema()
-                    self.schema.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetResultSetMetadataResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    if self.schema is not None:
+      oprot.writeFieldBegin('schema', TType.STRUCT, 2)
+      self.schema.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetResultSetMetadataResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        if self.schema is not None:
-            oprot.writeFieldBegin('schema', TType.STRUCT, 2)
-            self.schema.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TFetchResultsReq(object):
-    """
+  """
     Attributes:
      - operationHandle
      - orientation
@@ -6288,95 +6217,94 @@ class TFetchResultsReq(object):
 
     """
 
+  def __init__(self, operationHandle=None, orientation=0, maxRows=None, fetchType=0, ):
+    self.operationHandle = operationHandle
+    self.orientation = orientation
+    self.maxRows = maxRows
+    self.fetchType = fetchType
 
-    def __init__(self, operationHandle=None, orientation=0, maxRows=None, fetchType=0,):
-        self.operationHandle = operationHandle
-        self.orientation = orientation
-        self.maxRows = maxRows
-        self.fetchType = fetchType
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.operationHandle = TOperationHandle()
+          self.operationHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.I32:
+          self.orientation = iprot.readI32()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.I64:
+          self.maxRows = iprot.readI64()
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.I16:
+          self.fetchType = iprot.readI16()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.operationHandle = TOperationHandle()
-                    self.operationHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.I32:
-                    self.orientation = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.I64:
-                    self.maxRows = iprot.readI64()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.I16:
-                    self.fetchType = iprot.readI16()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TFetchResultsReq')
+    if self.operationHandle is not None:
+      oprot.writeFieldBegin('operationHandle', TType.STRUCT, 1)
+      self.operationHandle.write(oprot)
+      oprot.writeFieldEnd()
+    if self.orientation is not None:
+      oprot.writeFieldBegin('orientation', TType.I32, 2)
+      oprot.writeI32(self.orientation)
+      oprot.writeFieldEnd()
+    if self.maxRows is not None:
+      oprot.writeFieldBegin('maxRows', TType.I64, 3)
+      oprot.writeI64(self.maxRows)
+      oprot.writeFieldEnd()
+    if self.fetchType is not None:
+      oprot.writeFieldBegin('fetchType', TType.I16, 4)
+      oprot.writeI16(self.fetchType)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TFetchResultsReq')
-        if self.operationHandle is not None:
-            oprot.writeFieldBegin('operationHandle', TType.STRUCT, 1)
-            self.operationHandle.write(oprot)
-            oprot.writeFieldEnd()
-        if self.orientation is not None:
-            oprot.writeFieldBegin('orientation', TType.I32, 2)
-            oprot.writeI32(self.orientation)
-            oprot.writeFieldEnd()
-        if self.maxRows is not None:
-            oprot.writeFieldBegin('maxRows', TType.I64, 3)
-            oprot.writeI64(self.maxRows)
-            oprot.writeFieldEnd()
-        if self.fetchType is not None:
-            oprot.writeFieldBegin('fetchType', TType.I16, 4)
-            oprot.writeI16(self.fetchType)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.operationHandle is None:
+      raise TProtocolException(message='Required field operationHandle is unset!')
+    if self.orientation is None:
+      raise TProtocolException(message='Required field orientation is unset!')
+    if self.maxRows is None:
+      raise TProtocolException(message='Required field maxRows is unset!')
+    return
 
-    def validate(self):
-        if self.operationHandle is None:
-            raise TProtocolException(message='Required field operationHandle is unset!')
-        if self.orientation is None:
-            raise TProtocolException(message='Required field orientation is unset!')
-        if self.maxRows is None:
-            raise TProtocolException(message='Required field maxRows is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TFetchResultsResp(object):
-    """
+  """
     Attributes:
      - status
      - hasMoreRows
@@ -6384,82 +6312,81 @@ class TFetchResultsResp(object):
 
     """
 
+  def __init__(self, status=None, hasMoreRows=None, results=None, ):
+    self.status = status
+    self.hasMoreRows = hasMoreRows
+    self.results = results
 
-    def __init__(self, status=None, hasMoreRows=None, results=None,):
-        self.status = status
-        self.hasMoreRows = hasMoreRows
-        self.results = results
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.BOOL:
+          self.hasMoreRows = iprot.readBool()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRUCT:
+          self.results = TRowSet()
+          self.results.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.BOOL:
-                    self.hasMoreRows = iprot.readBool()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.STRUCT:
-                    self.results = TRowSet()
-                    self.results.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TFetchResultsResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    if self.hasMoreRows is not None:
+      oprot.writeFieldBegin('hasMoreRows', TType.BOOL, 2)
+      oprot.writeBool(self.hasMoreRows)
+      oprot.writeFieldEnd()
+    if self.results is not None:
+      oprot.writeFieldBegin('results', TType.STRUCT, 3)
+      self.results.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TFetchResultsResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        if self.hasMoreRows is not None:
-            oprot.writeFieldBegin('hasMoreRows', TType.BOOL, 2)
-            oprot.writeBool(self.hasMoreRows)
-            oprot.writeFieldEnd()
-        if self.results is not None:
-            oprot.writeFieldBegin('results', TType.STRUCT, 3)
-            self.results.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetDelegationTokenReq(object):
-    """
+  """
     Attributes:
      - sessionHandle
      - owner
@@ -6467,1216 +6394,1208 @@ class TGetDelegationTokenReq(object):
 
     """
 
+  def __init__(self, sessionHandle=None, owner=None, renewer=None, ):
+    self.sessionHandle = sessionHandle
+    self.owner = owner
+    self.renewer = renewer
 
-    def __init__(self, sessionHandle=None, owner=None, renewer=None,):
-        self.sessionHandle = sessionHandle
-        self.owner = owner
-        self.renewer = renewer
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.sessionHandle = TSessionHandle()
+          self.sessionHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.owner = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRING:
+          self.renewer = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.sessionHandle = TSessionHandle()
-                    self.sessionHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.owner = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.STRING:
-                    self.renewer = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetDelegationTokenReq')
+    if self.sessionHandle is not None:
+      oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
+      self.sessionHandle.write(oprot)
+      oprot.writeFieldEnd()
+    if self.owner is not None:
+      oprot.writeFieldBegin('owner', TType.STRING, 2)
+      oprot.writeString(self.owner)
+      oprot.writeFieldEnd()
+    if self.renewer is not None:
+      oprot.writeFieldBegin('renewer', TType.STRING, 3)
+      oprot.writeString(self.renewer)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetDelegationTokenReq')
-        if self.sessionHandle is not None:
-            oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
-            self.sessionHandle.write(oprot)
-            oprot.writeFieldEnd()
-        if self.owner is not None:
-            oprot.writeFieldBegin('owner', TType.STRING, 2)
-            oprot.writeString(self.owner.encode('utf-8') if sys.version_info[0] == 2 else self.owner)
-            oprot.writeFieldEnd()
-        if self.renewer is not None:
-            oprot.writeFieldBegin('renewer', TType.STRING, 3)
-            oprot.writeString(self.renewer.encode('utf-8') if sys.version_info[0] == 2 else self.renewer)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.sessionHandle is None:
+      raise TProtocolException(message='Required field sessionHandle is unset!')
+    if self.owner is None:
+      raise TProtocolException(message='Required field owner is unset!')
+    if self.renewer is None:
+      raise TProtocolException(message='Required field renewer is unset!')
+    return
 
-    def validate(self):
-        if self.sessionHandle is None:
-            raise TProtocolException(message='Required field sessionHandle is unset!')
-        if self.owner is None:
-            raise TProtocolException(message='Required field owner is unset!')
-        if self.renewer is None:
-            raise TProtocolException(message='Required field renewer is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetDelegationTokenResp(object):
-    """
+  """
     Attributes:
      - status
      - delegationToken
 
     """
 
+  def __init__(self, status=None, delegationToken=None, ):
+    self.status = status
+    self.delegationToken = delegationToken
 
-    def __init__(self, status=None, delegationToken=None,):
-        self.status = status
-        self.delegationToken = delegationToken
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.delegationToken = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.delegationToken = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetDelegationTokenResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    if self.delegationToken is not None:
+      oprot.writeFieldBegin('delegationToken', TType.STRING, 2)
+      oprot.writeString(self.delegationToken)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetDelegationTokenResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        if self.delegationToken is not None:
-            oprot.writeFieldBegin('delegationToken', TType.STRING, 2)
-            oprot.writeString(self.delegationToken.encode('utf-8') if sys.version_info[0] == 2 else self.delegationToken)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TCancelDelegationTokenReq(object):
-    """
+  """
     Attributes:
      - sessionHandle
      - delegationToken
 
     """
 
+  def __init__(self, sessionHandle=None, delegationToken=None, ):
+    self.sessionHandle = sessionHandle
+    self.delegationToken = delegationToken
 
-    def __init__(self, sessionHandle=None, delegationToken=None,):
-        self.sessionHandle = sessionHandle
-        self.delegationToken = delegationToken
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.sessionHandle = TSessionHandle()
+          self.sessionHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.delegationToken = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.sessionHandle = TSessionHandle()
-                    self.sessionHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.delegationToken = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TCancelDelegationTokenReq')
+    if self.sessionHandle is not None:
+      oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
+      self.sessionHandle.write(oprot)
+      oprot.writeFieldEnd()
+    if self.delegationToken is not None:
+      oprot.writeFieldBegin('delegationToken', TType.STRING, 2)
+      oprot.writeString(self.delegationToken)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TCancelDelegationTokenReq')
-        if self.sessionHandle is not None:
-            oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
-            self.sessionHandle.write(oprot)
-            oprot.writeFieldEnd()
-        if self.delegationToken is not None:
-            oprot.writeFieldBegin('delegationToken', TType.STRING, 2)
-            oprot.writeString(self.delegationToken.encode('utf-8') if sys.version_info[0] == 2 else self.delegationToken)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.sessionHandle is None:
+      raise TProtocolException(message='Required field sessionHandle is unset!')
+    if self.delegationToken is None:
+      raise TProtocolException(message='Required field delegationToken is unset!')
+    return
 
-    def validate(self):
-        if self.sessionHandle is None:
-            raise TProtocolException(message='Required field sessionHandle is unset!')
-        if self.delegationToken is None:
-            raise TProtocolException(message='Required field delegationToken is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TCancelDelegationTokenResp(object):
-    """
+  """
     Attributes:
      - status
 
     """
 
+  def __init__(self, status=None, ):
+    self.status = status
 
-    def __init__(self, status=None,):
-        self.status = status
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TCancelDelegationTokenResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TCancelDelegationTokenResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TRenewDelegationTokenReq(object):
-    """
+  """
     Attributes:
      - sessionHandle
      - delegationToken
 
     """
 
+  def __init__(self, sessionHandle=None, delegationToken=None, ):
+    self.sessionHandle = sessionHandle
+    self.delegationToken = delegationToken
 
-    def __init__(self, sessionHandle=None, delegationToken=None,):
-        self.sessionHandle = sessionHandle
-        self.delegationToken = delegationToken
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.sessionHandle = TSessionHandle()
+          self.sessionHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.delegationToken = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.sessionHandle = TSessionHandle()
-                    self.sessionHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.delegationToken = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TRenewDelegationTokenReq')
+    if self.sessionHandle is not None:
+      oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
+      self.sessionHandle.write(oprot)
+      oprot.writeFieldEnd()
+    if self.delegationToken is not None:
+      oprot.writeFieldBegin('delegationToken', TType.STRING, 2)
+      oprot.writeString(self.delegationToken)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TRenewDelegationTokenReq')
-        if self.sessionHandle is not None:
-            oprot.writeFieldBegin('sessionHandle', TType.STRUCT, 1)
-            self.sessionHandle.write(oprot)
-            oprot.writeFieldEnd()
-        if self.delegationToken is not None:
-            oprot.writeFieldBegin('delegationToken', TType.STRING, 2)
-            oprot.writeString(self.delegationToken.encode('utf-8') if sys.version_info[0] == 2 else self.delegationToken)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.sessionHandle is None:
+      raise TProtocolException(message='Required field sessionHandle is unset!')
+    if self.delegationToken is None:
+      raise TProtocolException(message='Required field delegationToken is unset!')
+    return
 
-    def validate(self):
-        if self.sessionHandle is None:
-            raise TProtocolException(message='Required field sessionHandle is unset!')
-        if self.delegationToken is None:
-            raise TProtocolException(message='Required field delegationToken is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TRenewDelegationTokenResp(object):
-    """
+  """
     Attributes:
      - status
 
     """
 
+  def __init__(self, status=None, ):
+    self.status = status
 
-    def __init__(self, status=None,):
-        self.status = status
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TRenewDelegationTokenResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TRenewDelegationTokenResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetQueryIdReq(object):
-    """
+  """
     Attributes:
      - operationHandle
 
     """
 
+  def __init__(self, operationHandle=None, ):
+    self.operationHandle = operationHandle
 
-    def __init__(self, operationHandle=None,):
-        self.operationHandle = operationHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.operationHandle = TOperationHandle()
+          self.operationHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.operationHandle = TOperationHandle()
-                    self.operationHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetQueryIdReq')
+    if self.operationHandle is not None:
+      oprot.writeFieldBegin('operationHandle', TType.STRUCT, 1)
+      self.operationHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetQueryIdReq')
-        if self.operationHandle is not None:
-            oprot.writeFieldBegin('operationHandle', TType.STRUCT, 1)
-            self.operationHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.operationHandle is None:
+      raise TProtocolException(message='Required field operationHandle is unset!')
+    return
 
-    def validate(self):
-        if self.operationHandle is None:
-            raise TProtocolException(message='Required field operationHandle is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetQueryIdResp(object):
-    """
+  """
     Attributes:
      - queryId
 
     """
 
+  def __init__(self, queryId=None, ):
+    self.queryId = queryId
 
-    def __init__(self, queryId=None,):
-        self.queryId = queryId
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRING:
+          self.queryId = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRING:
-                    self.queryId = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetQueryIdResp')
+    if self.queryId is not None:
+      oprot.writeFieldBegin('queryId', TType.STRING, 1)
+      oprot.writeString(self.queryId)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetQueryIdResp')
-        if self.queryId is not None:
-            oprot.writeFieldBegin('queryId', TType.STRING, 1)
-            oprot.writeString(self.queryId.encode('utf-8') if sys.version_info[0] == 2 else self.queryId)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.queryId is None:
+      raise TProtocolException(message='Required field queryId is unset!')
+    return
 
-    def validate(self):
-        if self.queryId is None:
-            raise TProtocolException(message='Required field queryId is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetLogReq(object):
-    """
+  """
     Attributes:
      - operationHandle
 
     """
 
+  def __init__(self, operationHandle=None, ):
+    self.operationHandle = operationHandle
 
-    def __init__(self, operationHandle=None,):
-        self.operationHandle = operationHandle
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.operationHandle = TOperationHandle()
+          self.operationHandle.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.operationHandle = TOperationHandle()
-                    self.operationHandle.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetLogReq')
+    if self.operationHandle is not None:
+      oprot.writeFieldBegin('operationHandle', TType.STRUCT, 1)
+      self.operationHandle.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetLogReq')
-        if self.operationHandle is not None:
-            oprot.writeFieldBegin('operationHandle', TType.STRUCT, 1)
-            self.operationHandle.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.operationHandle is None:
+      raise TProtocolException(message='Required field operationHandle is unset!')
+    return
 
-    def validate(self):
-        if self.operationHandle is None:
-            raise TProtocolException(message='Required field operationHandle is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
+  def __ne__(self, other):
+    return not (self == other)
 
 
 class TGetLogResp(object):
-    """
+  """
     Attributes:
      - status
      - log
 
     """
 
+  def __init__(self, status=None, log=None, ):
+    self.status = status
+    self.log = log
 
-    def __init__(self, status=None, log=None,):
-        self.status = status
-        self.log = log
+  def read(self, iprot):
+    if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+      iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.status = TStatus()
+          self.status.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.log = iprot.readString()
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
 
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.status = TStatus()
-                    self.status.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRING:
-                    self.log = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
+  def write(self, oprot):
+    if oprot._fast_encode is not None and self.thrift_spec is not None:
+      oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+      return
+    oprot.writeStructBegin('TGetLogResp')
+    if self.status is not None:
+      oprot.writeFieldBegin('status', TType.STRUCT, 1)
+      self.status.write(oprot)
+      oprot.writeFieldEnd()
+    if self.log is not None:
+      oprot.writeFieldBegin('log', TType.STRING, 2)
+      oprot.writeString(self.log)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
 
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TGetLogResp')
-        if self.status is not None:
-            oprot.writeFieldBegin('status', TType.STRUCT, 1)
-            self.status.write(oprot)
-            oprot.writeFieldEnd()
-        if self.log is not None:
-            oprot.writeFieldBegin('log', TType.STRING, 2)
-            oprot.writeString(self.log.encode('utf-8') if sys.version_info[0] == 2 else self.log)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
+  def validate(self):
+    if self.status is None:
+      raise TProtocolException(message='Required field status is unset!')
+    if self.log is None:
+      raise TProtocolException(message='Required field log is unset!')
+    return
 
-    def validate(self):
-        if self.status is None:
-            raise TProtocolException(message='Required field status is unset!')
-        if self.log is None:
-            raise TProtocolException(message='Required field log is unset!')
-        return
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.items()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+  def __ne__(self, other):
+    return not (self == other)
 
-    def __ne__(self, other):
-        return not (self == other)
+
 all_structs.append(TTypeQualifierValue)
 TTypeQualifierValue.thrift_spec = (
-    None,  # 0
-    (1, TType.I32, 'i32Value', None, None, ),  # 1
-    (2, TType.STRING, 'stringValue', 'UTF8', None, ),  # 2
+  None,  # 0
+  (1, TType.I32, 'i32Value', None, None,),  # 1
+  (2, TType.STRING, 'stringValue', 'UTF8', None,),  # 2
 )
 all_structs.append(TTypeQualifiers)
 TTypeQualifiers.thrift_spec = (
-    None,  # 0
-    (1, TType.MAP, 'qualifiers', (TType.STRING, 'UTF8', TType.STRUCT, [TTypeQualifierValue, None], False), None, ),  # 1
+  None,  # 0
+  (1, TType.MAP, 'qualifiers', (TType.STRING, 'UTF8', TType.STRUCT, [TTypeQualifierValue, None], False), None,),  # 1
 )
 all_structs.append(TPrimitiveTypeEntry)
 TPrimitiveTypeEntry.thrift_spec = (
-    None,  # 0
-    (1, TType.I32, 'type', None, None, ),  # 1
-    (2, TType.STRUCT, 'typeQualifiers', [TTypeQualifiers, None], None, ),  # 2
+  None,  # 0
+  (1, TType.I32, 'type', None, None,),  # 1
+  (2, TType.STRUCT, 'typeQualifiers', [TTypeQualifiers, None], None,),  # 2
 )
 all_structs.append(TArrayTypeEntry)
 TArrayTypeEntry.thrift_spec = (
-    None,  # 0
-    (1, TType.I32, 'objectTypePtr', None, None, ),  # 1
+  None,  # 0
+  (1, TType.I32, 'objectTypePtr', None, None,),  # 1
 )
 all_structs.append(TMapTypeEntry)
 TMapTypeEntry.thrift_spec = (
-    None,  # 0
-    (1, TType.I32, 'keyTypePtr', None, None, ),  # 1
-    (2, TType.I32, 'valueTypePtr', None, None, ),  # 2
+  None,  # 0
+  (1, TType.I32, 'keyTypePtr', None, None,),  # 1
+  (2, TType.I32, 'valueTypePtr', None, None,),  # 2
 )
 all_structs.append(TStructTypeEntry)
 TStructTypeEntry.thrift_spec = (
-    None,  # 0
-    (1, TType.MAP, 'nameToTypePtr', (TType.STRING, 'UTF8', TType.I32, None, False), None, ),  # 1
+  None,  # 0
+  (1, TType.MAP, 'nameToTypePtr', (TType.STRING, 'UTF8', TType.I32, None, False), None,),  # 1
 )
 all_structs.append(TUnionTypeEntry)
 TUnionTypeEntry.thrift_spec = (
-    None,  # 0
-    (1, TType.MAP, 'nameToTypePtr', (TType.STRING, 'UTF8', TType.I32, None, False), None, ),  # 1
+  None,  # 0
+  (1, TType.MAP, 'nameToTypePtr', (TType.STRING, 'UTF8', TType.I32, None, False), None,),  # 1
 )
 all_structs.append(TUserDefinedTypeEntry)
 TUserDefinedTypeEntry.thrift_spec = (
-    None,  # 0
-    (1, TType.STRING, 'typeClassName', 'UTF8', None, ),  # 1
+  None,  # 0
+  (1, TType.STRING, 'typeClassName', 'UTF8', None,),  # 1
 )
 all_structs.append(TTypeEntry)
 TTypeEntry.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'primitiveEntry', [TPrimitiveTypeEntry, None], None, ),  # 1
-    (2, TType.STRUCT, 'arrayEntry', [TArrayTypeEntry, None], None, ),  # 2
-    (3, TType.STRUCT, 'mapEntry', [TMapTypeEntry, None], None, ),  # 3
-    (4, TType.STRUCT, 'structEntry', [TStructTypeEntry, None], None, ),  # 4
-    (5, TType.STRUCT, 'unionEntry', [TUnionTypeEntry, None], None, ),  # 5
-    (6, TType.STRUCT, 'userDefinedTypeEntry', [TUserDefinedTypeEntry, None], None, ),  # 6
+  None,  # 0
+  (1, TType.STRUCT, 'primitiveEntry', [TPrimitiveTypeEntry, None], None,),  # 1
+  (2, TType.STRUCT, 'arrayEntry', [TArrayTypeEntry, None], None,),  # 2
+  (3, TType.STRUCT, 'mapEntry', [TMapTypeEntry, None], None,),  # 3
+  (4, TType.STRUCT, 'structEntry', [TStructTypeEntry, None], None,),  # 4
+  (5, TType.STRUCT, 'unionEntry', [TUnionTypeEntry, None], None,),  # 5
+  (6, TType.STRUCT, 'userDefinedTypeEntry', [TUserDefinedTypeEntry, None], None,),  # 6
 )
 all_structs.append(TTypeDesc)
 TTypeDesc.thrift_spec = (
-    None,  # 0
-    (1, TType.LIST, 'types', (TType.STRUCT, [TTypeEntry, None], False), None, ),  # 1
+  None,  # 0
+  (1, TType.LIST, 'types', (TType.STRUCT, [TTypeEntry, None], False), None,),  # 1
 )
 all_structs.append(TColumnDesc)
 TColumnDesc.thrift_spec = (
-    None,  # 0
-    (1, TType.STRING, 'columnName', 'UTF8', None, ),  # 1
-    (2, TType.STRUCT, 'typeDesc', [TTypeDesc, None], None, ),  # 2
-    (3, TType.I32, 'position', None, None, ),  # 3
-    (4, TType.STRING, 'comment', 'UTF8', None, ),  # 4
+  None,  # 0
+  (1, TType.STRING, 'columnName', 'UTF8', None,),  # 1
+  (2, TType.STRUCT, 'typeDesc', [TTypeDesc, None], None,),  # 2
+  (3, TType.I32, 'position', None, None,),  # 3
+  (4, TType.STRING, 'comment', 'UTF8', None,),  # 4
 )
 all_structs.append(TTableSchema)
 TTableSchema.thrift_spec = (
-    None,  # 0
-    (1, TType.LIST, 'columns', (TType.STRUCT, [TColumnDesc, None], False), None, ),  # 1
+  None,  # 0
+  (1, TType.LIST, 'columns', (TType.STRUCT, [TColumnDesc, None], False), None,),  # 1
 )
 all_structs.append(TBoolValue)
 TBoolValue.thrift_spec = (
-    None,  # 0
-    (1, TType.BOOL, 'value', None, None, ),  # 1
+  None,  # 0
+  (1, TType.BOOL, 'value', None, None,),  # 1
 )
 all_structs.append(TByteValue)
 TByteValue.thrift_spec = (
-    None,  # 0
-    (1, TType.BYTE, 'value', None, None, ),  # 1
+  None,  # 0
+  (1, TType.BYTE, 'value', None, None,),  # 1
 )
 all_structs.append(TI16Value)
 TI16Value.thrift_spec = (
-    None,  # 0
-    (1, TType.I16, 'value', None, None, ),  # 1
+  None,  # 0
+  (1, TType.I16, 'value', None, None,),  # 1
 )
 all_structs.append(TI32Value)
 TI32Value.thrift_spec = (
-    None,  # 0
-    (1, TType.I32, 'value', None, None, ),  # 1
+  None,  # 0
+  (1, TType.I32, 'value', None, None,),  # 1
 )
 all_structs.append(TI64Value)
 TI64Value.thrift_spec = (
-    None,  # 0
-    (1, TType.I64, 'value', None, None, ),  # 1
+  None,  # 0
+  (1, TType.I64, 'value', None, None,),  # 1
 )
 all_structs.append(TDoubleValue)
 TDoubleValue.thrift_spec = (
-    None,  # 0
-    (1, TType.DOUBLE, 'value', None, None, ),  # 1
+  None,  # 0
+  (1, TType.DOUBLE, 'value', None, None,),  # 1
 )
 all_structs.append(TStringValue)
 TStringValue.thrift_spec = (
-    None,  # 0
-    (1, TType.STRING, 'value', 'UTF8', None, ),  # 1
+  None,  # 0
+  (1, TType.STRING, 'value', 'UTF8', None,),  # 1
 )
 all_structs.append(TColumnValue)
 TColumnValue.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'boolVal', [TBoolValue, None], None, ),  # 1
-    (2, TType.STRUCT, 'byteVal', [TByteValue, None], None, ),  # 2
-    (3, TType.STRUCT, 'i16Val', [TI16Value, None], None, ),  # 3
-    (4, TType.STRUCT, 'i32Val', [TI32Value, None], None, ),  # 4
-    (5, TType.STRUCT, 'i64Val', [TI64Value, None], None, ),  # 5
-    (6, TType.STRUCT, 'doubleVal', [TDoubleValue, None], None, ),  # 6
-    (7, TType.STRUCT, 'stringVal', [TStringValue, None], None, ),  # 7
+  None,  # 0
+  (1, TType.STRUCT, 'boolVal', [TBoolValue, None], None,),  # 1
+  (2, TType.STRUCT, 'byteVal', [TByteValue, None], None,),  # 2
+  (3, TType.STRUCT, 'i16Val', [TI16Value, None], None,),  # 3
+  (4, TType.STRUCT, 'i32Val', [TI32Value, None], None,),  # 4
+  (5, TType.STRUCT, 'i64Val', [TI64Value, None], None,),  # 5
+  (6, TType.STRUCT, 'doubleVal', [TDoubleValue, None], None,),  # 6
+  (7, TType.STRUCT, 'stringVal', [TStringValue, None], None,),  # 7
 )
 all_structs.append(TRow)
 TRow.thrift_spec = (
-    None,  # 0
-    (1, TType.LIST, 'colVals', (TType.STRUCT, [TColumnValue, None], False), None, ),  # 1
+  None,  # 0
+  (1, TType.LIST, 'colVals', (TType.STRUCT, [TColumnValue, None], False), None,),  # 1
 )
 all_structs.append(TBoolColumn)
 TBoolColumn.thrift_spec = (
-    None,  # 0
-    (1, TType.LIST, 'values', (TType.BOOL, None, False), None, ),  # 1
-    (2, TType.STRING, 'nulls', 'BINARY', None, ),  # 2
+  None,  # 0
+  (1, TType.LIST, 'values', (TType.BOOL, None, False), None,),  # 1
+  (2, TType.STRING, 'nulls', 'BINARY', None,),  # 2
 )
 all_structs.append(TByteColumn)
 TByteColumn.thrift_spec = (
-    None,  # 0
-    (1, TType.LIST, 'values', (TType.BYTE, None, False), None, ),  # 1
-    (2, TType.STRING, 'nulls', 'BINARY', None, ),  # 2
+  None,  # 0
+  (1, TType.LIST, 'values', (TType.BYTE, None, False), None,),  # 1
+  (2, TType.STRING, 'nulls', 'BINARY', None,),  # 2
 )
 all_structs.append(TI16Column)
 TI16Column.thrift_spec = (
-    None,  # 0
-    (1, TType.LIST, 'values', (TType.I16, None, False), None, ),  # 1
-    (2, TType.STRING, 'nulls', 'BINARY', None, ),  # 2
+  None,  # 0
+  (1, TType.LIST, 'values', (TType.I16, None, False), None,),  # 1
+  (2, TType.STRING, 'nulls', 'BINARY', None,),  # 2
 )
 all_structs.append(TI32Column)
 TI32Column.thrift_spec = (
-    None,  # 0
-    (1, TType.LIST, 'values', (TType.I32, None, False), None, ),  # 1
-    (2, TType.STRING, 'nulls', 'BINARY', None, ),  # 2
+  None,  # 0
+  (1, TType.LIST, 'values', (TType.I32, None, False), None,),  # 1
+  (2, TType.STRING, 'nulls', 'BINARY', None,),  # 2
 )
 all_structs.append(TI64Column)
 TI64Column.thrift_spec = (
-    None,  # 0
-    (1, TType.LIST, 'values', (TType.I64, None, False), None, ),  # 1
-    (2, TType.STRING, 'nulls', 'BINARY', None, ),  # 2
+  None,  # 0
+  (1, TType.LIST, 'values', (TType.I64, None, False), None,),  # 1
+  (2, TType.STRING, 'nulls', 'BINARY', None,),  # 2
 )
 all_structs.append(TDoubleColumn)
 TDoubleColumn.thrift_spec = (
-    None,  # 0
-    (1, TType.LIST, 'values', (TType.DOUBLE, None, False), None, ),  # 1
-    (2, TType.STRING, 'nulls', 'BINARY', None, ),  # 2
+  None,  # 0
+  (1, TType.LIST, 'values', (TType.DOUBLE, None, False), None,),  # 1
+  (2, TType.STRING, 'nulls', 'BINARY', None,),  # 2
 )
 all_structs.append(TStringColumn)
 TStringColumn.thrift_spec = (
-    None,  # 0
-    (1, TType.LIST, 'values', (TType.STRING, 'UTF8', False), None, ),  # 1
-    (2, TType.STRING, 'nulls', 'BINARY', None, ),  # 2
+  None,  # 0
+  (1, TType.LIST, 'values', (TType.STRING, 'UTF8', False), None,),  # 1
+  (2, TType.STRING, 'nulls', 'BINARY', None,),  # 2
 )
 all_structs.append(TBinaryColumn)
 TBinaryColumn.thrift_spec = (
-    None,  # 0
-    (1, TType.LIST, 'values', (TType.STRING, 'BINARY', False), None, ),  # 1
-    (2, TType.STRING, 'nulls', 'BINARY', None, ),  # 2
+  None,  # 0
+  (1, TType.LIST, 'values', (TType.STRING, 'BINARY', False), None,),  # 1
+  (2, TType.STRING, 'nulls', 'BINARY', None,),  # 2
 )
 all_structs.append(TColumn)
 TColumn.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'boolVal', [TBoolColumn, None], None, ),  # 1
-    (2, TType.STRUCT, 'byteVal', [TByteColumn, None], None, ),  # 2
-    (3, TType.STRUCT, 'i16Val', [TI16Column, None], None, ),  # 3
-    (4, TType.STRUCT, 'i32Val', [TI32Column, None], None, ),  # 4
-    (5, TType.STRUCT, 'i64Val', [TI64Column, None], None, ),  # 5
-    (6, TType.STRUCT, 'doubleVal', [TDoubleColumn, None], None, ),  # 6
-    (7, TType.STRUCT, 'stringVal', [TStringColumn, None], None, ),  # 7
-    (8, TType.STRUCT, 'binaryVal', [TBinaryColumn, None], None, ),  # 8
+  None,  # 0
+  (1, TType.STRUCT, 'boolVal', [TBoolColumn, None], None,),  # 1
+  (2, TType.STRUCT, 'byteVal', [TByteColumn, None], None,),  # 2
+  (3, TType.STRUCT, 'i16Val', [TI16Column, None], None,),  # 3
+  (4, TType.STRUCT, 'i32Val', [TI32Column, None], None,),  # 4
+  (5, TType.STRUCT, 'i64Val', [TI64Column, None], None,),  # 5
+  (6, TType.STRUCT, 'doubleVal', [TDoubleColumn, None], None,),  # 6
+  (7, TType.STRUCT, 'stringVal', [TStringColumn, None], None,),  # 7
+  (8, TType.STRUCT, 'binaryVal', [TBinaryColumn, None], None,),  # 8
 )
 all_structs.append(TRowSet)
 TRowSet.thrift_spec = (
-    None,  # 0
-    (1, TType.I64, 'startRowOffset', None, None, ),  # 1
-    (2, TType.LIST, 'rows', (TType.STRUCT, [TRow, None], False), None, ),  # 2
-    (3, TType.LIST, 'columns', (TType.STRUCT, [TColumn, None], False), None, ),  # 3
-    (4, TType.STRING, 'binaryColumns', 'BINARY', None, ),  # 4
-    (5, TType.I32, 'columnCount', None, None, ),  # 5
+  None,  # 0
+  (1, TType.I64, 'startRowOffset', None, None,),  # 1
+  (2, TType.LIST, 'rows', (TType.STRUCT, [TRow, None], False), None,),  # 2
+  (3, TType.LIST, 'columns', (TType.STRUCT, [TColumn, None], False), None,),  # 3
+  (4, TType.STRING, 'binaryColumns', 'BINARY', None,),  # 4
+  (5, TType.I32, 'columnCount', None, None,),  # 5
 )
 all_structs.append(TStatus)
 TStatus.thrift_spec = (
-    None,  # 0
-    (1, TType.I32, 'statusCode', None, None, ),  # 1
-    (2, TType.LIST, 'infoMessages', (TType.STRING, 'UTF8', False), None, ),  # 2
-    (3, TType.STRING, 'sqlState', 'UTF8', None, ),  # 3
-    (4, TType.I32, 'errorCode', None, None, ),  # 4
-    (5, TType.STRING, 'errorMessage', 'UTF8', None, ),  # 5
+  None,  # 0
+  (1, TType.I32, 'statusCode', None, None,),  # 1
+  (2, TType.LIST, 'infoMessages', (TType.STRING, 'UTF8', False), None,),  # 2
+  (3, TType.STRING, 'sqlState', 'UTF8', None,),  # 3
+  (4, TType.I32, 'errorCode', None, None,),  # 4
+  (5, TType.STRING, 'errorMessage', 'UTF8', None,),  # 5
 )
 all_structs.append(THandleIdentifier)
 THandleIdentifier.thrift_spec = (
-    None,  # 0
-    (1, TType.STRING, 'guid', 'BINARY', None, ),  # 1
-    (2, TType.STRING, 'secret', 'BINARY', None, ),  # 2
+  None,  # 0
+  (1, TType.STRING, 'guid', 'BINARY', None,),  # 1
+  (2, TType.STRING, 'secret', 'BINARY', None,),  # 2
 )
 all_structs.append(TSessionHandle)
 TSessionHandle.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'sessionId', [THandleIdentifier, None], None, ),  # 1
+  None,  # 0
+  (1, TType.STRUCT, 'sessionId', [THandleIdentifier, None], None,),  # 1
 )
 all_structs.append(TOperationHandle)
 TOperationHandle.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'operationId', [THandleIdentifier, None], None, ),  # 1
-    (2, TType.I32, 'operationType', None, None, ),  # 2
-    (3, TType.BOOL, 'hasResultSet', None, None, ),  # 3
-    (4, TType.DOUBLE, 'modifiedRowCount', None, None, ),  # 4
+  None,  # 0
+  (1, TType.STRUCT, 'operationId', [THandleIdentifier, None], None,),  # 1
+  (2, TType.I32, 'operationType', None, None,),  # 2
+  (3, TType.BOOL, 'hasResultSet', None, None,),  # 3
+  (4, TType.DOUBLE, 'modifiedRowCount', None, None,),  # 4
 )
 all_structs.append(TOpenSessionReq)
 TOpenSessionReq.thrift_spec = (
-    None,  # 0
-    (1, TType.I32, 'client_protocol', None, 9, ),  # 1
-    (2, TType.STRING, 'username', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'password', 'UTF8', None, ),  # 3
-    (4, TType.MAP, 'configuration', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 4
+  None,  # 0
+  (1, TType.I32, 'client_protocol', None, 9,),  # 1
+  (2, TType.STRING, 'username', 'UTF8', None,),  # 2
+  (3, TType.STRING, 'password', 'UTF8', None,),  # 3
+  (4, TType.MAP, 'configuration', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None,),  # 4
 )
 all_structs.append(TOpenSessionResp)
 TOpenSessionResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.I32, 'serverProtocolVersion', None, 9, ),  # 2
-    (3, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 3
-    (4, TType.MAP, 'configuration', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 4
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
+  (2, TType.I32, 'serverProtocolVersion', None, 9,),  # 2
+  (3, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None,),  # 3
+  (4, TType.MAP, 'configuration', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None,),  # 4
 )
 all_structs.append(TSetClientInfoReq)
 TSetClientInfoReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.MAP, 'configuration', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None,),  # 1
+  (2, TType.MAP, 'configuration', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None,),  # 2
 )
 all_structs.append(TSetClientInfoResp)
 TSetClientInfoResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
 )
 all_structs.append(TCloseSessionReq)
 TCloseSessionReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
+  None,  # 0
+  (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None,),  # 1
 )
 all_structs.append(TCloseSessionResp)
 TCloseSessionResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
 )
 all_structs.append(TGetInfoValue)
 TGetInfoValue.thrift_spec = (
-    None,  # 0
-    (1, TType.STRING, 'stringValue', 'UTF8', None, ),  # 1
-    (2, TType.I16, 'smallIntValue', None, None, ),  # 2
-    (3, TType.I32, 'integerBitmask', None, None, ),  # 3
-    (4, TType.I32, 'integerFlag', None, None, ),  # 4
-    (5, TType.I32, 'binaryValue', None, None, ),  # 5
-    (6, TType.I64, 'lenValue', None, None, ),  # 6
+  None,  # 0
+  (1, TType.STRING, 'stringValue', 'UTF8', None,),  # 1
+  (2, TType.I16, 'smallIntValue', None, None,),  # 2
+  (3, TType.I32, 'integerBitmask', None, None,),  # 3
+  (4, TType.I32, 'integerFlag', None, None,),  # 4
+  (5, TType.I32, 'binaryValue', None, None,),  # 5
+  (6, TType.I64, 'lenValue', None, None,),  # 6
 )
 all_structs.append(TGetInfoReq)
 TGetInfoReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.I32, 'infoType', None, None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None,),  # 1
+  (2, TType.I32, 'infoType', None, None,),  # 2
 )
 all_structs.append(TGetInfoResp)
 TGetInfoResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.STRUCT, 'infoValue', [TGetInfoValue, None], None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
+  (2, TType.STRUCT, 'infoValue', [TGetInfoValue, None], None,),  # 2
 )
 all_structs.append(TExecuteStatementReq)
 TExecuteStatementReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.STRING, 'statement', 'UTF8', None, ),  # 2
-    (3, TType.MAP, 'confOverlay', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 3
-    (4, TType.BOOL, 'runAsync', None, False, ),  # 4
-    (5, TType.I64, 'queryTimeout', None, 0, ),  # 5
+  None,  # 0
+  (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None,),  # 1
+  (2, TType.STRING, 'statement', 'UTF8', None,),  # 2
+  (3, TType.MAP, 'confOverlay', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None,),  # 3
+  (4, TType.BOOL, 'runAsync', None, False,),  # 4
+  (5, TType.I64, 'queryTimeout', None, 0,),  # 5
 )
 all_structs.append(TExecuteStatementResp)
 TExecuteStatementResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
+  (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None,),  # 2
 )
 all_structs.append(TGetTypeInfoReq)
 TGetTypeInfoReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
+  None,  # 0
+  (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None,),  # 1
 )
 all_structs.append(TGetTypeInfoResp)
 TGetTypeInfoResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
+  (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None,),  # 2
 )
 all_structs.append(TGetCatalogsReq)
 TGetCatalogsReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
+  None,  # 0
+  (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None,),  # 1
 )
 all_structs.append(TGetCatalogsResp)
 TGetCatalogsResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
+  (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None,),  # 2
 )
 all_structs.append(TGetSchemasReq)
 TGetSchemasReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.STRING, 'catalogName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'schemaName', 'UTF8', None, ),  # 3
+  None,  # 0
+  (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None,),  # 1
+  (2, TType.STRING, 'catalogName', 'UTF8', None,),  # 2
+  (3, TType.STRING, 'schemaName', 'UTF8', None,),  # 3
 )
 all_structs.append(TGetSchemasResp)
 TGetSchemasResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
+  (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None,),  # 2
 )
 all_structs.append(TGetTablesReq)
 TGetTablesReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.STRING, 'catalogName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'schemaName', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'tableName', 'UTF8', None, ),  # 4
-    (5, TType.LIST, 'tableTypes', (TType.STRING, 'UTF8', False), None, ),  # 5
+  None,  # 0
+  (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None,),  # 1
+  (2, TType.STRING, 'catalogName', 'UTF8', None,),  # 2
+  (3, TType.STRING, 'schemaName', 'UTF8', None,),  # 3
+  (4, TType.STRING, 'tableName', 'UTF8', None,),  # 4
+  (5, TType.LIST, 'tableTypes', (TType.STRING, 'UTF8', False), None,),  # 5
 )
 all_structs.append(TGetTablesResp)
 TGetTablesResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
+  (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None,),  # 2
 )
 all_structs.append(TGetTableTypesReq)
 TGetTableTypesReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
+  None,  # 0
+  (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None,),  # 1
 )
 all_structs.append(TGetTableTypesResp)
 TGetTableTypesResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
+  (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None,),  # 2
 )
 all_structs.append(TGetColumnsReq)
 TGetColumnsReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.STRING, 'catalogName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'schemaName', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'tableName', 'UTF8', None, ),  # 4
-    (5, TType.STRING, 'columnName', 'UTF8', None, ),  # 5
+  None,  # 0
+  (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None,),  # 1
+  (2, TType.STRING, 'catalogName', 'UTF8', None,),  # 2
+  (3, TType.STRING, 'schemaName', 'UTF8', None,),  # 3
+  (4, TType.STRING, 'tableName', 'UTF8', None,),  # 4
+  (5, TType.STRING, 'columnName', 'UTF8', None,),  # 5
 )
 all_structs.append(TGetColumnsResp)
 TGetColumnsResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
+  (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None,),  # 2
 )
 all_structs.append(TGetFunctionsReq)
 TGetFunctionsReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.STRING, 'catalogName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'schemaName', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'functionName', 'UTF8', None, ),  # 4
+  None,  # 0
+  (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None,),  # 1
+  (2, TType.STRING, 'catalogName', 'UTF8', None,),  # 2
+  (3, TType.STRING, 'schemaName', 'UTF8', None,),  # 3
+  (4, TType.STRING, 'functionName', 'UTF8', None,),  # 4
 )
 all_structs.append(TGetFunctionsResp)
 TGetFunctionsResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
+  (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None,),  # 2
 )
 all_structs.append(TGetPrimaryKeysReq)
 TGetPrimaryKeysReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.STRING, 'catalogName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'schemaName', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'tableName', 'UTF8', None, ),  # 4
+  None,  # 0
+  (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None,),  # 1
+  (2, TType.STRING, 'catalogName', 'UTF8', None,),  # 2
+  (3, TType.STRING, 'schemaName', 'UTF8', None,),  # 3
+  (4, TType.STRING, 'tableName', 'UTF8', None,),  # 4
 )
 all_structs.append(TGetPrimaryKeysResp)
 TGetPrimaryKeysResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
+  (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None,),  # 2
 )
 all_structs.append(TGetCrossReferenceReq)
 TGetCrossReferenceReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.STRING, 'parentCatalogName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'parentSchemaName', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'parentTableName', 'UTF8', None, ),  # 4
-    (5, TType.STRING, 'foreignCatalogName', 'UTF8', None, ),  # 5
-    (6, TType.STRING, 'foreignSchemaName', 'UTF8', None, ),  # 6
-    (7, TType.STRING, 'foreignTableName', 'UTF8', None, ),  # 7
+  None,  # 0
+  (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None,),  # 1
+  (2, TType.STRING, 'parentCatalogName', 'UTF8', None,),  # 2
+  (3, TType.STRING, 'parentSchemaName', 'UTF8', None,),  # 3
+  (4, TType.STRING, 'parentTableName', 'UTF8', None,),  # 4
+  (5, TType.STRING, 'foreignCatalogName', 'UTF8', None,),  # 5
+  (6, TType.STRING, 'foreignSchemaName', 'UTF8', None,),  # 6
+  (7, TType.STRING, 'foreignTableName', 'UTF8', None,),  # 7
 )
 all_structs.append(TGetCrossReferenceResp)
 TGetCrossReferenceResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
+  (2, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None,),  # 2
 )
 all_structs.append(TGetOperationStatusReq)
 TGetOperationStatusReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None, ),  # 1
-    (2, TType.BOOL, 'getProgressUpdate', None, None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None,),  # 1
+  (2, TType.BOOL, 'getProgressUpdate', None, None,),  # 2
 )
 all_structs.append(TProgressUpdateResp)
 TProgressUpdateResp.thrift_spec = (
-    None,  # 0
-    (1, TType.LIST, 'headerNames', (TType.STRING, 'UTF8', False), None, ),  # 1
-    (2, TType.LIST, 'rows', (TType.LIST, (TType.STRING, 'UTF8', False), False), None, ),  # 2
-    (3, TType.DOUBLE, 'progressedPercentage', None, None, ),  # 3
-    (4, TType.I32, 'status', None, None, ),  # 4
-    (5, TType.STRING, 'footerSummary', 'UTF8', None, ),  # 5
-    (6, TType.I64, 'startTime', None, None, ),  # 6
+  None,  # 0
+  (1, TType.LIST, 'headerNames', (TType.STRING, 'UTF8', False), None,),  # 1
+  (2, TType.LIST, 'rows', (TType.LIST, (TType.STRING, 'UTF8', False), False), None,),  # 2
+  (3, TType.DOUBLE, 'progressedPercentage', None, None,),  # 3
+  (4, TType.I32, 'status', None, None,),  # 4
+  (5, TType.STRING, 'footerSummary', 'UTF8', None,),  # 5
+  (6, TType.I64, 'startTime', None, None,),  # 6
 )
 all_structs.append(TGetOperationStatusResp)
 TGetOperationStatusResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.I32, 'operationState', None, None, ),  # 2
-    (3, TType.STRING, 'sqlState', 'UTF8', None, ),  # 3
-    (4, TType.I32, 'errorCode', None, None, ),  # 4
-    (5, TType.STRING, 'errorMessage', 'UTF8', None, ),  # 5
-    (6, TType.STRING, 'taskStatus', 'UTF8', None, ),  # 6
-    (7, TType.I64, 'operationStarted', None, None, ),  # 7
-    (8, TType.I64, 'operationCompleted', None, None, ),  # 8
-    (9, TType.BOOL, 'hasResultSet', None, None, ),  # 9
-    (10, TType.STRUCT, 'progressUpdateResponse', [TProgressUpdateResp, None], None, ),  # 10
-    (11, TType.I64, 'numModifiedRows', None, None, ),  # 11
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
+  (2, TType.I32, 'operationState', None, None,),  # 2
+  (3, TType.STRING, 'sqlState', 'UTF8', None,),  # 3
+  (4, TType.I32, 'errorCode', None, None,),  # 4
+  (5, TType.STRING, 'errorMessage', 'UTF8', None,),  # 5
+  (6, TType.STRING, 'taskStatus', 'UTF8', None,),  # 6
+  (7, TType.I64, 'operationStarted', None, None,),  # 7
+  (8, TType.I64, 'operationCompleted', None, None,),  # 8
+  (9, TType.BOOL, 'hasResultSet', None, None,),  # 9
+  (10, TType.STRUCT, 'progressUpdateResponse', [TProgressUpdateResp, None], None,),  # 10
+  (11, TType.I64, 'numModifiedRows', None, None,),  # 11
 )
 all_structs.append(TCancelOperationReq)
 TCancelOperationReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None, ),  # 1
+  None,  # 0
+  (1, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None,),  # 1
 )
 all_structs.append(TCancelOperationResp)
 TCancelOperationResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
 )
 all_structs.append(TCloseOperationReq)
 TCloseOperationReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None, ),  # 1
+  None,  # 0
+  (1, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None,),  # 1
 )
 all_structs.append(TCloseOperationResp)
 TCloseOperationResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
 )
 all_structs.append(TGetResultSetMetadataReq)
 TGetResultSetMetadataReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None, ),  # 1
+  None,  # 0
+  (1, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None,),  # 1
 )
 all_structs.append(TGetResultSetMetadataResp)
 TGetResultSetMetadataResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.STRUCT, 'schema', [TTableSchema, None], None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
+  (2, TType.STRUCT, 'schema', [TTableSchema, None], None,),  # 2
 )
 all_structs.append(TFetchResultsReq)
 TFetchResultsReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None, ),  # 1
-    (2, TType.I32, 'orientation', None, 0, ),  # 2
-    (3, TType.I64, 'maxRows', None, None, ),  # 3
-    (4, TType.I16, 'fetchType', None, 0, ),  # 4
+  None,  # 0
+  (1, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None,),  # 1
+  (2, TType.I32, 'orientation', None, 0,),  # 2
+  (3, TType.I64, 'maxRows', None, None,),  # 3
+  (4, TType.I16, 'fetchType', None, 0,),  # 4
 )
 all_structs.append(TFetchResultsResp)
 TFetchResultsResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.BOOL, 'hasMoreRows', None, None, ),  # 2
-    (3, TType.STRUCT, 'results', [TRowSet, None], None, ),  # 3
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
+  (2, TType.BOOL, 'hasMoreRows', None, None,),  # 2
+  (3, TType.STRUCT, 'results', [TRowSet, None], None,),  # 3
 )
 all_structs.append(TGetDelegationTokenReq)
 TGetDelegationTokenReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.STRING, 'owner', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'renewer', 'UTF8', None, ),  # 3
+  None,  # 0
+  (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None,),  # 1
+  (2, TType.STRING, 'owner', 'UTF8', None,),  # 2
+  (3, TType.STRING, 'renewer', 'UTF8', None,),  # 3
 )
 all_structs.append(TGetDelegationTokenResp)
 TGetDelegationTokenResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.STRING, 'delegationToken', 'UTF8', None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
+  (2, TType.STRING, 'delegationToken', 'UTF8', None,),  # 2
 )
 all_structs.append(TCancelDelegationTokenReq)
 TCancelDelegationTokenReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.STRING, 'delegationToken', 'UTF8', None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None,),  # 1
+  (2, TType.STRING, 'delegationToken', 'UTF8', None,),  # 2
 )
 all_structs.append(TCancelDelegationTokenResp)
 TCancelDelegationTokenResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
 )
 all_structs.append(TRenewDelegationTokenReq)
 TRenewDelegationTokenReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.STRING, 'delegationToken', 'UTF8', None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None,),  # 1
+  (2, TType.STRING, 'delegationToken', 'UTF8', None,),  # 2
 )
 all_structs.append(TRenewDelegationTokenResp)
 TRenewDelegationTokenResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
 )
 all_structs.append(TGetQueryIdReq)
 TGetQueryIdReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None, ),  # 1
+  None,  # 0
+  (1, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None,),  # 1
 )
 all_structs.append(TGetQueryIdResp)
 TGetQueryIdResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRING, 'queryId', 'UTF8', None, ),  # 1
+  None,  # 0
+  (1, TType.STRING, 'queryId', 'UTF8', None,),  # 1
 )
 all_structs.append(TGetLogReq)
 TGetLogReq.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None, ),  # 1
+  None,  # 0
+  (1, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None,),  # 1
 )
 all_structs.append(TGetLogResp)
 TGetLogResp.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.STRING, 'log', 'UTF8', None, ),  # 2
+  None,  # 0
+  (1, TType.STRUCT, 'status', [TStatus, None], None,),  # 1
+  (2, TType.STRING, 'log', 'UTF8', None,),  # 2
 )
 fix_spec(all_structs)
 del all_structs

--- a/tools/ci/check_for_python_lint.sh
+++ b/tools/ci/check_for_python_lint.sh
@@ -26,6 +26,7 @@ files=`git diff --name-only origin/master --diff-filter=b | egrep .py$ | \
   grep -v /migrations/ | \
   grep -v apps/oozie/src/oozie/tests.py | \
   grep -v tools/ops/ | \
+  grep - v apps/beeswax/gen-py/ | \
   grep -v /org_migrations/`
 
 cd $HOME


### PR DESCRIPTION
Table creation in Hive or Impala fails with UnicodeDecodeError: 'ascii' codec can't decode byte

Internal jira: CDPD-22129

Due to change in the thrift code to look at python base version and based on that use utf-8 encoding the issue started happening.  Based on the information from one of the internal jira python 3 uses the else part which is similar to what was there in before sys.version_info was added to the thrift code.

So removed if condition and retained only the else part example

From: oprot.writeString(self.log.encode('utf-8') if sys.version_info[0] == 2 else self.log)
To: oprot.writeString(self.log)
