### PR TITLE
[sqls] Avoid JSON.bigdataParse is not a function on result display

### DIFF
--- a/desktop/core/src/desktop/js/catalog/api.ts
+++ b/desktop/core/src/desktop/js/catalog/api.ts
@@ -35,6 +35,7 @@ import DataCatalogEntry, {
 } from 'catalog/DataCatalogEntry';
 import { Cluster, Compute, Connector, Namespace } from 'config/types';
 import { hueWindow } from 'types/types';
+import 'utils/json.bigDataParse';
 import sleep from 'utils/timing/sleep';
 import UUID from 'utils/string/UUID';
 


### PR DESCRIPTION
TypeError: JSON.bigdataParse is not a function
