### PR TITLE
[editor] Use gist link input field for sharing saved query

### DIFF
--- a/desktop/core/src/desktop/js/ko/components/doc/__snapshots__/ko.linkSharing.test.js.snap
+++ b/desktop/core/src/desktop/js/ko/components/doc/__snapshots__/ko.linkSharing.test.js.snap
@@ -46,9 +46,11 @@ exports[`ko.linkSharing.js should render component activated 1`] = `
     </div>
   </div></div>
     </div>
-    <div class=\\"shared-link\\">
-      <div id=\\"sharedLinkInput\\" data-bind=\\"text: link\\">https://www.gethue.com/hueundefined</div>
-      <button class=\\"btn\\" data-clipboard-target=\\"#sharedLinkInput\\" data-bind=\\"clipboard\\"><i class=\\"fa fa-clipboard\\"></i></button>
+    <div class=\\"input-append\\">
+      <form autocomplete=\\"off\\">
+        <input id=\\"sharedLinkInput\\" style=\\"width: 520px\\" autocorrect=\\"off\\" autocomplete=\\"do-not-autocomplete\\" autocapitalize=\\"off\\" spellcheck=\\"false\\" onfocus=\\"this.select()\\" data-bind=\\"value: link\\" type=\\"text\\" readonly=\\"readonly\\">
+        <button class=\\"btn\\" type=\\"button\\" data-clipboard-target=\\"#sharedLinkInput\\" data-bind=\\"clipboard\\"><i class=\\"fa fa-clipboard\\"></i></button>
+      </form>
     </div>
     <!-- /ko -->
   </div></div>"

--- a/desktop/core/src/desktop/js/ko/components/doc/ko.linkSharing.js
+++ b/desktop/core/src/desktop/js/ko/components/doc/ko.linkSharing.js
@@ -56,9 +56,11 @@ const TEMPLATE = `
         }
       "></div>
     </div>
-    <div class="shared-link">
-      <div id="sharedLinkInput" data-bind="text: link"></div>
-      <button class="btn" data-clipboard-target="#sharedLinkInput" data-bind="clipboard"><i class="fa fa-clipboard"></i></button>
+    <div class="input-append">
+      <form autocomplete="off">
+        <input id="sharedLinkInput" style="width: 520px" ${ window.PREVENT_AUTOFILL_INPUT_ATTRS } onfocus="this.select()" data-bind="value: link" type="text" readonly="readonly"/>
+        <button class="btn" type="button" data-clipboard-target="#sharedLinkInput" data-bind="clipboard"><i class="fa fa-clipboard"></i></button>
+      </form>
     </div>
     <!-- /ko -->
   </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Fixes long sharing links issue by having default horizontal scroll than using `div` to show link.

