### PR TITLE
[importer] removing 'Search index' option from drop down menu for 'manual' setup

### DIFF
--- a/desktop/libs/indexer/src/indexer/templates/importer.mako
+++ b/desktop/libs/indexer/src/indexer/templates/importer.mako
@@ -2327,7 +2327,7 @@ ${ commonheader(_("Importer"), "indexer", user, request, "60px") | n,unicode }
           }
           if (format.value === 'index' && (
               wizard.source.inputFormat() === 'stream' ||
-              ['file', 'query', 'stream', 'manual'].indexOf(wizard.source.inputFormat()) === -1)) {
+              ['file', 'query', 'stream'].indexOf(wizard.source.inputFormat()) === -1)) {
             return false;
           }
           if (format.value === 'table' &&


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Removing 'Search index' for 'Manually'  Source type input.
- So now we have three options (Table, Database, Folder) for the manual set as you can see in the attached ss.
- Need to remove the Database and Folder options also?

![Screenshot 2021-08-10 at 3 42 45 PM](https://user-images.githubusercontent.com/36241930/128849616-49707faa-8c13-42a4-b0c7-9b9cf84efb9c.png)
