### PR TITLE
[core] Fix skipped pip install if system python has same libs preinst…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ desktop: virtual-env
 	@if [ "$(PYTHON_VER)" = "python2.7" ] && [ "$(findstring apps,$(MAKECMDGOALS))" = "apps" ]; then \
 	  echo "--- start installing PIP_MODULES"; \
 	  $(ENV_PIP) install --upgrade pip; \
-	  $(ENV_PIP) install $(PIP_MODULES); \
+	  $(ENV_PIP) install --upgrade --force-reinstall $(PIP_MODULES); \
 	  echo "--- done installing PIP_MODULES"; \
 	else echo "--- skip installing PIP_MODULES"; \
 	fi


### PR DESCRIPTION
…alled

## What changes were proposed in this pull request?

In our Ubuntu 20 build system, it has cryptography-3.3.2 installed at /usr/local/lib/python2.7/dist-packages, so `make apps` skipped install cryptography in Hue's virtual environment. Later, the parcel installed on an Ubuntu 20 host doesn't have cryptography in system Python, ImportError will be thrown when start Hue server.
`ImportError: No module named cryptography`

And the lib can't be found.
```
root@yc-c7i7u-1:~# cd /opt/cloudera/parcels/CDH/lib/hue
root@yc-c7i7u-1:/opt/cloudera/parcels/CDH/lib/hue# build/env/bin/pip freeze | grep cryptography
root@yc-c7i7u-1:/opt/cloudera/parcels/CDH/lib/hue# 
root@yc-c7i7u-1:/opt/cloudera/parcels/CDH/lib/hue# ll build/env/lib/python2.7/site-packages | grep cryptography
root@yc-c7i7u-1:/opt/cloudera/parcels/CDH/lib/hue# 
```

To fix the issue, force reinstall the pip modules even system Python has same lib preinstalled.

## How was this patch tested?

Tested `make apps` on CentOS 7 and Ubuntu 20, then find cryptography in Hue's virtual environment:

```
~/hue$ ll build/env/lib/python2.7/site-packages  | grep cryptography
drwxr-xr-x   4 jenkins users    223 Jun 17 22:57 cryptography/
drwxr-xr-x   2 jenkins users    198 Jun 17 22:57 cryptography-3.3.2.dist-info/
```

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
