### PR TITLE
[pypi] Bump dateutil to 2.8.1

### DIFF
--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -53,7 +53,7 @@ pylint-django==2.3.0
 pysaml2>=4.5.0
 pytest==6.0.2
 pytest-django==3.10.0
-python-dateutil==2.4.2
+python-dateutil==2.8.1
 python-daemon==2.2.4
 python-ldap==3.1.0
 python-oauth2==1.1.0


### PR DESCRIPTION
2.4 is old and does conflict with newer libs