### PR TITLE
[abfs] Do not try to set credentials headers when Raz is on

### DIFF
--- a/desktop/core/src/desktop/lib/fs/__init__.py
+++ b/desktop/core/src/desktop/lib/fs/__init__.py
@@ -22,6 +22,7 @@ from builtins import filter
 import posixpath
 import sys
 
+from desktop.lib.fs.proxyfs import ProxyFS  # Imported later from this module
 
 if sys.version_info[0] > 2:
   from urllib.parse import urlparse as lib_urlparse

--- a/desktop/core/src/desktop/lib/fs/__init__.py
+++ b/desktop/core/src/desktop/lib/fs/__init__.py
@@ -21,14 +21,13 @@ standard_library.install_aliases()
 from builtins import filter
 import posixpath
 import sys
-import urllib.parse
 
-from desktop.lib.fs.proxyfs import ProxyFS
 
 if sys.version_info[0] > 2:
   from urllib.parse import urlparse as lib_urlparse
 else:
   from urlparse import urlparse as lib_urlparse
+
 
 def splitpath(path):
   split = lib_urlparse(path)
@@ -42,7 +41,3 @@ def splitpath(path):
     parts = ['/'] + posixpath.normpath(path).split('/')
   # Filter empty parts out
   return list(filter(len, parts))
-
-
-
-

--- a/desktop/core/src/desktop/lib/raz/clients.py
+++ b/desktop/core/src/desktop/lib/raz/clients.py
@@ -16,12 +16,8 @@
 
 import logging
 
-from requests_kerberos import HTTPKerberosAuth
-
 from desktop.conf import RAZ
 from desktop.lib.raz.raz_client import get_raz_client
-from desktop.lib.raz.ranger.clients.ranger_raz_adls import RangerRazAdls
-from desktop.lib.raz.ranger.clients.ranger_raz_s3 import RangerRazS3
 
 
 LOG = logging.getLogger(__name__)
@@ -32,7 +28,7 @@ class S3RazClient():
   def __init__(self, username):
     self.username = username
 
-  def get_url(self, action='GET', path=None, headers=None, perm='read'):
+  def get_url(self, action='GET', path=None, headers=None):
     '''
     Example of headers:
     {
@@ -56,14 +52,15 @@ class S3RazClient():
 
 class AdlsRazClient():
 
-  def __init__(self):
-    if RAZ.API_AUTHENTICATION.get() == 'kerberos':
-      auth = HTTPKerberosAuth()
-    else:
-      auth = None
+  def __init__(self, username):
+    self.username = username
 
-    self.ranger = RangerRazAdls(RAZ.API_URL.get(), auth)
+  def get_url(self, action='GET', path=None, headers=None):
+    c = get_raz_client(
+      raz_url=RAZ.API_URL.get(),
+      username=self.username,
+      auth=RAZ.API_AUTHENTICATION.get(),
+      service='adls',
+    )
 
-  def get_url(self, storage_account, container, relative_path, perm='read'):
-    # e.g. get_url('<storage_account>', '<container>', '<relative_path>', 'read')
-    return self.ranger.get_dsas_token(storage_account, container, relative_path, perm)
+    return c.check_access(method=action, url=path, headers=headers)

--- a/desktop/core/src/desktop/lib/rest/http_client.py
+++ b/desktop/core/src/desktop/lib/rest/http_client.py
@@ -58,8 +58,13 @@ def get_request_session(url, logger):
     with CACHE_SESSION_LOCK:
       CACHE_SESSION[url] = requests.Session()
       logger.debug("Setting request Session")
-      CACHE_SESSION[url].mount(url, requests.adapters.HTTPAdapter(pool_connections=conf.CHERRYPY_SERVER_THREADS.get(),
-                                                                  pool_maxsize=conf.CHERRYPY_SERVER_THREADS.get()))
+      CACHE_SESSION[url].mount(
+        url,
+        requests.adapters.HTTPAdapter(
+          pool_connections=conf.CHERRYPY_SERVER_THREADS.get(),
+          pool_maxsize=conf.CHERRYPY_SERVER_THREADS.get()
+        )
+      )
       logger.debug("Setting session adapter for %s" % url)
 
   return CACHE_SESSION

--- a/desktop/core/src/desktop/lib/rest/http_client.py
+++ b/desktop/core/src/desktop/lib/rest/http_client.py
@@ -200,7 +200,7 @@ class HttpClient(object):
     if urlencode:
       path = urllib_quote(smart_str(path))
 
-    url = self._make_url(path, params)
+    url = self._make_url(path, params, do_urlencode=urlencode)
 
     if http_method in ("GET", "DELETE"):
       if data is not None:
@@ -243,12 +243,12 @@ class HttpClient(object):
             exceptions.TooManyRedirects) as ex:
       raise self._exc_class(ex)
 
-  def _make_url(self, path, params):
+  def _make_url(self, path, params, do_urlencode=True):
     res = self._base_url
     if path:
       res += posixpath.normpath('/' + path.lstrip('/'))
     if params:
-      param_str = urlencode(params)
+      param_str = urlencode(params) if do_urlencode else '&'.join(['%s=%s' % (k, v) for k, v in params.items()])
       res += '?' + param_str
     return iri_to_uri(res)
 

--- a/desktop/core/src/desktop/lib/rest/raz_http_client.py
+++ b/desktop/core/src/desktop/lib/rest/raz_http_client.py
@@ -48,9 +48,6 @@ class RazHttpClient(HttpClient):
     """
     raz_client = AdlsRazClient(username=self.username)
 
-    container = 'hue'
-    storage_account = 'gethue.dfs.core.windows.net'
-
     url = self._make_url(path, params)
 
     token = raz_client.get_url(action=http_method, path=url, headers=headers)

--- a/desktop/core/src/desktop/lib/rest/raz_http_client.py
+++ b/desktop/core/src/desktop/lib/rest/raz_http_client.py
@@ -15,17 +15,10 @@
 # limitations under the License.
 
 import logging
-import sys
 
 from desktop import conf
 from desktop.lib.raz.clients import AdlsRazClient
 from desktop.lib.rest.http_client import HttpClient
-
-
-if sys.version_info[0] > 2:
-  import urllib.request, urllib.error
-else:
-  from urllib import quote as urllib_quote
 
 
 LOG = logging.getLogger(__name__)
@@ -52,8 +45,8 @@ class RazHttpClient(HttpClient):
 
     token = raz_client.get_url(action=http_method, path=url, headers=headers)
 
-    signed_path = path + ('?' if '?' in url else '&') + token
-
+    signed_path = path + ('?' if '?' in url else '&') + token  # Same as using as params
+    print(111)
     return super(RazHttpClient, self).execute(
         http_method=http_method,
         path=signed_path,
@@ -61,7 +54,7 @@ class RazHttpClient(HttpClient):
         data=data,
         headers=headers,
         allow_redirects=allow_redirects,
-        urlencode=urlencode,
+        urlencode=False,
         files=files,
         stream=stream,
         clear_cookies=clear_cookies,

--- a/desktop/core/src/desktop/lib/rest/raz_http_client.py
+++ b/desktop/core/src/desktop/lib/rest/raz_http_client.py
@@ -33,11 +33,6 @@ LOG = logging.getLogger(__name__)
 
 class RazHttpClient(HttpClient):
 
-  def __init__(self):
-    # Note: there is no concept of base_url and credentials anymore
-    # Maybe create here: http_client.HttpClient(url, exc_class=WebHdfsException, logger=LOG)
-    pass
-
   def execute(self, http_method, path, params=None, data=None, headers=None, allow_redirects=False, urlencode=True,
               files=None, stream=False, clear_cookies=False, timeout=conf.REST_CONN_TIMEOUT.get()):
 

--- a/desktop/core/src/desktop/lib/rest/raz_http_client_test.py
+++ b/desktop/core/src/desktop/lib/rest/raz_http_client_test.py
@@ -16,7 +16,6 @@
 
 import sys
 
-
 from nose.tools import assert_equal, assert_false, assert_true
 
 from desktop.lib.rest.raz_http_client import RazHttpClient
@@ -31,26 +30,25 @@ else:
 class TestRazHttpClient():
 
   def test_get_file(self):
-    with patch('desktop.lib.rest.raz_http_client.AdlsRazClient.get_url') as get_url:
-      with patch('desktop.lib.rest.raz_http_client.HttpClient.execute') as execute:
+    with patch('desktop.lib.rest.raz_http_client.AdlsRazClient.get_url') as raz_get_url:
+      with patch('desktop.lib.rest.raz_http_client.HttpClient.execute') as http_execute:
 
-        get_url.return_value = 'https://gethue.blob.core.windows.net/hue/data/customer.csv?sv=2014-02-14&sr=b&' + \
-          'sig=pJL%2FWyed41tptiwBM5ymYre4qF8wzrO05tS5MCjkutc%3D&st=2015-01-02T01%3A40%3A51Z&se=2015-01-02T02%3A00%3A51Z&sp=r'
-        execute.return_value = 'my file'
+        raz_get_url.return_value = 'sv=2014-02-14&sr=b&sig=pJL%2FWyed41tptiwBM5ymYre4qF8wzrO05tS5MCjkutc%3D&st=2015-01-02T01%3A40%3A51Z&se=2015-01-02T02%3A00%3A51Z&sp=r'
+        http_execute.return_value = 'my file content'
 
         client = RazHttpClient(username='test', base_url='https://gethue.blob.core.windows.net')
         f = client.execute(http_method='GET', path='/gethue/data/customer.csv')
 
-        assert_equal('my file', f)
-        get_url.assert_called_with(action='GET', path='https://gethue.blob.core.windows.net/gethue/data/customer.csv', headers=None)
-        execute.assert_called_with(
+        assert_equal('my file content', f)
+        raz_get_url.assert_called_with(action='GET', path='https://gethue.blob.core.windows.net/gethue/data/customer.csv', headers=None)
+        http_execute.assert_called_with(
             http_method='GET',
-            path='/gethue/data/customer.csv&https://gethue.blob.core.windows.net/hue/data/customer.csv?sv=2014-02-14&sr=b&sig=pJL%2FWyed41tptiwBM5ymYre4qF8wzrO05tS5MCjkutc%3D&st=2015-01-02T01%3A40%3A51Z&se=2015-01-02T02%3A00%3A51Z&sp=r',
+            path='/gethue/data/customer.csv&sv=2014-02-14&sr=b&sig=pJL%2FWyed41tptiwBM5ymYre4qF8wzrO05tS5MCjkutc%3D&st=2015-01-02T01%3A40%3A51Z&se=2015-01-02T02%3A00%3A51Z&sp=r',
             params=None,
             data=None,
             headers=None,
             allow_redirects=False,
-            urlencode=True,
+            urlencode=False,
             files=None,
             stream=False,
             clear_cookies=False,

--- a/desktop/core/src/desktop/lib/rest/raz_http_client_test.py
+++ b/desktop/core/src/desktop/lib/rest/raz_http_client_test.py
@@ -38,12 +38,21 @@ class TestRazHttpClient():
           'sig=pJL%2FWyed41tptiwBM5ymYre4qF8wzrO05tS5MCjkutc%3D&st=2015-01-02T01%3A40%3A51Z&se=2015-01-02T02%3A00%3A51Z&sp=r'
         execute.return_value = 'my file'
 
-        client = RazHttpClient()
+        client = RazHttpClient(username='test', base_url='https://gethue.blob.core.windows.net')
         f = client.execute(http_method='GET', path='/gethue/data/customer.csv')
 
         assert_equal('my file', f)
-        get_url.assert_called_with('gethue.dfs.core.windows.net', 'hue', relative_path='/gethue/data/customer.csv', perm='read')
-        execute.assert_called_with(http_method='GET', path='https://gethue.blob.core.windows.net/hue/data/customer.csv?' + \
-          'sv=2014-02-14&sr=b&sig=pJL%2FWyed41tptiwBM5ymYre4qF8wzrO05tS5MCjkutc%3D&' + \
-          'st=2015-01-02T01%3A40%3A51Z&se=2015-01-02T02%3A00%3A51Z&sp=r'
+        get_url.assert_called_with(action='GET', path='https://gethue.blob.core.windows.net/gethue/data/customer.csv', headers=None)
+        execute.assert_called_with(
+            http_method='GET',
+            path='/gethue/data/customer.csv&https://gethue.blob.core.windows.net/hue/data/customer.csv?sv=2014-02-14&sr=b&sig=pJL%2FWyed41tptiwBM5ymYre4qF8wzrO05tS5MCjkutc%3D&st=2015-01-02T01%3A40%3A51Z&se=2015-01-02T02%3A00%3A51Z&sp=r',
+            params=None,
+            data=None,
+            headers=None,
+            allow_redirects=False,
+            urlencode=True,
+            files=None,
+            stream=False,
+            clear_cookies=False,
+            timeout=120
         )

--- a/desktop/libs/azure/src/azure/abfs/abfs.py
+++ b/desktop/libs/azure/src/azure/abfs/abfs.py
@@ -124,9 +124,11 @@ class ABFS(object):
 
   def get_client(self, url):
     if RAZ.IS_ENABLED.get():
-      return resource.Resource(RazHttpClient())
+      client = RazHttpClient(url, exc_class=WebHdfsException, logger=LOG)
     else:
-      return resource.Resource(http_client.HttpClient(url, exc_class=WebHdfsException, logger=LOG))
+      client = http_client.HttpClient(url, exc_class=WebHdfsException, logger=LOG)
+
+    return resource.Resource(client)
 
   def _getheaders(self):
     headers = {

--- a/desktop/libs/azure/src/azure/abfs/abfs.py
+++ b/desktop/libs/azure/src/azure/abfs/abfs.py
@@ -129,10 +129,14 @@ class ABFS(object):
       return resource.Resource(http_client.HttpClient(url, exc_class=WebHdfsException, logger=LOG))
 
   def _getheaders(self):
-    return {
-      "Authorization": self._token_type + " " + self._access_token,
+    headers = {
       "x-ms-version" : "2019-02-02" # Note: this is required for setaccesscontrols
     }
+
+    if self._token_type and self._access_token:
+      headers["Authorization"] = self._token_type + " " + self._access_token
+
+    return headers
 
   @property
   def superuser(self):

--- a/desktop/libs/azure/src/azure/client.py
+++ b/desktop/libs/azure/src/azure/client.py
@@ -30,16 +30,26 @@ LOG = logging.getLogger(__name__)
 
 
 def _make_adls_client(identifier, user):
+  auth_provider = get_credential_provider(identifier, user)
   client_conf = conf.ADLS_CLUSTERS[identifier]
-  return WebHdfs.from_config(client_conf, get_credential_provider(identifier, user))
+
+  return WebHdfs.from_config(client_conf, auth_provider)
 
 def _make_abfs_client(identifier, user):
+  auth_provider = get_credential_provider(identifier, user, version='v2.0')
   client_conf = conf.ABFS_CLUSTERS[identifier]
-  return ABFS.from_config(client_conf, get_credential_provider(identifier, user, version='v2.0'))
+
+  return ABFS.from_config(client_conf, auth_provider)
 
 def get_credential_provider(identifier, user, version=None):
-  client_conf = conf.AZURE_ACCOUNTS[identifier] if identifier in conf.AZURE_ACCOUNTS else None
-  return CredentialProviderIDBroker(IDBroker.from_core_site('azure', user)) if conf_idbroker.is_idbroker_enabled('azure') else CredentialProviderAD(ActiveDirectory.from_config(client_conf, version=version))
+  from desktop.conf import RAZ
+  if RAZ.IS_ENABLED.get():
+    return RazCredentialProvider()
+  else:
+    client_conf = conf.AZURE_ACCOUNTS[identifier] if identifier in conf.AZURE_ACCOUNTS else None
+    return CredentialProviderIDBroker(IDBroker.from_core_site('azure', user)) if conf_idbroker.is_idbroker_enabled('azure') \
+        else CredentialProviderAD(ActiveDirectory.from_config(client_conf, version=version))
+
 
 class CredentialProviderAD(object):
   def __init__(self, ad):
@@ -54,3 +64,8 @@ class CredentialProviderIDBroker(object):
 
   def get_credentials(self):
     return self.idbroker.get_cab()
+
+class RazCredentialProvider(object):
+  def get_credentials(self):
+    # No credentials are required
+    return {}

--- a/desktop/libs/azure/src/azure/client.py
+++ b/desktop/libs/azure/src/azure/client.py
@@ -44,7 +44,7 @@ def _make_abfs_client(identifier, user):
 def get_credential_provider(identifier, user, version=None):
   from desktop.conf import RAZ
   if RAZ.IS_ENABLED.get():
-    return RazCredentialProvider()
+    return RazCredentialProvider(username=user)
   else:
     client_conf = conf.AZURE_ACCOUNTS[identifier] if identifier in conf.AZURE_ACCOUNTS else None
     return CredentialProviderIDBroker(IDBroker.from_core_site('azure', user)) if conf_idbroker.is_idbroker_enabled('azure') \
@@ -66,6 +66,9 @@ class CredentialProviderIDBroker(object):
     return self.idbroker.get_cab()
 
 class RazCredentialProvider(object):
+  def __init__(self, username):
+    self.username = username
+
   def get_credentials(self):
     # No credentials are required
-    return {}
+    return {'username': self.username}

--- a/desktop/libs/azure/src/azure/conf.py
+++ b/desktop/libs/azure/src/azure/conf.py
@@ -155,18 +155,26 @@ def is_adls_enabled():
 
 def is_abfs_enabled():
   from desktop.conf import RAZ  # Must be imported dynamically in order to have proper value
-  
+
   return ('default' in list(AZURE_ACCOUNTS.keys()) and AZURE_ACCOUNTS['default'].get_raw() and AZURE_ACCOUNTS['default'].CLIENT_ID.get() \
     or (conf_idbroker.is_idbroker_enabled('azure') and has_azure_metadata())) and 'default' in list(ABFS_CLUSTERS.keys()) \
     or (RAZ.IS_ENABLED.get() and 'default' in list(ABFS_CLUSTERS.keys()))
 
 def has_adls_access(user):
+  from desktop.conf import RAZ  # Must be imported dynamically in order to have proper value
   from desktop.auth.backend import is_admin
-  return user.is_authenticated and user.is_active and (is_admin(user) or user.has_hue_permission(action="adls_access", app="filebrowser"))
+
+  return user.is_authenticated and user.is_active and (
+    is_admin(user) or user.has_hue_permission(action="adls_access", app="filebrowser") or RAZ.IS_ENABLED.get()
+  )
 
 def has_abfs_access(user):
+  from desktop.conf import RAZ  # Must be imported dynamically in order to have proper value
   from desktop.auth.backend import is_admin
-  return user.is_authenticated and user.is_active and (is_admin(user) or user.has_hue_permission(action="abfs_access", app="filebrowser"))
+
+  return user.is_authenticated and user.is_active and (
+    is_admin(user) or user.has_hue_permission(action="abfs_access", app="filebrowser") or RAZ.IS_ENABLED.get()
+  )
 
 def azure_metadata():
   global AZURE_METADATA


### PR DESCRIPTION
- [aws] Do not enabled S3 when Azure Raz is enabled
- [fs] Fix left out Python 2 url lib import
- [abfs] Do not require Hue admin privileges for access if RAZ is enabled
- [abfs] Do not require credentials in client when Raz is on
- [abfs] Do not try to set credentials headers when Raz is on
- [abfs] Go through Raz when enabled
