### PR TITLE
[ui] Avoid displaying any API error in a popup

### DIFF
--- a/desktop/core/src/desktop/js/jquery/plugins/jquery.notify.js
+++ b/desktop/core/src/desktop/js/jquery/plugins/jquery.notify.js
@@ -53,6 +53,11 @@ Plugin.prototype.show = function () {
   _this.options.message = _this.options.message.replace(/(<([^>]+)>)/gi, ''); // escape HTML messages
   _this.options.message = hueUtils.deXSS(_this.options.message); // escape XSS messages
 
+  if (/^(504|upstream connect error)/.test(this.options.message)) {
+    console.warn(this.options.message);
+    return;
+  }
+
   if (
     _this.options.message !== '' &&
     $('.jHueNotify .message').last().text() !== _this.options.message


### PR DESCRIPTION
This introduce a blacklist of error messages to avoid.

Some error will happen occasionally and will confuse the users.
Most of the ones seen are on idempotent calls, not critical (e.g. get
progress logs) and can be only logged in the consol.

Could be done here or in notifyError, but feels like we might miss some
there.

Note that the main cause is not necessary Hue itself replying with a 504, but could
be an underlying service replying with a 504 error which is not caught by the
Hue API (even if it should).

Hue has 100s of different calls possible and some main "culprits"
like get_logs could be handle on a per by case, but we need a catch all
solution too.

As these errors come the API, they are already logged (no need to