### PR TITLE
[auto_login] Auto create 'hue' user for auto_login config flag

### DIFF
--- a/desktop/core/src/desktop/middleware.py
+++ b/desktop/core/src/desktop/middleware.py
@@ -51,7 +51,7 @@ from useradmin.models import User
 
 import desktop.views
 from desktop import appmanager, metrics
-from desktop.auth.backend import is_admin
+from desktop.auth.backend import is_admin, find_or_create_user, ensure_has_a_group, rewrite_user
 from desktop.conf import AUTH, HTTP_ALLOWED_METHODS, ENABLE_PROMETHEUS, KNOX, DJANGO_DEBUG_MODE, AUDIT_EVENT_LOG_DIR, \
     SERVER_USER, REDIRECT_WHITELIST, SECURE_CONTENT_SECURITY_POLICY, has_connectors
 from desktop.context_processors import get_app_name
@@ -367,6 +367,10 @@ class LoginAndPermissionMiddleware(MiddlewareMixin):
         return None
 
     if AUTH.AUTO_LOGIN_ENABLED.get():
+      user = find_or_create_user(username='hue', password='hue')
+      ensure_has_a_group(user)
+      user = rewrite_user(user)
+
       user = authenticate(request, username='hue', password='hue')
       if user is not None:
         login(request, user)

--- a/desktop/core/src/desktop/middleware.py
+++ b/desktop/core/src/desktop/middleware.py
@@ -367,9 +367,13 @@ class LoginAndPermissionMiddleware(MiddlewareMixin):
         return None
 
     if AUTH.AUTO_LOGIN_ENABLED.get():
+      # Auto-create the hue/hue user if not already present
       user = find_or_create_user(username='hue', password='hue')
       ensure_has_a_group(user)
       user = rewrite_user(user)
+
+      user.is_active = True
+      user.save()
 
       user = authenticate(request, username='hue', password='hue')
       if user is not None:


### PR DESCRIPTION
## What changes were proposed in this pull request?

- If user 'hue' is not present, then auto-create it for the 'auto_login_enabled' config flag along with authenticating it.

