### PR TITLE
[slack] Fix dialect when creating gist for detected SQL

### DIFF
--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -108,7 +108,7 @@ def handle_select_statement(host_domain, is_http_secure, channel_id, user_id, st
   slack_user = check_slack_user_permission(host_domain, user_id)
   user = get_user(channel_id, slack_user)
 
-  default_dialect = get_cluster_config(rewrite_user(user))['default_sql_interpreter']
+  default_dialect = get_cluster_config(rewrite_user(user))['main_button_action']['dialect']
 
   gist_response = _gist_create(host_domain, is_http_secure, user, statement, default_dialect)
 

--- a/desktop/core/src/desktop/lib/botserver/views_tests.py
+++ b/desktop/core/src/desktop/lib/botserver/views_tests.py
@@ -113,7 +113,9 @@ class TestBotServer(unittest.TestCase):
               get_user.return_value = self.user
 
               get_cluster_config.return_value = {
-                'default_sql_interpreter': 'hive'
+                'main_button_action': {
+                  'dialect': 'hive'
+                },
               }
               _gist_create.return_value = {
                 'link': 'gist_link'


### PR DESCRIPTION
## What changes were proposed in this pull request?

- `type` changes when enable_connectors is enabled. Using more trusted field for smoother `dialect` name

<img width="784" alt="Screenshot 2021-05-26 at 10 41 51 PM" src="https://user-images.githubusercontent.com/42064744/119702879-92e61200-be73-11eb-9c9a-880525979221.png">

## How was this patch tested?

- Successfully running unit test


For demo.gethe.com

<img width="402" alt="Screenshot 2021-05-26 at 10 30 32 PM" src="https://user-images.githubusercontent.com/42064744/119702840-86fa5000-be73-11eb-9647-b1ef8372d5f1.png">


