### PR TITLE
[ci] Hide GH false positive error check in LDAP tests

### DIFF
--- a/.github/workflows/commitflow-py3.yml
+++ b/.github/workflows/commitflow-py3.yml
@@ -44,4 +44,4 @@ jobs:
 
     - name: run tests
       run: |
-        PYTHONWARNINGS=always ./build/env/bin/hue test unit --with-xunit --with-cover
+        PYTHONWARNINGS=default,ignore:::ldap,ignore:::ldap.*,ignore:::useradmin.*,ignore:::useradmin,ignore:::useradmin.ldap_test ./build/env/bin/hue test unit --with-xunit --with-cover --logging-filter=-nose,-ldap

--- a/apps/useradmin/src/useradmin/test_ldap.py
+++ b/apps/useradmin/src/useradmin/test_ldap.py
@@ -795,6 +795,7 @@ class TestUserAdminLdap(BaseUserAdminTests):
     class LdapTestConnectionError(LdapTestConnection):
       def find_users(self, user, find_by_dn=False):
         raise ldap.LDAPError('No such object')
+
     ldap_access.CACHED_LDAP_CONN = LdapTestConnectionError()
 
     c = make_logged_in_client('test', is_superuser=True)

--- a/tools/examples/components/sql-scratchpad/src/components/SqlScratchpad.tsx
+++ b/tools/examples/components/sql-scratchpad/src/components/SqlScratchpad.tsx
@@ -22,6 +22,7 @@ interface SqlScratchpadState {
   executor?: Executor;
 }
 
+
 export class SqlScratchpad extends React.Component<{}, SqlScratchpadState> {
   state = {
     activeExecutable: undefined,


### PR DESCRIPTION
Try moving warning suppression to test function
