### PR TITLE
[importer] adding column name check in the importer

### DIFF
--- a/desktop/libs/indexer/src/indexer/templates/importer.mako
+++ b/desktop/libs/indexer/src/indexer/templates/importer.mako
@@ -1137,7 +1137,7 @@ ${ commonheader(_("Importer"), "indexer", user, request, "60px") | n,unicode }
 <script type="text/html" id="table-field-template">
   <div>
     <label data-bind="visible: level() == 0 || ($parent.type() != 'array' && $parent.type() != 'map')">${ _('Name') }&nbsp;
-      <input type="text" class="input-large" placeholder="${ _('Field name') }" required data-bind="textInput: name">
+      <input type="text" class="input-large" placeholder="${ _('Field name') }" required data-bind="textInput: name" pattern="[a-zA-Z0-9_]+$" title="${ _('Only alphanumeric and underscore characters') }">
     </label>
 
     <label class="margin-left-5">${ _('Type') }&nbsp;


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Adding column check only alphanumeric and '_' are allowed because
- as hive [not supporting](https://issues.apache.org/jira/browse/HIVE-10120) the '.' and ':'. And we also not supporting special chars as of now.
- impala only [supports](https://documentation.sas.com/doc/en/pgmsascdc/9.4_3.5/acreldb/n0zbh5w5ucvt2gn1t1gnpm6e0sl3.htm#:~:text=Impala%20table%20and%20column%20names,converts%20uppercase%20characters%20to%20lowercase.) the alphanumeric and '-'
