### PR TITLE
[core] Fix PIP_MODULES installation on build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,9 +147,13 @@ $(BLD_DIR_ENV)/stamp:
 desktop: parent-pom
 # END DEV ONLY >>>>
 desktop: virtual-env
-	@if [ "$(PYTHON_VER)" = "python2.7" ] && [ "$(MAKECMDGOALS)" = "apps" ]; then \
+	# Normally dev only do "make apps", but build system is calling "make apps docs"
+	@if [ "$(PYTHON_VER)" = "python2.7" ] && [ "$(findstring apps,$(MAKECMDGOALS))" = "apps" ]; then \
+	  echo "--- start installing PIP_MODULES"; \
 	  $(ENV_PIP) install --upgrade pip; \
 	  $(ENV_PIP) install $(PIP_MODULES); \
+	  echo "--- done installing PIP_MODULES"; \
+	else echo "--- skip installing PIP_MODULES"; \
 	fi
 	@$(MAKE) -C desktop
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix install PIP_MODULES in the build system when it calls "make apps docs", which is value of $(MAKECMDGOALS)

## How was this patch tested?

Running a canary build

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
