### PR TITLE
[Django40 Warning] RemovedInDjango40Warning: smart_text() is deprecated in favor of smart_str()

### DIFF
--- a/apps/useradmin/src/useradmin/ldap_access.py
+++ b/apps/useradmin/src/useradmin/ldap_access.py
@@ -21,6 +21,7 @@ User Admin to work seamlessly with LDAP.
 from builtins import str, object
 
 import logging
+import sys
 
 LOG = logging.getLogger(__name__)
 
@@ -33,12 +34,15 @@ except ImportError:
   SCOPE_SUBTREE = None
 import re
 
-from django.utils.encoding import smart_text
-
 import desktop.conf
 from desktop.lib.python_util import CaseInsensitiveDict
 
 from useradmin.models import User
+
+if sys.version_info[0] > 2:
+  from django.utils.encoding import smart_str
+else:
+  from django.utils.encoding import smart_text as smart_str
 
 CACHED_LDAP_CONN = None
 
@@ -245,26 +249,26 @@ class LdapConnection(object):
 
           ldap_info = {
             'dn': dn,
-            'username': smart_text(data[user_name_attr][0])
+            'username': smart_str(data[user_name_attr][0])
           }
 
           if 'givenName' in data:
-            first_name = smart_text(data['givenName'][0])
+            first_name = smart_str(data['givenName'][0])
             if len(first_name) > 30:
               LOG.warn('First name is truncated to 30 characters for [<User: %s>].' % ldap_info['username'])
             ldap_info['first'] = first_name[:30]
           if 'sn' in data:
-            last_name = smart_text(data['sn'][0])
+            last_name = smart_str(data['sn'][0])
             if len(last_name) > 30:
               LOG.warn('Last name is truncated to 30 characters for [<User: %s>].' % ldap_info['username'])
             ldap_info['last'] = last_name[:30]
           if 'mail' in data:
-            ldap_info['email'] = smart_text(data['mail'][0])
+            ldap_info['email'] = smart_str(data['mail'][0])
           # memberOf and isMemberOf should be the same if they both exist
           if 'memberOf' in data:
-            ldap_info['groups'] = [smart_text(member) for member in data['memberOf']]
+            ldap_info['groups'] = [smart_str(member) for member in data['memberOf']]
           if 'isMemberOf' in data:
-            ldap_info['groups'] = [smart_text(member) for member in data['isMemberOf']]
+            ldap_info['groups'] = [smart_str(member) for member in data['isMemberOf']]
 
           user_info.append(ldap_info)
     return user_info

--- a/apps/useradmin/src/useradmin/tests.py
+++ b/apps/useradmin/src/useradmin/tests.py
@@ -41,6 +41,7 @@ from desktop import appmanager
 from desktop.auth.backend import is_admin, create_user
 from desktop.conf import APP_BLACKLIST, ENABLE_ORGANIZATIONS, ENABLE_PROMETHEUS
 from desktop.lib.django_test_util import make_logged_in_client
+from desktop.lib.i18n import smart_unicode
 from desktop.lib.test_utils import grant_access
 from desktop.views import home
 from hadoop import pseudo_hdfs4
@@ -55,10 +56,8 @@ from useradmin.models import HuePermission, GroupPermission, UserProfile, get_pr
 from useradmin.hue_password_policy import reset_password_policy
 
 if sys.version_info[0] > 2:
-  from django.utils.encoding import smart_text as smart_unicode
   from unittest.mock import patch, Mock
 else:
-  from django.utils.encoding import smart_unicode
   from mock import patch, Mock
 
 

--- a/desktop/core/src/desktop/lib/i18n.py
+++ b/desktop/core/src/desktop/lib/i18n.py
@@ -23,9 +23,15 @@ import codecs
 import logging
 import os
 import re
+import sys
 
 import desktop.conf
 import django.utils.encoding
+
+if sys.version_info[0] > 2:
+  from django.utils.encoding import smart_str as django_smart_unicode
+else:
+  from django.utils.encoding import smart_text as django_smart_unicode
 
 SITE_ENCODING = None
 REPLACEMENT_CHAR = u'\ufffd'
@@ -58,9 +64,11 @@ def smart_unicode(s, strings_only=False, errors='strict', encoding=None):
   """
   Wrapper around Django's version, while supplying our configured encoding.
   Decode char array to unicode.
+  For py3 -> this is becoming a 'string' now (no more 'unicode' in py3).
   """
-  return django.utils.encoding.smart_text(
-        s, encoding if encoding is not None else get_site_encoding(), strings_only, errors)
+
+  return django_smart_unicode(
+    s, encoding if encoding is not None else get_site_encoding(), strings_only, errors)
 
 def force_unicode(s, strings_only=False, errors='strict'):
   """


### PR DESCRIPTION
## What changes were proposed in this pull request?

- in python3 -> smart_text -> smart_str (the are alias in python 3 attached ss)
- in python2 -> import smart_text as smart_str

## How was this patch tested?

<img width="853" alt="Screenshot 2021-03-18 at 7 06 04 PM" src="https://user-images.githubusercontent.com/36241930/111635148-3506cf80-881d-11eb-838b-d130cdc96d14.png">
<img width="1114" alt="Screenshot 2021-03-18 at 7 06 46 PM" src="https://user-images.githubusercontent.com/36241930/111635168-3932ed00-881d-11eb-9ad9-2a5e6bb1fe71.png">

