### PR TITLE
[slack] Add docs link in gethue.com Slack section

### DIFF
--- a/docs/gethue/themes/stack-hue-theme/layouts/partials/home.en.html
+++ b/docs/gethue/themes/stack-hue-theme/layouts/partials/home.en.html
@@ -167,10 +167,10 @@
             <h2>Install the Slack App!</h2>
             <p class="lead">
               Assist users with their SQL queries and leverage different
-              <a href="/blog/2021-04-09-collaborate-on-your-sql-queries-and-results-directly-within-slack/">features</a>
+              <a href="{{ .Site.Params.docsHost }}/user/concept/#slack">features</a>
               such as rich preview for links, sharing from Editor etc. directly in Slack.
               <br /> Give your Hue hostname below and
-              <a href="/blog/2021-05-18-installing-hue-slack-app-in-three-simple-steps/">install</a>
+              <a href="{{ .Site.Params.docsHost }}/administrator/configuration/server/#manual-slack-app-installation">install</a>
               it in your workspace within seconds...
             </p>
             <form autocomplete="off" onsubmit="return check(event)">


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add Docs link instead of blog in the slack section on gethue.com
