### PR TITLE
[Phoenix] Drag & Drop table from assist only sets the table name and not SELECT sample

### DIFF
--- a/desktop/core/src/desktop/js/ko/components/ko.editorDroppableMenu.js
+++ b/desktop/core/src/desktop/js/ko/components/ko.editorDroppableMenu.js
@@ -66,7 +66,11 @@ class EditorDroppableMenu extends DisposableComponent {
     this.identifier = ko.observable('');
 
     this.meta.subscribe(async meta => {
-      if (meta && meta.database && meta.table) {
+      if (
+        meta &&
+        ((meta.connector.dialect === 'phoenix' && meta.database === '') || meta.database) &&
+        meta.table
+      ) {
         this.identifier(
           (await sqlUtils.backTickIfNeeded(meta.connector, meta.database)) +
             '.' +
@@ -117,7 +121,12 @@ class EditorDroppableMenu extends DisposableComponent {
         }
         editor.moveCursorToPosition(position);
         const before = editor.getTextBeforeCursor();
-        if (meta.database && meta.table && !meta.column && /.*;|^\s*$/.test(before)) {
+        if (
+          ((meta.connector.dialect === 'phoenix' && meta.database === '') || meta.database) &&
+          meta.table &&
+          !meta.column &&
+          /.*;|^\s*$/.test(before)
+        ) {
           this.menu.show(e);
         } else {
           if (/\S+$/.test(before) && before.charAt(before.length - 1) !== '.') {


### PR DESCRIPTION

## What changes were proposed in this pull request?

- adding select sample for empty('') database only for phoenix dialect

## How was this patch tested?

- 
<img width="1155" alt="Screenshot 2021-04-13 at 11 14 30 AM" src="https://user-images.githubusercontent.com/36241930/114503055-573c1380-9c4a-11eb-8aa7-4b608ea0758f.png">
