### PR TITLE
[oozie] Replace ABFS path in workflow files with full path

### DIFF
--- a/apps/oozie/src/oozie/models2.py
+++ b/apps/oozie/src/oozie/models2.py
@@ -36,6 +36,8 @@ from xml.sax.saxutils import escape
 from django.urls import reverse
 from django.db.models import Q
 
+from azure.abfs.__init__ import abfspath
+
 from desktop.conf import USE_DEFAULT_CONFIGURATION
 from desktop.lib import django_mako
 from desktop.lib.exceptions_renderable import PopupException
@@ -980,6 +982,11 @@ class Node(object):
       self.data['properties']['files'] = files
       self.data['properties']['archives'] = []
 
+    for i, f in enumerate(self.data['properties']['files']):
+      file_path = f['value']
+      if file_path.lower().startswith("abfs"):
+        file_path = abfspath(file_path)
+        self.data['properties']['files'][i] = {'value': file_path}
 
     data = {
       'node': self.data,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace ABFS path with full path in data['properties']['files']), so avoid following error from Shell-action workflow log:
```
org.apache.oozie.action.ActionExecutorException: JA009: abfs://my_container/testdata/TestLangShell.sh#TestLangShell.sh has invalid authority.
	at org.apache.oozie.action.ActionExecutor.convertExceptionHelper(ActionExecutor.java:469)
	at org.apache.oozie.action.ActionExecutor.convertException(ActionExecutor.java:447)
	at org.apache.oozie.action.hadoop.JavaActionExecutor.submitLauncher(JavaActionExecutor.java:1181)
	at org.apache.oozie.action.hadoop.JavaActionExecutor.start(JavaActionExecutor.java:1723)
	at org.apache.oozie.command.wf.ActionStartXCommand.execute(ActionStartXCommand.java:243)
	at org.apache.oozie.command.wf.ActionStartXCommand.execute(ActionStartXCommand.java:68)
	at org.apache.oozie.command.XCommand.call(XCommand.java:291)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at org.apache.oozie.service.CallableQueueService$CallableWrapper.run(CallableQueueService.java:210)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: abfs://my_container/testdata/TestLangShell.sh#TestLangShell.sh has invalid authority.
	at org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore.authorityParts(AzureBlobFileSystemStore.java:240)
	at org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore.<init>(AzureBlobFileSystemStore.java:156)
	at org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem.initialize(AzureBlobFileSystem.java:113)
	at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:3433)
	at org.apache.hadoop.fs.FileSystem.access$300(FileSystem.java:161)
	at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:3538)
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:3485)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:521)
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:361)
	at org.apache.oozie.util.ClasspathUtils.addToClasspathIfNotJar(ClasspathUtils.java:182)
	at org.apache.oozie.util.ClasspathUtils.setupClasspath(ClasspathUtils.java:73)
	at org.apache.oozie.action.hadoop.JavaActionExecutor.setEnvironmentVariables(JavaActionExecutor.java:1477)
	at org.apache.oozie.action.hadoop.JavaActionExecutor.lambda$createAppSubmissionContext$1(JavaActionExecutor.java:1296)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1898)
	at org.apache.oozie.action.hadoop.JavaActionExecutor.createAppSubmissionContext(JavaActionExecutor.java:1295)
	at org.apache.oozie.action.hadoop.JavaActionExecutor.submitLauncher(JavaActionExecutor.java:1156)
	... 9 more
```
## How was this patch tested?

patch the Azure Data Hub cluster and tested.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
