### PR TITLE
[core] Add request as positional arg for RemoteUserDjangoBackend

### DIFF
--- a/desktop/core/src/desktop/auth/backend.py
+++ b/desktop/core/src/desktop/auth/backend.py
@@ -750,7 +750,7 @@ class RemoteUserDjangoBackend(django.contrib.auth.backends.RemoteUserBackend):
   """
   Delegates to Django's RemoteUserBackend and requires HueRemoteUserMiddleware
   """
-  def authenticate(self, remote_user=None):
+  def authenticate(self, request=None, remote_user=None):
     username = self.clean_username(remote_user)
     username = force_username_case(username)
     is_super = False


### PR DESCRIPTION
This patch is needed for Django 2.1+ since the
django.contrib.auth.authenticate() function requires 'request' as
positional argument. In #2004 we partially addressed the issue, but not
completely.

This commit is present only in Django 1.11's and 2.0's branches:
https://github.com/django/django/commit/3008f30f194af386c354416be4c483f0f6b15f33

There is a warning msg stating that 'request' should be moved as first
positional argument.

## What changes were proposed in this pull request?

Add a new parameter to the RemoteUserDjangoBackend backend class since it is required by Django 2.1+.

## How was this patch tested?

Tested live patching a 4.9 testing release.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
