### PR TITLE
[helm] Support custom annotations for ingress

### DIFF
--- a/tools/kubernetes/helm/hue/templates/ingress-http.yaml
+++ b/tools/kubernetes/helm/hue/templates/ingress-http.yaml
@@ -9,6 +9,9 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-name: "hue-balancer-ingress"
     nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
+{{- with .Values.ingress.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   rules:
   - host: {{ .Values.ingress.domain }}

--- a/tools/kubernetes/helm/hue/templates/ingress-https.yaml
+++ b/tools/kubernetes/helm/hue/templates/ingress-https.yaml
@@ -18,6 +18,9 @@ metadata:
     nginx.ingress.kubernetes.io/auth-secret: basic-auth-hue
     nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
     {{ end }}
+{{- with .Values.ingress.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   rules:
   - host: {{ .Values.ingress.domain }}

--- a/tools/kubernetes/helm/hue/templates/ingress-traefik-hue.yaml
+++ b/tools/kubernetes/helm/hue/templates/ingress-traefik-hue.yaml
@@ -5,6 +5,9 @@ metadata:
   name: hue
   annotations:
     kubernetes.io/ingress.class: traefik
+{{- with .Values.ingress.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   rules:
   - host: {{ .Values.domain }}

--- a/tools/kubernetes/helm/hue/values.yaml
+++ b/tools/kubernetes/helm/hue/values.yaml
@@ -65,6 +65,7 @@ ingress:
   domain: "demo.gethue.com"
   # extraHosts:
   # - "demo.hue.com"
+  # annotations: {}
   email: "team@gethue.com"
   loadBalancerIp: "127.0.0.1"
 aws:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Split of #2065 (reopen #2067 in new branch)

- Support extra annotations for ingress. This would permit setting extra annotations for ingress. Example in values file:

```
ingress:
  create: True
  type: "ngnix-ssl"
  domain: "hue.k8s.domain.io"
  annotations:
    nginx.ingress.kubernetes.io/force-ssl-redirect: "true" # force redirection to HTTPS
```

## How was this patch tested?

- Manual testing by upgrading an existing deployment
