### PR TITLE
[redaction] redaction engine throws exception when the query is having non-ascii character

### DIFF
--- a/desktop/core/src/desktop/redaction/engine.py
+++ b/desktop/core/src/desktop/redaction/engine.py
@@ -19,6 +19,7 @@ from builtins import object
 import json
 import re
 
+from django.utils.encoding import smart_str
 
 class RedactionEngine(object):
   """
@@ -106,7 +107,7 @@ class RedactionRule(object):
     """
 
     if message and (self.trigger is None or self.trigger.search(message)):
-      return self.regex.sub(self.replace, message)
+      return self.regex.sub(smart_str(self.replace), message)
     else:
       return message
 

--- a/desktop/core/src/desktop/redaction/tests.py
+++ b/desktop/core/src/desktop/redaction/tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: ascii -*-
+# -*- coding: utf-8 -*-
 # Licensed to Cloudera, Inc. under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/desktop/core/src/desktop/redaction/tests.py
+++ b/desktop/core/src/desktop/redaction/tests.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: ascii -*-
 # Licensed to Cloudera, Inc. under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/desktop/core/src/desktop/redaction/tests.py
+++ b/desktop/core/src/desktop/redaction/tests.py
@@ -439,28 +439,27 @@ class TestRedactionLogFilter(object):
     assert_equal(errors, [])
 
 def byte_range(first, last):
-    return list(range(first, last+1))
+  return list(range(first, last+1))
 
 first_values = byte_range(0x00, 0x7F) + byte_range(0xC2, 0xF4)
 trailing_values = byte_range(0x80, 0xBF)
 
 def random_utf8_char():
-    first = random.choice(first_values)
-    if first <= 0x7F:
-        value = bytearray([first])
-    elif first <= 0xDF:
-        value = bytearray([first, random.choice(trailing_values)])
-    elif first == 0xE0:
-        value = bytearray([first, random.choice(byte_range(0xA0, 0xBF)), random.choice(trailing_values)])
-    elif first == 0xED:
-        value = bytearray([first, random.choice(byte_range(0x80, 0x9F)), random.choice(trailing_values)])
-    elif first <= 0xEF:
-        value = bytearray([first, random.choice(trailing_values), random.choice(trailing_values)])
-    elif first == 0xF0:
-        value = bytearray([first, random.choice(byte_range(0x90, 0xBF)), random.choice(trailing_values), random.choice(trailing_values)])
-    elif first <= 0xF3:
-        value = bytearray([first, random.choice(trailing_values), random.choice(trailing_values), random.choice(trailing_values)])
-    elif first == 0xF4:
-        value = bytearray([first, random.choice(byte_range(0x80, 0x8F)), random.choice(trailing_values), random.choice(trailing_values)])
-
-    return value.decode('utf8')
+  first = random.choice(first_values)
+  if first <= 0x7F:
+    value = bytearray([first])
+  elif first <= 0xDF:
+    value = bytearray([first, random.choice(trailing_values)])
+  elif first == 0xE0:
+    value = bytearray([first, random.choice(byte_range(0xA0, 0xBF)), random.choice(trailing_values)])
+  elif first == 0xED:
+    value = bytearray([first, random.choice(byte_range(0x80, 0x9F)), random.choice(trailing_values)])
+  elif first <= 0xEF:
+    value = bytearray([first, random.choice(trailing_values), random.choice(trailing_values)])
+  elif first == 0xF0:
+    value = bytearray([first, random.choice(byte_range(0x90, 0xBF)), random.choice(trailing_values), random.choice(trailing_values)])
+  elif first <= 0xF3:
+    value = bytearray([first, random.choice(trailing_values), random.choice(trailing_values), random.choice(trailing_values)])
+  elif first == 0xF4:
+    value = bytearray([first, random.choice(byte_range(0x80, 0x8F)), random.choice(trailing_values), random.choice(trailing_values)])
+  return value.decode('utf8')


### PR DESCRIPTION
## What changes were proposed in this pull request?
- #1972 - redaction engine throws exception when the query is having non-ascii  character

## How was this patch tested?

- Tested manually in Python-3 and python-2 server , fix works well
<img width="1056" alt="Screenshot 2021-04-04 at 7 52 33 PM" src="https://user-images.githubusercontent.com/18462803/113511794-4f5fdd80-957f-11eb-8445-a1a040178034.png">

