### PR TITLE
[ci] Run autosquash only on the Hue repo branches

### DIFF
--- a/.github/workflows/autosquash.yml
+++ b/.github/workflows/autosquash.yml
@@ -21,6 +21,7 @@ jobs:
   autosquash:
     name: Autosquash
     runs-on: ubuntu-18.04
+    if: github.repository == 'cloudera/hue'
     steps:
       - uses: tibdex/autosquash@v2
         with:


### PR DESCRIPTION
To avoid errors on PR on Forks:
https://github.com/tibdex/autosquash/issues/53
