### PR TITLE
Improved autocompletion around backticked partial identifiers

### DIFF
--- a/desktop/core/src/desktop/js/parse/sql/calcite/sqlParseSupport.js
+++ b/desktop/core/src/desktop/js/parse/sql/calcite/sqlParseSupport.js
@@ -20,7 +20,8 @@ import {
   initSyntaxParser,
   identifierEquals,
   equalIgnoreCase,
-  SIMPLE_TABLE_REF_SUGGESTIONS
+  SIMPLE_TABLE_REF_SUGGESTIONS,
+  adjustForPartialBackticks
 } from 'parse/sql/sqlParseUtils';
 
 const initSqlParser = function (parser) {
@@ -649,15 +650,6 @@ const initSqlParser = function (parser) {
         parser.yy.result.suggestCommonTableExpressions = ctes;
       }
     }
-  };
-
-  parser.identifyPartials = function (beforeCursor, afterCursor) {
-    const beforeMatch = beforeCursor.match(/[0-9a-zA-Z_]*$/);
-    const afterMatch = afterCursor.match(/^[0-9a-zA-Z_]*(?:\((?:[^)]*\))?)?/);
-    return {
-      left: beforeMatch ? beforeMatch[0].length : 0,
-      right: afterMatch ? afterMatch[0].length : 0
-    };
   };
 
   const addCleanTablePrimary = function (tables, tablePrimary) {
@@ -1395,6 +1387,7 @@ const initSqlParser = function (parser) {
       linkTablePrimaries();
       parser.commitLocations();
       // Clean up and prioritize
+      adjustForPartialBackticks(parser);
       prioritizeSuggestions();
     } catch (err) {
       if (debug) {

--- a/desktop/core/src/desktop/js/parse/sql/calcite/test/calciteAutocompleteParser.Select.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/calcite/test/calciteAutocompleteParser.Select.test.js
@@ -232,8 +232,9 @@ describe('calciteAutocompleteParser.js SELECT statements', () => {
       afterCursor: '',
       expectedResult: {
         lowerCase: false,
-        suggestTables: {},
+        suggestTables: { appendBacktick: true },
         suggestDatabases: {
+          appendBacktick: true,
           appendDot: true
         }
       }

--- a/desktop/core/src/desktop/js/parse/sql/calcite/test/calciteAutocompleteParser.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/calcite/test/calciteAutocompleteParser.test.js
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { assertPartials } from 'parse/sql/sharedParserTests';
 import calciteAutocompleteParser from '../calciteAutocompleteParser';
 
 describe('calciteAutocompleteParser.js', () => {
@@ -277,98 +278,7 @@ describe('calciteAutocompleteParser.js', () => {
 
   describe('partial removal', () => {
     it('should identify part lengths', () => {
-      const limitChars = [
-        ' ',
-        '\n',
-        '\t',
-        '&',
-        '~',
-        '%',
-        '!',
-        '.',
-        ',',
-        '+',
-        '-',
-        '*',
-        '/',
-        '=',
-        '<',
-        '>',
-        ')',
-        '[',
-        ']',
-        ';'
-      ];
-
-      expect(calciteAutocompleteParser.identifyPartials('', '')).toEqual({ left: 0, right: 0 });
-      expect(calciteAutocompleteParser.identifyPartials('foo', '')).toEqual({ left: 3, right: 0 });
-      expect(calciteAutocompleteParser.identifyPartials(' foo', '')).toEqual({ left: 3, right: 0 });
-      expect(calciteAutocompleteParser.identifyPartials('asdf 1234', '')).toEqual({
-        left: 4,
-        right: 0
-      });
-
-      expect(calciteAutocompleteParser.identifyPartials('foo', 'bar')).toEqual({
-        left: 3,
-        right: 3
-      });
-
-      expect(calciteAutocompleteParser.identifyPartials('fo', 'o()')).toEqual({
-        left: 2,
-        right: 3
-      });
-
-      expect(calciteAutocompleteParser.identifyPartials('fo', 'o(')).toEqual({ left: 2, right: 2 });
-      expect(calciteAutocompleteParser.identifyPartials('fo', 'o(bla bla)')).toEqual({
-        left: 2,
-        right: 10
-      });
-
-      expect(calciteAutocompleteParser.identifyPartials('foo ', '')).toEqual({ left: 0, right: 0 });
-      expect(calciteAutocompleteParser.identifyPartials("foo '", "'")).toEqual({
-        left: 0,
-        right: 0
-      });
-
-      expect(calciteAutocompleteParser.identifyPartials('foo "', '"')).toEqual({
-        left: 0,
-        right: 0
-      });
-      limitChars.forEach(char => {
-        expect(calciteAutocompleteParser.identifyPartials('bar foo' + char, '')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(calciteAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo', '')).toEqual(
-          {
-            left: 6,
-            right: 0
-          }
-        );
-
-        expect(
-          calciteAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo ', '')
-        ).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(calciteAutocompleteParser.identifyPartials('', char + 'foo bar')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(calciteAutocompleteParser.identifyPartials('', 'foofoo' + char)).toEqual({
-          left: 0,
-          right: 6
-        });
-
-        expect(calciteAutocompleteParser.identifyPartials('', ' foofoo' + char)).toEqual({
-          left: 0,
-          right: 0
-        });
-      });
+      assertPartials(calciteAutocompleteParser);
     });
   });
 });

--- a/desktop/core/src/desktop/js/parse/sql/dasksql/sqlParseSupport.js
+++ b/desktop/core/src/desktop/js/parse/sql/dasksql/sqlParseSupport.js
@@ -20,7 +20,8 @@ import {
   initSyntaxParser,
   identifierEquals,
   equalIgnoreCase,
-  SIMPLE_TABLE_REF_SUGGESTIONS
+  SIMPLE_TABLE_REF_SUGGESTIONS,
+  adjustForPartialBackticks
 } from 'parse/sql/sqlParseUtils';
 
 const initSqlParser = function (parser) {
@@ -643,15 +644,6 @@ const initSqlParser = function (parser) {
         parser.yy.result.suggestCommonTableExpressions = ctes;
       }
     }
-  };
-
-  parser.identifyPartials = function (beforeCursor, afterCursor) {
-    const beforeMatch = beforeCursor.match(/[0-9a-zA-Z_]*$/);
-    const afterMatch = afterCursor.match(/^[0-9a-zA-Z_]*(?:\((?:[^)]*\))?)?/);
-    return {
-      left: beforeMatch ? beforeMatch[0].length : 0,
-      right: afterMatch ? afterMatch[0].length : 0
-    };
   };
 
   const addCleanTablePrimary = function (tables, tablePrimary) {
@@ -1374,6 +1366,7 @@ const initSqlParser = function (parser) {
       linkTablePrimaries();
       parser.commitLocations();
       // Clean up and prioritize
+      adjustForPartialBackticks(parser);
       prioritizeSuggestions();
     } catch (err) {
       if (debug) {

--- a/desktop/core/src/desktop/js/parse/sql/dasksql/test/dasksqlAutocompleteParser.Select.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/dasksql/test/dasksqlAutocompleteParser.Select.test.js
@@ -232,8 +232,9 @@ describe('dasksqlAutocompleteParser.js SELECT statements', () => {
       afterCursor: '',
       expectedResult: {
         lowerCase: false,
-        suggestTables: {},
+        suggestTables: { appendBacktick: true },
         suggestDatabases: {
+          appendBacktick: true,
           appendDot: true
         }
       }

--- a/desktop/core/src/desktop/js/parse/sql/dasksql/test/dasksqlAutocompleteParser.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/dasksql/test/dasksqlAutocompleteParser.test.js
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { assertPartials } from 'parse/sql/sharedParserTests';
 import dasksqlAutocompleteParser from '../dasksqlAutocompleteParser';
 
 describe('dasksqlAutocompleteParser.js', () => {
@@ -215,98 +216,7 @@ describe('dasksqlAutocompleteParser.js', () => {
 
   describe('partial removal', () => {
     it('should identify part lengths', () => {
-      const limitChars = [
-        ' ',
-        '\n',
-        '\t',
-        '&',
-        '~',
-        '%',
-        '!',
-        '.',
-        ',',
-        '+',
-        '-',
-        '*',
-        '/',
-        '=',
-        '<',
-        '>',
-        ')',
-        '[',
-        ']',
-        ';'
-      ];
-
-      expect(dasksqlAutocompleteParser.identifyPartials('', '')).toEqual({ left: 0, right: 0 });
-      expect(dasksqlAutocompleteParser.identifyPartials('foo', '')).toEqual({ left: 3, right: 0 });
-      expect(dasksqlAutocompleteParser.identifyPartials(' foo', '')).toEqual({ left: 3, right: 0 });
-      expect(dasksqlAutocompleteParser.identifyPartials('asdf 1234', '')).toEqual({
-        left: 4,
-        right: 0
-      });
-
-      expect(dasksqlAutocompleteParser.identifyPartials('foo', 'bar')).toEqual({
-        left: 3,
-        right: 3
-      });
-
-      expect(dasksqlAutocompleteParser.identifyPartials('fo', 'o()')).toEqual({
-        left: 2,
-        right: 3
-      });
-
-      expect(dasksqlAutocompleteParser.identifyPartials('fo', 'o(')).toEqual({ left: 2, right: 2 });
-      expect(dasksqlAutocompleteParser.identifyPartials('fo', 'o(bla bla)')).toEqual({
-        left: 2,
-        right: 10
-      });
-
-      expect(dasksqlAutocompleteParser.identifyPartials('foo ', '')).toEqual({ left: 0, right: 0 });
-      expect(dasksqlAutocompleteParser.identifyPartials("foo '", "'")).toEqual({
-        left: 0,
-        right: 0
-      });
-
-      expect(dasksqlAutocompleteParser.identifyPartials('foo "', '"')).toEqual({
-        left: 0,
-        right: 0
-      });
-      limitChars.forEach(char => {
-        expect(dasksqlAutocompleteParser.identifyPartials('bar foo' + char, '')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(dasksqlAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo', '')).toEqual(
-          {
-            left: 6,
-            right: 0
-          }
-        );
-
-        expect(
-          dasksqlAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo ', '')
-        ).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(dasksqlAutocompleteParser.identifyPartials('', char + 'foo bar')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(dasksqlAutocompleteParser.identifyPartials('', 'foofoo' + char)).toEqual({
-          left: 0,
-          right: 6
-        });
-
-        expect(dasksqlAutocompleteParser.identifyPartials('', ' foofoo' + char)).toEqual({
-          left: 0,
-          right: 0
-        });
-      });
+      assertPartials(dasksqlAutocompleteParser);
     });
   });
 });

--- a/desktop/core/src/desktop/js/parse/sql/druid/sqlParseSupport.js
+++ b/desktop/core/src/desktop/js/parse/sql/druid/sqlParseSupport.js
@@ -20,7 +20,8 @@ import {
   initSyntaxParser,
   identifierEquals,
   equalIgnoreCase,
-  SIMPLE_TABLE_REF_SUGGESTIONS
+  SIMPLE_TABLE_REF_SUGGESTIONS,
+  adjustForPartialBackticks
 } from 'parse/sql/sqlParseUtils';
 
 const initSqlParser = function (parser) {
@@ -643,15 +644,6 @@ const initSqlParser = function (parser) {
         parser.yy.result.suggestCommonTableExpressions = ctes;
       }
     }
-  };
-
-  parser.identifyPartials = function (beforeCursor, afterCursor) {
-    const beforeMatch = beforeCursor.match(/[0-9a-zA-Z_]*$/);
-    const afterMatch = afterCursor.match(/^[0-9a-zA-Z_]*(?:\((?:[^)]*\))?)?/);
-    return {
-      left: beforeMatch ? beforeMatch[0].length : 0,
-      right: afterMatch ? afterMatch[0].length : 0
-    };
   };
 
   const addCleanTablePrimary = function (tables, tablePrimary) {
@@ -1389,6 +1381,7 @@ const initSqlParser = function (parser) {
       linkTablePrimaries();
       parser.commitLocations();
       // Clean up and prioritize
+      adjustForPartialBackticks(parser);
       prioritizeSuggestions();
     } catch (err) {
       if (debug) {

--- a/desktop/core/src/desktop/js/parse/sql/druid/test/druidAutocompleteParser.Select.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/druid/test/druidAutocompleteParser.Select.test.js
@@ -232,8 +232,9 @@ describe('druidAutocompleteParser.js SELECT statements', () => {
       afterCursor: '',
       expectedResult: {
         lowerCase: false,
-        suggestTables: {},
+        suggestTables: { appendBacktick: true },
         suggestDatabases: {
+          appendBacktick: true,
           appendDot: true
         }
       }

--- a/desktop/core/src/desktop/js/parse/sql/druid/test/druidAutocompleteParser.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/druid/test/druidAutocompleteParser.test.js
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { assertPartials } from 'parse/sql/sharedParserTests';
 import druidAutocompleteParser from '../druidAutocompleteParser';
 
 describe('druidAutocompleteParser.js', () => {
@@ -277,94 +278,7 @@ describe('druidAutocompleteParser.js', () => {
 
   describe('partial removal', () => {
     it('should identify part lengths', () => {
-      const limitChars = [
-        ' ',
-        '\n',
-        '\t',
-        '&',
-        '~',
-        '%',
-        '!',
-        '.',
-        ',',
-        '+',
-        '-',
-        '*',
-        '/',
-        '=',
-        '<',
-        '>',
-        ')',
-        '[',
-        ']',
-        ';'
-      ];
-
-      expect(druidAutocompleteParser.identifyPartials('', '')).toEqual({ left: 0, right: 0 });
-      expect(druidAutocompleteParser.identifyPartials('foo', '')).toEqual({ left: 3, right: 0 });
-      expect(druidAutocompleteParser.identifyPartials(' foo', '')).toEqual({ left: 3, right: 0 });
-      expect(druidAutocompleteParser.identifyPartials('asdf 1234', '')).toEqual({
-        left: 4,
-        right: 0
-      });
-
-      expect(druidAutocompleteParser.identifyPartials('foo', 'bar')).toEqual({
-        left: 3,
-        right: 3
-      });
-
-      expect(druidAutocompleteParser.identifyPartials('fo', 'o()')).toEqual({
-        left: 2,
-        right: 3
-      });
-
-      expect(druidAutocompleteParser.identifyPartials('fo', 'o(')).toEqual({ left: 2, right: 2 });
-      expect(druidAutocompleteParser.identifyPartials('fo', 'o(bla bla)')).toEqual({
-        left: 2,
-        right: 10
-      });
-
-      expect(druidAutocompleteParser.identifyPartials('foo ', '')).toEqual({ left: 0, right: 0 });
-      expect(druidAutocompleteParser.identifyPartials("foo '", "'")).toEqual({
-        left: 0,
-        right: 0
-      });
-
-      expect(druidAutocompleteParser.identifyPartials('foo "', '"')).toEqual({
-        left: 0,
-        right: 0
-      });
-      limitChars.forEach(char => {
-        expect(druidAutocompleteParser.identifyPartials('bar foo' + char, '')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(druidAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo', '')).toEqual({
-          left: 6,
-          right: 0
-        });
-
-        expect(druidAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo ', '')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(druidAutocompleteParser.identifyPartials('', char + 'foo bar')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(druidAutocompleteParser.identifyPartials('', 'foofoo' + char)).toEqual({
-          left: 0,
-          right: 6
-        });
-
-        expect(druidAutocompleteParser.identifyPartials('', ' foofoo' + char)).toEqual({
-          left: 0,
-          right: 0
-        });
-      });
+      assertPartials(druidAutocompleteParser);
     });
   });
 });

--- a/desktop/core/src/desktop/js/parse/sql/elasticsearch/sqlParseSupport.js
+++ b/desktop/core/src/desktop/js/parse/sql/elasticsearch/sqlParseSupport.js
@@ -20,7 +20,8 @@ import {
   initSyntaxParser,
   identifierEquals,
   equalIgnoreCase,
-  SIMPLE_TABLE_REF_SUGGESTIONS
+  SIMPLE_TABLE_REF_SUGGESTIONS,
+  adjustForPartialBackticks
 } from 'parse/sql/sqlParseUtils';
 
 const initSqlParser = function (parser) {
@@ -643,15 +644,6 @@ const initSqlParser = function (parser) {
         parser.yy.result.suggestCommonTableExpressions = ctes;
       }
     }
-  };
-
-  parser.identifyPartials = function (beforeCursor, afterCursor) {
-    const beforeMatch = beforeCursor.match(/[0-9a-zA-Z_]*$/);
-    const afterMatch = afterCursor.match(/^[0-9a-zA-Z_]*(?:\((?:[^)]*\))?)?/);
-    return {
-      left: beforeMatch ? beforeMatch[0].length : 0,
-      right: afterMatch ? afterMatch[0].length : 0
-    };
   };
 
   const addCleanTablePrimary = function (tables, tablePrimary) {
@@ -1389,6 +1381,7 @@ const initSqlParser = function (parser) {
       linkTablePrimaries();
       parser.commitLocations();
       // Clean up and prioritize
+      adjustForPartialBackticks(parser);
       prioritizeSuggestions();
     } catch (err) {
       if (debug) {

--- a/desktop/core/src/desktop/js/parse/sql/elasticsearch/test/elasticsearchAutocompleteParser.Select.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/elasticsearch/test/elasticsearchAutocompleteParser.Select.test.js
@@ -232,8 +232,9 @@ describe('elasticsearchAutocompleteParser.js SELECT statements', () => {
       afterCursor: '',
       expectedResult: {
         lowerCase: false,
-        suggestTables: {},
+        suggestTables: { appendBacktick: true },
         suggestDatabases: {
+          appendBacktick: true,
           appendDot: true
         }
       }

--- a/desktop/core/src/desktop/js/parse/sql/elasticsearch/test/elasticsearchAutocompleteParser.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/elasticsearch/test/elasticsearchAutocompleteParser.test.js
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { assertPartials } from 'parse/sql/sharedParserTests';
 import elasticsearchAutocompleteParser from '../elasticsearchAutocompleteParser';
 
 describe('elasticsearchAutocompleteParser.js', () => {
@@ -277,118 +278,7 @@ describe('elasticsearchAutocompleteParser.js', () => {
 
   describe('partial removal', () => {
     it('should identify part lengths', () => {
-      const limitChars = [
-        ' ',
-        '\n',
-        '\t',
-        '&',
-        '~',
-        '%',
-        '!',
-        '.',
-        ',',
-        '+',
-        '-',
-        '*',
-        '/',
-        '=',
-        '<',
-        '>',
-        ')',
-        '[',
-        ']',
-        ';'
-      ];
-
-      expect(elasticsearchAutocompleteParser.identifyPartials('', '')).toEqual({
-        left: 0,
-        right: 0
-      });
-
-      expect(elasticsearchAutocompleteParser.identifyPartials('foo', '')).toEqual({
-        left: 3,
-        right: 0
-      });
-
-      expect(elasticsearchAutocompleteParser.identifyPartials(' foo', '')).toEqual({
-        left: 3,
-        right: 0
-      });
-
-      expect(elasticsearchAutocompleteParser.identifyPartials('asdf 1234', '')).toEqual({
-        left: 4,
-        right: 0
-      });
-
-      expect(elasticsearchAutocompleteParser.identifyPartials('foo', 'bar')).toEqual({
-        left: 3,
-        right: 3
-      });
-
-      expect(elasticsearchAutocompleteParser.identifyPartials('fo', 'o()')).toEqual({
-        left: 2,
-        right: 3
-      });
-
-      expect(elasticsearchAutocompleteParser.identifyPartials('fo', 'o(')).toEqual({
-        left: 2,
-        right: 2
-      });
-
-      expect(elasticsearchAutocompleteParser.identifyPartials('fo', 'o(bla bla)')).toEqual({
-        left: 2,
-        right: 10
-      });
-
-      expect(elasticsearchAutocompleteParser.identifyPartials('foo ', '')).toEqual({
-        left: 0,
-        right: 0
-      });
-
-      expect(elasticsearchAutocompleteParser.identifyPartials("foo '", "'")).toEqual({
-        left: 0,
-        right: 0
-      });
-
-      expect(elasticsearchAutocompleteParser.identifyPartials('foo "', '"')).toEqual({
-        left: 0,
-        right: 0
-      });
-      limitChars.forEach(char => {
-        expect(elasticsearchAutocompleteParser.identifyPartials('bar foo' + char, '')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(
-          elasticsearchAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo', '')
-        ).toEqual({
-          left: 6,
-          right: 0
-        });
-
-        expect(
-          elasticsearchAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo ', '')
-        ).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(elasticsearchAutocompleteParser.identifyPartials('', char + 'foo bar')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(elasticsearchAutocompleteParser.identifyPartials('', 'foofoo' + char)).toEqual({
-          left: 0,
-          right: 6
-        });
-
-        expect(elasticsearchAutocompleteParser.identifyPartials('', ' foofoo' + char)).toEqual({
-          left: 0,
-          right: 0
-        });
-      });
+      assertPartials(elasticsearchAutocompleteParser);
     });
   });
 });

--- a/desktop/core/src/desktop/js/parse/sql/flink/sqlParseSupport.js
+++ b/desktop/core/src/desktop/js/parse/sql/flink/sqlParseSupport.js
@@ -20,7 +20,8 @@ import {
   initSyntaxParser,
   identifierEquals,
   equalIgnoreCase,
-  SIMPLE_TABLE_REF_SUGGESTIONS
+  SIMPLE_TABLE_REF_SUGGESTIONS,
+  adjustForPartialBackticks
 } from 'parse/sql/sqlParseUtils';
 
 const initSqlParser = function (parser) {
@@ -643,15 +644,6 @@ const initSqlParser = function (parser) {
         parser.yy.result.suggestCommonTableExpressions = ctes;
       }
     }
-  };
-
-  parser.identifyPartials = function (beforeCursor, afterCursor) {
-    const beforeMatch = beforeCursor.match(/[0-9a-zA-Z_]*$/);
-    const afterMatch = afterCursor.match(/^[0-9a-zA-Z_]*(?:\((?:[^)]*\))?)?/);
-    return {
-      left: beforeMatch ? beforeMatch[0].length : 0,
-      right: afterMatch ? afterMatch[0].length : 0
-    };
   };
 
   const addCleanTablePrimary = function (tables, tablePrimary) {
@@ -1389,6 +1381,7 @@ const initSqlParser = function (parser) {
       linkTablePrimaries();
       parser.commitLocations();
       // Clean up and prioritize
+      adjustForPartialBackticks(parser);
       prioritizeSuggestions();
     } catch (err) {
       if (debug) {

--- a/desktop/core/src/desktop/js/parse/sql/flink/test/flinkAutocompleteParser.Select.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/flink/test/flinkAutocompleteParser.Select.test.js
@@ -232,8 +232,9 @@ describe('flinkAutocompleteParser.js SELECT statements', () => {
       afterCursor: '',
       expectedResult: {
         lowerCase: false,
-        suggestTables: {},
+        suggestTables: { appendBacktick: true },
         suggestDatabases: {
+          appendBacktick: true,
           appendDot: true
         }
       }

--- a/desktop/core/src/desktop/js/parse/sql/flink/test/flinkAutocompleteParser.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/flink/test/flinkAutocompleteParser.test.js
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { assertPartials } from 'parse/sql/sharedParserTests';
 import flinkAutocompleteParser from '../flinkAutocompleteParser';
 
 describe('flinkAutocompleteParser.js', () => {
@@ -277,94 +278,7 @@ describe('flinkAutocompleteParser.js', () => {
 
   describe('partial removal', () => {
     it('should identify part lengths', () => {
-      const limitChars = [
-        ' ',
-        '\n',
-        '\t',
-        '&',
-        '~',
-        '%',
-        '!',
-        '.',
-        ',',
-        '+',
-        '-',
-        '*',
-        '/',
-        '=',
-        '<',
-        '>',
-        ')',
-        '[',
-        ']',
-        ';'
-      ];
-
-      expect(flinkAutocompleteParser.identifyPartials('', '')).toEqual({ left: 0, right: 0 });
-      expect(flinkAutocompleteParser.identifyPartials('foo', '')).toEqual({ left: 3, right: 0 });
-      expect(flinkAutocompleteParser.identifyPartials(' foo', '')).toEqual({ left: 3, right: 0 });
-      expect(flinkAutocompleteParser.identifyPartials('asdf 1234', '')).toEqual({
-        left: 4,
-        right: 0
-      });
-
-      expect(flinkAutocompleteParser.identifyPartials('foo', 'bar')).toEqual({
-        left: 3,
-        right: 3
-      });
-
-      expect(flinkAutocompleteParser.identifyPartials('fo', 'o()')).toEqual({
-        left: 2,
-        right: 3
-      });
-
-      expect(flinkAutocompleteParser.identifyPartials('fo', 'o(')).toEqual({ left: 2, right: 2 });
-      expect(flinkAutocompleteParser.identifyPartials('fo', 'o(bla bla)')).toEqual({
-        left: 2,
-        right: 10
-      });
-
-      expect(flinkAutocompleteParser.identifyPartials('foo ', '')).toEqual({ left: 0, right: 0 });
-      expect(flinkAutocompleteParser.identifyPartials("foo '", "'")).toEqual({
-        left: 0,
-        right: 0
-      });
-
-      expect(flinkAutocompleteParser.identifyPartials('foo "', '"')).toEqual({
-        left: 0,
-        right: 0
-      });
-      limitChars.forEach(char => {
-        expect(flinkAutocompleteParser.identifyPartials('bar foo' + char, '')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(flinkAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo', '')).toEqual({
-          left: 6,
-          right: 0
-        });
-
-        expect(flinkAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo ', '')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(flinkAutocompleteParser.identifyPartials('', char + 'foo bar')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(flinkAutocompleteParser.identifyPartials('', 'foofoo' + char)).toEqual({
-          left: 0,
-          right: 6
-        });
-
-        expect(flinkAutocompleteParser.identifyPartials('', ' foofoo' + char)).toEqual({
-          left: 0,
-          right: 0
-        });
-      });
+      assertPartials(flinkAutocompleteParser);
     });
   });
 });

--- a/desktop/core/src/desktop/js/parse/sql/generic/sqlParseSupport.js
+++ b/desktop/core/src/desktop/js/parse/sql/generic/sqlParseSupport.js
@@ -20,7 +20,8 @@ import {
   initSyntaxParser,
   identifierEquals,
   equalIgnoreCase,
-  SIMPLE_TABLE_REF_SUGGESTIONS
+  SIMPLE_TABLE_REF_SUGGESTIONS,
+  adjustForPartialBackticks
 } from 'parse/sql/sqlParseUtils';
 
 const initSqlParser = function (parser) {
@@ -643,15 +644,6 @@ const initSqlParser = function (parser) {
         parser.yy.result.suggestCommonTableExpressions = ctes;
       }
     }
-  };
-
-  parser.identifyPartials = function (beforeCursor, afterCursor) {
-    const beforeMatch = beforeCursor.match(/[0-9a-zA-Z_]*$/);
-    const afterMatch = afterCursor.match(/^[0-9a-zA-Z_]*(?:\((?:[^)]*\))?)?/);
-    return {
-      left: beforeMatch ? beforeMatch[0].length : 0,
-      right: afterMatch ? afterMatch[0].length : 0
-    };
   };
 
   const addCleanTablePrimary = function (tables, tablePrimary) {
@@ -1389,6 +1381,7 @@ const initSqlParser = function (parser) {
       linkTablePrimaries();
       parser.commitLocations();
       // Clean up and prioritize
+      adjustForPartialBackticks(parser);
       prioritizeSuggestions();
     } catch (err) {
       if (debug) {

--- a/desktop/core/src/desktop/js/parse/sql/generic/test/genericAutocompleteParser.Select.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/generic/test/genericAutocompleteParser.Select.test.js
@@ -232,8 +232,9 @@ describe('genericAutocompleteParser.js SELECT statements', () => {
       afterCursor: '',
       expectedResult: {
         lowerCase: false,
-        suggestTables: {},
+        suggestTables: { appendBacktick: true },
         suggestDatabases: {
+          appendBacktick: true,
           appendDot: true
         }
       }

--- a/desktop/core/src/desktop/js/parse/sql/generic/test/genericAutocompleteParser.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/generic/test/genericAutocompleteParser.test.js
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { assertPartials } from 'parse/sql/sharedParserTests';
 import genericAutocompleteParser from '../genericAutocompleteParser';
 
 describe('genericAutocompleteParser.js', () => {
@@ -277,98 +278,7 @@ describe('genericAutocompleteParser.js', () => {
 
   describe('partial removal', () => {
     it('should identify part lengths', () => {
-      const limitChars = [
-        ' ',
-        '\n',
-        '\t',
-        '&',
-        '~',
-        '%',
-        '!',
-        '.',
-        ',',
-        '+',
-        '-',
-        '*',
-        '/',
-        '=',
-        '<',
-        '>',
-        ')',
-        '[',
-        ']',
-        ';'
-      ];
-
-      expect(genericAutocompleteParser.identifyPartials('', '')).toEqual({ left: 0, right: 0 });
-      expect(genericAutocompleteParser.identifyPartials('foo', '')).toEqual({ left: 3, right: 0 });
-      expect(genericAutocompleteParser.identifyPartials(' foo', '')).toEqual({ left: 3, right: 0 });
-      expect(genericAutocompleteParser.identifyPartials('asdf 1234', '')).toEqual({
-        left: 4,
-        right: 0
-      });
-
-      expect(genericAutocompleteParser.identifyPartials('foo', 'bar')).toEqual({
-        left: 3,
-        right: 3
-      });
-
-      expect(genericAutocompleteParser.identifyPartials('fo', 'o()')).toEqual({
-        left: 2,
-        right: 3
-      });
-
-      expect(genericAutocompleteParser.identifyPartials('fo', 'o(')).toEqual({ left: 2, right: 2 });
-      expect(genericAutocompleteParser.identifyPartials('fo', 'o(bla bla)')).toEqual({
-        left: 2,
-        right: 10
-      });
-
-      expect(genericAutocompleteParser.identifyPartials('foo ', '')).toEqual({ left: 0, right: 0 });
-      expect(genericAutocompleteParser.identifyPartials("foo '", "'")).toEqual({
-        left: 0,
-        right: 0
-      });
-
-      expect(genericAutocompleteParser.identifyPartials('foo "', '"')).toEqual({
-        left: 0,
-        right: 0
-      });
-      limitChars.forEach(char => {
-        expect(genericAutocompleteParser.identifyPartials('bar foo' + char, '')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(genericAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo', '')).toEqual(
-          {
-            left: 6,
-            right: 0
-          }
-        );
-
-        expect(
-          genericAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo ', '')
-        ).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(genericAutocompleteParser.identifyPartials('', char + 'foo bar')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(genericAutocompleteParser.identifyPartials('', 'foofoo' + char)).toEqual({
-          left: 0,
-          right: 6
-        });
-
-        expect(genericAutocompleteParser.identifyPartials('', ' foofoo' + char)).toEqual({
-          left: 0,
-          right: 0
-        });
-      });
+      assertPartials(genericAutocompleteParser);
     });
   });
 });

--- a/desktop/core/src/desktop/js/parse/sql/hive/sqlParseSupport.js
+++ b/desktop/core/src/desktop/js/parse/sql/hive/sqlParseSupport.js
@@ -21,7 +21,8 @@ import {
   initSyntaxParser,
   identifierEquals,
   equalIgnoreCase,
-  SIMPLE_TABLE_REF_SUGGESTIONS
+  SIMPLE_TABLE_REF_SUGGESTIONS,
+  adjustForPartialBackticks
 } from 'parse/sql/sqlParseUtils';
 
 const initSqlParser = function (parser) {
@@ -706,15 +707,6 @@ const initSqlParser = function (parser) {
         parser.yy.result.suggestCommonTableExpressions = ctes;
       }
     }
-  };
-
-  parser.identifyPartials = function (beforeCursor, afterCursor) {
-    const beforeMatch = beforeCursor.match(/[0-9a-zA-Z_]*$/);
-    const afterMatch = afterCursor.match(/^[0-9a-zA-Z_]*(?:\((?:[^)]*\))?)?/);
-    return {
-      left: beforeMatch ? beforeMatch[0].length : 0,
-      right: afterMatch ? afterMatch[0].length : 0
-    };
   };
 
   parser.expandLateralViews = function (lateralViews, originalIdentifierChain, columnSuggestion) {
@@ -1542,6 +1534,7 @@ const initSqlParser = function (parser) {
       linkTablePrimaries();
       parser.commitLocations();
       // Clean up and prioritize
+      adjustForPartialBackticks(parser);
       prioritizeSuggestions();
     } catch (err) {
       if (debug) {

--- a/desktop/core/src/desktop/js/parse/sql/hive/test/hiveAutocompleteParser.Select.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/hive/test/hiveAutocompleteParser.Select.test.js
@@ -179,8 +179,9 @@ describe('hiveAutocompleteParser.js SELECT statements', () => {
       afterCursor: '',
       expectedResult: {
         lowerCase: false,
-        suggestTables: {},
+        suggestTables: { appendBacktick: true },
         suggestDatabases: {
+          appendBacktick: true,
           appendDot: true
         }
       }

--- a/desktop/core/src/desktop/js/parse/sql/hive/test/hiveAutocompleteParser.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/hive/test/hiveAutocompleteParser.test.js
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { assertPartials } from 'parse/sql/sharedParserTests';
 import hiveAutocompleteParser from '../hiveAutocompleteParser';
 describe('hiveAutocompleteParser.js', () => {
   beforeAll(() => {
@@ -368,79 +369,7 @@ describe('hiveAutocompleteParser.js', () => {
 
   describe('partial removal', () => {
     it('should identify part lengths', () => {
-      const limitChars = [
-        ' ',
-        '\n',
-        '\t',
-        '&',
-        '~',
-        '%',
-        '!',
-        '.',
-        ',',
-        '+',
-        '-',
-        '*',
-        '/',
-        '=',
-        '<',
-        '>',
-        ')',
-        '[',
-        ']',
-        ';'
-      ];
-
-      expect(hiveAutocompleteParser.identifyPartials('', '')).toEqual({ left: 0, right: 0 });
-      expect(hiveAutocompleteParser.identifyPartials('foo', '')).toEqual({ left: 3, right: 0 });
-      expect(hiveAutocompleteParser.identifyPartials(' foo', '')).toEqual({ left: 3, right: 0 });
-      expect(hiveAutocompleteParser.identifyPartials('asdf 1234', '')).toEqual({
-        left: 4,
-        right: 0
-      });
-
-      expect(hiveAutocompleteParser.identifyPartials('foo', 'bar')).toEqual({ left: 3, right: 3 });
-      expect(hiveAutocompleteParser.identifyPartials('fo', 'o()')).toEqual({ left: 2, right: 3 });
-      expect(hiveAutocompleteParser.identifyPartials('fo', 'o(')).toEqual({ left: 2, right: 2 });
-      expect(hiveAutocompleteParser.identifyPartials('fo', 'o(bla bla)')).toEqual({
-        left: 2,
-        right: 10
-      });
-
-      expect(hiveAutocompleteParser.identifyPartials('foo ', '')).toEqual({ left: 0, right: 0 });
-      expect(hiveAutocompleteParser.identifyPartials("foo '", "'")).toEqual({ left: 0, right: 0 });
-      expect(hiveAutocompleteParser.identifyPartials('foo "', '"')).toEqual({ left: 0, right: 0 });
-      limitChars.forEach(char => {
-        expect(hiveAutocompleteParser.identifyPartials('bar foo' + char, '')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(hiveAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo', '')).toEqual({
-          left: 6,
-          right: 0
-        });
-
-        expect(hiveAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo ', '')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(hiveAutocompleteParser.identifyPartials('', char + 'foo bar')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(hiveAutocompleteParser.identifyPartials('', 'foofoo' + char)).toEqual({
-          left: 0,
-          right: 6
-        });
-
-        expect(hiveAutocompleteParser.identifyPartials('', ' foofoo' + char)).toEqual({
-          left: 0,
-          right: 0
-        });
-      });
+      assertPartials(hiveAutocompleteParser);
     });
   });
 

--- a/desktop/core/src/desktop/js/parse/sql/impala/sqlParseSupport.js
+++ b/desktop/core/src/desktop/js/parse/sql/impala/sqlParseSupport.js
@@ -20,7 +20,8 @@ import {
   initSharedAutocomplete,
   identifierEquals,
   equalIgnoreCase,
-  SIMPLE_TABLE_REF_SUGGESTIONS
+  SIMPLE_TABLE_REF_SUGGESTIONS,
+  adjustForPartialBackticks
 } from 'parse/sql/sqlParseUtils';
 
 const initSqlParser = function (parser) {
@@ -917,15 +918,6 @@ const initSqlParser = function (parser) {
     return expand(expandedChain[0].name, expandedChain);
   };
 
-  parser.identifyPartials = function (beforeCursor, afterCursor) {
-    const beforeMatch = beforeCursor.match(/[0-9a-zA-Z_]*$/);
-    const afterMatch = afterCursor.match(/^[0-9a-zA-Z_]*(?:\((?:[^)]*\))?)?/);
-    return {
-      left: beforeMatch ? beforeMatch[0].length : 0,
-      right: afterMatch ? afterMatch[0].length : 0
-    };
-  };
-
   const addCleanTablePrimary = function (tables, tablePrimary) {
     if (tablePrimary.alias) {
       tables.push({ alias: tablePrimary.alias, identifierChain: tablePrimary.identifierChain });
@@ -1669,6 +1661,7 @@ const initSqlParser = function (parser) {
       linkTablePrimaries();
       parser.commitLocations();
       // Clean up and prioritize
+      adjustForPartialBackticks(parser);
       prioritizeSuggestions();
     } catch (err) {
       if (debug) {

--- a/desktop/core/src/desktop/js/parse/sql/impala/test/impalaAutocompleteParser.Select.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/impala/test/impalaAutocompleteParser.Select.test.js
@@ -180,8 +180,9 @@ describe('impalaAutocompleteParser.js SELECT statements', () => {
       afterCursor: '',
       expectedResult: {
         lowerCase: false,
-        suggestTables: {},
+        suggestTables: { appendBacktick: true },
         suggestDatabases: {
+          appendBacktick: true,
           appendDot: true
         }
       }

--- a/desktop/core/src/desktop/js/parse/sql/impala/test/impalaAutocompleteParser.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/impala/test/impalaAutocompleteParser.test.js
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { assertPartials } from 'parse/sql/sharedParserTests';
 import impalaAutocompleteParser from '../impalaAutocompleteParser';
 describe('impalaAutocompleteParser.js', () => {
   beforeAll(() => {
@@ -407,92 +408,7 @@ describe('impalaAutocompleteParser.js', () => {
 
   describe('partial removal', () => {
     it('should identify part lengths', () => {
-      const limitChars = [
-        ' ',
-        '\n',
-        '\t',
-        '&',
-        '~',
-        '%',
-        '!',
-        '.',
-        ',',
-        '+',
-        '-',
-        '*',
-        '/',
-        '=',
-        '<',
-        '>',
-        ')',
-        '[',
-        ']',
-        ';'
-      ];
-
-      expect(impalaAutocompleteParser.identifyPartials('', '')).toEqual({ left: 0, right: 0 });
-      expect(impalaAutocompleteParser.identifyPartials('foo', '')).toEqual({ left: 3, right: 0 });
-      expect(impalaAutocompleteParser.identifyPartials(' foo', '')).toEqual({ left: 3, right: 0 });
-      expect(impalaAutocompleteParser.identifyPartials('asdf 1234', '')).toEqual({
-        left: 4,
-        right: 0
-      });
-
-      expect(impalaAutocompleteParser.identifyPartials('foo', 'bar')).toEqual({
-        left: 3,
-        right: 3
-      });
-
-      expect(impalaAutocompleteParser.identifyPartials('fo', 'o()')).toEqual({ left: 2, right: 3 });
-      expect(impalaAutocompleteParser.identifyPartials('fo', 'o(')).toEqual({ left: 2, right: 2 });
-      expect(impalaAutocompleteParser.identifyPartials('fo', 'o(bla bla)')).toEqual({
-        left: 2,
-        right: 10
-      });
-
-      expect(impalaAutocompleteParser.identifyPartials('foo ', '')).toEqual({ left: 0, right: 0 });
-      expect(impalaAutocompleteParser.identifyPartials("foo '", "'")).toEqual({
-        left: 0,
-        right: 0
-      });
-
-      expect(impalaAutocompleteParser.identifyPartials('foo "', '"')).toEqual({
-        left: 0,
-        right: 0
-      });
-      limitChars.forEach(char => {
-        expect(impalaAutocompleteParser.identifyPartials('bar foo' + char, '')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(impalaAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo', '')).toEqual({
-          left: 6,
-          right: 0
-        });
-
-        expect(impalaAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo ', '')).toEqual(
-          {
-            left: 0,
-            right: 0
-          }
-        );
-
-        expect(impalaAutocompleteParser.identifyPartials('', char + 'foo bar')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(impalaAutocompleteParser.identifyPartials('', 'foofoo' + char)).toEqual({
-          left: 0,
-          right: 6
-        });
-
-        expect(impalaAutocompleteParser.identifyPartials('', ' foofoo' + char)).toEqual({
-          left: 0,
-          right: 0
-        });
-      });
+      assertPartials(impalaAutocompleteParser);
     });
   });
 });

--- a/desktop/core/src/desktop/js/parse/sql/ksql/sqlParseSupport.js
+++ b/desktop/core/src/desktop/js/parse/sql/ksql/sqlParseSupport.js
@@ -20,7 +20,8 @@ import {
   initSyntaxParser,
   identifierEquals,
   equalIgnoreCase,
-  SIMPLE_TABLE_REF_SUGGESTIONS
+  SIMPLE_TABLE_REF_SUGGESTIONS,
+  adjustForPartialBackticks
 } from 'parse/sql/sqlParseUtils';
 
 const initSqlParser = function (parser) {
@@ -643,15 +644,6 @@ const initSqlParser = function (parser) {
         parser.yy.result.suggestCommonTableExpressions = ctes;
       }
     }
-  };
-
-  parser.identifyPartials = function (beforeCursor, afterCursor) {
-    const beforeMatch = beforeCursor.match(/[0-9a-zA-Z_]*$/);
-    const afterMatch = afterCursor.match(/^[0-9a-zA-Z_]*(?:\((?:[^)]*\))?)?/);
-    return {
-      left: beforeMatch ? beforeMatch[0].length : 0,
-      right: afterMatch ? afterMatch[0].length : 0
-    };
   };
 
   const addCleanTablePrimary = function (tables, tablePrimary) {
@@ -1363,6 +1355,7 @@ const initSqlParser = function (parser) {
       linkTablePrimaries();
       parser.commitLocations();
       // Clean up and prioritize
+      adjustForPartialBackticks(parser);
       prioritizeSuggestions();
     } catch (err) {
       if (debug) {

--- a/desktop/core/src/desktop/js/parse/sql/ksql/test/ksqlAutocompleteParser.Select.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/ksql/test/ksqlAutocompleteParser.Select.test.js
@@ -232,8 +232,9 @@ describe('ksqlAutocompleteParser.js SELECT statements', () => {
       afterCursor: '',
       expectedResult: {
         lowerCase: false,
-        suggestTables: {},
+        suggestTables: { appendBacktick: true },
         suggestDatabases: {
+          appendBacktick: true,
           appendDot: true
         }
       }

--- a/desktop/core/src/desktop/js/parse/sql/ksql/test/ksqlAutocompleteParser.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/ksql/test/ksqlAutocompleteParser.test.js
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { assertPartials } from 'parse/sql/sharedParserTests';
 import ksqlAutocompleteParser from '../ksqlAutocompleteParser';
 
 describe('ksqlAutocompleteParser.js', () => {
@@ -277,94 +278,7 @@ describe('ksqlAutocompleteParser.js', () => {
 
   describe('partial removal', () => {
     it('should identify part lengths', () => {
-      const limitChars = [
-        ' ',
-        '\n',
-        '\t',
-        '&',
-        '~',
-        '%',
-        '!',
-        '.',
-        ',',
-        '+',
-        '-',
-        '*',
-        '/',
-        '=',
-        '<',
-        '>',
-        ')',
-        '[',
-        ']',
-        ';'
-      ];
-
-      expect(ksqlAutocompleteParser.identifyPartials('', '')).toEqual({ left: 0, right: 0 });
-      expect(ksqlAutocompleteParser.identifyPartials('foo', '')).toEqual({ left: 3, right: 0 });
-      expect(ksqlAutocompleteParser.identifyPartials(' foo', '')).toEqual({ left: 3, right: 0 });
-      expect(ksqlAutocompleteParser.identifyPartials('asdf 1234', '')).toEqual({
-        left: 4,
-        right: 0
-      });
-
-      expect(ksqlAutocompleteParser.identifyPartials('foo', 'bar')).toEqual({
-        left: 3,
-        right: 3
-      });
-
-      expect(ksqlAutocompleteParser.identifyPartials('fo', 'o()')).toEqual({
-        left: 2,
-        right: 3
-      });
-
-      expect(ksqlAutocompleteParser.identifyPartials('fo', 'o(')).toEqual({ left: 2, right: 2 });
-      expect(ksqlAutocompleteParser.identifyPartials('fo', 'o(bla bla)')).toEqual({
-        left: 2,
-        right: 10
-      });
-
-      expect(ksqlAutocompleteParser.identifyPartials('foo ', '')).toEqual({ left: 0, right: 0 });
-      expect(ksqlAutocompleteParser.identifyPartials("foo '", "'")).toEqual({
-        left: 0,
-        right: 0
-      });
-
-      expect(ksqlAutocompleteParser.identifyPartials('foo "', '"')).toEqual({
-        left: 0,
-        right: 0
-      });
-      limitChars.forEach(char => {
-        expect(ksqlAutocompleteParser.identifyPartials('bar foo' + char, '')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(ksqlAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo', '')).toEqual({
-          left: 6,
-          right: 0
-        });
-
-        expect(ksqlAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo ', '')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(ksqlAutocompleteParser.identifyPartials('', char + 'foo bar')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(ksqlAutocompleteParser.identifyPartials('', 'foofoo' + char)).toEqual({
-          left: 0,
-          right: 6
-        });
-
-        expect(ksqlAutocompleteParser.identifyPartials('', ' foofoo' + char)).toEqual({
-          left: 0,
-          right: 0
-        });
-      });
+      assertPartials(ksqlAutocompleteParser);
     });
   });
 });

--- a/desktop/core/src/desktop/js/parse/sql/phoenix/sqlParseSupport.js
+++ b/desktop/core/src/desktop/js/parse/sql/phoenix/sqlParseSupport.js
@@ -20,7 +20,8 @@ import {
   initSyntaxParser,
   identifierEquals,
   equalIgnoreCase,
-  SIMPLE_TABLE_REF_SUGGESTIONS
+  SIMPLE_TABLE_REF_SUGGESTIONS,
+  adjustForPartialBackticks
 } from 'parse/sql/sqlParseUtils';
 
 const initSqlParser = function (parser) {
@@ -643,15 +644,6 @@ const initSqlParser = function (parser) {
         parser.yy.result.suggestCommonTableExpressions = ctes;
       }
     }
-  };
-
-  parser.identifyPartials = function (beforeCursor, afterCursor) {
-    const beforeMatch = beforeCursor.match(/[0-9a-zA-Z_]*$/);
-    const afterMatch = afterCursor.match(/^[0-9a-zA-Z_]*(?:\((?:[^)]*\))?)?/);
-    return {
-      left: beforeMatch ? beforeMatch[0].length : 0,
-      right: afterMatch ? afterMatch[0].length : 0
-    };
   };
 
   const addCleanTablePrimary = function (tables, tablePrimary) {
@@ -1368,6 +1360,7 @@ const initSqlParser = function (parser) {
       linkTablePrimaries();
       parser.commitLocations();
       // Clean up and prioritize
+      adjustForPartialBackticks(parser);
       prioritizeSuggestions();
     } catch (err) {
       if (debug) {

--- a/desktop/core/src/desktop/js/parse/sql/phoenix/test/phoenixAutocompleteParser.Select.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/phoenix/test/phoenixAutocompleteParser.Select.test.js
@@ -232,8 +232,9 @@ describe('phoenixAutocompleteParser.js SELECT statements', () => {
       afterCursor: '',
       expectedResult: {
         lowerCase: false,
-        suggestTables: {},
+        suggestTables: { appendBacktick: true },
         suggestDatabases: {
+          appendBacktick: true,
           appendDot: true
         }
       }

--- a/desktop/core/src/desktop/js/parse/sql/phoenix/test/phoenixAutocompleteParser.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/phoenix/test/phoenixAutocompleteParser.test.js
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { assertPartials } from 'parse/sql/sharedParserTests';
 import phoenixAutocompleteParser from '../phoenixAutocompleteParser';
 
 describe('phoenixAutocompleteParser.js', () => {
@@ -277,98 +278,7 @@ describe('phoenixAutocompleteParser.js', () => {
 
   describe('partial removal', () => {
     it('should identify part lengths', () => {
-      const limitChars = [
-        ' ',
-        '\n',
-        '\t',
-        '&',
-        '~',
-        '%',
-        '!',
-        '.',
-        ',',
-        '+',
-        '-',
-        '*',
-        '/',
-        '=',
-        '<',
-        '>',
-        ')',
-        '[',
-        ']',
-        ';'
-      ];
-
-      expect(phoenixAutocompleteParser.identifyPartials('', '')).toEqual({ left: 0, right: 0 });
-      expect(phoenixAutocompleteParser.identifyPartials('foo', '')).toEqual({ left: 3, right: 0 });
-      expect(phoenixAutocompleteParser.identifyPartials(' foo', '')).toEqual({ left: 3, right: 0 });
-      expect(phoenixAutocompleteParser.identifyPartials('asdf 1234', '')).toEqual({
-        left: 4,
-        right: 0
-      });
-
-      expect(phoenixAutocompleteParser.identifyPartials('foo', 'bar')).toEqual({
-        left: 3,
-        right: 3
-      });
-
-      expect(phoenixAutocompleteParser.identifyPartials('fo', 'o()')).toEqual({
-        left: 2,
-        right: 3
-      });
-
-      expect(phoenixAutocompleteParser.identifyPartials('fo', 'o(')).toEqual({ left: 2, right: 2 });
-      expect(phoenixAutocompleteParser.identifyPartials('fo', 'o(bla bla)')).toEqual({
-        left: 2,
-        right: 10
-      });
-
-      expect(phoenixAutocompleteParser.identifyPartials('foo ', '')).toEqual({ left: 0, right: 0 });
-      expect(phoenixAutocompleteParser.identifyPartials("foo '", "'")).toEqual({
-        left: 0,
-        right: 0
-      });
-
-      expect(phoenixAutocompleteParser.identifyPartials('foo "', '"')).toEqual({
-        left: 0,
-        right: 0
-      });
-      limitChars.forEach(char => {
-        expect(phoenixAutocompleteParser.identifyPartials('bar foo' + char, '')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(phoenixAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo', '')).toEqual(
-          {
-            left: 6,
-            right: 0
-          }
-        );
-
-        expect(
-          phoenixAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo ', '')
-        ).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(phoenixAutocompleteParser.identifyPartials('', char + 'foo bar')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(phoenixAutocompleteParser.identifyPartials('', 'foofoo' + char)).toEqual({
-          left: 0,
-          right: 6
-        });
-
-        expect(phoenixAutocompleteParser.identifyPartials('', ' foofoo' + char)).toEqual({
-          left: 0,
-          right: 0
-        });
-      });
+      assertPartials(phoenixAutocompleteParser);
     });
   });
 });

--- a/desktop/core/src/desktop/js/parse/sql/presto/sqlParseSupport.js
+++ b/desktop/core/src/desktop/js/parse/sql/presto/sqlParseSupport.js
@@ -20,7 +20,8 @@ import {
   initSyntaxParser,
   identifierEquals,
   equalIgnoreCase,
-  SIMPLE_TABLE_REF_SUGGESTIONS
+  SIMPLE_TABLE_REF_SUGGESTIONS,
+  adjustForPartialBackticks
 } from 'parse/sql/sqlParseUtils';
 
 const initSqlParser = function (parser) {
@@ -677,15 +678,6 @@ const initSqlParser = function (parser) {
         parser.yy.result.suggestCommonTableExpressions = ctes;
       }
     }
-  };
-
-  parser.identifyPartials = function (beforeCursor, afterCursor) {
-    const beforeMatch = beforeCursor.match(/[0-9a-zA-Z_]*$/);
-    const afterMatch = afterCursor.match(/^[0-9a-zA-Z_]*(?:\((?:[^)]*\))?)?/);
-    return {
-      left: beforeMatch ? beforeMatch[0].length : 0,
-      right: afterMatch ? afterMatch[0].length : 0
-    };
   };
 
   parser.expandLateralViews = function (lateralViews, originalIdentifierChain, columnSuggestion) {
@@ -1532,6 +1524,7 @@ const initSqlParser = function (parser) {
       linkTablePrimaries();
       parser.commitLocations();
       // Clean up and prioritize
+      adjustForPartialBackticks(parser);
       prioritizeSuggestions();
     } catch (err) {
       if (debug) {

--- a/desktop/core/src/desktop/js/parse/sql/presto/test/prestoAutocompleteParser.Select.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/presto/test/prestoAutocompleteParser.Select.test.js
@@ -179,8 +179,9 @@ describe('prestoAutocompleteParser.js SELECT statements', () => {
       afterCursor: '',
       expectedResult: {
         lowerCase: false,
-        suggestTables: {},
+        suggestTables: { appendBacktick: true },
         suggestDatabases: {
+          appendBacktick: true,
           appendDot: true
         }
       }

--- a/desktop/core/src/desktop/js/parse/sql/presto/test/prestoAutocompleteParser.test.js
+++ b/desktop/core/src/desktop/js/parse/sql/presto/test/prestoAutocompleteParser.test.js
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { assertPartials } from 'parse/sql/sharedParserTests';
 import prestoAutocompleteParser from '../prestoAutocompleteParser';
 describe('prestoAutocompleteParser.js', () => {
   beforeAll(() => {
@@ -430,93 +431,7 @@ describe('prestoAutocompleteParser.js', () => {
 
   describe('partial removal', () => {
     it('should identify part lengths', () => {
-      const limitChars = [
-        ' ',
-        '\n',
-        '\t',
-        '&',
-        '~',
-        '%',
-        '!',
-        '.',
-        ',',
-        '+',
-        '-',
-        '*',
-        '/',
-        '=',
-        '<',
-        '>',
-        ')',
-        '[',
-        ']',
-        ';'
-      ];
-
-      expect(prestoAutocompleteParser.identifyPartials('', '')).toEqual({ left: 0, right: 0 });
-      expect(prestoAutocompleteParser.identifyPartials('foo', '')).toEqual({ left: 3, right: 0 });
-      expect(prestoAutocompleteParser.identifyPartials(' foo', '')).toEqual({ left: 3, right: 0 });
-      expect(prestoAutocompleteParser.identifyPartials('asdf 1234', '')).toEqual({
-        left: 4,
-        right: 0
-      });
-
-      expect(prestoAutocompleteParser.identifyPartials('foo', 'bar')).toEqual({
-        left: 3,
-        right: 3
-      });
-
-      expect(prestoAutocompleteParser.identifyPartials('fo', 'o()')).toEqual({ left: 2, right: 3 });
-      expect(prestoAutocompleteParser.identifyPartials('fo', 'o(')).toEqual({ left: 2, right: 2 });
-      expect(prestoAutocompleteParser.identifyPartials('fo', 'o(bla bla)')).toEqual({
-        left: 2,
-        right: 10
-      });
-
-      expect(prestoAutocompleteParser.identifyPartials('foo ', '')).toEqual({ left: 0, right: 0 });
-      expect(prestoAutocompleteParser.identifyPartials("foo '", "'")).toEqual({
-        left: 0,
-        right: 0
-      });
-
-      expect(prestoAutocompleteParser.identifyPartials('foo "', '"')).toEqual({
-        left: 0,
-        right: 0
-      });
-
-      limitChars.forEach(char => {
-        expect(prestoAutocompleteParser.identifyPartials('bar foo' + char, '')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(prestoAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo', '')).toEqual({
-          left: 6,
-          right: 0
-        });
-
-        expect(prestoAutocompleteParser.identifyPartials('bar foo' + char + 'foofoo ', '')).toEqual(
-          {
-            left: 0,
-            right: 0
-          }
-        );
-
-        expect(prestoAutocompleteParser.identifyPartials('', char + 'foo bar')).toEqual({
-          left: 0,
-          right: 0
-        });
-
-        expect(prestoAutocompleteParser.identifyPartials('', 'foofoo' + char)).toEqual({
-          left: 0,
-          right: 6
-        });
-
-        expect(prestoAutocompleteParser.identifyPartials('', ' foofoo' + char)).toEqual({
-          left: 0,
-          right: 0
-        });
-      });
+      assertPartials(prestoAutocompleteParser);
     });
   });
 

--- a/desktop/core/src/desktop/js/parse/sql/sharedParserTests.ts
+++ b/desktop/core/src/desktop/js/parse/sql/sharedParserTests.ts
@@ -1,0 +1,146 @@
+interface CommonParser {
+  identifyPartials(
+    beforeCursor: string,
+    afterCursor: string
+  ): { backtickAfter: boolean; backtickBefore: boolean; left: number; right: number };
+}
+
+export const assertPartials = (parser: CommonParser): void => {
+  const limitChars = [
+    ' ',
+    '\n',
+    '\t',
+    '&',
+    '~',
+    '%',
+    '!',
+    '.',
+    ',',
+    '+',
+    '-',
+    '*',
+    '/',
+    '=',
+    '<',
+    '>',
+    ')',
+    '[',
+    ']',
+    ';'
+  ];
+
+  expect(parser.identifyPartials('', '')).toEqual({
+    backtickAfter: false,
+    backtickBefore: false,
+    left: 0,
+    right: 0
+  });
+  expect(parser.identifyPartials('foo', '')).toEqual({
+    backtickAfter: false,
+    backtickBefore: false,
+    left: 3,
+    right: 0
+  });
+  expect(parser.identifyPartials(' foo', '')).toEqual({
+    backtickAfter: false,
+    backtickBefore: false,
+    left: 3,
+    right: 0
+  });
+  expect(parser.identifyPartials('asdf 1234', '')).toEqual({
+    backtickAfter: false,
+    backtickBefore: false,
+    left: 4,
+    right: 0
+  });
+
+  expect(parser.identifyPartials('foo', 'bar')).toEqual({
+    backtickAfter: false,
+    backtickBefore: false,
+    left: 3,
+    right: 3
+  });
+
+  expect(parser.identifyPartials('fo', 'o()')).toEqual({
+    backtickAfter: false,
+    backtickBefore: false,
+    left: 2,
+    right: 3
+  });
+
+  expect(parser.identifyPartials('fo', 'o(')).toEqual({
+    backtickAfter: false,
+    backtickBefore: false,
+    left: 2,
+    right: 2
+  });
+  expect(parser.identifyPartials('fo', 'o(bla bla)')).toEqual({
+    backtickAfter: false,
+    backtickBefore: false,
+    left: 2,
+    right: 10
+  });
+
+  expect(parser.identifyPartials('foo ', '')).toEqual({
+    backtickAfter: false,
+    backtickBefore: false,
+    left: 0,
+    right: 0
+  });
+  expect(parser.identifyPartials("foo '", "'")).toEqual({
+    backtickAfter: false,
+    backtickBefore: false,
+    left: 0,
+    right: 0
+  });
+
+  expect(parser.identifyPartials('foo "', '"')).toEqual({
+    backtickAfter: false,
+    backtickBefore: false,
+    left: 0,
+    right: 0
+  });
+  limitChars.forEach(char => {
+    expect(parser.identifyPartials('bar foo' + char, '')).toEqual({
+      backtickAfter: false,
+      backtickBefore: false,
+      left: 0,
+      right: 0
+    });
+
+    expect(parser.identifyPartials('bar foo' + char + 'foofoo', '')).toEqual({
+      backtickAfter: false,
+      backtickBefore: false,
+      left: 6,
+      right: 0
+    });
+
+    expect(parser.identifyPartials('bar foo' + char + 'foofoo ', '')).toEqual({
+      backtickAfter: false,
+      backtickBefore: false,
+      left: 0,
+      right: 0
+    });
+
+    expect(parser.identifyPartials('', char + 'foo bar')).toEqual({
+      backtickAfter: false,
+      backtickBefore: false,
+      left: 0,
+      right: 0
+    });
+
+    expect(parser.identifyPartials('', 'foofoo' + char)).toEqual({
+      backtickAfter: false,
+      backtickBefore: false,
+      left: 0,
+      right: 6
+    });
+
+    expect(parser.identifyPartials('', ' foofoo' + char)).toEqual({
+      backtickAfter: false,
+      backtickBefore: false,
+      left: 0,
+      right: 0
+    });
+  });
+};

--- a/desktop/core/src/desktop/js/parse/types.ts
+++ b/desktop/core/src/desktop/js/parse/types.ts
@@ -119,6 +119,7 @@ export interface AutocompleteParseResult {
   };
   suggestColumnAliases?: ColumnAliasDetails[];
   suggestColumns?: {
+    appendBacktick?: boolean;
     identifierChain?: IdentifierChainEntry[];
     source?: string;
     tables: ParsedTable[];
@@ -126,11 +127,13 @@ export interface AutocompleteParseResult {
     udfRef?: string;
   };
   suggestCommonTableExpressions?: {
+    appendBacktick?: boolean;
     name: string;
     prependFrom: boolean;
     prependQuestionMark: boolean;
   }[];
   suggestDatabases?: {
+    appendBacktick?: boolean;
     appendDot?: boolean;
     prependFrom?: boolean;
     prependQuestionMark?: boolean;
@@ -167,6 +170,7 @@ export interface AutocompleteParseResult {
   suggestOrderBys?: CommonPopularSuggestion;
   suggestSetOptions?: boolean;
   suggestTables?: {
+    appendBacktick?: boolean;
     identifierChain?: IdentifierChainEntry[];
     onlyTables?: boolean;
     onlyViews?: boolean;

--- a/desktop/core/src/desktop/js/sql/autocompleteResults.js
+++ b/desktop/core/src/desktop/js/sql/autocompleteResults.js
@@ -852,7 +852,12 @@ class AutocompleteResults {
           databaseSuggestions.push({
             value:
               prefix +
-              (await sqlUtils.backTickIfNeeded(this.snippet.connector(), dbEntry.name)) +
+              (await sqlUtils.backTickIfNeeded(
+                this.snippet.connector(),
+                dbEntry.name,
+                undefined,
+                suggestDatabases.appendBacktick
+              )) +
               (suggestDatabases.appendDot ? '.' : ''),
             filterValue: dbEntry.name,
             meta: META_I18n.database,
@@ -920,7 +925,13 @@ class AutocompleteResults {
           }
           tableSuggestions.push({
             value:
-              prefix + (await sqlUtils.backTickIfNeeded(this.snippet.connector(), tableEntry.name)),
+              prefix +
+              (await sqlUtils.backTickIfNeeded(
+                this.snippet.connector(),
+                tableEntry.name,
+                undefined,
+                suggestTables.appendBacktick
+              )),
             filterValue: tableEntry.name,
             tableName: tableEntry.name,
             meta: META_I18n[tableEntry.getType().toLowerCase()],
@@ -1042,7 +1053,12 @@ class AutocompleteResults {
         typeof column.type !== 'undefined' && column.type !== 'COLREF' ? column.type : 'T';
       if (typeof column.alias !== 'undefined') {
         columnSuggestions.push({
-          value: await sqlUtils.backTickIfNeeded(this.snippet.connector(), column.alias),
+          value: await sqlUtils.backTickIfNeeded(
+            this.snippet.connector(),
+            column.alias,
+            undefined,
+            this.parseResult.suggestColumns?.appendBacktick
+          ),
           filterValue: column.alias,
           meta: type,
           category: CATEGORIES.COLUMN,
@@ -1058,7 +1074,9 @@ class AutocompleteResults {
         columnSuggestions.push({
           value: await sqlUtils.backTickIfNeeded(
             this.snippet.connector(),
-            column.identifierChain[column.identifierChain.length - 1].name
+            column.identifierChain[column.identifierChain.length - 1].name,
+            undefined,
+            this.parseResult.suggestColumns?.appendBacktick
           ),
           filterValue: column.identifierChain[column.identifierChain.length - 1].name,
           meta: type,
@@ -1086,7 +1104,12 @@ class AutocompleteResults {
             typeof column.type !== 'undefined' && column.type !== 'COLREF' ? column.type : 'T';
           if (column.alias) {
             columnSuggestions.push({
-              value: await sqlUtils.backTickIfNeeded(connector, column.alias),
+              value: await sqlUtils.backTickIfNeeded(
+                connector,
+                column.alias,
+                undefined,
+                this.parseResult.suggestColumns?.appendBacktick
+              ),
               filterValue: column.alias,
               meta: type,
               category: CATEGORIES.COLUMN,
@@ -1098,7 +1121,9 @@ class AutocompleteResults {
             columnSuggestions.push({
               value: await sqlUtils.backTickIfNeeded(
                 connector,
-                column.identifierChain[column.identifierChain.length - 1].name
+                column.identifierChain[column.identifierChain.length - 1].name,
+                undefined,
+                this.parseResult.suggestColumns?.appendBacktick
               ),
               filterValue: column.identifierChain[column.identifierChain.length - 1].name,
               meta: type,
@@ -1162,7 +1187,12 @@ class AutocompleteResults {
         });
 
         for (const childEntry of childEntries) {
-          let name = await sqlUtils.backTickIfNeeded(this.snippet.connector(), childEntry.name);
+          let name = await sqlUtils.backTickIfNeeded(
+            this.snippet.connector(),
+            childEntry.name,
+            undefined,
+            this.parseResult.suggestColumns?.appendBacktick
+          );
           if (this.dialect() === DIALECT.hive && (childEntry.isArray() || childEntry.isMap())) {
             name += '[]';
           }

--- a/desktop/core/src/desktop/js/sql/sqlUtils.ts
+++ b/desktop/core/src/desktop/js/sql/sqlUtils.ts
@@ -264,8 +264,12 @@ export default {
   backTickIfNeeded: async (
     connector: Connector,
     identifier: string,
-    sqlReferenceProvider?: SqlReferenceProvider
+    sqlReferenceProvider?: SqlReferenceProvider,
+    forceAppendBacktick?: boolean
   ): Promise<string> => {
+    if (forceAppendBacktick) {
+      return identifier + '`';
+    }
     const quoteChar =
       (connector.dialect_properties && connector.dialect_properties.sql_identifier_quote) || '`';
     if (identifier.indexOf(quoteChar) === 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gethue",
-  "version": "4.9.11",
+  "version": "4.9.12",
   "description": "Hue is an Open source SQL Query Editor for Databases/Warehouses",
   "keywords": [
     "Query Editor",


### PR DESCRIPTION
Still quite some test duplication for the parsers, will see for cleaning that up later.

Note that this only applies to started identifiers, so it won't apply to parsers that use " instead of ` as the user has to have typed the quote char to start with.

Resolves #2146, resolves #2147