### PR TITLE
[slack] Delete 'has_hue_permission' attr set by rewrite_user 

### DIFF
--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -144,6 +144,9 @@ def handle_on_link_shared(channel_id, message_ts, links):
         initial_comment='Here is your result file!'
         )
 
+    delattr(user, 'has_hue_permission')
+
+
 def _query_result(request, notebook, max_rows):
   snippet = notebook['snippets'][0]
   snippet['statement'] = notebook['snippets'][0]['statement_raw']


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Deleted 'has_hue_permission' from user object set by rewrite_user when its job is done.
- Ref. https://github.com/cloudera/hue/issues/1917

