### PR TITLE
[File Browser] Providing buttom 'Copy Path' for easy copy of S3 URL path in File Browser

### DIFF
--- a/apps/filebrowser/src/filebrowser/templates/listdir.mako
+++ b/apps/filebrowser/src/filebrowser/templates/listdir.mako
@@ -115,7 +115,7 @@ ${ fb_components.menubar() }
               % endif
             </ul>
           </div>
-
+          <button class="btn fileToolbarBtn" title="${_('Copy Path')}" data-bind="enable: selectedFiles().length == 1 && isCurrentDirSelected().length == 0, click: copyPath"><i class="fa fa-fw fa-files-o"></i> ${_('Copy Path')}</button>
           <button class="btn fileToolbarBtn" title="${_('Restore from trash')}" data-bind="visible: inRestorableTrash(), click: restoreTrashSelected, enable: selectedFiles().length > 0 && isCurrentDirSelected().length == 0"><i class="fa fa-cloud-upload"></i> ${_('Restore')}</button>
           <!-- ko ifnot: inTrash -->
           % if not is_trash_enabled:

--- a/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
+++ b/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
@@ -1700,6 +1700,13 @@ else:
         deleteSelected();
       };
 
+      self.copyPath = function () {
+        const path = $('<input>').val(self.selectedFile().path).appendTo('body').select()
+        document.execCommand('copy');
+        path.remove();
+        $.jHueNotify.info('${_('Path copied successfully to the clipboard')}');
+      }
+
       self.trashSelected = function () {
         self.skipTrash(false);
         deleteSelected();


### PR DESCRIPTION
## What changes were proposed in this pull request?

- adding a button to copy the URL of the selected file/folder.
- enabled when only 1 file or folder is selected.

## How was this patch tested?

- adding ss
![Screenshot 2021-07-13 at 3 14 37 PM](https://user-images.githubusercontent.com/36241930/125430450-8da888f2-c333-4bea-9aec-d9c4806b63ea.png)

