### PR TITLE
[importer] Add default_s3_home and initiate value in  getfilesystem

### DIFF
--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -44,7 +44,7 @@ from functools import partial
 from django.utils.http import http_date
 from django.utils.html import escape
 
-from aws.s3.s3fs import S3FileSystemException, S3ListAllBucketsException
+from aws.s3.s3fs import S3FileSystemException, S3ListAllBucketsException, get_s3_home_directory
 from desktop import appmanager
 from desktop.auth.backend import is_admin
 from desktop.lib import i18n
@@ -212,6 +212,14 @@ def view(request, path):
   if 'default_abfs_home' in request.GET:
     from azure.abfs.__init__ import get_home_dir_for_ABFS
     home_dir_path = get_home_dir_for_ABFS()
+    if request.fs.isdir(home_dir_path):
+      return format_preserving_redirect(
+          request,
+          '/filebrowser/view=' + urllib_quote(home_dir_path.encode('utf-8'), safe=SAFE_CHARACTERS_URI_COMPONENTS)
+      )
+
+  if 'default_s3_home' in request.GET:
+    home_dir_path = get_s3_home_directory()
     if request.fs.isdir(home_dir_path):
       return format_preserving_redirect(
           request,

--- a/desktop/core/src/desktop/auth/backend.py
+++ b/desktop/core/src/desktop/auth/backend.py
@@ -169,8 +169,7 @@ class DefaultUserAugmentor(object):
     return self._get_profile().get_groups()
 
   def get_home_directory(self, force_home=False):
-    return REMOTE_STORAGE_HOME.get() if hasattr(REMOTE_STORAGE_HOME, 'get') and REMOTE_STORAGE_HOME.get() and not force_home \
-        else self._get_profile().home_directory
+    return self._get_profile().home_directory
 
   def has_hue_permission(self, action, app):
     return self._get_profile().has_hue_permission(action=action, app=app)

--- a/desktop/core/src/desktop/js/jquery/plugins/jquery.filechooser.js
+++ b/desktop/core/src/desktop/js/jquery/plugins/jquery.filechooser.js
@@ -82,7 +82,7 @@ const defaults = {
     s3a: {
       scheme: 's3a',
       root: 's3a://',
-      home: 's3a://',
+      home: '/?default_s3_home',
       icon: {
         brand: 'fa-cubes',
         home: 'fa-cubes'
@@ -810,6 +810,20 @@ Plugin.prototype.init = function () {
       '<div class="filechooser-container" style="position: relative"><div class="filechooser-services" style="position: absolute"></div><div class="filechooser-tree" style="width: 560px"></div></div>'
     );
   $.post('/filebrowser/api/get_filesystems', data => {
+    let initialHome = '/';
+    if (self.options.initialPath == '') {
+      if (
+        Object.keys(data.filesystems).length > 1 &&
+        Object.keys(data.filesystems).indexOf('hdfs') != -1
+      ) {
+        initialHome = '/?default_to_home';
+        self.options.fsSelected = 'hdfs';
+      } else {
+        const _scheme = Object.keys(data.filesystems)[0];
+        initialHome = defaults.filesysteminfo[_scheme]['home'];
+        self.options.fsSelected = _scheme;
+      }
+    }
     const initialPath = $.trim(self.options.initialPath);
     const scheme = initialPath && initialPath.substring(0, initialPath.indexOf(':'));
     if (data && data.status === 0) {
@@ -827,7 +841,7 @@ Plugin.prototype.init = function () {
         hueLocalStorage(STORAGE_PREFIX + self.options.user + self.options.fsSelected)
       );
     } else {
-      self.navigateTo('/?default_to_home');
+      self.navigateTo(initialHome);
     }
   });
 };

--- a/desktop/libs/aws/src/aws/s3/s3fs.py
+++ b/desktop/libs/aws/src/aws/s3/s3fs.py
@@ -35,6 +35,7 @@ from aws import s3
 from aws.conf import get_default_region, get_locations, PERMISSION_ACTION_S3
 from aws.s3 import normpath, s3file, translate_s3_error, S3A_ROOT
 from aws.s3.s3stat import S3Stat
+from filebrowser.conf import REMOTE_STORAGE_HOME
 
 if sys.version_info[0] > 2:
   import urllib.request, urllib.error
@@ -80,6 +81,12 @@ def auth_error_handler(view_fn):
     except Exception as e:
       raise e
   return decorator
+
+
+def get_s3_home_directory():
+  return REMOTE_STORAGE_HOME.get() \
+         if hasattr(REMOTE_STORAGE_HOME, 'get') and REMOTE_STORAGE_HOME.get() \
+         else 's3a://'
 
 
 class S3FileSystem(object):


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the issue that when only S3 or ABFS is configured, file chooser won't throw exception and show a spinner inside the file chooser

## How was this patch tested?

1. only S3 is configured
2. only ABFS is configured
3. S3 and HDFS are configured
4. ABFS and HDFS are configured

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
