### PR TITLE
update trino connector configuration with note about alternate headers

### DIFF
--- a/docs/docs-site/content/administrator/configuration/connectors/_index.md
+++ b/docs/docs-site/content/administrator/configuration/connectors/_index.md
@@ -202,6 +202,8 @@ Pass Presto Session Properties without HTTPS enabled:
 
     options='{"url": "presto://username:password@localhost:8080/tpch/default","connect_args":"{\"session_props\": {\"query_max_run_time\": \"1m\"}}"}'
 
+**Note:** Hue does not use trino specific dialect of SQLAlchemy which may lead to a *catalog must be specified* error. This can be solved by setting `protocol.v1.alternate-header-name=Presto` in the Trino's configuration. More details about his can be found at [Trino Blog |  Migrating from PrestoSQL to Trino](https://trino.io/blog/2021/01/04/migrating-from-prestosql-to-trino.html)
+
 Alternative interfaces.
 
 Direct:


### PR DESCRIPTION
## What changes were proposed in this pull request?

- This PR adds a note in the documentation for Trino connector about a configuration that must be added in Trino for Hue to work with it

## How was this patch tested?

- Faced this [issue](https://github.com/cloudera/hue/issues/2389) which got fixed by adding the mentioned configuration in Trino 