### PR TITLE
[django_upgrade32] djangomako supporting Mako==1.1.4 now

### DIFF
--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -72,4 +72,4 @@ tabulate==0.8.9
 thrift==0.13.0
 thrift-sasl==0.4.2
 git+https://github.com/gethue/django-babel.git
-git+https://github.com/agl29/django-mako.git
+git+https://github.com/gethue/django-mako.git

--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -72,3 +72,4 @@ tabulate==0.8.9
 thrift==0.13.0
 thrift-sasl==0.4.2
 git+https://github.com/gethue/django-babel.git
+git+https://github.com/agl29/django-mako.git


### PR DESCRIPTION
## What changes were proposed in this pull request?

- when I change the Django version to 3.2 then I am hitting the [same](https://github.com/cloudera/hue/pull/1711) issue "**ModuleNotFoundError: No module named 'djangomako**'" as we were hitting earlier.
- so done all changes in my repo if approved then will transfer that to gethue.