### PR TITLE
[Django_warning]  NullBooleanField is deprecated. Support for it (except in historical migrations) will be removed in Django 4.0.

### DIFF
--- a/desktop/core/src/desktop/models.py
+++ b/desktop/core/src/desktop/models.py
@@ -1194,7 +1194,7 @@ class Document2(models.Model):
       db_index=True,
       verbose_name=_t('If managed under the cover by Hue and never by the user')
   )
-  is_trashed = models.NullBooleanField(default=False, db_index=True, verbose_name=_t('True if trashed'))
+  is_trashed = models.BooleanField(null=True, default=False, db_index=True, verbose_name=_t('True if trashed'))
 
   dependencies = models.ManyToManyField('self', symmetrical=False, related_name='dependents', db_index=True)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- https://docs.djangoproject.com/en/3.2/ref/models/fields/#nullbooleanfield