### PR TITLE
[slack] Give status 200 with PopUpException

### DIFF
--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -24,7 +24,7 @@ from tabulate import tabulate
 from desktop.lib.botserver.slack_client import slack_client, SLACK_VERIFICATION_TOKEN
 from desktop.lib.botserver.api import _send_message
 from desktop.lib.django_util import login_notrequired, JsonResponse
-from desktop.lib.exceptions_renderable import PopupException, SlackBotException
+from desktop.lib.exceptions_renderable import PopupException
 from desktop.models import Document2, _get_gist_document
 from desktop.auth.backend import rewrite_user
 
@@ -43,6 +43,10 @@ else:
   from django.utils.translation import ugettext as _
 
 LOG = logging.getLogger(__name__)
+
+class SlackBotException(PopupException):
+  def __init__(self, msg, detail=None, error_code=200):
+    PopupException.__init__(self, message=msg, detail=detail, error_code=error_code)
 
 
 @login_notrequired

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -101,7 +101,7 @@ def _send_ephemeral_message(channel_id, user_id, raw_sql_message):
   try:
     slack_client.chat_postEphemeral(channel=channel_id, user=user_id, text=raw_sql_message)
   except Exception as e:
-    raise PopupException(_("Error posting ephemeral message"), detail=e)
+    raise PopupException(_("Error posting ephemeral message"), detail=e, error_code=200)
 
 
 def handle_on_link_shared(host_domain, channel_id, message_ts, links, user_id):
@@ -118,10 +118,10 @@ def handle_on_link_shared(host_domain, channel_id, message_ts, links, user_id):
         doc = _get_gist_document(**query_id)
         doc_type = 'gist'
       else:
-        raise PopupException(_("Cannot unfurl link"))
+        raise PopupException(_("Cannot unfurl link"), error_code=200)
     except Document2.DoesNotExist:
       msg = "Document with {key} does not exist".format(key=query_id)
-      raise PopupException(_(msg))
+      raise PopupException(_(msg), error_code=200)
 
     # Permission check for Slack user to be Hue user
     slack_user = check_slack_user_permission(host_domain, user_id)
@@ -134,7 +134,7 @@ def handle_on_link_shared(host_domain, channel_id, message_ts, links, user_id):
     try:
       slack_client.chat_unfurl(channel=channel_id, ts=message_ts, unfurls=payload['payload'])
     except Exception as e:
-      raise PopupException(_("Cannot unfurl link"), detail=e)
+      raise PopupException(_("Cannot unfurl link"), detail=e, error_code=200)
     
     # Generate and upload result xlsx file only if result available
     if payload['file_status']:
@@ -154,7 +154,7 @@ def check_slack_user_permission(host_domain, user_id):
   try:
     slack_user = slack_client.users_info(user=user_id)
   except Exception as e:
-    raise PopupException(_("Cannot find query owner in Slack"), detail=e)
+    raise PopupException(_("Cannot find query owner in Slack"), detail=e, error_code=200)
 
   response = {
     'is_bot': slack_user['user']['is_bot'],
@@ -187,7 +187,7 @@ def send_result_file(request, channel_id, message_ts, doc, file_format):
       initial_comment='Here is your result file!'
     )
   except Exception as e:
-    raise PopupException(_("Cannot upload result file"), detail=e)
+    raise PopupException(_("Cannot upload result file"), detail=e, error_code=200)
 
 
 def _query_result(request, notebook, max_rows):

--- a/desktop/core/src/desktop/lib/exceptions_renderable.py
+++ b/desktop/core/src/desktop/lib/exceptions_renderable.py
@@ -83,7 +83,3 @@ class PopupException(Exception):
       response.status_code = self.error_code
 
     return response
-
-class SlackBotException(PopupException):
-  def __init__(self, msg, detail=None, error_code=200):
-    PopupException.__init__(self, message=msg, detail=detail, error_code=error_code)

--- a/desktop/core/src/desktop/lib/exceptions_renderable.py
+++ b/desktop/core/src/desktop/lib/exceptions_renderable.py
@@ -83,3 +83,7 @@ class PopupException(Exception):
       response.status_code = self.error_code
 
     return response
+
+class SlackBotException(PopupException):
+  def __init__(self, msg, detail=None, error_code=200):
+    PopupException.__init__(self, message=msg, detail=detail, error_code=error_code)


### PR DESCRIPTION
## What changes were proposed in this pull request?

- By default, it is 500 status code (Internal server error). This does not acknowledge the Slack event request, thereby Slack sends request again and again.
- With status 200, Slack event request will be acknowledged and also it will not clutter logs with multiple tries now

