### PR TITLE
[jwt] Allow developers test API calls without token in local dev env

### DIFF
--- a/desktop/core/src/desktop/auth/api_authentications.py
+++ b/desktop/core/src/desktop/auth/api_authentications.py
@@ -81,3 +81,16 @@ class JwtAuthentication(authentication.BaseAuthentication):
       user.profile.save()
 
     return (user, None)
+
+
+# for local dev env doesn't have authentication service
+class DummyCustomAuthentication(authentication.BaseAuthentication):
+
+  def authenticate(self, request):
+    LOG.debug('DummyCustomAuthentication: %s' % request.path)
+    user = find_or_create_user(username='hue', password='hue')
+    ensure_has_a_group(user)
+    user = rewrite_user(user)
+    user.is_active = True
+
+    return (user, None)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Moving from using Hue's JWT token to use external auth JWT token, and adding a dummy custom API auth class for development in local dev environment where doesn't have an external authentication service available.

## How was this patch tested?
Use cURL command to test following config

```
[desktop]
[[auth]]
api_auth=desktop.auth.api_authentications.DummyCustomAuthentication
```

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
