### PR TITLE
Default Home directory button in Filebrowser should be sanitized and should trust the input from untrusted source

### DIFF
--- a/apps/filebrowser/src/filebrowser/templates/fb_components.mako
+++ b/apps/filebrowser/src/filebrowser/templates/fb_components.mako
@@ -52,7 +52,7 @@ else:
             </span>
           </li>
         %else:
-          <li><a class="pointer breadcrumb-link homeLink" data-bind="click: $root.openHome, attr:{'href': window.HUE_BASE_URL + '/filebrowser/view=${ urllib_quote(path.encode('utf-8'), safe=SAFE_CHARACTERS_URI_COMPONENTS) }?default_to_home'}">
+          <li><a class="pointer breadcrumb-link homeLink" data-bind="click: $root.openHome, attr:{'href': window.HUE_BASE_URL + '/filebrowser/view=' + window.USER_HOME_DIR  + '?default_to_home'}">
             <i class="fa fa-home"></i> ${_('Home')}</a>
           </li>
         %endif
@@ -69,7 +69,7 @@ else:
         </li>
         % if is_trash_enabled:
         <li class="pull-right">
-          <a class="pointer breadcrumb-link trashLink" data-bind="click: $root.openTrash, attr:{'href': window.HUE_BASE_URL + '/filebrowser/view=${ urllib_quote(path.encode('utf-8'), safe=SAFE_CHARACTERS_URI_COMPONENTS) }?default_to_trash'}" title="${_('View trash')}">
+          <a class="pointer breadcrumb-link trashLink" data-bind="click: $root.openTrash, attr:{'href': window.HUE_BASE_URL + '/filebrowser/view='+ window.USER_HOME_DIR +'?default_to_trash'}" title="${_('View trash')}">
             <i class="fa fa-trash-o"></i> ${_('Trash')}
           </a>
         </li>
@@ -77,7 +77,7 @@ else:
       </ul>
     % else:
       <ul class="nav nav-pills hue-breadcrumbs-bar">
-        <li><a data-bind="hueLink: window.HUE_BASE_URL + '/filebrowser/view=${ urllib_quote(path.encode('utf-8'), safe=SAFE_CHARACTERS_URI_COMPONENTS) }?default_to_home'" class="breadcrumb-link homeLink"><i class="fa fa-home"></i> ${_('Home')}</a></li>
+        <li><a data-bind="hueLink: window.HUE_BASE_URL + '/filebrowser/view='+ window.USER_HOME_DIR +'?default_to_home'" class="breadcrumb-link homeLink"><i class="fa fa-home"></i> ${_('Home')}</a></li>
         <li>
           <ul class="hue-breadcrumbs" style="padding-right:40px; padding-top: 12px">
           % for breadcrumb_item in breadcrumbs:


### PR DESCRIPTION
### What changes were proposed in this pull request?

- #1965  -[filebrowser] GH-1965 Default Home directory button in Filebrowser should be sanitized and should trust the input from untrusted source

## How was this patch tested?

- Tested manually, The Fix works well.
- 
<img width="1442" alt="Screenshot 2021-04-01 at 5 58 19 PM" src="https://user-images.githubusercontent.com/18462803/113293802-dad53680-9313-11eb-9706-aaf10a29be2e.png">

