### PR TITLE
[editor] jHueNotify Error message shown in UI should sanitised to prevent Html injection

### DIFF
--- a/desktop/core/src/desktop/js/jquery/plugins/jquery.notify.js
+++ b/desktop/core/src/desktop/js/jquery/plugins/jquery.notify.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import $ from 'jquery';
+import hueUtils from 'utils/hueUtils';
 
 /*
  * jHue notify plugin
@@ -50,6 +51,7 @@ Plugin.prototype.show = function () {
   const MARGIN = 4;
 
   _this.options.message = _this.options.message.replace(/(<([^>]+)>)/gi, ''); // escape HTML messages
+  _this.options.message = hueUtils.deXSS(_this.options.message); // escape XSS messages
 
   if (
     _this.options.message !== '' &&

--- a/desktop/core/src/desktop/static/desktop/js/jquery.notify.js
+++ b/desktop/core/src/desktop/static/desktop/js/jquery.notify.js
@@ -49,6 +49,7 @@
     var MARGIN = 4;
 
     _this.options.message = _this.options.message.replace(/(<([^>]+)>)/ig, ''); // escape HTML messages
+    _this.options.message = hueUtils.deXSS(_this.options.message); // escape XSS messages
 
     if (_this.options.message !== '' && $(".jHueNotify .message").last().text() !== _this.options.message) {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

- GH-1942 - Error message shown in UI should sanitised to prevent Html injection

### How was this patch tested?

- Tested manually with possible error / warn messages that can be shown in UI , it shouldnt have XSS injection possible.

<img width="1468" alt="Screenshot 2021-03-25 at 7 04 39 PM" src="https://user-images.githubusercontent.com/18462803/112481381-f5039780-8d9c-11eb-9d5d-c14e19415a28.png">
