### PR TITLE
[slack] Email domain check with host domain

### DIFF
--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -67,5 +67,4 @@ tablib==0.13.0
 tabulate==0.8.9
 thrift==0.13.0
 thrift-sasl==0.4.2
-tldextract==3.1.0
 git+https://github.com/gethue/django-babel.git

--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -67,4 +67,5 @@ tablib==0.13.0
 tabulate==0.8.9
 thrift==0.13.0
 thrift-sasl==0.4.2
+tldextract==3.1.0
 git+https://github.com/gethue/django-babel.git

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -38,6 +38,7 @@ from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 
 if sys.version_info[0] > 2:
+  import tldextract
   from django.utils.translation import gettext as _
 else:
   from django.utils.translation import ugettext as _
@@ -162,7 +163,7 @@ def check_slack_user_permission(host_domain, user_id):
   }
   if not slack_user['user']['is_bot']:
     email_prefix, email_domain = slack_user['user']['profile']['email'].split('@')
-    if email_domain == host_domain:
+    if email_domain == tldextract.extract(host_domain).registered_domain:
       response['user_email_prefix'] = email_prefix
 
   return response

--- a/desktop/core/src/desktop/lib/botserver/views_tests.py
+++ b/desktop/core/src/desktop/lib/botserver/views_tests.py
@@ -33,6 +33,7 @@ from useradmin.models import User
 
 
 if sys.version_info[0] > 2:
+  import tldextract
   from unittest.mock import patch, Mock
 else:
   from mock import patch, Mock
@@ -56,6 +57,7 @@ class TestBotServer(unittest.TestCase):
     self.user_not_me = User.objects.get(username="test_not_me")
 
     self.host_domain = 'testserver.gethue.com'
+    self.email_domain = tldextract.extract(self.host_domain).registered_domain
 
   def test_handle_on_message(self):
     with patch('desktop.lib.botserver.views._send_message') as _send_message:
@@ -101,7 +103,7 @@ class TestBotServer(unittest.TestCase):
                   "user": {
                     "is_bot": False,
                     "profile": {
-                      "email": "test_not_me@{domain}".format(domain=self.host_domain)
+                      "email": "test_not_me@{domain}".format(domain=self.email_domain)
                     }
                   }
                 }
@@ -187,7 +189,7 @@ class TestBotServer(unittest.TestCase):
             "user": {
               "is_bot": False,
               "profile": {
-                "email": "test@{domain}".format(domain=self.host_domain)
+                "email": "test@{domain}".format(domain=self.email_domain)
               }
             }
           }
@@ -256,7 +258,7 @@ class TestBotServer(unittest.TestCase):
           "user": {
             "is_bot": False,
             "profile": {
-              "email": "test_user_not_exist@{domain}".format(domain=self.host_domain)
+              "email": "test_user_not_exist@{domain}".format(domain=self.email_domain)
             }
           }
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Return only those email prefixes whose email domain match with the host domain.
- Eg: Assuming host_domain as `gethue.com`
    If Slack user email is alice@gethue.com, then return `alice`
    If Slack user email is henry@example.com, then return None

## How was this patch tested?

- Patch tested by successfully updating and running unit tests
