### PR TITLE
[editor] Convert the mako syntax drop down to Vue and add it to the editor web component

### DIFF
--- a/desktop/core/src/desktop/js/apps/editor/components/aceEditor/AceEditor.vue
+++ b/desktop/core/src/desktop/js/apps/editor/components/aceEditor/AceEditor.vue
@@ -28,6 +28,7 @@
       :editor-id="id"
       :executor="executor"
     />
+    <ace-syntax-dropdown v-if="editor" :editor="editor" :editor-id="id" />
   </div>
 </template>
 
@@ -38,6 +39,7 @@
   import { Ace } from 'ext/ace';
 
   import { attachPredictTypeahead } from './acePredict';
+  import AceSyntaxDropdown from './AceSyntaxDropdown.vue';
   import AceAutocomplete from './autocomplete/AceAutocomplete.vue';
   import AceGutterHandler from './AceGutterHandler';
   import AceLocationHandler, { ACTIVE_STATEMENT_CHANGED_EVENT } from './AceLocationHandler';
@@ -72,6 +74,7 @@
   export default defineComponent({
     name: 'AceEditor',
     components: {
+      AceSyntaxDropdown,
       AceAutocomplete
     },
     props: {

--- a/desktop/core/src/desktop/js/apps/editor/components/aceEditor/AceLocationHandler.ts
+++ b/desktop/core/src/desktop/js/apps/editor/components/aceEditor/AceLocationHandler.ts
@@ -18,6 +18,11 @@ import { Ace } from 'ext/ace';
 import ace from 'ext/aceHelper';
 import KnockoutObservable from '@types/knockout';
 
+import {
+  SQL_SYNTAX_DROPDOWN_HIDE_TOPIC,
+  SQL_SYNTAX_DROPDOWN_SHOW_TOPIC,
+  SqlSyntaxDropdownShowEvent
+} from './events';
 import { ActiveStatementChangedEventDetails } from './types';
 import Executor from 'apps/editor/execution/executor';
 import DataCatalogEntry, { TableSourceMeta } from 'catalog/DataCatalogEntry';
@@ -417,7 +422,7 @@ export default class AceLocationHandler implements Disposable {
     const onContextMenu = (e: { clientX: number; clientY: number; preventDefault: () => void }) => {
       const selectionRange = this.editor.selection.getRange();
       huePubSub.publish('context.popover.hide');
-      huePubSub.publish('sql.syntax.dropdown.hide');
+      huePubSub.publish(SQL_SYNTAX_DROPDOWN_HIDE_TOPIC);
       if (selectionRange.isEmpty()) {
         const pointerPosition = this.editor.renderer.screenToTextCoordinates(
           e.clientX + 5,
@@ -514,7 +519,7 @@ export default class AceLocationHandler implements Disposable {
               });
             }
           } else if (token.syntaxError) {
-            huePubSub.publish('sql.syntax.dropdown.show', {
+            huePubSub.publish<SqlSyntaxDropdownShowEvent>(SQL_SYNTAX_DROPDOWN_SHOW_TOPIC, {
               editorId: this.editorId,
               data: token.syntaxError,
               editor: this.editor,

--- a/desktop/core/src/desktop/js/apps/editor/components/aceEditor/AceSyntaxDropdown.scss
+++ b/desktop/core/src/desktop/js/apps/editor/components/aceEditor/AceSyntaxDropdown.scss
@@ -1,0 +1,31 @@
+/*
+ Licensed to Cloudera, Inc. under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  Cloudera, Inc. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+.ace-syntax-dropdown-container {
+  position: fixed;
+  z-index: 10000;
+
+  .hue-dropdown-drawer-inner {
+    max-height: 200px;
+    overflow-y: auto;
+
+    li button {
+      font-size: 13px;
+    }
+  }
+}

--- a/desktop/core/src/desktop/js/apps/editor/components/aceEditor/AceSyntaxDropdown.vue
+++ b/desktop/core/src/desktop/js/apps/editor/components/aceEditor/AceSyntaxDropdown.vue
@@ -1,0 +1,121 @@
+<!--
+  Licensed to Cloudera, Inc. under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  Cloudera, Inc. licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<template>
+  <div class="ace-syntax-dropdown-container" :style="position">
+    <DropdownMenuOptions
+      :force-bottom-placement="true"
+      :open="visible"
+      :options="options"
+      @close="closePanel"
+      @option-selected="optionSelected"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+  import { Ace } from 'ext/ace';
+  import { defineComponent, PropType, ref, toRefs } from 'vue';
+
+  import './AceSyntaxDropdown.scss';
+  import { SQL_SYNTAX_DROPDOWN_SHOW_TOPIC, SqlSyntaxDropdownShowEvent } from './events';
+  import DropdownMenuOptions from 'components/dropdown/DropdownMenuOptions.vue';
+  import { Option } from 'components/dropdown/types';
+  import SubscriptionTracker from 'components/utils/SubscriptionTracker';
+  import huePubSub from 'utils/huePubSub';
+  import I18n from 'utils/i18n';
+  import { getFromLocalStorage, setInLocalStorage } from 'utils/storageUtils';
+
+  interface SyntaxOption extends Option {
+    suppress?: string;
+  }
+
+  export default defineComponent({
+    name: 'AceSyntaxDropdown',
+    components: { DropdownMenuOptions },
+    props: {
+      editor: {
+        type: Object as PropType<Ace.Editor>,
+        required: true
+      },
+      editorId: {
+        type: String,
+        required: true
+      }
+    },
+    emits: [],
+    setup(props) {
+      const { editor, editorId } = toRefs(props);
+      const subTracker = new SubscriptionTracker();
+      const visible = ref(false);
+      const range = ref<Ace.Range>();
+      const options = ref<SyntaxOption[]>([]);
+      const position = ref<Pick<CSSStyleDeclaration, 'left' | 'top'>>();
+
+      const closePanel = (): void => {
+        options.value = [];
+        range.value = undefined;
+        visible.value = false;
+      };
+
+      const optionSelected = ({ suppress, value }: SyntaxOption) => {
+        if (suppress) {
+          const currentSuppressedRules = getFromLocalStorage(
+            'hue.syntax.checker.suppressedRules',
+            {} as Record<string, boolean>
+          );
+          currentSuppressedRules[suppress] = true;
+          setInLocalStorage('hue.syntax.checker.suppressedRules', currentSuppressedRules);
+          huePubSub.publish('editor.refresh.statement.locations', editorId.value);
+        } else if (range.value) {
+          editor.value.session.replace(range.value, value);
+        }
+      };
+
+      subTracker.subscribe('sql.syntax.dropdown.hide', closePanel);
+
+      subTracker.subscribe<SqlSyntaxDropdownShowEvent>(SQL_SYNTAX_DROPDOWN_SHOW_TOPIC, details => {
+        if (details.editorId !== editorId.value) {
+          return;
+        }
+        const newOptions: SyntaxOption[] = details.data.expected.map(expected => ({
+          label: expected.text,
+          value: expected.text
+        }));
+        if (details.data.ruleId) {
+          newOptions.push({
+            label: '-',
+            value: '_divider_',
+            divider: true
+          });
+          newOptions.push({
+            label: I18n('Ignore this type of error'),
+            value: '_suppress_',
+            suppress: details.data.ruleId + details.data.text.toLowerCase()
+          });
+        }
+        position.value = { top: `${details.source.bottom}px`, left: `${details.source.left}px` };
+        range.value = details.range;
+        options.value = newOptions;
+        visible.value = true;
+      });
+
+      return { closePanel, options, optionSelected, position, visible };
+    }
+  });
+</script>

--- a/desktop/core/src/desktop/js/apps/editor/components/aceEditor/__snapshots__/AceEditor.test.ts.snap
+++ b/desktop/core/src/desktop/js/apps/editor/components/aceEditor/__snapshots__/AceEditor.test.ts.snap
@@ -99,5 +99,9 @@ exports[`AceEditor.vue should render 1`] = `
     sqlreferenceprovider="[object Object]"
     temporaryonly="false"
   />
+  <ace-syntax-dropdown-stub
+    editor="[object Object]"
+    editorid="some-id"
+  />
 </div>
 `;

--- a/desktop/core/src/desktop/js/apps/editor/components/aceEditor/autocomplete/AutocompleteResults.ts
+++ b/desktop/core/src/desktop/js/apps/editor/components/aceEditor/autocomplete/AutocompleteResults.ts
@@ -238,8 +238,8 @@ class AutocompleteResults {
     const foundArgumentDetails = (await getArgumentDetailsForUdf(
       this.sqlReferenceProvider,
       this.executor.connector(),
-      this.parseResult.udfArgument.name,
-      this.parseResult.udfArgument.position
+      this.parseResult.udfArgument!.name,
+      this.parseResult.udfArgument!.position
     )) || [{ type: 'T' }];
 
     if (foundArgumentDetails.length === 0 && this.parseResult.suggestColumns) {
@@ -701,7 +701,7 @@ class AutocompleteResults {
       try {
         const databases = await databasesPromise;
         const foundDb = databases.find(dbEntry =>
-          equalIgnoreCase(dbEntry.name, suggestTables.identifierChain[0].name)
+          equalIgnoreCase(dbEntry.name, suggestTables.identifierChain![0].name)
         );
         if (foundDb) {
           tableSuggestions = await getTableSuggestions();
@@ -1196,7 +1196,7 @@ class AutocompleteResults {
     // Last one is either partial name or empty
     parts.pop();
 
-    await new Promise(resolve => {
+    await new Promise<void>(resolve => {
       const apiHelperFn = (<{ [fn: string]: (arg: unknown) => JQueryXHR }>(<unknown>apiHelper))[
         fetchFunction
       ];

--- a/desktop/core/src/desktop/js/apps/editor/components/aceEditor/events.ts
+++ b/desktop/core/src/desktop/js/apps/editor/components/aceEditor/events.ts
@@ -1,0 +1,31 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Ace } from 'ext/ace';
+import { SyntaxError } from 'parse/types';
+
+export const SQL_SYNTAX_DROPDOWN_SHOW_TOPIC = 'sql.syntax.dropdown.show';
+export interface SqlSyntaxDropdownShowEvent {
+  editorId: string;
+  editor: Ace.Editor;
+  data: SyntaxError;
+  range: Ace.Range;
+  sourceType: string;
+  defaultDatabase: string;
+  source: { top: number; right: number; bottom: number; left: number };
+}
+
+export const SQL_SYNTAX_DROPDOWN_HIDE_TOPIC = 'sql.syntax.dropdown.hide';

--- a/desktop/core/src/desktop/js/components/dropdown/DropdownDivider.vue
+++ b/desktop/core/src/desktop/js/components/dropdown/DropdownDivider.vue
@@ -17,16 +17,13 @@
 -->
 
 <template>
-  <li>
-    <button @click.stop="$emit('click')"><slot /></button>
-  </li>
+  <li class="dropdown-divider">&nbsp;</li>
 </template>
 
 <script lang="ts">
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    name: 'DropdownMenuButton',
-    emits: ['click']
+    name: 'DropdownDivider'
   });
 </script>

--- a/desktop/core/src/desktop/js/components/dropdown/DropdownDrawer.scss
+++ b/desktop/core/src/desktop/js/components/dropdown/DropdownDrawer.scss
@@ -48,6 +48,11 @@
       list-style: none;
       font-size: 13px;
 
+      li.dropdown-divider {
+        height: 1px;
+        background-color: $hue-border-color;
+      }
+
       li {
         color: $fluid-gray-800;
 

--- a/desktop/core/src/desktop/js/components/dropdown/DropdownDrawer.vue
+++ b/desktop/core/src/desktop/js/components/dropdown/DropdownDrawer.vue
@@ -72,6 +72,10 @@
       triggerElement: {
         type: Object as PropType<HTMLElement | null>,
         default: null
+      },
+      forceBottomPlacement: {
+        type: Boolean,
+        default: false
       }
     },
     emits: ['close'],
@@ -95,7 +99,7 @@
         await nextTick();
 
         const { bottom, right } = isOutsideViewport(<HTMLElement>this.$refs.innerPanelElement);
-        if (bottom) {
+        if (bottom && !this.forceBottomPlacement) {
           const bottomOffset = this.triggerElement?.offsetHeight || 0;
           // position: relative Prevents fixed element from appearing below the window when at the bottom of the page
           this.parentPosition = { position: 'relative' };

--- a/desktop/core/src/desktop/js/components/dropdown/DropdownMenuOptions.vue
+++ b/desktop/core/src/desktop/js/components/dropdown/DropdownMenuOptions.vue
@@ -1,34 +1,38 @@
 <template>
   <DropdownDrawer
-    :open="open && options.length"
+    :open="open && options.length > 0"
+    :force-bottom-placement="forceBottomPlacement"
     :trigger-element="keydownElement"
     @close="$emit('close')"
   >
     <ul>
-      <DropdownMenuButton
-        v-for="(option, idx) of options"
-        :key="option.value || option"
-        :class="{ selected: idx === selectedIndex }"
-        @click="onOptionClick(option, idx)"
-      >
-        {{ getLabel(option) }}
-      </DropdownMenuButton>
+      <template v-for="(option, idx) of options" :key="option.value || option.label || option">
+        <DropdownMenuButton
+          v-if="!option.divider"
+          :class="{ selected: idx === selectedIndex }"
+          @click="onOptionClick(option, idx)"
+        >
+          {{ getLabel(option) }}
+        </DropdownMenuButton>
+        <DropdownDivider v-else />
+      </template>
     </ul>
   </DropdownDrawer>
 </template>
 
 <script lang="ts">
   import { defineComponent, PropType } from 'vue';
+  import DropdownDivider from './DropdownDivider.vue';
 
   import DropdownDrawer from './DropdownDrawer.vue';
   import DropdownMenuButton from './DropdownMenuButton.vue';
-  import { Option } from './DropDownMenuOptions';
+  import { Option } from './types';
 
   export const getLabel = (option: Option): string =>
     (option as { label: string }).label || (option as string);
 
   export default defineComponent({
-    components: { DropdownMenuButton, DropdownDrawer },
+    components: { DropdownDivider, DropdownMenuButton, DropdownDrawer },
     props: {
       options: {
         type: Array as PropType<Option[]>,
@@ -39,6 +43,10 @@
         default: null
       },
       open: {
+        type: Boolean,
+        default: false
+      },
+      forceBottomPlacement: {
         type: Boolean,
         default: false
       }
@@ -97,6 +105,7 @@
       onOptionClick(option: Option, index: number) {
         this.selectedIndex = index;
         this.$emit('option-selected', option);
+        this.$emit('close');
       }
     }
   });

--- a/desktop/core/src/desktop/js/components/dropdown/types.ts
+++ b/desktop/core/src/desktop/js/components/dropdown/types.ts
@@ -3,15 +3,15 @@
 // distributed with this work for additional information
 // regarding copyright ownership.  Cloudera, Inc. licenses this file
 // to you under the Apache License, Version 2.0 (the
-// 'License'); you may not use this file except in compliance
+// "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an 'AS IS' BASIS,
+// distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export type Option = string | { value: string; label: string };
+export type Option = string | { value: string; label: string; divider?: boolean };

--- a/desktop/core/src/desktop/js/parse/types.ts
+++ b/desktop/core/src/desktop/js/parse/types.ts
@@ -48,6 +48,7 @@ export interface SyntaxError {
   expectedStatementEnd?: boolean;
   loc: ParsedLocation;
   text: string;
+  ruleId?: string;
 }
 
 export interface IdentifierLocation {

--- a/desktop/libs/notebook/src/notebook/templates/editor2.mako
+++ b/desktop/libs/notebook/src/notebook/templates/editor2.mako
@@ -29,7 +29,6 @@
 
 <%namespace name="configKoComponents" file="/config_ko_components.mako" />
 <%namespace name="notebookKoComponents" file="/common_notebook_ko_components.mako" />
-<%namespace name="sqlSyntaxDropdown" file="/sql_syntax_dropdown.mako" />
 
 <link rel="stylesheet" href="${ static('notebook/css/editor2.css') }">
 <link rel="stylesheet" href="${ static('desktop/ext/css/bootstrap-editable.css') }">
@@ -1040,8 +1039,6 @@
     <!-- /ko -->
   </div>
 </div>
-
-${ sqlSyntaxDropdown.sqlSyntaxDropdown() }
 
 <script type="text/javascript">
   window.EDITOR_BINDABLE_ELEMENT = '#editorComponents';


### PR DESCRIPTION
Just for editor v2 and still need to wire up the web workers in the web component.