### PR TITLE
[lib] Revert django-axe 4.5.3 Model removale of trusted column

### DIFF
--- a/desktop/core/ext-py/django-axes-4.5.4/.travis.yml
+++ b/desktop/core/ext-py/django-axes-4.5.4/.travis.yml
@@ -31,10 +31,10 @@ after_success:
 deploy:
   provider: pypi
   user: jazzband
-  password:
-    secure: TCH5tGIggL2wsWce2svMwpEpPiwVOYqq1R3uSBTexszleP0OafNq/wZk2KZEReR5w1Aq68qp5F5Eeh2ZjJTq4f9M4LtTvqQzrmyNP55DYk/uB1rBJm9b4gBgMtAknxdI2g7unkhQEDo4suuPCVofM7rrDughySNpmvlUQYDttHQ=
   server: https://jazzband.co/projects/django-axes/upload
   distributions: sdist bdist_wheel
+  password:
+    secure: TCH5tGIggL2wsWce2svMwpEpPiwVOYqq1R3uSBTexszleP0OafNq/wZk2KZEReR5w1Aq68qp5F5Eeh2ZjJTq4f9M4LtTvqQzrmyNP55DYk/uB1rBJm9b4gBgMtAknxdI2g7unkhQEDo4suuPCVofM7rrDughySNpmvlUQYDttHQ=
   skip_existing: true
   on:
     tags: true

--- a/desktop/core/ext-py/django-axes-4.5.4/axes/admin.py
+++ b/desktop/core/ext-py/django-axes-4.5.4/axes/admin.py
@@ -100,7 +100,6 @@ class AccessLogAdmin(admin.ModelAdmin):
         'user_agent',
         'ip_address',
         'username',
-        'trusted',
         'http_accept',
         'path_info',
         'attempt_time',

--- a/desktop/core/ext-py/django-axes-4.5.4/axes/attempts.py
+++ b/desktop/core/ext-py/django-axes-4.5.4/axes/attempts.py
@@ -23,15 +23,15 @@ def _query_user_attempts(request, credentials=None):
     elif settings.AXES_USE_USER_AGENT:
         ua = request.META.get('HTTP_USER_AGENT', '<unknown>')[:255]
         attempts = AccessAttempt.objects.filter(
-            user_agent=ua, ip_address=ip, username=username
+            user_agent=ua, ip_address=ip, username=username, trusted=True
         )
     else:
         attempts = AccessAttempt.objects.filter(
-            ip_address=ip, username=username
+            ip_address=ip, username=username, trusted=True
         )
 
     if not attempts:
-        params = {}
+        params = {'trusted': False}
 
         if settings.AXES_ONLY_USER_FAILURES:
             params['username'] = username
@@ -109,13 +109,18 @@ def get_user_attempts(request, credentials=None):
 
         for attempt in attempts:
             if attempt.attempt_time + cool_off < timezone.now():
-                attempt.delete()
-                force_reload = True
-                failures_cached = get_axes_cache().get(cache_hash_key)
-                if failures_cached is not None:
-                    get_axes_cache().set(
-                        cache_hash_key, failures_cached - 1, cache_timeout
-                    )
+                if attempt.trusted:
+                    attempt.failures_since_start = 0
+                    attempt.save()
+                    get_axes_cache().set(cache_hash_key, 0, cache_timeout)
+                else:
+                    attempt.delete()
+                    force_reload = True
+                    failures_cached = get_axes_cache().get(cache_hash_key)
+                    if failures_cached is not None:
+                        get_axes_cache().set(
+                            cache_hash_key, failures_cached - 1, cache_timeout
+                        )
 
     # If objects were deleted, we need to update the queryset to reflect this,
     # so force a reload.

--- a/desktop/core/ext-py/django-axes-4.5.4/axes/migrations/0006_add_accessattempt_trusted.py
+++ b/desktop/core/ext-py/django-axes-4.5.4/axes/migrations/0006_add_accessattempt_trusted.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='accessattempt',
             name='trusted',
-            field=models.BooleanField(default=False),
+            field=models.BooleanField(db_index=True, default=False),
         ),
     ]
     

--- a/desktop/core/ext-py/django-axes-4.5.4/axes/models.py
+++ b/desktop/core/ext-py/django-axes-4.5.4/axes/models.py
@@ -24,6 +24,13 @@ class CommonAccess(models.Model):
         db_index=True,
     )
 
+    # Once a user logs in from an ip, that combination is trusted and not
+    # locked out in case of a distributed attack
+    trusted = models.BooleanField(
+        default=False,
+        db_index=True,
+    )
+
     http_accept = models.CharField(
         _('HTTP Accept'),
         max_length=1025,
@@ -71,13 +78,6 @@ class AccessAttempt(CommonAccess):
 
 
 class AccessLog(CommonAccess):
-    # Once a user logs in from an ip, that combination is trusted and not
-    # locked out in case of a distributed attack
-    trusted = models.BooleanField(
-        default=False,
-        db_index=True,
-    )
-
     logout_time = models.DateTimeField(
         _('Logout Time'),
         null=True,


### PR DESCRIPTION
Here we revert https://github.com/jazzband/django-axes/commit/60f2a8ed71698225fa93ca4047d61cfbdad0eac2
to put back the `trusted` column in the model.

But we don't delete the 0005 migration to avoid limbo in case it was
already applied.
