### PR TITLE
Hue audit logs are no longer being collected if Nav is not in use.

### DIFF
--- a/desktop/libs/metadata/src/metadata/metadata_sites.py
+++ b/desktop/libs/metadata/src/metadata/metadata_sites.py
@@ -49,7 +49,7 @@ def get_navigator_server_url():
 
 def get_navigator_audit_log_dir():
   """Returns audit_event_log_dir"""
-  return get_conf().get(_CONF_NAVIGATOR_AUDIT_LOG_DIR, '')
+  return get_conf().get(_CONF_NAVIGATOR_AUDIT_LOG_DIR, '/var/log/hue/audit.log')
 
 
 def get_navigator_audit_max_file_size():


### PR DESCRIPTION
Jira: CDPD-14904

Since Nav is not being used the audit logs are not collected. Just by adding the default path to /var/log/hue addresses the issue.