### PR TITLE
[Django4_warning_force_str] RemovedInDjango40Warning: force_text() is deprecated in favor of force_str().

### DIFF
--- a/apps/beeswax/src/beeswax/server/dbms.py
+++ b/apps/beeswax/src/beeswax/server/dbms.py
@@ -53,9 +53,9 @@ from beeswax.models import QueryHistory, QUERY_TYPES
 
 
 if sys.version_info[0] > 2:
-  from django.utils.encoding import force_text as force_unicode
+  from django.utils.encoding import force_str
 else:
-  from django.utils.encoding import force_unicode
+  from django.utils.encoding import force_unicode as force_str
 
 
 LOG = logging.getLogger(__name__)
@@ -1292,5 +1292,5 @@ def expand_exception(exc, db, handle=None):
   if not exc.args or not exc.args[0]:
     error_message = _("Unknown exception.")
   else:
-    error_message = force_unicode(exc.args[0], strings_only=True, errors='replace')
+    error_message = force_str(exc.args[0], strings_only=True, errors='replace')
   return error_message, log

--- a/apps/beeswax/src/beeswax/templates/list_designs.mako
+++ b/apps/beeswax/src/beeswax/templates/list_designs.mako
@@ -22,9 +22,9 @@
     from desktop.views import commonheader, commonfooter
 
     if sys.version_info[0] > 2:
-      from django.utils.encoding import force_text as force_unicode
+      from django.utils.encoding import force_str
     else:
-      from django.utils.encoding import force_unicode
+      from django.utils.encoding import force_unicode as force_str
 %>
 
 <%namespace name="actionbar" file="actionbar.mako" />
@@ -110,11 +110,11 @@ ${ layout.menubar(section='saved queries') }
               data-clone-url="${ url(app_name + ':clone_design', design_id=design.id) }" data-row-selector-exclude="true"></div>
           </td>
           <td>
-            <a href="${ url(app_name + ':execute_design', design_id=design.id) }" data-row-selector="true">${ force_unicode(design.name) }</a>
+            <a href="${ url(app_name + ':execute_design', design_id=design.id) }" data-row-selector="true">${ force_str(design.name) }</a>
           </td>
           <td>
           % if design.desc:
-            ${ force_unicode(design.desc) }
+            ${ force_str(design.desc) }
           % endif
           </td>
           <td>${ design.owner.username }</td>

--- a/apps/oozie/src/oozie/models.py
+++ b/apps/oozie/src/oozie/models.py
@@ -61,10 +61,10 @@ from oozie.timezones import TIMEZONES
 
 if sys.version_info[0] > 2:
   from io import BytesIO as string_io
-  from django.utils.encoding import force_text as force_unicode
+  from django.utils.encoding import force_str
 else:
   from cStringIO import StringIO as string_io
-  from django.utils.encoding import force_unicode
+  from django.utils.encoding import force_unicode as force_str
 
 
 LOG = logging.getLogger(__name__)
@@ -173,8 +173,8 @@ class Job(models.Model):
     return self.deployment_dir != '' and fs.exists(self.deployment_dir)
 
   def __str__(self):
-    res = '%s - %s' % (force_unicode(self.name), self.owner)
-    return force_unicode(res)
+    res = '%s - %s' % (force_str(self.name), self.owner)
+    return force_str(res)
 
   def get_full_node(self):
     try:
@@ -588,7 +588,7 @@ class Workflow(Job):
       mapping = {}
     tmpl = 'editor/gen/workflow.xml.mako'
     xml = re.sub(re.compile('\s*\n+', re.MULTILINE), '\n', django_mako.render_to_string(tmpl, {'workflow': self, 'mapping': mapping}))
-    return force_unicode(xml)
+    return force_str(xml)
 
   def compress(self, mapping=None, fp=string_io()):
     metadata = {
@@ -1895,7 +1895,7 @@ class Bundle(Job):
       mapping = {}
     tmpl = "editor/gen/bundle.xml.mako"
 
-    return force_unicode(
+    return force_str(
               re.sub(re.compile('\s*\n+', re.MULTILINE), '\n', django_mako.render_to_string(tmpl, {
                 'bundle': self,
                 'mapping': mapping

--- a/apps/oozie/src/oozie/models2.py
+++ b/apps/oozie/src/oozie/models2.py
@@ -58,9 +58,9 @@ from oozie.utils import utc_datetime_format, UTC_TIME_FORMAT, convert_to_server_
 from oozie.importlib.workflows import generate_v2_graph_nodes, MalformedWfDefException, InvalidTagWithNamespaceException
 
 if sys.version_info[0] > 2:
-  from django.utils.encoding import force_text as force_unicode
+  from django.utils.encoding import force_str
 else:
-  from django.utils.encoding import force_unicode
+  from django.utils.encoding import force_unicode as force_str
 
 WORKFLOW_DEPTH_LIMIT = 24
 LOG = logging.getLogger(__name__)
@@ -93,7 +93,7 @@ class Job(object):
     }))
 
   def __str__(self):
-    return '%s' % force_unicode(self.name)
+    return '%s' % force_str(self.name)
 
   def deployment_dir(self):
     return None
@@ -497,7 +497,7 @@ class Workflow(Job):
       'node_mapping': node_mapping,
       'workflow_mapping': workflow_mapping
     }))
-    return force_unicode(xml.strip())
+    return force_str(xml.strip())
 
   def get_absolute_url(self):
     return reverse('oozie:edit_workflow') + '?workflow=%s' % self.id if self.document else ''
@@ -3741,7 +3741,7 @@ class Bundle(Job):
 
     mapping.update(dict(list(self.get_coordinator_docs().values('uuid', 'name'))))
     tmpl = "editor2/gen/bundle.xml.mako"
-    return force_unicode(
+    return force_str(
               re.sub(re.compile('\s*\n+', re.MULTILINE), '\n', django_mako.render_to_string(tmpl, {
                 'bundle': self,
                 'mapping': mapping

--- a/desktop/core/src/desktop/lib/django_forms.py
+++ b/desktop/core/src/desktop/lib/django_forms.py
@@ -40,10 +40,10 @@ from desktop.lib.i18n import smart_str
 if sys.version_info[0] > 2:
   import urllib.request, urllib.error
   from urllib.parse import quote_plus as urllib_quote_plus
-  from django.utils.encoding import force_text as force_unicode
+  from django.utils.encoding import force_str
 else:
   from urllib import quote_plus as urllib_quote_plus
-  from django.utils.encoding import force_unicode
+  from django.utils.encoding import force_unicode as force_str
 
 LOG = logging.getLogger(__name__)
 
@@ -352,7 +352,7 @@ class SubmitButton(Input):
 
     if value != '':
       # Only add the 'value' attribute if a value is non-empty.
-      final_attrs['value'] = force_unicode(value)
+      final_attrs['value'] = force_str(value)
     return mark_safe(u'<button%s>%s</button>' % (flatatt(final_attrs), getattr(self, "label", "Submit")))
 
 

--- a/desktop/core/src/desktop/lib/exceptions_renderable.py
+++ b/desktop/core/src/desktop/lib/exceptions_renderable.py
@@ -24,9 +24,9 @@ import sys
 import traceback
 
 if sys.version_info[0] > 2:
-  from django.utils.encoding import force_text as force_unicode
+  from django.utils.encoding import force_str
 else:
-  from django.utils.encoding import force_unicode
+  from django.utils.encoding import force_unicode as force_str
 
 import desktop.lib.django_util
 
@@ -64,9 +64,9 @@ class PopupException(Exception):
 
   def response(self, request):
     data = {
-      'title': force_unicode(self.title),
-      'message': force_unicode(self.message),
-      'detail': force_unicode(self.detail) if self.detail else None,
+      'title': force_str(self.title),
+      'message': force_str(self.message),
+      'detail': force_str(self.detail) if self.detail else None,
       'traceback': self.traceback,
       'is_embeddable': request.GET.get('is_embeddable', False)
     }

--- a/desktop/core/src/desktop/lib/i18n.py
+++ b/desktop/core/src/desktop/lib/i18n.py
@@ -75,8 +75,10 @@ def force_unicode(s, strings_only=False, errors='strict'):
   Wrapper around Django's version, while supplying our configured encoding.
   Decode char array to unicode.
   """
-  return django.utils.encoding.force_text(
-        s, get_site_encoding(), strings_only, errors)
+  if sys.version_info[0] > 2:
+    return django.utils.encoding.force_str(s, get_site_encoding(), strings_only, errors)
+  else:
+    return django.utils.encoding.force_unicode(s, get_site_encoding(), strings_only, errors)
 
 def smart_str(s, strings_only=False, errors='strict'):
   """

--- a/desktop/libs/dashboard/src/dashboard/api.py
+++ b/desktop/libs/dashboard/src/dashboard/api.py
@@ -47,9 +47,9 @@ from dashboard.models import Collection2, augment_solr_response, pairwise2, augm
   NESTED_FACET_FORM, COMPARE_FACET, QUERY_FACET, extract_solr_exception_message
 
 if sys.version_info[0] > 2:
-    from django.utils.encoding import force_text as force_unicode
+    from django.utils.encoding import force_str
 else:
-    from django.utils.encoding import force_unicode
+    from django.utils.encoding import force_unicode as force_str
 
 LOG = logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ def search(request):
     except Exception as e:
       raise PopupException(e, title=_('Error while accessing Solr'))
 
-      response['error'] = force_unicode(e)
+      response['error'] = force_str(e)
   else:
     response['error'] = _('There is no collection to search.')
 
@@ -105,7 +105,7 @@ def query_suggest(request):
     result['response'] = response
     result['status'] = 0
   except Exception as e:
-    result['message'] = force_unicode(e)
+    result['message'] = force_str(e)
 
   return JsonResponse(result)
 
@@ -131,7 +131,7 @@ def index_fields_dynamic(request):
     ]
     result['status'] = 0
   except Exception as e:
-    result['message'] = force_unicode(e)
+    result['message'] = force_str(e)
 
   return JsonResponse(result)
 
@@ -150,7 +150,7 @@ def nested_documents(request):
     result['status'] = 0
   except Exception as e:
     LOG.exception('Failed to list nested documents')
-    result['message'] = force_unicode(e)
+    result['message'] = force_str(e)
     result['has_nested_documents'] = False
 
   return JsonResponse(result)
@@ -177,7 +177,7 @@ def get_document(request):
       result['status'] = 1
 
   except Exception as e:
-    result['message'] = force_unicode(e)
+    result['message'] = force_str(e)
 
   return JsonResponse(result)
 
@@ -218,9 +218,9 @@ def update_document(request):
       result['message'] = json.loads(e.message)['error']['msg']
     except:
       LOG.exception('Failed to parse json response')
-      result['message'] = force_unicode(e)
+      result['message'] = force_str(e)
   except Exception as e:
-    result['message'] = force_unicode(e)
+    result['message'] = force_str(e)
 
   return JsonResponse(result)
 
@@ -243,7 +243,7 @@ def get_stats(request):
 
   except Exception as e:
     LOG.exception('Failed to get stats for field')
-    result['message'] = force_unicode(e)
+    result['message'] = force_str(e)
     if 'not currently supported' in result['message']:
       result['status'] = 1
       result['message'] = _('This field type does not support stats')
@@ -281,7 +281,7 @@ def get_terms(request):
     result['message'] = ''
 
   except Exception as e:
-    result['message'] = force_unicode(e)
+    result['message'] = force_str(e)
     if 'not currently supported' in result['message']:
       result['status'] = 1
       result['message'] = _('This field does not support stats')
@@ -362,7 +362,7 @@ def get_timeline(request):
     result['status'] = 0
     result['message'] = ''
   except Exception as e:
-    result['message'] = force_unicode(e)
+    result['message'] = force_str(e)
 
   return JsonResponse(result)
 
@@ -385,7 +385,7 @@ def new_facet(request):
     result['facet'] = _create_facet(collection, request.user, facet_id, facet_label, facet_field, widget_type, window_size)
     result['status'] = 0
   except Exception as e:
-    result['message'] = force_unicode(e)
+    result['message'] = force_str(e)
 
   return JsonResponse(result)
 
@@ -570,7 +570,7 @@ def get_range_facet(request):
     result['status'] = 0
 
   except Exception as e:
-    result['message'] = force_unicode(e)
+    result['message'] = force_str(e)
 
   return JsonResponse(result)
 
@@ -590,7 +590,7 @@ def get_collection(request):
     result['status'] = 0
 
   except Exception as e:
-    result['message'] = force_unicode(e)
+    result['message'] = force_str(e)
 
   return JsonResponse(result)
 
@@ -610,6 +610,6 @@ def get_collections(request):
       result['status'] = 0
       result['collection'] = [json.loads(request.POST.get('collection'))['name']]
     else:
-      result['message'] = force_unicode(e)
+      result['message'] = force_str(e)
 
   return JsonResponse(result)

--- a/desktop/libs/hadoop/src/hadoop/fs/hadoopfs.py
+++ b/desktop/libs/hadoop/src/hadoop/fs/hadoopfs.py
@@ -46,10 +46,10 @@ from hadoop.fs import normpath, SEEK_SET, SEEK_CUR, SEEK_END
 from hadoop.fs.exceptions import PermissionDeniedException
 
 if sys.version_info[0] > 2:
-  from django.utils.encoding import force_text as force_unicode
+  from django.utils.encoding import force_str
   from urllib.parse import urlsplit as lib_urlsplit
 else:
-  from django.utils.encoding import force_unicode
+  from django.utils.encoding import force_unicode as force_str
   from urlparse import urlsplit as lib_urlsplit
 
 LOG = logging.getLogger(__name__)
@@ -78,7 +78,7 @@ def encode_fs_path(path):
 
 def decode_fs_path(path):
   """decode_fs_path(bytestring) -> unicode path"""
-  return force_unicode(path, HDFS_ENCODING, errors='strict')
+  return force_str(path, HDFS_ENCODING, errors='strict')
 
 
 def _coerce_exceptions(function):
@@ -91,8 +91,8 @@ def _coerce_exceptions(function):
     try:
       return function(*args, **kwargs)
     except Exception as e:
-      e.msg = force_unicode(e.msg, errors='replace')
-      e.stack = force_unicode(e.stack, errors='replace')
+      e.msg = force_str(e.msg, errors='replace')
+      e.stack = force_str(e.stack, errors='replace')
       LOG.exception("Exception in Hadoop FS call " + function.__name__)
       if e.clazz == HADOOP_ACCESSCONTROLEXCEPTION:
         raise PermissionDeniedException(e.msg, e)


### PR DESCRIPTION
## What changes were proposed in this pull request?

- for py3 ->
        `from django.utils.encoding import force_text as force unicode` to `from django.utils.encoding import force_str`
- for py2 ->
         `from django.utils.encoding import force unicode` to `from django.utils.encoding import force_unicode as force_str`
and in the code `force_unicode` is changed to `force_str`

## How was this patch tested?

- 
<img width="528" alt="Screenshot 2021-03-22 at 5 49 49 PM" src="https://user-images.githubusercontent.com/36241930/111989131-5e826c80-8b37-11eb-8d7f-c7aa85f3d367.png">
<img width="844" alt="Screenshot 2021-03-22 at 5 52 01 PM" src="https://user-images.githubusercontent.com/36241930/111989143-62ae8a00-8b37-11eb-8d1c-5eb4300fe346.png">

links for the above ss -> 
- https://docs.djangoproject.com/en/3.0/_modules/django/utils/encoding/
- https://docs.djangoproject.com/en/3.1/ref/utils/
