### PR TITLE
Add Django Doctor config to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.djangodoctor]
+directories = ["apps", "desktop/core/src/desktop/"]
+ignore = [
+	"desktop/core/src/desktop/js/",
+	"desktop/core/src/desktop/old_migrations/",
+	"desktop/core/src/desktop/static/",
+	"desktop/core/src/desktop/test_data/",
+]


### PR DESCRIPTION
## What changes were proposed in this pull request?

- @romainr and I discussed adding django doctor config. It filters out noise when Django Doctor analyses the codebase.

## How was this patch tested?

The analysis was ran on this branch and it worked as expected: https://django.doctor/higher-tier/hue/add-django-doctor-config/

![2021-07-13-21-22-django doctor](https://user-images.githubusercontent.com/5485798/125536418-237dc4f0-1a0d-4466-a1dd-a1d624b43ea8.png)

@romainr please feedback if you want more directories filtered out. I think the static folders with the html can be filtered out for example. Django Doctor thinks they are Django templates but I think they are not.

Also please have a look at https://django.doctor/config#codes and let me know if there are checks you want turned off