### PR TITLE
[importer_direct_upload] correcting the dialect value when enable_connector=true

### DIFF
--- a/desktop/core/src/desktop/js/apps/notebook/snippet.js
+++ b/desktop/core/src/desktop/js/apps/notebook/snippet.js
@@ -208,18 +208,7 @@ class Snippet {
     });
 
     self.isSqlDialect = ko.pureComputed(() => {
-      return vm.getSnippetViewSettings(self.type()).sqlDialect;
-    });
-
-    self.connector = ko.pureComputed(() => {
-      // To support optimizer changes in editor v2
-      return {
-        optimizer: self.type() === 'hive' || self.type() === 'impala' ? 'api' : 'off',
-        type: self.type(),
-        id: self.type(),
-        dialect: self.type(),
-        is_sql: self.isSqlDialect()
-      };
+      return vm.getSnippetViewSettings(self.dialect()).sqlDialect;
     });
 
     self.dialect = ko.pureComputed(() => this.connector().dialect);


### PR DESCRIPTION
## What changes were proposed in this pull request?

- self.type() is a number in case of enable_connector = true because of it we are not getting the snippet view settings?
- https://github.com/cloudera/hue/blob/master/desktop/core/src/desktop/js/apps/notebook/snippet.js#L211
- https://github.com/cloudera/hue/blob/master/desktop/libs/notebook/src/notebook/templates/editor2.mako#L1060
