### PR TITLE
HiveServerClient: Set schemaName to None for sparksql

### DIFF
--- a/apps/beeswax/src/beeswax/server/hive_server2_lib.py
+++ b/apps/beeswax/src/beeswax/server/hive_server2_lib.py
@@ -814,7 +814,7 @@ class HiveServerClient(object):
     req = TGetSchemasReq()
     if schemaName is not None:
       req.schemaName = schemaName
-    if self.query_server.get('dialect') == 'impala':
+    if self.query_server.get('dialect') in ['impala', 'sparksql']:
       req.schemaName = None
 
     (res, session) = self.call(self._client.GetSchemas, req)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Same as for impala.
This works around/solves an issue where Spark's Thriftserver fails when a wildcard/asterisk is used as schemaName

## How was this patch tested?
Tested manually

Fixes part of #2252 