### PR TITLE
Enable disabling SSL verification in http_client.py

### DIFF
--- a/desktop/core/src/desktop/lib/rest/http_client.py
+++ b/desktop/core/src/desktop/lib/rest/http_client.py
@@ -222,6 +222,8 @@ class HttpClient(object):
     if clear_cookies:
       self._session.cookies.clear()
 
+    request_kwargs['verify'] = self._session.verify
+
     try:
       resp = getattr(self._session, http_method.lower())(url, **request_kwargs)
       if resp.status_code >= 300:

--- a/desktop/core/src/desktop/lib/rest/http_client_test.py
+++ b/desktop/core/src/desktop/lib/rest/http_client_test.py
@@ -41,10 +41,11 @@ def test_http_error_rest_exception():
 
 class MockedSession(object):
 
-  def __init__(self, cookies=None):
+  def __init__(self, cookies=None, verify=True):
     self.cookies = cookies or {}
+    self.verify = verify
 
-  def put(self, relpath=None, params=None, data=None, contenttype=None, allow_redirects=False, clear_cookies=False, timeout=REST_CONN_TIMEOUT.get()):
+  def put(self, relpath=None, params=None, data=None, verify=True, contenttype=None, allow_redirects=False, clear_cookies=False, timeout=REST_CONN_TIMEOUT.get()):
     return MockedResponse()
 
 


### PR DESCRIPTION

## What changes were proposed in this pull request?


To disable SSL verification in http_client.py one need to pass it to the session.get(url, verify=False). The current code just sets the _session object which is not taken into account.

## How was this patch tested?

Verified this fix by making the change in the live cluster.
