### PR TITLE
[aws] Standardize as lower case s3a:// prefix to avoid corner cases

### DIFF
--- a/apps/filebrowser/src/filebrowser/templates/listdir.mako
+++ b/apps/filebrowser/src/filebrowser/templates/listdir.mako
@@ -49,7 +49,7 @@ ${ fb_components.menubar() }
   %endif
 </style>
 
-<div id="${ path.startswith('S3A://') and 'filebrowser_s3Components' or path.startswith('abfs://') and 'filebrowser_abfsComponents' or 'filebrowserComponents' }" class="container-fluid filebrowser">
+<div id="${ path.startswith('s3a://') and 'filebrowser_s3Components' or path.startswith('abfs://') and 'filebrowser_abfsComponents' or 'filebrowserComponents' }" class="container-fluid filebrowser">
   <div class="card card-small">
     <div class="actionbar">
     <%actionbar:render>

--- a/desktop/core/src/desktop/js/api/urls.js
+++ b/desktop/core/src/desktop/js/api/urls.js
@@ -25,7 +25,7 @@ export const HDFS_API_PREFIX = '/filebrowser/view=' + encodeURIComponent('/');
 export const ADLS_API_PREFIX = '/filebrowser/view=' + encodeURIComponent('adl:/');
 export const ABFS_API_PREFIX = '/filebrowser/view=' + encodeURIComponent('ABFS://');
 export const GIT_API_PREFIX = '/desktop/api/vcs/contents/';
-export const S3_API_PREFIX = '/filebrowser/view=' + encodeURIComponent('S3A://');
+export const S3_API_PREFIX = '/filebrowser/view=' + encodeURIComponent('s3a://');
 export const IMPALA_INVALIDATE_API = '/impala/api/invalidate';
 export const CONFIG_SAVE_API = '/desktop/api/configurations/save/';
 export const CONFIG_APPS_API = '/desktop/api/configurations';

--- a/desktop/core/src/desktop/js/ko/bindings/ace/ko.aceEditor.js
+++ b/desktop/core/src/desktop/js/ko/bindings/ace/ko.aceEditor.js
@@ -652,7 +652,7 @@ registerBinding(NAME, {
 
     const dblClickS3ItemSub = huePubSub.subscribe('assist.dblClickS3Item', assistS3Entry => {
       if ($el.data('last-active-editor')) {
-        editor.session.insert(editor.getCursorPosition(), "'S3A://" + assistS3Entry.path + "'");
+        editor.session.insert(editor.getCursorPosition(), "'s3a://" + assistS3Entry.path + "'");
       }
     });
 

--- a/desktop/core/src/desktop/models.py
+++ b/desktop/core/src/desktop/models.py
@@ -1982,7 +1982,7 @@ class ClusterConfig(object):
       })
 
     if 'filebrowser' in self.apps and fsmanager.is_enabled_and_has_access('s3a', self.user):
-      home_path = remote_home_storage if remote_home_storage else 'S3A://'.encode('utf-8')
+      home_path = remote_home_storage if remote_home_storage else 's3a://'.encode('utf-8')
       interpreters.append({
         'type': 's3',
         'displayName': _('S3'),

--- a/desktop/core/src/desktop/templates/common_header.mako
+++ b/desktop/core/src/desktop/templates/common_header.mako
@@ -248,7 +248,7 @@ ${ hueIcons.symbols() }
               <i class="fa fa-fw fa-file" style="vertical-align: middle"></i>${_('HDFS Browser')}</a>
             </li>
             % if is_s3_enabled:
-            <li><a href="/${apps['filebrowser'].display_name}/view=S3A://">
+            <li><a href="/${apps['filebrowser'].display_name}/view=s3a://">
               <i class="fa fa-fw fa-cubes" style="vertical-align: middle"></i>${_('S3 Browser')}</a>
             </li>
             % endif
@@ -267,7 +267,7 @@ ${ hueIcons.symbols() }
       </li>
       <li class="hideMoreThan1380">
         % if is_s3_enabled:
-          <a title="${_('S3 Browser')}" data-rel="navigator-tooltip" href="/${apps['filebrowser'].display_name}/view=S3A://">
+          <a title="${_('S3 Browser')}" data-rel="navigator-tooltip" href="/${apps['filebrowser'].display_name}/view=s3a://">
             <i class="fa fa-cubes"></i>
           </a>
         % endif


### PR DESCRIPTION
If not we miss this checks:

  # Check if protocol missing / and add it back (e.g. Kubernetes ingress can strip double slash)
  if path.startswith('abfs:/') and not path.startswith('abfs://'):
    path = path.replace('abfs:/', 'abfs://')
  if path.startswith('s3a:/') and not path.startswith('s3a://'):
    path = path.replace('s3a:/', 's3a://')
