### PR TITLE
[tablebrowser] Fix the link in left assist popover to the table in ta…

### DIFF
--- a/desktop/core/src/desktop/js/apps/tableBrowser/metastoreViewModel.js
+++ b/desktop/core/src/desktop/js/apps/tableBrowser/metastoreViewModel.js
@@ -180,7 +180,10 @@ class MetastoreViewModel {
     });
 
     huePubSub.subscribe('metastore.url.change', () => {
-      const prefix = '/hue/metastore/';
+      const prefix =
+        window.HUE_BASE_URL && window.HUE_BASE_URL.length
+          ? window.HUE_BASE_URL + '/metastore/'
+          : '/hue/metastore/';
       if (this.source() && this.source().namespace()) {
         const params = {
           source_type: this.source().type
@@ -351,9 +354,14 @@ class MetastoreViewModel {
   }
 
   loadUrl() {
-    const path = window.location.pathname.substr(4) || '/metastore/tables';
+    const path = window.location.pathname.startsWith(window.HUE_BASE_URL)
+      ? window.location.pathname.substr(window.HUE_BASE_URL.length)
+      : window.location.pathname.substr(4) || '/metastore/tables';
     const pathParts = path.split('/');
     if (pathParts[0] === '') {
+      pathParts.shift();
+    }
+    while (pathParts[0] === 'hue') {
       pathParts.shift();
     }
     if (pathParts[0] === 'metastore') {


### PR DESCRIPTION
…ble browser when Knox enabled

## What changes were proposed in this pull request?

When Knox backend is enabled, click on the link "Table Browser" at the right bottom corner in the popover doesn't go the table web_logs in table browser, but instead go the "Databases"
![image](https://user-images.githubusercontent.com/106372/118204553-50541c80-b413-11eb-9f03-82625caa93bb.png)

## How was this patch tested?

Tested on a Knox enabled cluster

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
