### PR TITLE
[core] Remove duplicated line that cause build issue

### DIFF
--- a/tools/app_reg/registry.py
+++ b/tools/app_reg/registry.py
@@ -19,7 +19,6 @@
 Registry for the applications
 """
 
-from builtins import object
 import glob
 import logging
 import os


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove the duplicated line 
  ```from builtins import object```
because there is another one below
  ```
if sys.version_info[0] > 2:
  from builtins import object
```

## How was this patch tested?

Run canary build and passed this error

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
