### PR TITLE
[fb] Show better error message for no write/modify access

### DIFF
--- a/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
+++ b/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
@@ -1981,7 +1981,7 @@ else:
           onComplete: function (id, fileName, response) {
             self.pendingUploads(self.pendingUploads() - 1);
             if (response.status != 0) {
-              $(document).trigger('error', "${ _('Error: ') }" + response.data);
+              $(document).trigger('error', "${ _('Error: Upload failed') }");
             }
             else {
               $(document).trigger('info', response.path + "${ _(' uploaded successfully.') }");


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Initially showed `Error: undefined` which doesn't give any context.
