### PR TITLE
[blog] Localized blogs published in May-June 2021 into Japanese

### DIFF
--- a/docs/gethue/content/jp/posts/2021-05-18-installing-hue-slack-app-in-three-simple-steps.md
+++ b/docs/gethue/content/jp/posts/2021-05-18-installing-hue-slack-app-in-three-simple-steps.md
@@ -1,0 +1,93 @@
+---
+title: Hue Slackアプリを3つの簡単なステップでインストール
+author: Hue Team
+type: post
+date: 2021-05-18T00:00:00+00:00
+url: /blog/2021-05-18-installing-hue-slack-app-in-three-simple-steps
+sf_thumbnail_type:
+  - none
+sf_thumbnail_link_type:
+  - link_to_post
+sf_detail_type:
+  - none
+sf_page_title:
+  - 1
+sf_page_title_style:
+  - standard
+sf_no_breadcrumbs:
+  - 1
+sf_page_title_bg:
+  - none
+sf_page_title_text_style:
+  - light
+sf_background_image_size:
+  - cover
+sf_social_sharing:
+  - 1
+sf_related_articles:
+  - 1
+sf_sidebar_config:
+  - left-sidebar
+sf_left_sidebar:
+  - Sidebar-2
+sf_right_sidebar:
+  - Sidebar-1
+sf_caption_position:
+  - caption-right
+sf_remove_promo_bar:
+  - 1
+ampforwp-amp-on-off:
+  - default
+categories:
+  - Version 4.10
+---
+
+チーム内の他のSQLユーザーとの共同作業を支援するSQLアシスタントが欲しいと思ったことはありませんか？ それも Slack に？
+
+このHueとSlackの統合は、SlackチャンネルでのSQLクエリをアシストしてくれます。 [使い方も簡単](https://docs.gethue.com/user/concept/#slack)で、Slackのワークスペースの管理者であれば、たった3ステップで簡単にインストールできます。
+
+Slackは最近、Slackアプリ向けに[アプリマニフェスト](https://api.slack.com/reference/manifests)のベータ版をリリースしました。 マニフェストを使用すると、あらかじめ定義された構成でアプリケーションを作成することができます。
+
+アプリマニフェストの最新バージョンは [Hueリポジトリ](https://github.com/cloudera/hue/blob/master/tools/slack/manifest.yml) にチェックインされています。
+
+共有マニフェストでは、 _demo.gethue.com_ の2つを**Hueインスタンスのホスト名**で更新します:
+- **unfurl_domains**の下
+- **event_subscriptions**の下、**request_url** `https://<hue-instance-hostname>/desktop/slack/events/`で
+
+さて、いよいよ自分のアプリを作成してみましょう。
+- https://api.slack.com/apps に移動し、 **Create New App** をクリックします。
+- **From an app manifest** オプションとアプリをインストールするワークスペースを選択して**Next**をクリックします。
+- **YAML** を選択し、マニフェストコードを貼り付けて (上記の必要な変更を行っていることを確認してください) 、 **Next** をクリックします。
+- レビューの概要を読み、問題がなければ、 **Create** をクリックします。
+- アプリが作成されたら、ワークスペースにインストールしましょう！
+
+![Slack のインストールフロー](https://cdn.gethue.com/uploads/2021/05/slack-install.gif)
+
+Hueでプラグインを行う最後のステップを完了し、hue.ini設定ファイルを更新しましょう:
+- **OAuth & Permissions page**に移動し、 **Bot User OAuth Token** をコピーして、 **slack_bot_user_token** を更新します。(例: xoxb-xxxxxxxxxxxxxxxxxxxxxxxxx)
+- 同様に、 **Basic Information** ページに移動して **Verification Token** をコピーし、**slack_verification_token** を更新します。
+
+そして、これを hue.ini ファイルの `[desktop]` セクションに貼り付けます
+
+    [[slack]]
+    is_enabled=true
+    slack_verification_token=<your-slack-verification-token>
+    slack_bot_user_token=<your-slack-bot-user-token>
+
+手続きは以上です！ あなただけのHueアプリの準備ができました！
+### 試してみましょう！
+
+[Slack ワークスペース](https://hue-sql-assistant.slack.com/) にログインし、以下の Slack アカウントの資格情報を使用してデモSQL Assistant にアクセスしてください。
+
+      email: demo@gethue.com
+      password: gethue
+
+[デモのライブエディタ](https://demo.gethue.com/)でいくつかのクエリを実行し、そのリンクを共有します。 [ユーザーガイド](https://docs.gethue.com/user/concept/#share-to-slack) または [ブログ](https://jp.gethue.com/blog/2021-04-09-collaborate-on-your-sql-queries-and-results-directly-within-slack/) を読んで、今後のアップデートにご期待ください。
+
+</br> </br>
+
+どのような[フィードバック](https://github.com/cloudera/hue/issues) や質問も大歓迎です！ ここや<a href="https://discourse.gethue.com/">フォーラム</a> で気軽にコメントし、<a href="https://docs.gethue.com/quickstart/">SQLクエリ</a> のクイックスタートをしてください！
+
+宜しくお願い致します！
+
+Harsh from the Hue Team

--- a/docs/gethue/content/jp/posts/2021-05-26-improved-hue-importer-select-a-file-choose-a-dialect-create-a-table.md
+++ b/docs/gethue/content/jp/posts/2021-05-26-improved-hue-importer-select-a-file-choose-a-dialect-create-a-table.md
@@ -1,0 +1,90 @@
+---
+title: 改善されたHueのImporter -- ファイルの選択、方言の選択、テーブルの作成
+author: Hue Team
+type: post
+date: 2021-05-26T00:00:00+00:00
+url: /blog/2021-05-26-improved-hue-importer-select-a-file-choose-a-dialect-create-a-table
+sf_thumbnail_type:
+  - none
+sf_thumbnail_link_type:
+  - link_to_post
+sf_detail_type:
+  - none
+sf_page_title:
+  - 1
+sf_page_title_style:
+  - standard
+sf_no_breadcrumbs:
+  - 1
+sf_page_title_bg:
+  - none
+sf_page_title_text_style:
+  - light
+sf_background_image_size:
+  - cover
+sf_social_sharing:
+  - 1
+sf_related_articles:
+  - 1
+sf_sidebar_config:
+  - left-sidebar
+sf_left_sidebar:
+  - Sidebar-2
+sf_right_sidebar:
+  - Sidebar-1
+sf_caption_position:
+  - caption-right
+sf_remove_promo_bar:
+  - 1
+ampforwp-amp-on-off:
+  - default
+categories:
+  - Version 4.10
+  - Development
+  - Query
+---
+
+Hueを設定して、パブリッククラウドで、ユーザーがCSVファイルから新しいSQLテーブルを作成できるようにするのに苦労したことがある方は、これがはるかに簡単になったことを知って喜んでいただけると思います。
+
+Hueのプロユーザーであれば、Hue の[Importer](https://docs.gethue.com/developer/api/rest/#data-importer)をご存知でしょう。 ファイルからテーブルを作成することができます。 これまでは、ファイルは[HDFS](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/HdfsDesign.html)や、[S3](https://gethue.com/introducing-s3-support-in-hue/)や [ABFS](https://docs.gethue.com/administrator/configuration/connectors/#azure-file-systems)などのクラウドオブジェクトストレージ上にある必要がありました。 今では、コンピュータからファイルをブラウズして選択し、HueのさまざまなSQLの[方言](https://docs.gethue.com/administrator/configuration/connectors/) でテーブルを作成できます。 Apache Hive, Apache Impala, Apache Phoenix, MySqlの方言に対応しています。
+
+### ゴール
+
+* ソースに関係なく、Hue Importerを使用してファイルをアップロードする。
+
+### 目的
+* 誰もがHDFSやS3/ABFSにアクセスできるわけではありません。 ビジネスアナリストは、自分のコンピュータにあるデータセットを素早く分析し、データのクリーンアップやその他のデータエンジニアリングタスクを省略する必要があることがよくあります。
+* この機能を使用すると、コンピュータからファイルをインポートして、数回のクリックでテーブルを作成することができます.
+
+### テーブルを作成する手順
+
+![Importer direct upload steps gif](https://cdn.gethue.com/uploads/2021/05/Importer_direct_upload_steps.gif)
+
+### ワークフロー
+![Importer direct upload steps app diagram](https://cdn.gethue.com/uploads/2021/05/Importer_direct_upload_workflow-2.png)
+
+### ファイルと API
+
+  * この機能を実装するために、3つのAPIを使用しています。
+    * [Guess_format](https://github.com/cloudera/hue/blob/master/desktop/libs/indexer/src/indexer/api3.py#L121) (ファイル形式を推測する)
+    * [Guess_field_types](https://github.com/cloudera/hue/blob/master/desktop/libs/indexer/src/indexer/api3.py#L228) (カラムの型を推測する)
+    * [Importer_submit](https://github.com/cloudera/hue/blob/master/desktop/libs/indexer/src/indexer/api3.py#L444) (テーブルを作成する)
+  * さまざまな SQL 方言がどのように実装されているのかに興味がある場合は、 [sql.py](https://github.com/cloudera/hue/blob/master/desktop/libs/indexer/src/indexer/indexers/sql.py) ファイルをご覧ください。
+
+  **注：** 現在、Hueは数千行の小さなCSVファイルをサポートしています。
+
+
+### 中間ステップ
+  * ステップ 1 ![Importer direct upload step1](https://cdn.gethue.com/uploads/2021/05/Importer_direct_upload_step1.png)  
+    ファイルを選択すると、Hueはファイル形式を推測し、区切り文字を識別して、テーブルのプレビューを生成します。
+  * ステップ 2 ![Importer direct upload step2](https://cdn.gethue.com/uploads/2021/05/Importer_direct_upload_step2-2.png)  
+    SQL の方言を選択すると、Hueは列のデータ型を自動検出します。 列名とそのデータ型は編集できます。
+
+
+この機能は、最新の Hue または [demo.gethue.com](https://demo.gethue.com/hue/indexer/importer).  
+で試すことができます。 </br> </br> このプロジェクトでは、より多くのSQL方言をサポートするための[貢献](https://github.com/cloudera/hue/#development)を喜んで歓迎いたします。  
+ご意見やご質問はありますか？ ここや[ディスカッション](https://discourse.gethue.com/) まで気軽にコメントして、[SQLクエリ](https://docs.gethue.com/quickstart/) のクイックスタートをしてください！
+
+どうぞよろしくお願いします！
+
+Ayush from the Hue Team

--- a/docs/gethue/content/jp/posts/2021-05-29-create-own-sql-editor-via-webcomponent-and-public-api.md
+++ b/docs/gethue/content/jp/posts/2021-05-29-create-own-sql-editor-via-webcomponent-and-public-api.md
@@ -1,0 +1,124 @@
+---
+title: Sqlスクラッチパッドコンポーネントとパブリック REST API を使用して、5 分で独自の SQL エディター (BYOE) を構築する
+author: Hue Team
+type: post
+date: 2021-05-29T00:00:00+00:00
+url: /blog/2021-05-29-create-own-sql-editor-via-webcomponent-and-public-api
+sf_thumbnail_type:
+  - none
+sf_thumbnail_link_type:
+  - link_to_post
+sf_detail_type:
+  - none
+sf_page_title:
+  - 1
+sf_page_title_style:
+  - standard
+sf_no_breadcrumbs:
+  - 1
+sf_page_title_bg:
+  - none
+sf_page_title_text_style:
+  - light
+sf_background_image_size:
+  - cover
+sf_social_sharing:
+  - 1
+sf_related_articles:
+  - 1
+sf_sidebar_config:
+  - left-sidebar
+sf_left_sidebar:
+  - Sidebar-2
+sf_right_sidebar:
+  - Sidebar-1
+sf_caption_position:
+  - caption-right
+sf_remove_promo_bar:
+  - 1
+ampforwp-amp-on-off:
+  - default
+categories:
+  - Version 4.10
+  - Development
+  - Query
+---
+
+Hueの新しいSQLスクラッチパッドWebコンポーネントとREST APIを、プロジェクトに活用する。
+
+[HueのSQL Editor](https://gethue.com/)プロジェクトは、[10年以上](https://gethue.com/blog/2020-01-28-ten-years-data-querying-ux-evolution/)にわたって進化し続けており、あらゆるデータベースやデータウェアハウスへのクエリを実行できます。 プロジェクト全体を完全に分離されたコンポーネントに分割したことが、急速に進化し、長い間生き続けることができた理由の一つです。
+
+既に人気のある[SQL Parser](https://docs.gethue.com/developer/components/parsers/) コンポーネントに、 [SQL スクラッチパッド](https://docs.gethue.com/developer/components/scratchpad/) コンポーネントが加わりました。
+
+![The SQL Scratchpad is a lightweight repackaging of the mature Hue SQL Editor](https://cdn-images-1.medium.com/max/2494/0*XnfuFshfdqc9vX74.png)*SQL スクラッチパッドは、成熟したHueのSQLエディタの軽量の再パッケージング*
+> <sql-scratchpad />
+
+主な追加の利点は、エディタの共有と統合が容易になったことです。したがって、エンドユーザにとって、より良い単一のエディタを作ることに集中するのではなく、車輪を再発明して様々な重複するSQLエディタを再作成することを避けるための、強力なケースとなります。
+
+ここでは、コンポーネントの追加がいかに簡単であるかを示すライブデモを紹介します。
+
+![Adding the component in 3 lines and watching the interaction with the public API of demo.gethue.com](https://cdn-images-1.medium.com/max/2356/1*yXRjYQN_eRUimzlXPl5SwQ.gif)*3行でコンポーネントを追加し、demo.gethue.com の公開API との連携を確認する*
+
+### 仕組み
+
+![The SQL Editor is a module published to a registry called NPM. The component can then be integrated in any Web page. It then communicates via a REST API with the Hue server which interacts with the Databases we want to query.](https://cdn-images-1.medium.com/max/2242/1*stLGGVTXa_V_PK2s1i6vIQ.png)*SQLエディタは、NPMというレジストリに公開されたモジュールです。 コンポーネントは、任意のWebページに統合することができます。 その後SQLエディタは、クエリを行いたいデータベースとやり取りするHueサーバーと、REST APIを介して通信します。*
+
+**クエリエディタのコンポーネント**
+
+このコンポーネントをWebページに統合するのは簡単です。 以下のHTMLコードをindex.htmlファイルにコピーして貼り付け、FireFoxで開いてください。
+
+    <!DOCTYPE html>
+    <html>
+    
+    <head>
+      <title>SQL Scratchpad</title>
+      <script type="text/javascript" src="https://unpkg.com/gethue/lib/components/SqlScratchpadWebComponent.js"></script>
+    </head>
+    
+    <body>
+      <div style="position: absolute; height: 100%; width: 100%">
+        <sql-scratchpad api-url="https://demo.gethue.com" username="demo" password="demo" dialect="hive" />
+      </div>
+    </body>
+    
+    </html>
+
+そして「それだけです」！
+
+![ローカルの HTML ページを Firefox で直接開く](https://cdn-images-1.medium.com/max/2000/1*JzVbsWHqzZPI2pEAhG2mwQ.png) <br>*ローカルの HTML ページを Firefox で直接開く*
+
+オートコンプリートはローカルパーサによって動作し、表示されます。 これは明らかに、自分自身ではSQL構文の手助けしかできません。 テーブルやカラムのリストのような動的コンテンツを取得して SQL クエリを実行するには、コンポーネントがクエリ API を指す必要があります。
+
+次のステップとコンポーネントをより深く統合については、 [NPM Hueレジストリ](https://www.npmjs.com/package/gethue) を参照してください。
+
+**クエリエディタAPI**
+
+エディタコンポーネントを真に生かすためには、ユーザーを認証してクエリを実行するサービスと対話する必要があります。
+
+これを可能にするのが、新しい [パブリック REST API](https://docs.gethue.com/developer/api/rest/#execute-a-query) であり、これまでよりもずっと簡単に使用できます。 これは通常のログインページとまったく同じ認証を利用しており、その後JWTトークンを提供するだけですみます。
+
+たとえば、以下のようにアクセストークンを要求するだけです。
+
+    curl -X POST https://demo.gethue.com/api/token/auth -d 'username=demo&password=demo'
+
+その後、以下の各コールでトークンの値を指定します。
+
+    curl -X POST https://demo.gethue.com/api/editor/execute/hive --data 'statement=SHOW TABLES' -H "Authorization: Bearer <token value>"
+
+SQL クエリを実行するためのエンドポイントは大幅に簡素化され、SQL 方言とクエリステートメント、または以前に実行のために送信されたクエリの ID などの必要な情報のみが要求されるようになりました。
+
+    curl -X POST https://demo.gethue.com/api/editor/check_status --data 'operationId=63ce87ba-ca0f-4653-8aeb-e9f5c1781b78'
+
+この最初のリリースでは、SQLコンテンツの編集と実行が可能です。 完全なエディタの一般的な機能が徐々に統合されていますが、例えば以下のような機能があります。
+
+* クエリの書式設定と共有
+* 結果のダウンロード
+* ポップアップでスクラッチパッドを開く(例：PySparkでの埋め込みSQLの編集)
+
+認証情報を必要としないようにするために、SSO とローカルの JWT トークンを検証するオプションも近日公開予定です。
+
+[SQLスクラッチパッドンポーネント](https://docs.gethue.com/developer/components/scratchpad/) とそのAPIは急速に進化しています。 今こそお試しいただいて、 [フィードバック](https://github.com/cloudera/hue/issues) を送っていただいたり、貢献していただくための絶好の機会です！
+
+どうぞよろしくお願いします！
+
+Romain from the Hue Team

--- a/docs/gethue/content/jp/posts/2021-06-14-release-hue-4-10.md
+++ b/docs/gethue/content/jp/posts/2021-06-14-release-hue-4-10.md
@@ -1,0 +1,131 @@
+---
+title: Hue4.10（新しいSQLエディタコンポーネント、REST API、小さなファイルのインポート、Slackアプリなど）がリリースされました！
+author: Hue Team
+type: post
+date: 2021-06-10T00:00:00+00:00
+url: /blog/hue-4-10-sql-scratchpad-component-rest-api-small-file-importer-slack-app/
+sf_thumbnail_type:
+  - none
+sf_thumbnail_link_type:
+  - link_to_post
+sf_detail_type:
+  - none
+sf_page_title:
+  - 1
+sf_page_title_style:
+  - standard
+sf_no_breadcrumbs:
+  - 1
+sf_page_title_bg:
+  - none
+sf_page_title_text_style:
+  - light
+sf_background_image_size:
+  - cover
+sf_social_sharing:
+  - 1
+sf_related_articles:
+  - 1
+sf_sidebar_config:
+  - left-sidebar
+sf_left_sidebar:
+  - Sidebar-2
+sf_right_sidebar:
+  - Sidebar-1
+sf_caption_position:
+  - caption-right
+sf_remove_promo_bar:
+  - 1
+ampforwp-amp-on-off:
+  - default
+categories:
+  - Version 4.10
+  - Release
+---
+
+データエクスプローラーの皆さん、こんにちは
+
+Hueチームはすべての貢献者に感謝し、Hue4.10をリリースすることを嬉しく思います！
+
+<a href="https://cdn.gethue.com/uploads/2021/02/hue-4.9.png">
+  <img src="https://cdn.gethue.com/uploads/2021/02/hue-4.9.png" />
+</a>
+
+&nbsp;
+
+前回の[４. 9](/blog/hue-4-9-sql-dialects-phoenix-dasksql-flink-components/) に比べ、4.10では主に以下のような[主な改善](/categories/version-4.10/) があります。
+
+
+## SQLエディタ・コンポーネントとAPI
+[SQL スクラッチパッド](https://docs.gethue.com/developer/components/scratchpad/) コンポーネントを利用し、HTMLの3行だけで独自の SQL エディターを構築できるようになりました。 また、クエリを実行するための、パブリック [REST API](https://docs.gethue.com/developer/api/rest/) の最初のバージョンが公開されました。
+
+[SQL スクラッチパッドと REST API](/blog/2021-05-29-create-own-sql-editor-via-webcomponent-and-public-api/)の詳細をご覧ください。
+
+ここでは、コンポーネントの追加がどう簡単なのかを示すライブデモをご覧いただけます。
+
+{{< rawhtml >}}
+<p>
+  <div style="position: absolute; height: 10%; width: 100%">
+    <sql-scratchpad api-url="https://demo.gethue.com" username="demo" password="demo" dialect="mysql" />
+  </div>
+
+  <script type="text/javascript" src="https://unpkg.com/gethue/lib/components/SqlScratchpadWebComponent.js"></script>
+
+  <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+</p>
+{{< /rawhtml >}}
+
+![3行でコンポーネントを追加し、demo.gethue.com のパブリックAPI とのやり取りを見る](https://cdn-images-1.medium.com/max/2356/1*yXRjYQN_eRUimzlXPl5SwQ.gif)*3行でコンポーネントを追加し、demo.gethue.com のパブリックAPI とのやり取りを見る*
+
+## テーブル作成ウィザード
+
+小さなファイルを介して3回クリックするだけで、Hive、Impala、MySql、Phoenix SQLのテーブルを作成できます。 HDFSやS3のようなストレージファイルシステムを設定する必要はなく、ブラウザ経由でアップロードして、ウィザードに従うだけです。
+
+[小さいファイルからテーブルを作成](/blog/2021-05-26-improved-hue-importer-select-a-file-choose-a-dialect-create-a-table/)する方法についての詳細を読む。
+
+![Importer direct upload steps](https://cdn.gethue.com/uploads/2021/05/Importer_direct_upload_steps.gif)
+
+## Slack App
+SQLクエリの豊富なプレビュー、自動リンク、クエリバンク、Slackへの結果のエクスポート機能により、Slackでのコラボレーションがより充実したものになります。
+
+数回クリックするだけで[アプリをインストール ](/blog/2021-05-18-installing-hue-slack-app-in-three-simple-steps/)して[アシスタンスの機能](https://docs.gethue.com/user/concept/#slack)について詳しく知ることができます。
+
+![Slack のインストールフロー](https://cdn.gethue.com/uploads/2021/05/slack-install.gif)
+
+## 技術スタック & ツール
+
+- [ユーザーに資格情報キーを与えずにS3ファイルへの適切なアクセスを提供する](/blog/2021-04-23-s3-file-access-without-any-credentials-and-signed-urls/)
+- [コンテナーアプリをパッケージとして配布する](/blog/2021-04-19-publish-kubernetes-container-application-via-package-with-helm/)
+- [ダウンタイムなしに Web/API サービスのアップグレードを行う](/blog/2021-03-06-web-api-service-upgrade-no-downtime-kubernetes-rollout/)
+- [SQLによるHBaseへの対話的なクエリ - 技術講演（Tech Talk)](/blog/2021-04-05-interactively-querying-hbase-via-sql-tech-talk/)
+- [Webserver スタックのアップグレード時のプロセスと学び - Django のアップグレード (1.11 から 3.1)](/blog/2021-03-09-process-and-learnings-when-upgrading-the-webserver-stack-django-upgrade-1-to-3/)
+- [Vue 3 の紹介と Hue クエリエディタでの Web コンポーネント](/blog/vue3-build-cli-options-composition-api-template-web-components-hue/)
+- Docker Image のサイズを [60%縮小](https://github.com/cloudera/hue/pull/2129)
+- [Phoenix SQL](/sql-querying-apache-hbase-with-apache-phoenix/) のカラムキーが左アシストに表示されるようになった
+
+
+700以上のコミットと100以上のバグ修正が含まれています！ すべての変更の詳細については[リリース ノート](https://docs.gethue.com/releases/release-notes-4.10.0/) をご覧ください。
+
+使ってみてください！
+
+* Docker
+    ```
+    docker run -it -p 8888:8888 gethue/4.10.0
+    ```
+* Kubernetes :
+    ```
+    helm repo add gethue https://helm.gethue.com
+    helm repo update
+    helm install hue gethue/hue
+    ```
+* [demo.gethue.com](demo.gethue.com)
+* [Tarball](https://cdn.gethue.com/downloads/hue-4.10.0.tgz) または [source](https://github.com/cloudera/hue/archive/release-4.10.0.zip)
+
+</br> </br>
+
+ご意見やご質問はありますか? ここや<a href="https://discourse.gethue.com/">フォーラム</a> で気軽にコメントいただき、<a href="https://docs.gethue.com/quickstart/">SQLクエリ</a> のクイックスタートをしてください！
+
+
+どうぞよろしくお願いします！
+
+Romain from the Hue Team


### PR DESCRIPTION
Hi Hue Team,
Congratulations on the release of Hue 4.10! I translated the hue blogs into Japanese.

## What changes were proposed in this pull request?

- Localized the blogs published in May-Jun into Japanese

## How was this patch tested?

- Verified on my browser using 'hugo serve'

Please let me know if you have any questions.

Regards,
--
Tatsuo
