### PR TITLE
[api] Refactor _patch_operation_id_request in public APIs

### DIFF
--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -167,14 +167,16 @@ def _get_interpreter_from_dialect(dialect, user):
 
 
 def _patch_operation_id_request(django_request):
-  if django_request.POST.get('operationId') and not django_request.POST.get('snippet'):
-    data = {
-      'snippet': '{"type":"1","result":{}}',
-      'operationId': django_request.POST.get('operationId')
-    }
+  data = {}
 
-    django_request.POST = QueryDict(mutable=True)
-    django_request.POST.update(data)
+  if not django_request.POST.get('snippet'):
+    data['snippet'] = '{"type":"mysql","result":{}}'
+
+  if django_request.POST.get('operationId'):
+    data['operationId'] = django_request.POST.get('operationId')
+
+  django_request.POST = QueryDict(mutable=True)
+  django_request.POST.update(data)
 
 
 def get_django_request(request):

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -172,10 +172,7 @@ def _patch_operation_id_request(django_request):
   if not django_request.POST.get('snippet'):
     data['snippet'] = '{"type":"mysql","result":{}}'
 
-  if django_request.POST.get('operationId'):
-    data['operationId'] = django_request.POST.get('operationId')
-
-  django_request.POST = QueryDict(mutable=True)
+  django_request.POST = django_request.POST.copy() # Makes it mutable along with copying the object
   django_request.POST.update(data)
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Updated the _patch_operation_id_request function to decouple the snippet logic.

## How was this patch tested?

- Tested manually by running `show tables` query and then using APIs which call this method


