### PR TITLE
[helm] Upgrade apiVersion to networking.k8s.io/v1 in k8s 1.19+

### DIFF
--- a/tools/kubernetes/helm/hue/templates/ingress-http-v1.yaml
+++ b/tools/kubernetes/helm/hue/templates/ingress-http-v1.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.ingress.create (eq .Values.ingress.type "nginx") (semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion) -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hue
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/session-cookie-name: "hue-balancer-ingress"
+    nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
+    nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
+{{- with .Values.ingress.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  rules:
+  - host: {{ .Values.ingress.domain }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: hue-balancer
+            port:
+              number: 80
+        pathType: ImplementationSpecific
+        path: /
+  {{- range .Values.ingress.extraHosts }}
+  - host: {{ . | quote }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: hue-balancer
+            port:
+              number: 80
+        pathType: ImplementationSpecific
+        path: /
+  {{- end }}
+{{- end -}}

--- a/tools/kubernetes/helm/hue/templates/ingress-http-v1beta.yaml
+++ b/tools/kubernetes/helm/hue/templates/ingress-http-v1beta.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.create (eq .Values.ingress.type "nginx") -}}
+{{- if and .Values.ingress.create (eq .Values.ingress.type "nginx") (semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion) -}}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:

--- a/tools/kubernetes/helm/hue/templates/ingress-https-v1.yaml
+++ b/tools/kubernetes/helm/hue/templates/ingress-https-v1.yaml
@@ -1,5 +1,5 @@
-{{- if and .Values.ingress.create (eq .Values.ingress.type "nginx-ssl") -}}
-apiVersion: networking.k8s.io/v1beta1
+{{- if and .Values.ingress.create (eq .Values.ingress.type "nginx-ssl") (semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion) -}}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: hue
@@ -13,11 +13,11 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-name: "hue-balancer"
     nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
-    {{ if .Values.ingress.hasAuth }}
+    {{- if .Values.ingress.hasAuth -}}
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: basic-auth-hue
     nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
-    {{ end }}
+    {{- end -}}
 {{- with .Values.ingress.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}
@@ -28,32 +28,44 @@ spec:
       paths:
       {{ if .Values.websocket.enabled }}
       - backend:
-          serviceName: daphne-websocket
-          servicePort: 8001
+          service:
+            name: daphne-websocket
+            port:
+              number: 8001
+        pathType: ImplementationSpecific
         path: /(ws/.*)
       {{- end -}}
       - backend:
-          serviceName: hue-balancer
-          servicePort: 80
+          service:
+            name: hue-balancer
+            port:
+              number: 80
+        pathType: ImplementationSpecific
         path: /(.*)
   {{- range .Values.ingress.extraHosts }}
   - host: {{ . | quote }}
     http:
       paths:
       - backend:
-          serviceName: hue-balancer
-          servicePort: 80
+          service:
+            name: hue-balancer
+            port:
+              number: 80
+        pathType: ImplementationSpecific
         path: /
   {{- end }}
-  {{ if .Values.api.enabled }}
+  {{- if .Values.api.enabled }}
   - host: {{ .Values.api.domain }}
     http:
       paths:
       - backend:
-          serviceName: hue-api
-          servicePort: 8005
+          service:
+            name: hue-balancer
+            port:
+              number: 80
+        pathType: ImplementationSpecific
         path: /
-  {{ end }}
+  {{- end }}
   tls:
   - hosts:
     - {{ .Values.ingress.domain }}

--- a/tools/kubernetes/helm/hue/templates/ingress-https-v1.yaml
+++ b/tools/kubernetes/helm/hue/templates/ingress-https-v1.yaml
@@ -13,11 +13,11 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-name: "hue-balancer"
     nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
-    {{- if .Values.ingress.hasAuth -}}
+    {{- if .Values.ingress.hasAuth }}
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: basic-auth-hue
     nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
-    {{- end -}}
+    {{- end }}
 {{- with .Values.ingress.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}
@@ -26,7 +26,7 @@ spec:
   - host: {{ .Values.ingress.domain }}
     http:
       paths:
-      {{ if .Values.websocket.enabled }}
+      {{- if .Values.websocket.enabled }}
       - backend:
           service:
             name: daphne-websocket
@@ -34,7 +34,7 @@ spec:
               number: 8001
         pathType: ImplementationSpecific
         path: /(ws/.*)
-      {{- end -}}
+      {{- end }}
       - backend:
           service:
             name: hue-balancer
@@ -69,11 +69,11 @@ spec:
   tls:
   - hosts:
     - {{ .Values.ingress.domain }}
-    {{- range .Values.ingress.extraHosts -}}
+    {{- range .Values.ingress.extraHosts }}
     - {{ . | quote }}
-    {{- end -}}
-    {{- if .Values.api.enabled -}}
+    {{- end }}
+    {{- if .Values.api.enabled }}
     - {{ .Values.api.domain }}
-    {{- end -}}
+    {{- end }}
     secretName: letsencrypt-hue-prod-tls
 {{- end -}}

--- a/tools/kubernetes/helm/hue/templates/ingress-https-v1beta.yaml
+++ b/tools/kubernetes/helm/hue/templates/ingress-https-v1beta.yaml
@@ -13,11 +13,11 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-name: "hue-balancer"
     nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
-    {{- if .Values.ingress.hasAuth -}}
+    {{- if .Values.ingress.hasAuth }}
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: basic-auth-hue
     nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
-    {{- end -}}
+    {{- end }}
 {{- with .Values.ingress.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}
@@ -26,12 +26,12 @@ spec:
   - host: {{ .Values.ingress.domain }}
     http:
       paths:
-      {{ if .Values.websocket.enabled }}
+      {{- if .Values.websocket.enabled }}
       - backend:
           serviceName: daphne-websocket
           servicePort: 8001
         path: /(ws/.*)
-      {{- end -}}
+      {{- end }}
       - backend:
           serviceName: hue-balancer
           servicePort: 80
@@ -45,7 +45,7 @@ spec:
           servicePort: 80
         path: /
   {{- end }}
-  {{ if .Values.api.enabled }}
+  {{- if .Values.api.enabled }}
   - host: {{ .Values.api.domain }}
     http:
       paths:
@@ -53,15 +53,15 @@ spec:
           serviceName: hue-api
           servicePort: 8005
         path: /
-  {{ end }}
+  {{- end }}
   tls:
   - hosts:
     - {{ .Values.ingress.domain }}
-    {{- range .Values.ingress.extraHosts -}}
+    {{- range .Values.ingress.extraHosts }}
     - {{ . | quote }}
-    {{- end -}}
-    {{- if .Values.api.enabled -}}
+    {{- end }}
+    {{- if .Values.api.enabled }}
     - {{ .Values.api.domain }}
-    {{- end -}}
+    {{- end }}
     secretName: letsencrypt-hue-prod-tls
 {{- end -}}

--- a/tools/kubernetes/helm/hue/templates/ingress-https-v1beta.yaml
+++ b/tools/kubernetes/helm/hue/templates/ingress-https-v1beta.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.create (eq .Values.ingress.type "nginx-ssl") -}}
+{{- if and .Values.ingress.create (eq .Values.ingress.type "nginx-ssl") (semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion) -}}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -13,11 +13,11 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-name: "hue-balancer"
     nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
-    {{ if .Values.ingress.hasAuth }}
+    {{- if .Values.ingress.hasAuth -}}
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: basic-auth-hue
     nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
-    {{ end }}
+    {{- end -}}
 {{- with .Values.ingress.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Split of #2065

- Upgrade apiVersion to networking.k8s.io/v1 in k8s 1.19+

The apiVersion networking.k8s.io/v1beta1 is deprecated in k8s 1.19+ and would be removed in k8s 1.22

In case of #2066 is merged, I will update the extraHosts additions to:

```
  {{- range .Values.ingress.extraHosts }}
  - host: {{ . | quote }}
    http:
      paths:
      {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
      - backend:
          service:
            name: hue-balancer
            port:
              number: 80
        pathType: ImplementationSpecific
        path: /
      {{- else }}
      - backend:
          serviceName: hue-balancer
          servicePort: 80
        path: /
      {{- end }}
  {{- end }}
```

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
