### PR TITLE
[slack] Add get_channels API and its UTs

### DIFF
--- a/desktop/core/src/desktop/lib/botserver/api.py
+++ b/desktop/core/src/desktop/lib/botserver/api.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import json
+import sys
+from pprint import pprint
+
+from desktop import conf
+from desktop.decorators import api_error_handler
+from desktop.lib.django_util import JsonResponse
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext as _
+else:
+  from django.utils.translation import ugettext as _
+
+LOG = logging.getLogger(__name__)
+
+SLACK_VERIFICATION_TOKEN = conf.SLACK.SLACK_VERIFICATION_TOKEN.get()
+SLACK_BOT_USER_TOKEN = conf.SLACK.SLACK_BOT_USER_TOKEN.get()
+
+slack_client = None
+if conf.SLACK.IS_ENABLED.get():
+  from slack_sdk import WebClient
+  slack_client = WebClient(token=SLACK_BOT_USER_TOKEN)
+
+@api_error_handler
+def get_channels(request):
+  bot_channels = []
+
+  try:
+    response = slack_client.users_conversations()
+  except Exception as e:
+    raise PopupException(_('Error fetching channels where bot is present'), detail=e)
+
+  for channel in response.get('channels'):
+    bot_channels.append(channel['name'])
+
+  return JsonResponse({
+    'channels': bot_channels,
+  })

--- a/desktop/core/src/desktop/lib/botserver/api_tests.py
+++ b/desktop/core/src/desktop/lib/botserver/api_tests.py
@@ -64,7 +64,6 @@ class TestApi(object):
 
       response = self.client.post(reverse('botserver.api.get_channels'))
       data = json.loads(response.content)
-      print(data)
 
       assert_equal(200, response.status_code)
       assert_equal(['channel-1', 'channel-2'], data.get('channels'))

--- a/desktop/core/src/desktop/lib/botserver/api_tests.py
+++ b/desktop/core/src/desktop/lib/botserver/api_tests.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import sys
+import unittest
+
+from django.urls import reverse
+from nose.plugins.skip import SkipTest
+from nose.tools import assert_equal, assert_true, assert_false, assert_raises
+
+from desktop import conf
+from desktop.lib.django_test_util import make_logged_in_client
+
+from useradmin.models import User
+
+if sys.version_info[0] > 2:
+  from unittest.mock import patch, Mock
+else:
+  from mock import patch, Mock
+
+class TestApi(object):
+
+  def setUp(self):
+    self.client = make_logged_in_client(username="api_user", recreate=True, is_superuser=False, is_admin=True)
+    self.user = User.objects.get(username="api_user")
+
+  @classmethod
+  def setUpClass(cls):
+    if not conf.SLACK.IS_ENABLED.get():
+      raise SkipTest
+
+  def test_get_channels(self):
+    with patch('desktop.lib.botserver.api.slack_client.users_conversations') as users_conversations:
+
+      users_conversations.return_value = {
+        'ok': True,
+        'channels': [
+          {
+            'name': 'channel-1',
+          },
+          {
+            'name': 'channel-2',
+          }
+        ],
+        "response_metadata": {
+          "next_cursor": "",
+        }
+      }
+
+      response = self.client.post(reverse('botserver.api.get_channels'))
+      data = json.loads(response.content)
+      print(data)
+
+      assert_equal(200, response.status_code)
+      assert_equal(['channel-1', 'channel-2'], data.get('channels'))

--- a/desktop/core/src/desktop/lib/botserver/slack_client.py
+++ b/desktop/core/src/desktop/lib/botserver/slack_client.py
@@ -15,31 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-import json
-import sys
+from desktop import conf
 
-from desktop.lib.botserver.slack_client import slack_client
-from desktop.decorators import api_error_handler
-from desktop.lib.django_util import JsonResponse
+SLACK_VERIFICATION_TOKEN = conf.SLACK.SLACK_VERIFICATION_TOKEN.get()
+SLACK_BOT_USER_TOKEN = conf.SLACK.SLACK_BOT_USER_TOKEN.get()
 
-if sys.version_info[0] > 2:
-  from django.utils.translation import gettext as _
-else:
-  from django.utils.translation import ugettext as _
-
-LOG = logging.getLogger(__name__)
-
-@api_error_handler
-def get_channels(request):
-
-  try:
-    response = slack_client.users_conversations()
-  except Exception as e:
-    raise PopupException(_('Error fetching channels where bot is present'), detail=e)
-
-  bot_channels = [channel.get('name') for channel in response.get('channels')]
-
-  return JsonResponse({
-    'channels': bot_channels,
-  })
+slack_client = None
+if conf.SLACK.IS_ENABLED.get():
+  from slack_sdk import WebClient
+  slack_client = WebClient(token=SLACK_BOT_USER_TOKEN)

--- a/desktop/core/src/desktop/lib/botserver/urls.py
+++ b/desktop/core/src/desktop/lib/botserver/urls.py
@@ -17,7 +17,7 @@
 
 import sys
 
-from desktop.lib.botserver import views
+from desktop.lib.botserver import views, api
 
 if sys.version_info[0] > 2:
   from django.urls import re_path
@@ -25,5 +25,7 @@ else:
   from django.conf.urls import url as re_path
 
 urlpatterns = [
-  re_path(r'^events/', views.slack_events, name='slack_events')
+  re_path(r'^events/', views.slack_events, name='desktop.lib.botserver.views.slack_events'),
+
+  re_path(r'^api/channels/get/?$', api.get_channels, name='botserver.api.get_channels'),
 ]

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -19,10 +19,9 @@ import logging
 import json
 import sys
 from urllib.parse import urlsplit
-from pprint import pprint
 from tabulate import tabulate
 
-from desktop import conf
+from desktop.lib.botserver.slack_client import slack_client, SLACK_VERIFICATION_TOKEN
 from desktop.lib.django_util import login_notrequired, JsonResponse
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.models import Document2, _get_gist_document
@@ -43,14 +42,6 @@ else:
   from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
-
-SLACK_VERIFICATION_TOKEN = conf.SLACK.SLACK_VERIFICATION_TOKEN.get()
-SLACK_BOT_USER_TOKEN = conf.SLACK.SLACK_BOT_USER_TOKEN.get()
-
-slack_client = None
-if conf.SLACK.IS_ENABLED.get():
-  from slack_sdk import WebClient
-  slack_client = WebClient(token=SLACK_BOT_USER_TOKEN)
 
 
 @login_notrequired


### PR DESCRIPTION
## What changes were proposed in this pull request?

- `get_channels` -> all channels where bot is present
- Separate api.py and api_tests.py for unit tests
- Add url

## How was this patch tested?

- Successfully running UTs

## To-Do

- Currently default limit is 100 channels, add dealing with pagination and fetching channels with [cursor](https://api.slack.com/methods/users.conversations#arg_cursor)?? @romainr 
