### PR TITLE
[slack] Use Slack user's display name to check for Hue user and update UTs

### DIFF
--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -122,7 +122,7 @@ def handle_on_link_shared(channel_id, message_ts, links, user_id):
 
     # Permission check for Slack user to be Hue user
     try:
-      user = User.objects.get(username=slack_email_prefix(user_id))
+      user = User.objects.get(username=slack_display_name(user_id))
     except User.DoesNotExist:
       raise PopupException(_("Slack user does not have access to the query"))
 
@@ -143,14 +143,14 @@ def handle_on_link_shared(channel_id, message_ts, links, user_id):
       send_result_file(request, channel_id, message_ts, doc, 'xls')
 
 
-def slack_email_prefix(user_id):
+def slack_display_name(user_id):
   try:
     slack_user = slack_client.users_info(user=user_id)
   except Exception as e:
     raise PopupException(_("Cannot find query owner in Slack"), detail=e)
   
   if slack_user['ok']:
-    return slack_user['user']['profile']['email'].split('@')[0]
+    return slack_user['user']['profile']['display_name']
 
 
 def send_result_file(request, channel_id, message_ts, doc, file_format):

--- a/desktop/core/src/desktop/lib/botserver/views_tests.py
+++ b/desktop/core/src/desktop/lib/botserver/views_tests.py
@@ -46,11 +46,11 @@ class TestBotServer(unittest.TestCase):
       raise SkipTest
   
   def setUp(self):
-    # Slack user email: test@example.com
+    # Slack user display name: test
     self.client = make_logged_in_client(username="test", groupname="default", recreate=True, is_superuser=False)
     self.user = User.objects.get(username="test")
 
-    # Other slack user email: test_not_me@example.com
+    # Other slack user display name: test_not_me
     self.client_not_me = make_logged_in_client(username="test_not_me", groupname="default", recreate=True, is_superuser=False)
     self.user_not_me = User.objects.get(username="test_not_me")
 
@@ -110,7 +110,7 @@ class TestBotServer(unittest.TestCase):
               "ok": True,
               "user": {
                 "profile": {
-                  "email": "test_not_me@example.com"
+                  "display_name": "test_not_me"
                 }
               }
             }
@@ -155,7 +155,7 @@ class TestBotServer(unittest.TestCase):
                 "ok": True,
                 "user": {
                   "profile": {
-                    "email": "test_not_me@example.com"
+                    "display_name": "test_not_me"
                   }
                 }
               }
@@ -187,7 +187,7 @@ class TestBotServer(unittest.TestCase):
           "ok": True,
           "user": {
             "profile": {
-              "email": "test_user_not_exist@example.com"
+              "display_name": "test_user_not_exist"
             }
           }
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Checking for Slack user's display name to map with Hue user
- Removed checking with email id so we also dont need **user:read.email** permission scope now
- Updated UTs accordingly

## How was this patch tested?

- Successfully passing UTs
- Demo user can access queries from 'demo' Hue user
![Screenshot 2021-04-07 at 4 14 42 PM](https://user-images.githubusercontent.com/42064744/113854310-5f183580-97bc-11eb-932a-81dcb939ca37.png)


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
