### PR TITLE
[Django4.0 Warning] RemovedInDjango40Warning: django.utils.http.urlquote() is deprecated in favor of urllib.parse.quote()

### DIFF
--- a/desktop/core/src/desktop/lib/export_csvxls.py
+++ b/desktop/core/src/desktop/lib/export_csvxls.py
@@ -32,13 +32,14 @@ import tablib
 
 from django.http import StreamingHttpResponse, HttpResponse
 from django.utils.encoding import smart_str
-from django.utils.http import urlquote
 from desktop.lib import i18n
 
 if sys.version_info[0] > 2:
   from io import BytesIO as string_io
+  from urllib.parse import quote
 else:
   from StringIO import StringIO as string_io
+  from django.utils.http import urlquote as quote
 
 
 LOG = logging.getLogger(__name__)
@@ -164,7 +165,7 @@ def make_response(generator, format, name, encoding=None, user_agent=None): #TOD
     format = format.encode('ascii')
     resp['Content-Disposition'] = b'attachment; filename="%s.%s"' % (name, format)
   except UnicodeEncodeError:
-    name = urlquote(name)
+    name = quote(name)
     if user_agent is not None and 'Firefox' in user_agent:
       # Preserving non-ASCII filename. See RFC https://tools.ietf.org/html/rfc6266#appendix-D, only FF works
       resp['Content-Disposition'] = 'attachment; filename*="%s.%s"' % (name, format)

--- a/desktop/core/src/desktop/middleware.py
+++ b/desktop/core/src/desktop/middleware.py
@@ -43,7 +43,6 @@ from django.core import exceptions
 from django.http import HttpResponseNotAllowed, HttpResponseForbidden
 from django.urls import resolve
 from django.http import HttpResponseRedirect, HttpResponse
-from django.utils.http import urlquote
 from django.utils.deprecation import MiddlewareMixin
 
 from hadoop import cluster
@@ -66,9 +65,10 @@ from desktop.log.access import access_log, log_page_hit, access_warn
 if sys.version_info[0] > 2:
   from django.utils.translation import gettext as _
   from django.utils.http import url_has_allowed_host_and_scheme
+  from urllib.parse import quote
 else:
   from django.utils.translation import ugettext as _
-  from django.utils.http import is_safe_url as url_has_allowed_host_and_scheme
+  from django.utils.http import is_safe_url as url_has_allowed_host_and_scheme, urlquote as quote
 
 
 LOG = logging.getLogger(__name__)
@@ -384,11 +384,11 @@ class LoginAndPermissionMiddleware(MiddlewareMixin):
           'url': "%s?%s=%s" % (
               settings.LOGIN_URL,
               REDIRECT_FIELD_NAME,
-              urlquote('/hue' + request.get_full_path().replace('is_embeddable=true', '').replace('&&', '&'))
+              quote('/hue' + request.get_full_path().replace('is_embeddable=true', '').replace('&&', '&'))
           )
         }) # Remove embeddable so redirect from & to login works. Login page is not embeddable
       else:
-        return HttpResponseRedirect("%s?%s=%s" % (settings.LOGIN_URL, REDIRECT_FIELD_NAME, urlquote(request.get_full_path())))
+        return HttpResponseRedirect("%s?%s=%s" % (settings.LOGIN_URL, REDIRECT_FIELD_NAME, quote(request.get_full_path())))
 
   def process_response(self, request, response):
     if hasattr(request, 'ts') and hasattr(request, 'view_func'):


### PR DESCRIPTION
## What changes were proposed in this pull request?

- for python 3 -> `from urllib.parse import quote`
- fro python 2 -> `from django.utils.http import urlquote as quote`

## How was this patch tested?
For python3
- 
<img width="846" alt="Screenshot 2021-03-23 at 6 15 07 PM" src="https://user-images.githubusercontent.com/36241930/112148508-f9e11380-8c03-11eb-8304-ecf7e959483b.png">

- 
<img width="807" alt="Screenshot 2021-03-23 at 6 14 43 PM" src="https://user-images.githubusercontent.com/36241930/112148561-06fe0280-8c04-11eb-9735-44072e422aed.png">

for python2

- 
<img width="821" alt="Screenshot 2021-03-23 at 6 18 36 PM" src="https://user-images.githubusercontent.com/36241930/112148702-3280ed00-8c04-11eb-9fd0-c188c08fb2ac.png">

links ->
 1-> https://docs.djangoproject.com/en/3.0/_modules/django/utils/http/
2 -> https://docs.djangoproject.com/en/1.11/_modules/django/utils/http/