### PR TITLE
GH-2375 "location"-Button in Table Browser to open in New Window than popup box

### DIFF
--- a/apps/metastore/src/metastore/templates/metastore.mako
+++ b/apps/metastore/src/metastore/templates/metastore.mako
@@ -266,7 +266,7 @@ ${ components.menubar(is_embeddable) }
         <!-- /ko -->
         <!-- ko if: details.properties.format !== 'kudu' -->
         <div>
-          <a href="javascript: void(0);" data-bind="storageContextPopover: { path: hdfs_link.replace('/filebrowser/view=', ''), offset: { left: 5 } }"> ${_('location')}</a>
+          <a data-bind="hueLink: hdfs_link" target="_blank" title="${_('Open data location')}">${_('Location')}</a>
         </div>
       <!-- /ko -->
     </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?
GH-2375 -"location"-Button in Table Browser to open in New Window than popup box

## How was this patch tested?

- Tested manually works well
<img width="1351" alt="Screenshot 2021-07-23 at 9 42 56 AM" src="https://user-images.githubusercontent.com/18462803/126736585-fff54c77-1081-4886-b289-dff05a884e93.png">
<img width="922" alt="Screenshot 2021-07-23 at 9 43 04 AM" src="https://user-images.githubusercontent.com/18462803/126736593-20f36ec8-2178-4ba9-b9d7-c5db0b2a6d0a.png">
