### PR TITLE
[lib] Change boto2 to not override the User Agent if already present

### DIFF
--- a/desktop/core/ext-py/boto-2.46.1/boto/connection.py
+++ b/desktop/core/ext-py/boto-2.46.1/boto/connection.py
@@ -372,7 +372,8 @@ class HTTPRequest(object):
                     self.headers[key] = quote(val.encode('utf-8'), safe)
             setattr(self, '_headers_quoted', True)
 
-        self.headers['User-Agent'] = UserAgent
+        if not self.headers('User-Agent'):
+          self.headers['User-Agent'] = UserAgent
 
         connection._auth_handler.add_auth(self, **kwargs)
 

--- a/desktop/core/ext-py/boto-2.46.1/boto/s3/key.py
+++ b/desktop/core/ext-py/boto-2.46.1/boto/s3/key.py
@@ -890,9 +890,10 @@ class Key(object):
         else:
             headers = headers.copy()
         # Overwrite user-supplied user-agent.
-        for header in find_matching_headers('User-Agent', headers):
-            del headers[header]
-        headers['User-Agent'] = UserAgent
+        #for header in find_matching_headers('User-Agent', headers):
+        #    del headers[header]
+        if not headers.get('User-Agent'):
+          headers['User-Agent'] = UserAgent
         # If storage_class is None, then a user has not explicitly requested
         # a storage class, so we can assume STANDARD here
         if self._storage_class not in [None, 'STANDARD']:


### PR DESCRIPTION
This enables to reuse the boto HttpRequest client with Raz signed URLs.
The Raz URLs are signed and the User Agent is part of the signature,
so this one should not be changed.
