### PR TITLE
[jwt] Refactor custom JWT authentication config

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -358,12 +358,15 @@
     # Multiple Authentication backend combinations are supported by specifying a comma-separated list in order of priority.
     ## backend=desktop.auth.backend.AllowFirstUserDjangoBackend
 
-    # Custom Authentication backends for the REST API.
-    # Multiple Authentication backends are supported by specifying a comma-separated list in order of priority.
-    ## api_auth=rest_framework_simplejwt.authentication.JWTAuthentication,rest_framework.authentication.SessionAuthentication
+    [[[jwt]]]
+      # Turns on Custom JWT Authentication as ready to use.
+      ## is_enabled=false
 
-    # Verify custom JWT.
-    ## verify_custom_jwt=true
+      # Endpoint to fetch the public key from verification server.
+      ## key_server_url=https://ext_authz:8000
+
+      # Verify custom JWT signature.
+      ## verify_custom_jwt=true
 
     # Class which defines extra accessor methods for User objects.
     ## user_aug=desktop.auth.backend.DefaultUserAugmentor

--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -361,16 +361,6 @@
     # Multiple Authentication backends for REST APIs are supported by specifying a comma-separated list in order of priority.
     ## api_auth=rest_framework_simplejwt.authentication.JWTAuthentication,rest_framework.authentication.SessionAuthentication
 
-    [[[jwt]]]
-      # Adds custom JWT Authentication backend for REST APIs in top priority.
-      ## is_enabled=false
-
-      # Endpoint to fetch the public key from verification server.
-      ## key_server_url=https://ext_authz:8000
-
-      # Verify custom JWT signature.
-      ## verify=true
-
     # Class which defines extra accessor methods for User objects.
     ## user_aug=desktop.auth.backend.DefaultUserAugmentor
 
@@ -438,6 +428,16 @@
 
     # If behind_reverse_proxy is True, it will look for the IP address from this header. Default: HTTP_X_FORWARDED_FOR
     ## reverse_proxy_header=HTTP_X_FORWARDED_FOR
+
+    [[[jwt]]]
+      # Adds custom JWT Authentication backend for REST APIs in top priority.
+      ## is_enabled=false
+
+      # Endpoint to fetch the public key from verification server.
+      ## key_server_url=https://ext_authz:8000
+
+      # Verify custom JWT signature.
+      ## verify=true
 
   # Configuration options for connecting to LDAP and Active Directory
   # -------------------------------------------------------------------

--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -358,8 +358,11 @@
     # Multiple Authentication backend combinations are supported by specifying a comma-separated list in order of priority.
     ## backend=desktop.auth.backend.AllowFirstUserDjangoBackend
 
+    # Multiple Authentication backends for REST APIs are supported by specifying a comma-separated list in order of priority.
+    ## api_auth=rest_framework_simplejwt.authentication.JWTAuthentication,rest_framework.authentication.SessionAuthentication
+
     [[[jwt]]]
-      # Turns on Custom JWT Authentication as ready to use.
+      # Adds custom JWT Authentication backend for REST APIs in top priority.
       ## is_enabled=false
 
       # Endpoint to fetch the public key from verification server.

--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -369,7 +369,7 @@
       ## key_server_url=https://ext_authz:8000
 
       # Verify custom JWT signature.
-      ## verify_custom_jwt=true
+      ## verify=true
 
     # Class which defines extra accessor methods for User objects.
     ## user_aug=desktop.auth.backend.DefaultUserAugmentor

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -373,7 +373,7 @@
       ## key_server_url=https://ext_authz:8000
 
       # Verify custom JWT signature.
-      ## verify_custom_jwt=true
+      ## verify=true
 
     # Class which defines extra accessor methods for User objects.
     ## user_aug=desktop.auth.backend.DefaultUserAugmentor

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -362,8 +362,11 @@
     # Multiple Authentication backend combinations are supported by specifying a comma-separated list in order of priority.
     ## backend=desktop.auth.backend.AllowFirstUserDjangoBackend
 
+    # Multiple Authentication backends for REST APIs are supported by specifying a comma-separated list in order of priority.
+    ## api_auth=rest_framework_simplejwt.authentication.JWTAuthentication,rest_framework.authentication.SessionAuthentication
+
     [[[jwt]]]
-      # Turns on Custom JWT Authentication as ready to use.
+      # Adds custom JWT Authentication backend for REST APIs in top priority.
       ## is_enabled=false
 
       # Endpoint to fetch the public key from verification server.

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -362,12 +362,15 @@
     # Multiple Authentication backend combinations are supported by specifying a comma-separated list in order of priority.
     ## backend=desktop.auth.backend.AllowFirstUserDjangoBackend
 
-    # Custom Authentication backends for the REST API.
-    # Multiple Authentication backends are supported by specifying a comma-separated list in order of priority.
-    ## api_auth=rest_framework_simplejwt.authentication.JWTAuthentication,rest_framework.authentication.SessionAuthentication
+    [[[jwt]]]
+      # Turns on Custom JWT Authentication as ready to use.
+      ## is_enabled=false
 
-    # Verify custom JWT.
-    ## verify_custom_jwt=true
+      # Endpoint to fetch the public key from verification server.
+      ## key_server_url=https://ext_authz:8000
+
+      # Verify custom JWT signature.
+      ## verify_custom_jwt=true
 
     # Class which defines extra accessor methods for User objects.
     ## user_aug=desktop.auth.backend.DefaultUserAugmentor

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -365,16 +365,6 @@
     # Multiple Authentication backends for REST APIs are supported by specifying a comma-separated list in order of priority.
     ## api_auth=rest_framework_simplejwt.authentication.JWTAuthentication,rest_framework.authentication.SessionAuthentication
 
-    [[[jwt]]]
-      # Adds custom JWT Authentication backend for REST APIs in top priority.
-      ## is_enabled=false
-
-      # Endpoint to fetch the public key from verification server.
-      ## key_server_url=https://ext_authz:8000
-
-      # Verify custom JWT signature.
-      ## verify=true
-
     # Class which defines extra accessor methods for User objects.
     ## user_aug=desktop.auth.backend.DefaultUserAugmentor
 
@@ -442,6 +432,16 @@
 
     # If behind_reverse_proxy is True, it will look for the IP address from this header. Default: HTTP_X_FORWARDED_FOR
     ## reverse_proxy_header=HTTP_X_FORWARDED_FOR
+
+    [[[jwt]]]
+      # Adds custom JWT Authentication backend for REST APIs in top priority.
+      ## is_enabled=false
+
+      # Endpoint to fetch the public key from verification server.
+      ## key_server_url=https://ext_authz:8000
+
+      # Verify custom JWT signature.
+      ## verify=true
 
   # Configuration options for connecting to LDAP and Active Directory
   # -------------------------------------------------------------------

--- a/desktop/core/src/desktop/auth/api_authentications.py
+++ b/desktop/core/src/desktop/auth/api_authentications.py
@@ -54,7 +54,7 @@ class JwtAuthentication(authentication.BaseAuthentication):
         access_token,
         'secret',
         algorithms=["RS256"],
-        verify=AUTH.VERIFY_CUSTOM_JWT.get()
+        verify=AUTH.JWT.VERIFY_CUSTOM_JWT.get()
       )
     except jwt.DecodeError:
       raise exceptions.AuthenticationFailed('JwtAuthentication: Invalid token')

--- a/desktop/core/src/desktop/auth/api_authentications.py
+++ b/desktop/core/src/desktop/auth/api_authentications.py
@@ -54,7 +54,7 @@ class JwtAuthentication(authentication.BaseAuthentication):
         access_token,
         'secret',
         algorithms=["RS256"],
-        verify=AUTH.JWT.VERIFY_CUSTOM_JWT.get()
+        verify=AUTH.JWT.VERIFY.get()
       )
     except jwt.DecodeError:
       raise exceptions.AuthenticationFailed('JwtAuthentication: Invalid token')

--- a/desktop/core/src/desktop/auth/api_authentications_tests.py
+++ b/desktop/core/src/desktop/auth/api_authentications_tests.py
@@ -48,11 +48,6 @@ class TestJwtAuthentication():
       }
     )
 
-  @classmethod
-  def setUpClass(cls):
-    if not AUTH.JWT.IS_ENABLED.get():
-      raise SkipTest
-
   def test_authenticate_existing_user(self):
     with patch('desktop.auth.api_authentications.jwt.decode') as jwt_decode:
 

--- a/desktop/core/src/desktop/auth/api_authentications_tests.py
+++ b/desktop/core/src/desktop/auth/api_authentications_tests.py
@@ -104,14 +104,14 @@ class TestJwtAuthentication():
   def test_check_token_verification_flag(self):
 
     # When verification flag is True for old sample token
-    reset = AUTH.JWT.VERIFY_CUSTOM_JWT.set_for_testing(True)
+    reset = AUTH.JWT.VERIFY.set_for_testing(True)
     try:
       assert_raises(exceptions.AuthenticationFailed, JwtAuthentication().authenticate, self.request)
     finally:
       reset()
 
     # When verification flag is False
-    reset = AUTH.JWT.VERIFY_CUSTOM_JWT.set_for_testing(False)
+    reset = AUTH.JWT.VERIFY.set_for_testing(False)
     try:
       user, token = JwtAuthentication().authenticate(request=self.request)
 

--- a/desktop/core/src/desktop/auth/api_authentications_tests.py
+++ b/desktop/core/src/desktop/auth/api_authentications_tests.py
@@ -18,6 +18,7 @@
 import sys
 
 from nose.tools import assert_equal, assert_true, assert_false, assert_raises
+from nose.plugins.skip import SkipTest
 
 from desktop.auth.backend import rewrite_user
 from desktop.auth.api_authentications import JwtAuthentication
@@ -47,6 +48,10 @@ class TestJwtAuthentication():
       }
     )
 
+  @classmethod
+  def setUpClass(cls):
+    if not AUTH.JWT.IS_ENABLED.get():
+      raise SkipTest
 
   def test_authenticate_existing_user(self):
     with patch('desktop.auth.api_authentications.jwt.decode') as jwt_decode:
@@ -104,10 +109,14 @@ class TestJwtAuthentication():
   def test_check_token_verification_flag(self):
 
     # When verification flag is True for old sample token
-    assert_raises(exceptions.AuthenticationFailed, JwtAuthentication().authenticate, self.request)
+    reset = AUTH.JWT.VERIFY_CUSTOM_JWT.set_for_testing(True)
+    try:
+      assert_raises(exceptions.AuthenticationFailed, JwtAuthentication().authenticate, self.request)
+    finally:
+      reset()
 
     # When verification flag is False
-    reset = AUTH.VERIFY_CUSTOM_JWT.set_for_testing(False)
+    reset = AUTH.JWT.VERIFY_CUSTOM_JWT.set_for_testing(False)
     try:
       user, token = JwtAuthentication().authenticate(request=self.request)
 

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -1078,13 +1078,21 @@ AUTH = ConfigSection(
                         "desktop.auth.backend.AllowAllBackend (allows everyone), " +
                         "desktop.auth.backend.AllowFirstUserDjangoBackend (relies on Django and user manager, after the first login). " +
                         "Multiple Authentication backends are supported by specifying a comma-separated list in order of priority.")),
+    API_AUTH=Config(
+        "api_auth",
+        default=[
+          'rest_framework_simplejwt.authentication.JWTAuthentication',
+          'rest_framework.authentication.SessionAuthentication'],
+        type=coerce_csv,
+        help=_("Multiple Authentication backends are supported by specifying a comma-separated list in order of priority.")
+    ),
     JWT=ConfigSection(
       key="jwt",
       help=_("Configuration for Custom JWT Authentication."),
       members=dict(
         IS_ENABLED=Config(
             key='is_enabled',
-            help=_('Turns on Custom JWT Authentication as ready to use.'),
+            help=_('Adds custom JWT Authentication backend for REST APIs in top priority.'),
             type=coerce_bool,
             default=False,
         ),

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -1078,38 +1078,6 @@ AUTH = ConfigSection(
                         "desktop.auth.backend.AllowAllBackend (allows everyone), " +
                         "desktop.auth.backend.AllowFirstUserDjangoBackend (relies on Django and user manager, after the first login). " +
                         "Multiple Authentication backends are supported by specifying a comma-separated list in order of priority.")),
-    API_AUTH=Config(
-        "api_auth",
-        default=[
-          'rest_framework_simplejwt.authentication.JWTAuthentication',
-          'rest_framework.authentication.SessionAuthentication'],
-        type=coerce_csv,
-        help=_("Multiple Authentication backends are supported by specifying a comma-separated list in order of priority.")
-    ),
-    JWT=ConfigSection(
-      key="jwt",
-      help=_("Configuration for Custom JWT Authentication."),
-      members=dict(
-        IS_ENABLED=Config(
-            key='is_enabled',
-            help=_('Adds custom JWT Authentication backend for REST APIs in top priority.'),
-            type=coerce_bool,
-            default=False,
-        ),
-        KEY_SERVER_URL=Config(
-            key="key_server_url",
-            default=None,
-            type=str,
-            help=_("Endpoint to fetch the public key from verification server.")
-        ),
-        VERIFY=Config(
-            key="verify",
-            default=True,
-            type=coerce_bool,
-            help=_("Verify custom JWT signature.")
-        ),
-      )
-    ),
     USER_AUGMENTOR=Config("user_augmentor",
                    default="desktop.auth.backend.DefaultUserAugmentor",
                    help=_("Class which defines extra accessor methods for User objects.")),
@@ -1220,6 +1188,38 @@ AUTH = ConfigSection(
       help=_("If True, will auto log any request as a `hue` user that needs to exist."),
       type=coerce_bool,
       default=False,
+    ),
+    API_AUTH=Config(
+        "api_auth",
+        default=[
+          'rest_framework_simplejwt.authentication.JWTAuthentication',
+          'rest_framework.authentication.SessionAuthentication'],
+        type=coerce_csv,
+        help=_("Multiple Authentication backends are supported by specifying a comma-separated list in order of priority.")
+    ),
+    JWT=ConfigSection(
+      key="jwt",
+      help=_("Configuration for Custom JWT Authentication."),
+      members=dict(
+        IS_ENABLED=Config(
+            key='is_enabled',
+            help=_('Adds custom JWT Authentication backend for REST APIs in top priority.'),
+            type=coerce_bool,
+            default=False,
+        ),
+        KEY_SERVER_URL=Config(
+            key="key_server_url",
+            default=None,
+            type=str,
+            help=_("Endpoint to fetch the public key from verification server.")
+        ),
+        VERIFY=Config(
+            key="verify",
+            default=True,
+            type=coerce_bool,
+            help=_("Verify custom JWT signature.")
+        ),
+      )
     ),
 ))
 

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -1102,8 +1102,8 @@ AUTH = ConfigSection(
             type=str,
             help=_("Endpoint to fetch the public key from verification server.")
         ),
-        VERIFY_CUSTOM_JWT=Config(
-            key="verify_custom_jwt",
+        VERIFY=Config(
+            key="verify",
             default=True,
             type=coerce_bool,
             help=_("Verify custom JWT signature.")

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -1078,21 +1078,29 @@ AUTH = ConfigSection(
                         "desktop.auth.backend.AllowAllBackend (allows everyone), " +
                         "desktop.auth.backend.AllowFirstUserDjangoBackend (relies on Django and user manager, after the first login). " +
                         "Multiple Authentication backends are supported by specifying a comma-separated list in order of priority.")),
-    API_AUTH=Config(
-        "api_auth",
-        default=[
-          'rest_framework_simplejwt.authentication.JWTAuthentication',
-          'rest_framework.authentication.SessionAuthentication'],
-        type=coerce_csv,
-        help=_(
-          "Custom Authentication backends for the REST API." +
-          "Multiple Authentication backends are supported by specifying a comma-separated list in order of priority.")
-    ),
-    VERIFY_CUSTOM_JWT=Config(
-        key="verify_custom_jwt",
-        default=True,
-        type=coerce_bool,
-        help=_("Verify custom JWT.")
+    JWT=ConfigSection(
+      key="jwt",
+      help=_("Configuration for Custom JWT Authentication."),
+      members=dict(
+        IS_ENABLED=Config(
+            key='is_enabled',
+            help=_('Turns on Custom JWT Authentication as ready to use.'),
+            type=coerce_bool,
+            default=False,
+        ),
+        KEY_SERVER_URL=Config(
+            key="key_server_url",
+            default=None,
+            type=str,
+            help=_("Endpoint to fetch the public key from verification server.")
+        ),
+        VERIFY_CUSTOM_JWT=Config(
+            key="verify_custom_jwt",
+            default=True,
+            type=coerce_bool,
+            help=_("Verify custom JWT signature.")
+        ),
+      )
     ),
     USER_AUGMENTOR=Config("user_augmentor",
                    default="desktop.auth.backend.DefaultUserAugmentor",

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -334,8 +334,13 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
       'rest_framework.permissions.IsAuthenticated',
     ],
-    'DEFAULT_AUTHENTICATION_CLASSES': desktop.conf.AUTH.API_AUTH.get()
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+          'rest_framework_simplejwt.authentication.JWTAuthentication',
+          'rest_framework.authentication.SessionAuthentication'
+    ]
 }
+if desktop.conf.AUTH.JWT.IS_ENABLED.get():
+  REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'].insert(0, 'desktop.auth.api_authentications.JwtAuthentication')
 
 SIMPLE_JWT = {
   'ACCESS_TOKEN_LIFETIME': datetime.timedelta(days=1),

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -334,12 +334,9 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
       'rest_framework.permissions.IsAuthenticated',
     ],
-    'DEFAULT_AUTHENTICATION_CLASSES': [
-          'rest_framework_simplejwt.authentication.JWTAuthentication',
-          'rest_framework.authentication.SessionAuthentication'
-    ]
+    'DEFAULT_AUTHENTICATION_CLASSES': desktop.conf.AUTH.API_AUTH.get()
 }
-if desktop.conf.AUTH.JWT.IS_ENABLED.get():
+if desktop.conf.AUTH.JWT.IS_ENABLED.get() and 'desktop.auth.api_authentications.JwtAuthentication' not in REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES']:
   REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'].insert(0, 'desktop.auth.api_authentications.JwtAuthentication')
 
 SIMPLE_JWT = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Much cleaner config flags and values to enable it
- Separate section [[[jwt]]] under [[auth]]
- Update unit tests

```
[[auth]]
[[[jwt]]]

# Turns on Custom JWT Authentication as ready to use.
## is_enabled=false

# Endpoint to fetch the public key from verification server.
## key_server_url=https://ext_authz:8000

# Verify custom JWT signature.
## verify_custom_jwt=true
```