### PR TITLE
Issue #2379 - Fix JSON decode error with Oozie action submission in Python 3.x environments.

### DIFF
--- a/desktop/libs/liboozie/src/liboozie/oozie_api.py
+++ b/desktop/libs/liboozie/src/liboozie/oozie_api.py
@@ -246,7 +246,11 @@ class OozieApi(object):
     if parameters is not None:
       params.update(parameters)
 
-    return self._root.put('job/%s' % jobid, params, data=config_gen(properties), contenttype=_XML_CONTENT_TYPE)
+    resp = self._root.put('job/%s' % jobid, params, data=config_gen(properties), contenttype=_XML_CONTENT_TYPE)
+    if sys.version_info[0] > 2:
+      resp = resp.decode()
+
+    return resp
 
   def submit_workflow(self, application_path, properties=None):
     """


### PR DESCRIPTION

## What changes were proposed in this pull request?

- Modify job_control in the oozie_api to decode the response to the action submission for Python 3 environments.  This fixes issue #2379 which causes a JSON decode error when trying to Kill and Oozie workflow, coord, or bundle.

## How was this patch tested?

- Tested manually by trying to kill an oozie workflow, bundle, and coordinator from the Job Browser.  Also exercised the other Oozie actions.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
