### PR TITLE
[connector] correcting the name form 'kafka sql' to 'ksql'

### DIFF
--- a/desktop/core/src/desktop/js/ko/components/assist/ko.assistDbPanel.js
+++ b/desktop/core/src/desktop/js/ko/components/assist/ko.assistDbPanel.js
@@ -828,7 +828,7 @@ class AssistDbPanel {
     }
 
     if (this.isStreams) {
-      const connector = findEditorConnector(connector => connector.dialect === 'kafka sql');
+      const connector = findEditorConnector(connector => connector.dialect === 'ksql');
       this.setSingleSource(connector, navigationSettings, true);
       return;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- error was when click on stream logo in left assist-> 
![Screenshot 2021-08-23 at 5 56 24 PM](https://user-images.githubusercontent.com/36241930/130447303-22acf67d-4e17-4da2-9932-d2c46253f80b.png)

- error gone after 'ksql' dialect 
![Screenshot 2021-08-23 at 6 01 07 PM](https://user-images.githubusercontent.com/36241930/130447450-e6d680bd-7f21-4ec0-8fa0-84bac16a5560.png)


