### PR TITLE
[oozie] Fix application path for submit_external_job

### DIFF
--- a/apps/oozie/src/oozie/views/dashboard.py
+++ b/apps/oozie/src/oozie/views/dashboard.py
@@ -32,6 +32,8 @@ from django.utils.functional import wraps
 from django.urls import reverse
 from django.shortcuts import redirect
 
+from azure.abfs.__init__ import abfspath
+
 from desktop.conf import TIME_ZONE
 from desktop.lib import django_mako
 from desktop.lib.django_util import JsonResponse, render
@@ -968,6 +970,16 @@ def _rerun_bundle(request, oozie_id, args, params, properties):
 
 def submit_external_job(request, application_path):
   ParametersFormSet = formset_factory(ParameterForm, extra=0)
+
+  if application_path.startswith('abfs:/') and not application_path.startswith('abfs://'):
+    application_path = application_path.replace("abfs:/", "abfs://")
+  elif application_path.startswith('s3a:/') and not application_path.startswith('s3a://'):
+    application_path = application_path.replace('s3a:/', 's3a://')
+  else:
+    application_path = "/" + application_path
+
+  if application_path.startswith("abfs://"):
+    application_path = abfspath(application_path)
 
   if request.method == 'POST':
     params_form = ParametersFormSet(request.POST)


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are 2 issues fixed for submit_external_job
1. add '/' back to application_path due knox
2. add '@' domain for ABFS path

## How was this patch tested?

Tested DH clusters

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
