### PR TITLE
[lib] Avoid infinite loop on 500 errors in file chooser popup

### DIFF
--- a/desktop/core/src/desktop/views.py
+++ b/desktop/core/src/desktop/views.py
@@ -450,8 +450,10 @@ def serve_500_error(request, *args, **kwargs):
         # If (None, None, None), default server error describing why this failed.
         return django.views.debug.technical_500_response(request, *exc_info)
       else:
-        # Could have an empty traceback
-        return render("500.mako", request, {'traceback': traceback.extract_tb(exc_info[2])})
+        tb = traceback.extract_tb(exc_info[2])
+        if request.is_ajax():
+          tb = '\n'.join(tb.format())
+        return render("500.mako", request, {'traceback': tb})
     else:
       # exc_info could be empty
       return render("500.mako", request, {})


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/share/hue/build/env/lib/python3.6/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/usr/share/hue/build/env/lib/python3.6/site-packages/django/utils/deprecation.py", line 114, in __call__
    response = response or self.get_response(request)
  File "/usr/share/hue/build/env/lib/python3.6/site-packages/django/core/handlers/exception.py", line 49, in inner
    response = response_for_exception(request, exc)
  File "/usr/share/hue/build/env/lib/python3.6/site-packages/django/core/handlers/exception.py", line 103, in response_for_exception
    response = handle_uncaught_exception(request, get_resolver(get_urlconf()), sys.exc_info())
  File "/usr/share/hue/build/env/lib/python3.6/site-packages/django/core/handlers/exception.py", line 142, in handle_uncaught_exception
    return callback(request, **param_dict)
  File "/usr/share/hue/desktop/core/src/desktop/views.py", line 454, in serve_500_error
    return render("500.mako", request, {'traceback': traceback.extract_tb(exc_info[2])})
  File "/usr/share/hue/desktop/core/src/desktop/lib/django_util.py", line 239, in render
    return render_json(data, request.GET.get("callback"), status=status)
  File "/usr/share/hue/desktop/core/src/desktop/lib/django_util.py", line 319, in render_json
    json = encode_json(data, indent)
  File "/usr/share/hue/desktop/core/src/desktop/lib/django_util.py", line 291, in encode_json
    return json.dumps(data, indent=indent, cls=Encoder)
  File "/usr/lib/python3.6/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/lib/python3.6/json/encoder.py", line 201, in encode
    chunks = list(chunks)
  File "/usr/lib/python3.6/json/encoder.py", line 430, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/lib/python3.6/json/encoder.py", line 404, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.6/json/encoder.py", line 325, in _iterencode_list
    yield from chunks
  File "/usr/lib/python3.6/json/encoder.py", line 437, in _iterencode
    o = _default(o)
  File "/usr/share/hue/desktop/core/src/desktop/lib/django_util.py", line 89, in default
    return json.JSONEncoder.default(self, o)
  File "/usr/lib/python3.6/json/encoder.py", line 180, in default
    o.__class__.__name__)
TypeError: Object of type 'FrameSummary' is not JSON serializable
