### PR TITLE
[slack] Add doc read permission check 

### DIFF
--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -117,8 +117,7 @@ def handle_on_link_shared(channel_id, message_ts, links, user_id):
       else:
         raise PopupException(_("Cannot unfurl link"))
     except Document2.DoesNotExist:
-      key, value = next(iter(query_id.items()))
-      msg = "Document with {key} = {value} does not exist".format(key=key, value=value)
+      msg = "Document with {} does not exist".format(query_id)
       raise PopupException(_(msg))
 
     # Permission check for Slack user to be Hue user

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -117,14 +117,14 @@ def handle_on_link_shared(channel_id, message_ts, links, user_id):
       else:
         raise PopupException(_("Cannot unfurl link"))
     except Document2.DoesNotExist:
-      msg = "Document with {} does not exist".format(query_id)
+      msg = "Document with {key} does not exist".format(key=query_id)
       raise PopupException(_(msg))
 
     # Permission check for Slack user to be Hue user
     try:
       user = User.objects.get(username=slack_email_prefix(user_id))
     except User.DoesNotExist:
-      raise PopupException(_("Slack user has no permission to access the document"))
+      raise PopupException(_("Slack user does not have access to the query"))
 
     doc.can_read_or_exception(user)
 
@@ -147,7 +147,7 @@ def slack_email_prefix(user_id):
   try:
     slack_user = slack_client.users_info(user=user_id)
   except Exception as e:
-    raise PopupException(_("Cannot find slack user info"), detail=e)
+    raise PopupException(_("Cannot find query owner in Slack"), detail=e)
   
   if slack_user['ok']:
     return slack_user['user']['profile']['email'].split('@')[0]

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -105,8 +105,8 @@ def handle_on_link_shared(channel_id, message_ts, links):
     id_type, qid = urlsplit(item['url'])[3].split('=')
 
     try:
-      if path == '/hue/editor' and id_type == 'editor' and qid.isdigit():
-        doc = Document2.objects.get(id=qid)
+      if path == '/hue/editor' and id_type == 'editor':
+        doc = Document2.objects.get(id=qid) if qid.isdigit() else Document2.objects.get(uuid=qid)
         doc_type = 'Query'
       elif path == '/hue/gist' and id_type == 'uuid':
         doc = _get_gist_document(uuid=qid)
@@ -120,7 +120,7 @@ def handle_on_link_shared(channel_id, message_ts, links):
       msg = "Document with {key}={value} does not exist".format(key='uuid' if id_type == 'uuid' else 'id', value=qid)
       raise PopupException(_(msg))
     except User.DoesNotExist:
-      raise PopupException(_('Could not find user with username: {}').format(doc.owner.username))
+      raise PopupException(_('Could not find the user'))
 
     # Mock request for query execution and fetch result
     user = rewrite_user(user)

--- a/desktop/core/src/desktop/lib/botserver/views_tests.py
+++ b/desktop/core/src/desktop/lib/botserver/views_tests.py
@@ -72,12 +72,92 @@ class TestBotServer(unittest.TestCase):
       handle_on_message("channel", None, "hello hue test", "user_id")
       assert_true(say_hi_user.called)
 
-  def test_handle_on_link_shared(self):
+  def test_handle_query_history_link(self):
+    with patch('desktop.lib.botserver.views.slack_client.chat_unfurl') as chat_unfurl:
+      with patch('desktop.lib.botserver.views._make_unfurl_payload') as mock_unfurl_payload:
+        with patch('desktop.lib.botserver.views.send_result_file') as send_result_file:
+          with patch('desktop.lib.botserver.views.slack_client.users_info') as users_info:
+
+            # Slack user email: test@example.com
+            client = make_logged_in_client(username="test", groupname="default", recreate=True, is_superuser=False)
+            user = User.objects.get(username="test")
+            # Other slack user email: test_not_me@example.com
+            client_not_me = make_logged_in_client(username="test_not_me", groupname="default", recreate=True, is_superuser=False)
+            user_not_me = User.objects.get(username="test_not_me")
+
+            channel_id = "channel"
+            message_ts = "12.1"
+            user_id = "<@user_id>"
+
+            links = [{"url": "https://demo.gethue.com/hue/editor?editor=12345"}]
+            doc_data = {
+              "dialect": "mysql",
+              "snippets": [{
+                "database": "hue",
+                "statement_raw": "SELECT 5000",
+              }]
+            }
+            doc = Document2.objects.create(id=12345, data=json.dumps(doc_data), owner=user)
+            mock_unfurl_payload.return_value = {
+              'payload': {},
+              'file_status': True,
+            }
+
+            # Slack user is not Hue user
+            users_info.return_value = {
+              "ok": True,
+              "user": {
+                "profile": {
+                  "email": "test_user_not_exist@example.com"
+                }
+              }
+            }
+            assert_raises(PopupException, handle_on_link_shared, "channel", "12.1", links, "<@user_id>")
+            assert_false(chat_unfurl.called)
+            assert_false(send_result_file.called)
+
+            # Slack user is Hue user but without read access sends link
+            users_info.return_value = {
+              "ok": True,
+              "user": {
+                "profile": {
+                  "email": "test_not_me@example.com"
+                }
+              }
+            }
+            assert_raises(PopupException, handle_on_link_shared, "channel", "12.1", links, "<@user_id>")
+            assert_false(chat_unfurl.called)
+            assert_false(send_result_file.called)
+
+            # Slack user is Hue user with read access sends link
+            users_info.return_value = {
+              "ok": True,
+              "user": {
+                "profile": {
+                  "email": "test_not_me@example.com"
+                }
+              }
+            }
+            doc.update_permission(user, is_link_on=True)
+            handle_on_link_shared(channel_id, message_ts, links, user_id)
+
+            assert_true(chat_unfurl.called)
+            assert_true(send_result_file.called)
+
+            # Document does not exist
+            qhistory_url = "https://demo.gethue.com/hue/editor?editor=109644"
+            assert_raises(PopupException, handle_on_link_shared, "channel", "12.1", [{"url": qhistory_url}], "<@user_id>")
+
+            # Cannot unfurl link with invalid query link
+            inv_qhistory_url = "https://demo.gethue.com/hue/editor/?type=4"
+            assert_raises(PopupException, handle_on_link_shared, "channel", "12.1", [{"url": inv_qhistory_url}], "<@user_id>")
+
+  def test_handle_gist_link(self):
     with patch('desktop.lib.botserver.views.slack_client.chat_unfurl') as chat_unfurl:
       with patch('desktop.lib.botserver.views._make_unfurl_payload') as mock_unfurl_payload:
         with patch('desktop.lib.botserver.views._get_gist_document') as _get_gist_document:
-          with patch('desktop.lib.botserver.views.send_result_file') as send_result_file:
-            with patch('desktop.lib.botserver.views.slack_email_prefix') as email_prefix:
+          with patch('desktop.lib.botserver.views.slack_client.users_info') as users_info:
+            with patch('desktop.lib.botserver.views.send_result_file') as send_result_file:
 
               # Slack user email: test@example.com
               client = make_logged_in_client(username="test", groupname="default", recreate=True, is_superuser=False)
@@ -90,76 +170,47 @@ class TestBotServer(unittest.TestCase):
               message_ts = "12.1"
               user_id = "<@user_id>"
 
-              # Query link
-              links = [{"url": "https://demo.gethue.com/hue/editor?editor=12345"}]
-              doc_data = {
-                "dialect": "mysql",
-                "snippets": [{
-                  "database": "hue",
-                  "statement_raw": "SELECT 5000",
-                }]
-              }
-              doc = Document2.objects.create(id=12345, data=json.dumps(doc_data), owner=user)
-              mock_unfurl_payload.return_value = {
-                'payload': {},
-                'file_status': True,
-              }
-
-              # Other user sends link to unfurl without read permission
-              email_prefix.return_value = 'test_not_me'
-
-              assert_raises(PopupException, handle_on_link_shared, "channel", "12.1", links, "<@user_id>")
-              assert_false(chat_unfurl.called)
-              assert_false(send_result_file.called)
-
-              # User doesn't exist and read perm is also not set for link
-              email_prefix.return_value = 'test_user_not_exist'
-
-              assert_raises(PopupException, handle_on_link_shared, "channel", "12.1", links, "<@user_id>")
-              assert_false(chat_unfurl.called)
-              assert_false(send_result_file.called)
-
-              # Other user sends link which has read perm
-              email_prefix.return_value = 'test_not_me'
-              doc.share_link(user, perm='read') # Some user has set read perm to shared link
-
-              handle_on_link_shared(channel_id, message_ts, links, user_id)
-              assert_true(chat_unfurl.called)
-              assert_true(send_result_file.called)
-
-              # Doc owner sends link to unfurl
-              email_prefix.return_value = 'test'
-              handle_on_link_shared(channel_id, message_ts, links, user_id)
-
-              assert_true(chat_unfurl.called)
-              assert_true(send_result_file.called)
-             
-              # Gist link
               doc_data = {"statement_raw": "SELECT 98765"}
+              links = [{"url": "http://demo.gethue.com/hue/gist?uuid=some_uuid"}]
               _get_gist_document.return_value = Mock(data=json.dumps(doc_data), owner=user, extra='mysql')
-              links = [{"url": "http://demo.gethue.com/hue/gist?uuid=random"}]
-
               mock_unfurl_payload.return_value = {
                 'payload': {},
                 'file_status': False,
               }
+
+              # Slack user is not Hue user
+              users_info.return_value = {
+                "ok": True,
+                "user": {
+                  "profile": {
+                    "email": "test_user_not_exist@example.com"
+                  }
+                }
+              }
+              assert_raises(PopupException, handle_on_link_shared, "channel", "12.1", links, "<@user_id>")
+              assert_false(chat_unfurl.called)
+              assert_false(send_result_file.called)
+
+              # Slack user is Hue user sends link
+              users_info.return_value = {
+                "ok": True,
+                "user": {
+                  "profile": {
+                    "email": "test_not_me@example.com"
+                  }
+                }
+              }
               handle_on_link_shared(channel_id, message_ts, links, user_id)
+
               assert_true(chat_unfurl.called)
+              assert_false(send_result_file.called)
 
-              # Cannot unfurl link with invalid links
-              inv_qhistory_url = "https://demo.gethue.com/hue/editor/?type=4"
-              inv_gist_url = "http://demo.gethue.com/hue/gist?uuids/=xyz"
-              assert_raises(PopupException, handle_on_link_shared, "channel", "12.1", [{"url": inv_qhistory_url}], "<@user_id>")
-              assert_raises(PopupException, handle_on_link_shared, "channel", "12.1", [{"url": inv_gist_url}], "<@user_id>")
-
-              # Document does not exist
+              # Gist document does not exist
               _get_gist_document.side_effect = PopupException('Gist does not exist')
-
-              qhistory_url = "https://demo.gethue.com/hue/editor?editor=109644"
               gist_url = "https://demo.gethue.com/hue/gist?uuid=6d1c407b-d999-4dfd-ad23-d3a46c19a427"
-              assert_raises(PopupException, handle_on_link_shared, "channel", "12.1", [{"url": qhistory_url}], "<@user_id>")
+
               assert_raises(PopupException, handle_on_link_shared, "channel", "12.1", [{"url": gist_url}], "<@user_id>")
 
-              # chat_unfurl exception
-              chat_unfurl.side_effect = PopupException('Cannot unfurl link')
-              assert_raises(PopupException, handle_on_link_shared, "channel", "12.1", links, "<@user_id>")
+              # Cannot unfurl link with invalid gist link
+              inv_gist_url = "http://demo.gethue.com/hue/gist?uuids/=invalid_link"
+              assert_raises(PopupException, handle_on_link_shared, "channel", "12.1", [{"url": inv_gist_url}], "<@user_id>")


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Retrieve email prefix from slack user for Hue user
- Add read perm check for link else raise PopupException
- Currently not checking for gist until sharing perms setup for gists
- Update UTs with read perm check

Ref. #1919 
## How was this patch tested?

- Successfully running unit tests