### PR TITLE
[lib] Revert django-axe 4.5.3 DB migration of `axes_accessattempt.trusted`

### DIFF
--- a/desktop/core/ext-py/django-axes-4.5.4/axes/migrations/0006_add_accessattempt_trusted.py
+++ b/desktop/core/ext-py/django-axes-4.5.4/axes/migrations/0006_add_accessattempt_trusted.py
@@ -1,0 +1,21 @@
+# Revert field drop to keep the DB backward compatible with old Hue
+
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('axes', '0005_remove_accessattempt_trusted'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='accessattempt',
+            name='trusted',
+            field=models.BooleanField(default=False),
+        ),
+    ]
+    
+    


### PR DESCRIPTION
Login and Editor work fine with the unused DB column.

Add back `axes_accessattempt.trusted`:

Before:

mysql> describe axes_accessattempt;
+----------------------+---------------+------+-----+---------+----------------+
| Field                | Type          | Null | Key | Default | Extra          |
+----------------------+---------------+------+-----+---------+----------------+
| id                   | int           | NO   | PRI | NULL    | auto_increment |
| user_agent           | varchar(255)  | NO   | MUL | NULL    |                |
| ip_address           | char(39)      | YES  | MUL | NULL    |                |
| username             | varchar(255)  | YES  | MUL | NULL    |                |
| http_accept          | varchar(1025) | NO   |     | NULL    |                |
| path_info            | varchar(255)  | NO   |     | NULL    |                |
| attempt_time         | datetime(6)   | NO   |     | NULL    |                |
| get_data             | longtext      | NO   |     | NULL    |                |
| post_data            | longtext      | NO   |     | NULL    |                |
| failures_since_start | int unsigned  | NO   |     | NULL    |                |
+----------------------+---------------+------+-----+---------+----------------+
10 rows in set (0.00 sec)

Running migrations:
[01/Apr/2021 14:35:58 -0700] schema       DEBUG    ALTER TABLE `axes_accessattempt` ADD COLUMN `trusted` bool DEFAULT %s NOT NULL; (params [False])
[01/Apr/2021 14:35:58 -0700] schema       DEBUG    ALTER TABLE `axes_accessattempt` ALTER COLUMN `trusted` DROP DEFAULT; (params [])
  Applying axes.0007_add_accessattempt_trusted... OK

mysql> describe axes_accessattempt;
+----------------------+---------------+------+-----+---------+----------------+
| Field                | Type          | Null | Key | Default | Extra          |
+----------------------+---------------+------+-----+---------+----------------+
| id                   | int           | NO   | PRI | NULL    | auto_increment |
| user_agent           | varchar(255)  | NO   | MUL | NULL    |                |
| ip_address           | char(39)      | YES  | MUL | NULL    |                |
| username             | varchar(255)  | YES  | MUL | NULL    |                |
| http_accept          | varchar(1025) | NO   |     | NULL    |                |
| path_info            | varchar(255)  | NO   |     | NULL    |                |
| attempt_time         | datetime(6)   | NO   |     | NULL    |                |
| get_data             | longtext      | NO   |     | NULL    |                |
| post_data            | longtext      | NO   |     | NULL    |                |
| failures_since_start | int unsigned  | NO   |     | NULL    |                |
| trusted              | tinyint(1)    | NO   |     | NULL    |                |
+----------------------+---------------+------+-----+---------+----------------+
11 rows in set (0.01 sec)

Note: beware, same thing happening later in (4.5.4?)
`0006_remove_accesslog_trusted.py`:
https://github.com/jazzband/django-axes/tree/master/axes/migration
