### PR TITLE
Allow /api/token/auth can create user or make it active when auto log…

### DIFF
--- a/desktop/core/src/desktop/middleware.py
+++ b/desktop/core/src/desktop/middleware.py
@@ -308,7 +308,9 @@ class LoginAndPermissionMiddleware(MiddlewareMixin):
     if request.path in ['/oidc/authenticate/', '/oidc/callback/', '/oidc/logout/', '/hue/oidc_failed/']:
       return None
 
-    if request.path.startswith('/api/'):
+    if AUTH.AUTO_LOGIN_ENABLED.get() and request.path.startswith('/api/token/auth'):
+      pass # allow /api/token/auth can create user or make it active
+    elif request.path.startswith('/api/'):
       return None
 
     # Skip views not requiring login


### PR DESCRIPTION
…in enabled

## What changes were proposed in this pull request?

Allow /api/token/auth call to create user or make it active without go through Hue UI

## How was this patch tested?

Tested with a new empty database in local dev and cURL /api/token/auth, /api/editor/execute/hive, and /api/editor/fetch_result_data

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
