### PR TITLE
[slack] Give gist link for detected SELECT statements

### DIFF
--- a/desktop/core/src/desktop/api2.py
+++ b/desktop/core/src/desktop/api2.py
@@ -924,37 +924,45 @@ def gist_create(request):
   '''
   Only supporting Editor App currently.
   '''
-  response = {'status': 0}
 
   statement = request.POST.get('statement', '')
   gist_type = request.POST.get('doc_type', 'hive')
   name = request.POST.get('name', '')
   description = request.POST.get('description', '')
 
-  if not name:
-    name = _('%s Query') % gist_type.capitalize()
+  response = _gist_create(request.get_host(), request.is_secure(), request.user, name, statement, gist_type)
+
+  return JsonResponse(response)
+
+
+def _gist_create(host_domain, is_http_secure, user, name, statement, gist_type):
+  response = {'status': 0}
+
   statement_raw = statement
   if not statement.strip().startswith('--'):
-    statement = '-- Created by %s\n\n%s' % (request.user.get_full_name() or request.user.username, statement)
+    statement = '-- Created by %s\n\n%s' % (user.get_full_name() or user.username, statement)
+
+  if not name:
+    name = _('%s Query') % gist_type.capitalize()
 
   gist_doc = Document2.objects.create(
     name=name,
     type='gist',
-    owner=request.user,
+    owner=user,
     data=json.dumps({'statement': statement, 'statement_raw': statement_raw}),
     extra=gist_type,
-    parent_directory=Document2.objects.get_gist_directory(request.user)
+    parent_directory=Document2.objects.get_gist_directory(user)
   )
 
   response['id'] = gist_doc.id
   response['uuid'] = gist_doc.uuid
   response['link'] = '%(scheme)s://%(host)s/hue/gist?uuid=%(uuid)s' % {
-    'scheme': 'https' if request.is_secure() else 'http',
-    'host': request.get_host(),
+    'scheme': 'https' if is_http_secure else 'http',
+    'host': host_domain,
     'uuid': gist_doc.uuid,
   }
 
-  return JsonResponse(response)
+  return response
 
 
 @login_notrequired

--- a/desktop/core/src/desktop/api2.py
+++ b/desktop/core/src/desktop/api2.py
@@ -930,12 +930,12 @@ def gist_create(request):
   name = request.POST.get('name', '')
   description = request.POST.get('description', '')
 
-  response = _gist_create(request.get_host(), request.is_secure(), request.user, name, statement, gist_type)
+  response = _gist_create(request.get_host(), request.is_secure(), request.user, statement, gist_type, name)
 
   return JsonResponse(response)
 
 
-def _gist_create(host_domain, is_http_secure, user, name, statement, gist_type):
+def _gist_create(host_domain, is_http_secure, user, statement, gist_type, name=''):
   response = {'status': 0}
 
   statement_raw = statement

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -25,7 +25,7 @@ from desktop.lib.botserver.slack_client import slack_client, SLACK_VERIFICATION_
 from desktop.lib.botserver.api import _send_message
 from desktop.lib.django_util import login_notrequired, JsonResponse
 from desktop.lib.exceptions_renderable import PopupException
-from desktop.models import Document2, _get_gist_document
+from desktop.models import Document2, _get_gist_document, get_cluster_config
 from desktop.auth.backend import rewrite_user
 
 from notebook.api import _fetch_result_data, _check_status, _execute_notebook
@@ -107,12 +107,14 @@ def detect_select_statement(host_domain, is_http_secure, channel_id, user_id, st
   slack_user = check_slack_user_permission(host_domain, user_id)
   user = get_user(channel_id, slack_user)
 
+  default_dialect = get_cluster_config(rewrite_user(user))['default_sql_interpreter']
+
   gist_doc = Document2.objects.create(
-    name='Mysql Query blah',
+    name='{dialect_name} Query'.format(dialect_name=default_dialect),
     type='gist',
     owner=user,
-    data=json.dumps({'statement_raw': statement}),
-    extra='mysql',
+    data=json.dumps({'statement': statement, 'statement_raw': statement}),
+    extra=default_dialect,
     parent_directory=Document2.objects.get_gist_directory(user)
   )
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Removed ephemeral messages -- Cant be used in unfurling
- Detect SELECT statements
- Check Slack user permission to create gist
- Create gist and send link
- Can be shown in the message thread too if we don't want to clutter up the Slack channels

## How was this patch tested?

<img width="953" alt="Screenshot 2021-05-17 at 5 06 43 PM" src="https://user-images.githubusercontent.com/42064744/118482367-43486d80-b732-11eb-8658-d1e07e8146a5.png">



