### PR TITLE
[slack] Add username in Slack message for author context

### DIFF
--- a/desktop/core/src/desktop/js/ko/components/ko.shareGistModal.js
+++ b/desktop/core/src/desktop/js/ko/components/ko.shareGistModal.js
@@ -83,8 +83,7 @@ class ShareGistModal extends DisposableComponent {
     try {
       await ApiHelper.sendSlackMessageAsync({
         channel: this.selectedChannel,
-        message:
-          '@' + window.LOGGED_USERNAME + ': ' + this.messageDescription() + '\n' + this.link()
+        message: this.messageDescription() + '\n' + this.link()
       });
     } catch (err) {
       console.warn('Failed posting message in Slack channel');

--- a/desktop/core/src/desktop/js/ko/components/ko.shareGistModal.js
+++ b/desktop/core/src/desktop/js/ko/components/ko.shareGistModal.js
@@ -83,7 +83,8 @@ class ShareGistModal extends DisposableComponent {
     try {
       await ApiHelper.sendSlackMessageAsync({
         channel: this.selectedChannel,
-        message: this.messageDescription() + '\n' + this.link()
+        message:
+          '@' + window.LOGGED_USERNAME + ': ' + this.messageDescription() + '\n' + this.link()
       });
     } catch (err) {
       console.warn('Failed posting message in Slack channel');

--- a/desktop/core/src/desktop/lib/botserver/api.py
+++ b/desktop/core/src/desktop/lib/botserver/api.py
@@ -50,6 +50,7 @@ def send_message(request):
   channel = request.POST.get('channel')
   message = request.POST.get('message')
 
+  message = '@' + (request.user.get_full_name() or request.user.username) + ': ' + message
   slack_response = _send_message(channel, message)
 
   return JsonResponse({

--- a/desktop/core/src/desktop/lib/botserver/api_tests.py
+++ b/desktop/core/src/desktop/lib/botserver/api_tests.py
@@ -75,9 +75,9 @@ class TestApi(object):
          "ok": True,
       }
 
-      response = self.client.post(reverse('botserver.api.send_message'), {'channel': 'channel-1', 'message': 'some message'})
+      response = self.client.post(reverse('botserver.api.send_message'), {'channel': 'channel-1', 'message': 'message with link'})
       data = json.loads(response.content)
 
       assert_equal(200, response.status_code)
-      chat_postMessage.assert_called_with(channel='channel-1', text='some message')
+      chat_postMessage.assert_called_with(channel='channel-1', text='@api_user: message with link')
       assert_true(data.get('ok'))


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add hue username which send the link in Slack

## How was this patch tested?
<img width="670" alt="Screenshot 2021-05-01 at 6 10 51 PM" src="https://user-images.githubusercontent.com/42064744/116782751-9242a180-aaa8-11eb-96ee-b642e152f351.png">
