### PR TITLE
[k8s] Bump the helm version up to 1.0.3

### DIFF
--- a/tools/kubernetes/helm/hue/Chart.yaml
+++ b/tools/kubernetes/helm/hue/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Hue is an SQL Cloud Editor for Data Warehouses and Databases.
 name: hue
-version: 1.0.2
+version: 1.0.3
 appVersion: 1.0
 keywords:
 - Hue


### PR DESCRIPTION
Change list:

d9fa32fe6b Double-check https ingress trailing dash
9b98a355b6 [helm] rename current ingress to v1beta
43b86d9aa8 [helm] create networking.k8s.io/v1 for k8s 1.19+
9a24301d8c [helm] support custom annotations for ingress
c40e996b26 [k8s] Ingress and deployment for Daphne
1a97eba9c2 [k8s] Add config hash to deployments
341b2e80ce [k8s] Adding daphne properties
95db44d63d Use hue service name and port for traefik
1491436f40 Allow defining extra hosts for ingress
