### PR TITLE
[filebrowser] removing extra whitespace between the path

### DIFF
--- a/apps/filebrowser/src/filebrowser/templates/fb_components.mako
+++ b/apps/filebrowser/src/filebrowser/templates/fb_components.mako
@@ -57,14 +57,14 @@ else:
           </li>
         %endif
         <li>
-          <ul id="editBreadcrumb" class="hue-breadcrumbs editable-breadcrumbs" data-bind="foreach: breadcrumbs" style="padding-right:40px; padding-top: 12px" title="${_('Edit path')}">
-            <li data-bind="visible: label.slice(-1) == '/'">
+          <ul id="editBreadcrumb" class="hue-breadcrumbs editable-breadcrumbs" data-bind="foreach: breadcrumbs" style="padding-right:40px; padding-top: 12px" title="${_('Edit path')}"
+            ><li data-bind="visible: label.slice(-1) == '/'">
               <a data-bind="click: show, attr: {'href': '${url('filebrowser:filebrowser.views.view', path=urlencode(''))}' + url}"><span class="divider" data-bind="text: label"></span></a>
-            </li>
-            <li data-bind="visible: label.slice(-1) != '/'">
+            </li
+            ><li data-bind="visible: label.slice(-1) != '/'">
               <a data-bind="text: label, click: show, attr: {'href': '${url('filebrowser:filebrowser.views.view', path=urlencode(''))}' + url}"></a><span class="divider">/</span>
-            </li>
-          </ul>
+            </li
+          ></ul>
           <input id="hueBreadcrumbText" type="text" style="display:none" data-bind="value: currentPath" autocomplete="off" class="input-xxlarge" />
         </li>
         % if is_trash_enabled:


### PR DESCRIPTION
## What changes were proposed in this pull request?

- After searching got this link -> https://css-tricks.com/fighting-the-space-between-inline-block-elements/

before commit -> 
![Screenshot 2021-08-16 at 11 30 16 PM](https://user-images.githubusercontent.com/36241930/129608706-eca02aa7-cc62-4162-8162-8438e0209c71.png)
