### PR TITLE
[core] Sharing document is always turned off

### DIFF
--- a/desktop/core/src/desktop/js/apps/editor/EditorViewModel.js
+++ b/desktop/core/src/desktop/js/apps/editor/EditorViewModel.js
@@ -68,7 +68,7 @@ export default class EditorViewModel {
     this.sharingEnabled = ko.pureComputed(
       () =>
         this.config() &&
-        (this.config().hue_config.is_admin || this.config().hue_config.sharing_enabled)
+        (this.config().hue_config.is_admin || this.config().hue_config.enable_sharing)
     );
 
     huePubSub.publish(GET_KNOWN_CONFIG_EVENT, this.config);


### PR DESCRIPTION
Quick grepping: seems like a big bug where we should rename 'sharing_enabled --> enable_sharing'

sharing_enabled does not exist anywhere

In get_config

--> 'enable_sharing': ENABLE_SHARING.get()
