### PR TITLE
Update AutocompleteParseResult type

### DIFF
--- a/desktop/core/src/desktop/js/parse/types.ts
+++ b/desktop/core/src/desktop/js/parse/types.ts
@@ -167,7 +167,7 @@ export interface AutocompleteParseResult {
   suggestOrderBys?: CommonPopularSuggestion;
   suggestSetOptions?: boolean;
   suggestTables?: {
-    identifierChain: IdentifierChainEntry[];
+    identifierChain?: IdentifierChainEntry[];
     onlyTables?: boolean;
     onlyViews?: boolean;
     prependFrom?: boolean;

--- a/desktop/core/src/desktop/js/parse/types.ts
+++ b/desktop/core/src/desktop/js/parse/types.ts
@@ -125,12 +125,12 @@ export interface AutocompleteParseResult {
     types?: string[];
     udfRef?: string;
   };
-  suggestCommonTableExpressions: {
+  suggestCommonTableExpressions?: {
     name: string;
     prependFrom: boolean;
     prependQuestionMark: boolean;
   }[];
-  suggestDatabases: {
+  suggestDatabases?: {
     appendDot?: boolean;
     prependFrom?: boolean;
     prependQuestionMark?: boolean;
@@ -151,7 +151,7 @@ export interface AutocompleteParseResult {
     prependJoin?: boolean;
     tables: ParsedTable[];
   };
-  suggestJoinConditions: {
+  suggestJoinConditions?: {
     prependOn?: boolean;
     tables: ParsedTable[];
   };
@@ -177,7 +177,7 @@ export interface AutocompleteParseResult {
     missingEndQuote?: boolean;
     partialQuote?: boolean;
   };
-  udfArgument: {
+  udfArgument?: {
     name: string;
     position: number;
   };


### PR DESCRIPTION
## What changes were proposed in this pull request?

Marks some fields of `AutocompleteParseResult` as optional to reflect that they won't always be present.

I noticed this when inspecting some result objects I got from `genericAutocompleteParser.parseSql` that a bunch of non-optional fields often weren't present:

<img width="347" alt="image" src="https://user-images.githubusercontent.com/1400151/118343490-6a672b00-b4f7-11eb-9a69-8090f57ab144.png">

<img width="338" alt="image" src="https://user-images.githubusercontent.com/1400151/118344178-f595f000-b4fa-11eb-8645-897edbaf5b0d.png">


## How was this patch tested?

Not tested, but since this is only a type change, as long as the project compiles, it should be fine. I just made this change in the online editor and didn't even attempt to build things locally, so not sure if there will be type errors or not - will let CI determine that for me 😆 

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
