### PR TITLE
[create_session] Remove public API POST view from notebook_api

### DIFF
--- a/desktop/libs/notebook/src/notebook/api.py
+++ b/desktop/libs/notebook/src/notebook/api.py
@@ -26,7 +26,6 @@ import sys
 from django.urls import reverse
 from django.db.models import Q
 from django.views.decorators.http import require_GET, require_POST
-from rest_framework.decorators import api_view
 import opentracing.tracer
 
 from azure.abfs.__init__ import abfspath
@@ -103,7 +102,6 @@ def create_notebook(request):
   return JsonResponse(response)
 
 
-@api_view(["POST"])  # To fully port when Web Components are decoupled
 @require_POST
 @check_document_access_permission
 @api_error_handler


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Removing the DRF Public API view from notebook/api.py create_session.

## How was this patch tested?

- Successfully executing the `create_session` public API (auth token in bearer)

<img width="1101" alt="Screenshot 2021-08-04 at 6 14 24 PM" src="https://user-images.githubusercontent.com/42064744/128182754-71fa9865-d524-4d94-a7fc-b27fdd468a66.png">


