### PR TITLE
[Django upgrade] RemovedInDjango40Warning: request.is_ajax() is deprecated in Django3.1

### DIFF
--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -258,7 +258,7 @@ def view(request, path):
       return display(request, path)
   except S3FileSystemException as e:
     msg = _("S3 filesystem exception.")
-    if request.is_ajax():
+    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
       exception = {
         'error': smart_str(e)
       }
@@ -271,7 +271,7 @@ def view(request, path):
     if "Connection refused" in str(e):
       msg += _(" The HDFS REST service is not available. ")
 
-    if request.is_ajax():
+    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
       exception = {
         'error': msg
       }
@@ -341,7 +341,7 @@ def edit(request, path, form=None):
       breadcrumbs=parse_breadcrumbs(path),
       is_embeddable=request.GET.get('is_embeddable', False),
       show_download_button=SHOW_DOWNLOAD_BUTTON.get())
-  if not request.is_ajax():
+  if not request.headers.get('x-requested-with') == 'XMLHttpRequest':
     data['stats'] = stats;
     data['form'] = form;
   return render("edit.mako", request, data)
@@ -685,7 +685,7 @@ def display(request, path):
     raise PopupException(_("Not a file: '%(path)s'") % {'path': path})
 
   # display inline files just if it's not an ajax request
-  if not request.is_ajax():
+  if not request.headers.get('x-requested-with') == 'XMLHttpRequest':
     if _can_inline_display(path):
       return redirect(reverse('filebrowser:filebrowser_views_download', args=[path]) + '?disposition=inline')
 
@@ -1196,7 +1196,7 @@ def generic_op(form_class, request, op, parameter_names, piggyback=None, templat
         ret["result_error"] = True
 
       ret['user'] = request.user
-      if request.is_ajax():
+      if request.headers.get('x-requested-with') == 'XMLHttpRequest':
         return HttpResponse()
       else:
         return render(template, request, ret)

--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -58,6 +58,7 @@ from desktop.lib.i18n import smart_str
 from desktop.lib.paths import SAFE_CHARACTERS_URI, SAFE_CHARACTERS_URI_COMPONENTS
 from desktop.lib.tasks.compress_files.compress_utils import compress_files_in_hdfs
 from desktop.lib.tasks.extract_archive.extract_utils import extract_archive_in_hdfs
+from desktop.lib.view_util import is_ajax
 from desktop.views import serve_403_error
 from hadoop.core_site import get_trash_interval
 from hadoop.fs.hadoopfs import Hdfs
@@ -258,7 +259,7 @@ def view(request, path):
       return display(request, path)
   except S3FileSystemException as e:
     msg = _("S3 filesystem exception.")
-    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
+    if is_ajax(request):
       exception = {
         'error': smart_str(e)
       }
@@ -271,7 +272,7 @@ def view(request, path):
     if "Connection refused" in str(e):
       msg += _(" The HDFS REST service is not available. ")
 
-    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
+    if is_ajax(request):
       exception = {
         'error': msg
       }
@@ -341,9 +342,9 @@ def edit(request, path, form=None):
       breadcrumbs=parse_breadcrumbs(path),
       is_embeddable=request.GET.get('is_embeddable', False),
       show_download_button=SHOW_DOWNLOAD_BUTTON.get())
-  if not request.headers.get('x-requested-with') == 'XMLHttpRequest':
-    data['stats'] = stats;
-    data['form'] = form;
+  if not is_ajax(request):
+    data['stats'] = stats
+    data['form'] = form
   return render("edit.mako", request, data)
 
 def save_file(request):
@@ -685,7 +686,7 @@ def display(request, path):
     raise PopupException(_("Not a file: '%(path)s'") % {'path': path})
 
   # display inline files just if it's not an ajax request
-  if not request.headers.get('x-requested-with') == 'XMLHttpRequest':
+  if not is_ajax(request):
     if _can_inline_display(path):
       return redirect(reverse('filebrowser:filebrowser_views_download', args=[path]) + '?disposition=inline')
 
@@ -1196,7 +1197,7 @@ def generic_op(form_class, request, op, parameter_names, piggyback=None, templat
         ret["result_error"] = True
 
       ret['user'] = request.user
-      if request.headers.get('x-requested-with') == 'XMLHttpRequest':
+      if is_ajax(request):
         return HttpResponse()
       else:
         return render(template, request, ret)

--- a/apps/jobsub/src/jobsub/views.py
+++ b/apps/jobsub/src/jobsub/views.py
@@ -102,7 +102,7 @@ def list_designs(request):
   owner = request.GET.get('owner', '')
   name = request.GET.get('name', '')
 
-  if request.is_ajax():
+  if request.headers.get('x-requested-with') == 'XMLHttpRequest':
     return render_json({
       'designs': _list_designs(request, owner, name)
     }, js_safe=True)

--- a/apps/jobsub/src/jobsub/views.py
+++ b/apps/jobsub/src/jobsub/views.py
@@ -34,6 +34,7 @@ from desktop import appmanager
 from desktop.lib.django_util import render, render_json
 from desktop.lib.exceptions import StructuredException
 from desktop.lib.exceptions_renderable import PopupException
+from desktop.lib.view_util import is_ajax
 from desktop.log.access import access_warn
 from desktop.models import Document
 
@@ -102,7 +103,7 @@ def list_designs(request):
   owner = request.GET.get('owner', '')
   name = request.GET.get('name', '')
 
-  if request.headers.get('x-requested-with') == 'XMLHttpRequest':
+  if is_ajax(request):
     return render_json({
       'designs': _list_designs(request, owner, name)
     }, js_safe=True)

--- a/desktop/core/src/desktop/lib/metrics/views.py
+++ b/desktop/core/src/desktop/lib/metrics/views.py
@@ -41,7 +41,7 @@ def index(request):
       'metric': global_registry().dump_metrics(),
   }
 
-  if request.is_ajax() or request.GET.get("format") == "json":
+  if request.headers.get('x-requested-with') == 'XMLHttpRequest' or request.GET.get("format") == "json":
     return JsonResponse(rep, json_dumps_params={'indent': indent})
   else:
     return render(

--- a/desktop/core/src/desktop/lib/metrics/views.py
+++ b/desktop/core/src/desktop/lib/metrics/views.py
@@ -23,6 +23,7 @@ from django.views.decorators.http import require_GET
 
 from desktop.lib.django_util import JsonResponse, login_notrequired, render
 from desktop.lib.metrics.registry import global_registry
+from desktop.lib.view_util import is_ajax
 
 
 LOG = logging.getLogger(__name__)
@@ -41,7 +42,7 @@ def index(request):
       'metric': global_registry().dump_metrics(),
   }
 
-  if request.headers.get('x-requested-with') == 'XMLHttpRequest' or request.GET.get("format") == "json":
+  if is_ajax(request) or request.GET.get("format") == "json":
     return JsonResponse(rep, json_dumps_params={'indent': indent})
   else:
     return render(

--- a/desktop/core/src/desktop/lib/vcs/apis/github_api.py
+++ b/desktop/core/src/desktop/lib/vcs/apis/github_api.py
@@ -25,6 +25,7 @@ from desktop.lib.django_util import JsonResponse
 
 from desktop.lib.vcs.github_client import GithubClient
 from desktop.lib.vcs.apis.base_api import Api
+from desktop.lib.view_util import is_ajax
 
 if sys.version_info[0] > 2:
   from django.utils.translation import gettext as _
@@ -75,7 +76,7 @@ class GithubApi(Api):
         'status': -1,
         'auth_url':auth_url
       }
-      if request.headers.get('x-requested-with') == 'XMLHttpRequest':
+      if is_ajax(request):
         return JsonResponse(response)
 
       return HttpResponseRedirect(auth_url)

--- a/desktop/core/src/desktop/lib/vcs/apis/github_api.py
+++ b/desktop/core/src/desktop/lib/vcs/apis/github_api.py
@@ -75,7 +75,7 @@ class GithubApi(Api):
         'status': -1,
         'auth_url':auth_url
       }
-      if (request.is_ajax()):
+      if request.headers.get('x-requested-with') == 'XMLHttpRequest':
         return JsonResponse(response)
 
       return HttpResponseRedirect(auth_url)

--- a/desktop/core/src/desktop/lib/view_util.py
+++ b/desktop/core/src/desktop/lib/view_util.py
@@ -20,6 +20,7 @@ from __future__ import division
 import datetime
 import logging
 import math
+import sys
 
 from django.urls import reverse
 
@@ -88,6 +89,14 @@ def format_duration_in_millis(duration=0):
     output.append("%dm" % minutes)
   output.append("%ds" % seconds)
   return ":".join(output)
+
+def is_ajax(request):
+  if sys.version_info[0] > 2:
+    _is_ajax = request.headers.get('x-requested-with') == 'XMLHttpRequest'
+  else:
+    _is_ajax = request.is_ajax()
+  
+  return _is_ajax
 
 def location_to_url(location, strict=True, is_embeddable=False):
   """

--- a/desktop/core/src/desktop/middleware.py
+++ b/desktop/core/src/desktop/middleware.py
@@ -59,6 +59,7 @@ from desktop.lib import apputil, i18n, fsmanager
 from desktop.lib.django_util import JsonResponse, render, render_json
 from desktop.lib.exceptions import StructuredException
 from desktop.lib.exceptions_renderable import PopupException
+from desktop.lib.view_util import is_ajax
 from desktop.log import get_audit_logger
 from desktop.log.access import access_log, log_page_hit, access_warn
 
@@ -93,7 +94,7 @@ class AjaxMiddleware(MiddlewareMixin):
   GET parameters.
   """
   def process_request(self, request):
-    request.ajax = request.headers.get('x-requested-with') == 'XMLHttpRequest' or request.GET.get("format", "") == "json"
+    request.ajax = is_ajax(request) or request.GET.get("format", "") == "json"
     return None
 
 
@@ -568,7 +569,7 @@ class HtmlValidationMiddleware(MiddlewareMixin):
     return res
 
   def _is_html(self, request, response):
-    return not request.headers.get('x-requested-with') == 'XMLHttpRequest' and \
+    return not is_ajax(request) and \
         'html' in response['Content-Type'] and \
         200 <= response.status_code < 300
 

--- a/desktop/core/src/desktop/middleware.py
+++ b/desktop/core/src/desktop/middleware.py
@@ -93,7 +93,7 @@ class AjaxMiddleware(MiddlewareMixin):
   GET parameters.
   """
   def process_request(self, request):
-    request.ajax = request.is_ajax() or request.GET.get("format", "") == "json"
+    request.ajax = request.headers.get('x-requested-with') == 'XMLHttpRequest' or request.GET.get("format", "") == "json"
     return None
 
 
@@ -568,7 +568,7 @@ class HtmlValidationMiddleware(MiddlewareMixin):
     return res
 
   def _is_html(self, request, response):
-    return not request.is_ajax() and \
+    return not request.headers.get('x-requested-with') == 'XMLHttpRequest' and \
         'html' in response['Content-Type'] and \
         200 <= response.status_code < 300
 

--- a/desktop/core/src/desktop/views.py
+++ b/desktop/core/src/desktop/views.py
@@ -347,7 +347,7 @@ def threads(request):
   out = string_io()
   dump_traceback(file=out)
 
-  if request.is_ajax():
+  if request.headers.get('x-requested-with') == 'XMLHttpRequest':
     return HttpResponse(out.getvalue(), content_type="text/plain")
   else:
     return render("threads.mako", request, {'text': out.getvalue(), 'is_embeddable': request.GET.get('is_embeddable', False)})
@@ -458,7 +458,7 @@ def serve_500_error(request, *args, **kwargs):
         return django.views.debug.technical_500_response(request, *exc_info)
       else:
         tb = traceback.extract_tb(exc_info[2])
-        if request.is_ajax():
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
           tb = '\n'.join(tb.format())
         return render("500.mako", request, {'traceback': tb})
     else:

--- a/desktop/core/src/desktop/views.py
+++ b/desktop/core/src/desktop/views.py
@@ -60,6 +60,7 @@ from desktop.lib.django_util import JsonResponse, login_notrequired, render
 from desktop.lib.i18n import smart_str
 from desktop.lib.paths import get_desktop_root
 from desktop.lib.thread_util import dump_traceback
+from desktop.lib.view_util import is_ajax
 from desktop.log.access import access_log_level, access_warn, AccessInfo
 from desktop.log import set_all_debug as _set_all_debug, reset_all_debug as _reset_all_debug, get_all_debug as _get_all_debug
 from desktop.models import Settings, hue_version, _get_apps, UserPreferences
@@ -347,7 +348,7 @@ def threads(request):
   out = string_io()
   dump_traceback(file=out)
 
-  if request.headers.get('x-requested-with') == 'XMLHttpRequest':
+  if is_ajax(request):
     return HttpResponse(out.getvalue(), content_type="text/plain")
   else:
     return render("threads.mako", request, {'text': out.getvalue(), 'is_embeddable': request.GET.get('is_embeddable', False)})
@@ -458,7 +459,7 @@ def serve_500_error(request, *args, **kwargs):
         return django.views.debug.technical_500_response(request, *exc_info)
       else:
         tb = traceback.extract_tb(exc_info[2])
-        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
+        if is_ajax(request):
           tb = '\n'.join(tb.format())
         return render("500.mako", request, {'traceback': tb})
     else:


### PR DESCRIPTION
## What changes were proposed in this pull request?

- request.is_ajax() -> request.headers.get('x-requested-with') == 'XMLHttpRequest'
