### PR TITLE
[document ] When the username and group name are same, precedence goes to user not group 

### DIFF
--- a/desktop/core/src/desktop/js/ko/components/doc/ko.shareDocModal.js
+++ b/desktop/core/src/desktop/js/ko/components/doc/ko.shareDocModal.js
@@ -102,6 +102,7 @@ const TEMPLATE = `
             <input id="shareDocUserInput" placeholder="${ I18n('Type a username or a group name') }" type="text" data-bind="
                 autocomplete: {
                   source: shareAutocompleteUserSource.bind($data),
+                  select: function(event,ui) { onShareAutocompleteSelectEnter(event,ui);},
                   itemTemplate: 'user-search-autocomp-item',
                   noMatchTemplate: 'user-search-autocomp-no-match',
                   valueObservable: searchInput,


### PR DESCRIPTION
### What changes were proposed in this pull request?

- GH-1959 -  When the username and group name are same, precedence goes to user not group

### How was this patch tested?

- Tested manually with reproduction steps
- The UI should be able to add both user and group incase both have same name.
 
<img width="605" alt="Screenshot 2021-03-31 at 4 49 10 PM" src="https://user-images.githubusercontent.com/18462803/113136456-063b2100-9241-11eb-8d27-80f9c844c697.png">
