### PR TITLE
[libs] Bump djangorestframework-simplejwt

### DIFF
--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -26,7 +26,7 @@ django-nose==1.4.7
 django_opentracing==1.1.0
 django_prometheus==1.0.15
 django-webpack-loader==0.5.0
-djangorestframework-simplejwt==4.6.0
+djangorestframework-simplejwt==4.4.0  # For Python 3.6
 djangorestframework==3.12.2
 eventlet==0.31.0
 future==0.18.2


### PR DESCRIPTION
Trying to avoid

  File "/usr/share/hue/build/env/lib/python3.6/site-packages/rest_framework_simplejwt/backends.py", line 43, in encode
    return token.decode('utf-8')
AttributeError: 'str' object has no attribute 'decode'

https://github.com/jazzband/djangorestframework-simplejwt/issues/326
