### PR TITLE
Table assist max function does not return max value instead also exec…

### DIFF
--- a/apps/beeswax/src/beeswax/server/dbms.py
+++ b/apps/beeswax/src/beeswax/server/dbms.py
@@ -605,9 +605,9 @@ class HiveServer2Dbms(object):
     else:
       if operation == 'distinct':
         hql = "SELECT DISTINCT %s FROM `%s`.`%s` LIMIT %s;" % (column, database, table.name, limit)
-      if operation == 'max':
+      elif operation == 'max':
         hql = "SELECT max(%s) FROM `%s`.`%s`;" % (column, database, table.name)
-      if operation == 'min':
+      elif operation == 'min':
         hql = "SELECT min(%s) FROM `%s`.`%s`;" % (column, database, table.name)
       else:
         hql = "SELECT %s FROM `%s`.`%s` LIMIT %s;" % (column, database, table.name, limit)


### PR DESCRIPTION
…utes sample query with limit 100.

just that we were looking everything with `if operation =` instead of if..elif..else.
