### PR TITLE
[core] Add get_response to HueRemoteUserMiddleware

### DIFF
--- a/desktop/core/src/desktop/middleware.py
+++ b/desktop/core/src/desktop/middleware.py
@@ -809,6 +809,7 @@ class HueRemoteUserMiddleware(RemoteUserMiddleware):
     if not 'desktop.auth.backend.RemoteUserDjangoBackend' in AUTH.BACKEND.get():
       LOG.info('Unloading HueRemoteUserMiddleware')
       raise exceptions.MiddlewareNotUsed
+    super().__init__(get_response)
     self.header = AUTH.REMOTE_USER_HEADER.get()
 
 


### PR DESCRIPTION
After deploying Hue 4.9 I got the following error:

AttributeError: 'HueRemoteUserMiddleware' object has no attribute 'get_response'

I have Hue set up with
backend=desktop.auth.backend.RemoteUserDjangoBackend, httpd is in front
of it with Apereo Cas and passes the username as part of a remote
header. Never seen this issue before, but I suspect it is related to
libraries upgraded. The other backend have it as well, and adding it
makes everything work (as opposed to get a HTTP 500).

## What changes were proposed in this pull request?

- Add get_response to the HueRemoteUserMiddleware class to avoid exceptions and HTTP 500 during runtime.

## How was this patch tested?
Tested with Hue 4.9, with httpd in front of it with Apereo CAS (passing the username via http header)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
