### PR TITLE
[slack] Doc read access permission

### DIFF
--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -106,8 +106,8 @@ def handle_on_link_shared(channel_id, message_ts, links):
     id_type, qid = urlsplit(item['url'])[3].split('=')
 
     try:
-      if path == '/hue/editor' and id_type == 'editor' and qid.isdigit():
-        doc = Document2.objects.get(id=qid)
+      if path == '/hue/editor' and id_type == 'editor':
+        doc = Document2.objects.get(id=qid) if qid.isdigit() else Document2.objects.get(uuid=qid)
         doc_type = 'Query'
       elif path == '/hue/gist' and id_type == 'uuid' and ENABLE_GIST_PREVIEW.get():
         doc = _get_gist_document(uuid=qid)
@@ -121,7 +121,7 @@ def handle_on_link_shared(channel_id, message_ts, links):
       msg = "Document with {key}={value} does not exist".format(key='uuid' if id_type == 'uuid' else 'id', value=qid)
       raise PopupException(_(msg))
     except User.DoesNotExist:
-      raise PopupException(_('Could not find user with username: {}').format(doc.owner.username))
+      raise PopupException(_('Could not find the user'))
 
     # Mock request for query execution and fetch result
     user = rewrite_user(user)

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -106,7 +106,7 @@ def handle_on_link_shared(channel_id, message_ts, links):
     id_type, qid = urlsplit(item['url'])[3].split('=')
 
     try:
-      if path == '/hue/editor' and id_type == 'editor':
+      if path == '/hue/editor' and id_type == 'editor' and qid.isdigit():
         doc = Document2.objects.get(id=qid)
         doc_type = 'Query'
       elif path == '/hue/gist' and id_type == 'uuid' and ENABLE_GIST_PREVIEW.get():
@@ -114,12 +114,17 @@ def handle_on_link_shared(channel_id, message_ts, links):
         doc_type = 'Gist'
       else:
         raise PopupException(_("Cannot unfurl link"))
+      
+      user = User.objects.get(username=doc.owner.username)
+      doc.can_read_or_exception(user)
     except Document2.DoesNotExist:
       msg = "Document with {key}={value} does not exist".format(key='uuid' if id_type == 'uuid' else 'id', value=qid)
       raise PopupException(_(msg))
+    except User.DoesNotExist:
+      raise PopupException(_('Could not find user with username: {}').format(doc.owner.username))
 
     # Mock request for query execution and fetch result
-    user = rewrite_user(User.objects.get(username=doc.owner.username))
+    user = rewrite_user(user)
     request = MockRequest(user=user)
 
     payload = _make_unfurl_payload(request, item['url'], id_type, doc, doc_type)


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Added doc read permission check( ref. https://github.com/cloudera/hue/pull/1837#discussion_r585188780 )
- Added User does not exist exception
- Updated UTs
- Removed Document2.objects.get mocking and instead creating doc in testserver (to check doc access)

## How was this patch tested?
- By running updated unit tests