### PR TITLE
[helm] Allow defining extra hosts for ingress

### DIFF
--- a/tools/kubernetes/helm/hue/templates/ingress-http.yaml
+++ b/tools/kubernetes/helm/hue/templates/ingress-http.yaml
@@ -18,4 +18,13 @@ spec:
           serviceName: hue-balancer
           servicePort: 80
         path: /
+  {{- range .Values.ingress.extraHosts }}
+  - host: {{ . | quote }}
+    http:
+      paths:
+      - backend:
+          serviceName: hue-balancer
+          servicePort: 80
+        path: /
+  {{- end }}
 {{- end -}}

--- a/tools/kubernetes/helm/hue/templates/ingress-https.yaml
+++ b/tools/kubernetes/helm/hue/templates/ingress-https.yaml
@@ -26,6 +26,15 @@ spec:
           serviceName: hue-balancer
           servicePort: 80
         path: /
+  {{- range .Values.ingress.extraHosts }}
+  - host: {{ . | quote }}
+    http:
+      paths:
+      - backend:
+          serviceName: hue-balancer
+          servicePort: 80
+        path: /
+  {{- end }}
   {{ if .Values.api.enabled }}
   - host: {{ .Values.api.domain }}
     http:
@@ -38,6 +47,9 @@ spec:
   tls:
   - hosts:
     - {{ .Values.ingress.domain }}
+    {{- range .Values.ingress.extraHosts }}
+    - {{ . | quote }}
+    {{- end }}
     {{ if .Values.api.enabled }}
     - {{ .Values.api.domain }}
     {{ end }}

--- a/tools/kubernetes/helm/hue/templates/ingress-traefik-hue.yaml
+++ b/tools/kubernetes/helm/hue/templates/ingress-traefik-hue.yaml
@@ -14,4 +14,13 @@ spec:
         backend:
           serviceName: hue
           servicePort: hue
+  {{- range .Values.ingress.extraHosts }}
+  - host: {{ . | quote }}
+    http:
+      paths:
+      - backend:
+          serviceName: hue-balancer
+          servicePort: 80
+        path: /
+  {{- end }}
 {{- end -}}

--- a/tools/kubernetes/helm/hue/templates/ingress-traefik-hue.yaml
+++ b/tools/kubernetes/helm/hue/templates/ingress-traefik-hue.yaml
@@ -19,8 +19,8 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: hue-balancer
-          servicePort: 80
+          serviceName: hue
+          servicePort: hue
         path: /
   {{- end }}
 {{- end -}}

--- a/tools/kubernetes/helm/hue/values.yaml
+++ b/tools/kubernetes/helm/hue/values.yaml
@@ -63,6 +63,8 @@ ingress:
   # type: "nginx-ssl-staging"
   # type: "traefik"
   domain: "demo.gethue.com"
+  # extraHosts:
+  # - "demo.hue.com"
   email: "team@gethue.com"
   loadBalancerIp: "127.0.0.1"
 aws:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Split of #2065

Allow defining extra hosts for ingress. This would make it possible the network ingress accepts alternative domains.
Example in values file:

```
ingress:
  create: True
  type: "ngnix"
  domain: "hue.k8s.domain.io" # main domain zone controlled by external-dns
  extraHosts:
  - "hue.domain.io" # CNAME in public domain zone
``` 

## How was this patch tested?

- Manual testing by upgrading an existing deployment
