### PR TITLE
[importer] Fix filechooser has no initialPath

### DIFF
--- a/desktop/core/src/desktop/js/jquery/plugins/jquery.filechooser.js
+++ b/desktop/core/src/desktop/js/jquery/plugins/jquery.filechooser.js
@@ -165,8 +165,10 @@ Plugin.prototype.setOptions = function (options) {
   const self = this;
   self.options = $.extend({}, defaults, { user: window.LOGGED_USERNAME }, options);
   self.options.labels = $.extend({}, defaults.labels, DEFAULT_I18n, options ? options.labels : {});
-  const initialPath = $.trim(self.options.initialPath);
-  const scheme = initialPath && initialPath.substring(0, initialPath.indexOf(':'));
+  const targetPath = $.trim(self.previousPath)
+    ? $.trim(self.previousPath)
+    : $.trim(self.options.initialPath);
+  const scheme = targetPath && targetPath.substring(0, targetPath.indexOf(':'));
   if (scheme && scheme.length) {
     self.options.fsSelected = scheme;
   }
@@ -177,8 +179,8 @@ Plugin.prototype.setOptions = function (options) {
     .addClass('active');
 
   if (self.options.forceRefresh) {
-    if (initialPath != '') {
-      self.navigateTo(self.options.initialPath);
+    if (targetPath != '') {
+      self.navigateTo(targetPath);
     } else if (
       hueLocalStorage(STORAGE_PREFIX + self.options.user + self.options.fsSelected) != null
     ) {
@@ -188,8 +190,8 @@ Plugin.prototype.setOptions = function (options) {
     } else {
       self.navigateTo('/?default_to_home');
     }
-  } else if (initialPath != '') {
-    self.navigateTo(self.options.initialPath);
+  } else if (targetPath != '') {
+    self.navigateTo(targetPath);
   } else if (
     hueLocalStorage(STORAGE_PREFIX + self.options.user + self.options.fsSelected) != null
   ) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Only setup S3 file system in Hue config. When the file chooser open the very 1st time, it display S3 icon and file system. When open again, the initialPath is empty string, so file chooser only shows HDFS file system and S3 disappear.

Analysis:
The first time file chooser get called is via Plugin.prototype.init(). (fix in https://github.com/cloudera/hue/pull/1983)
After first call, file chooser get called is via Plugin.prototype.setOptions().

## How was this patch tested?

Tested locally with single filesystem, 2 filesystem and 3 filesystems three different setups.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
