### PR TITLE
changeURLParameter  fixbug

### DIFF
--- a/desktop/core/src/desktop/js/utils/url/changeURLParameter.ts
+++ b/desktop/core/src/desktop/js/utils/url/changeURLParameter.ts
@@ -27,8 +27,13 @@ const changeURLParameter = (param: string, value: string | null): void => {
       .forEach(p => {
         if (p.split('=')[0] !== param) {
           newSearch += p;
+          newSearch += '&';
         }
       });
+    if (newSearch !== '?') {
+      newSearch = newSearch.substr(0, newSearch.length -1);
+    }
+
     if (value) {
       newSearch += (newSearch !== '?' ? '&' : '') + param + '=' + value;
     }

--- a/desktop/core/src/desktop/js/utils/url/changeURLParameter.ts
+++ b/desktop/core/src/desktop/js/utils/url/changeURLParameter.ts
@@ -26,13 +26,12 @@ const changeURLParameter = (param: string, value: string | null): void => {
       .split('&')
       .forEach(p => {
         if (p.split('=')[0] !== param) {
+          if (newSearch !== '?') {
+            newSearch += '&';
+          }
           newSearch += p;
-          newSearch += '&';
         }
       });
-    if (newSearch !== '?') {
-      newSearch = newSearch.substr(0, newSearch.length -1);
-    }
 
     if (value) {
       newSearch += (newSearch !== '?' ? '&' : '') + param + '=' + value;


### PR DESCRIPTION
when there is more than one params in url, the `&` between params will lost

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
