### PR TITLE
Change impersonation to use principal_username

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/sql_alchemy_tests.py
+++ b/desktop/libs/notebook/src/notebook/connectors/sql_alchemy_tests.py
@@ -240,7 +240,9 @@ class TestApi(object):
     with patch('notebook.connectors.sql_alchemy.create_engine') as create_engine:
       engine = SqlAlchemyApi(self.user, interpreter)._create_engine()
 
-      create_engine.assert_called_with('presto://test@hue:8080/hue', pool_pre_ping=True)
+      create_engine.assert_called_with('presto://hue:8080/hue',
+                                       connect_args={'principal_username': 'test'},
+                                       pool_pre_ping=True)
 
 
   def test_explain(self):
@@ -250,7 +252,7 @@ class TestApi(object):
         with patch('notebook.connectors.sql_alchemy.SqlAlchemyApi._get_session') as _get_session:
 
           result = [{"id": 1}, {"select_type": "SIMPLE"}, {"Extra": "No tables used"}]
-          
+
           execute = Mock(return_value=result)
           _create_connection.return_value = Mock(
             execute=execute


### PR DESCRIPTION
- Change impersonation to use principal_username parameter introduced
  in PyHive 0.6.2
- Fix #1285

## What changes were proposed in this pull request?

- This will fix #1285

## How was this patch tested?

- `build/env/bin/hue test specific notebook`: success
- manual test

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
