### PR TITLE
[raz] Fix SAS token appending in url

### DIFF
--- a/desktop/core/src/desktop/lib/rest/raz_http_client.py
+++ b/desktop/core/src/desktop/lib/rest/raz_http_client.py
@@ -45,7 +45,10 @@ class RazHttpClient(HttpClient):
 
     response = raz_client.get_url(action=http_method, path=url, headers=headers)
 
-    signed_path = url + ('?' if '?' not in url else '&') + response['token']
+    signed_url = url + ('?' if '?' not in url else '&') + response['token']
+
+    # Required because `self._make_url` is called in base class execute method also
+    signed_path = path + signed_url.partition(path)[2]
 
     return super(RazHttpClient, self).execute(
         http_method=http_method,

--- a/desktop/core/src/desktop/lib/rest/raz_http_client.py
+++ b/desktop/core/src/desktop/lib/rest/raz_http_client.py
@@ -45,12 +45,11 @@ class RazHttpClient(HttpClient):
 
     response = raz_client.get_url(action=http_method, path=url, headers=headers)
 
-    signed_path = path + ('?' if '?' not in url else '&') + response['token']
+    signed_path = url + ('?' if '?' not in url else '&') + response['token']
 
     return super(RazHttpClient, self).execute(
         http_method=http_method,
         path=signed_path,
-        params=params,
         data=data,
         headers=headers,
         allow_redirects=allow_redirects,

--- a/desktop/core/src/desktop/lib/rest/raz_http_client_test.py
+++ b/desktop/core/src/desktop/lib/rest/raz_http_client_test.py
@@ -45,7 +45,7 @@ class TestRazHttpClient():
         raz_get_url.assert_called_with(action='GET', path='https://gethue.blob.core.windows.net/gethue/data/customer.csv?action=getStatus', headers=None)
         raz_http_execute.assert_called_with(
             http_method='GET',
-            path='https://gethue.blob.core.windows.net/gethue/data/customer.csv?action=getStatus&sv=2014-02-14&sr=b&sig=pJL%2FWyed41tptiwBM5ymYre4qF8wzrO05tS5MCjkutc%3D&st=2015-01-02T01%3A40%3A51Z&se=2015-01-02T02%3A00%3A51Z&sp=r',
+            path='/gethue/data/customer.csv?action=getStatus&sv=2014-02-14&sr=b&sig=pJL%2FWyed41tptiwBM5ymYre4qF8wzrO05tS5MCjkutc%3D&st=2015-01-02T01%3A40%3A51Z&se=2015-01-02T02%3A00%3A51Z&sp=r',
             data=None,
             headers=None,
             allow_redirects=False,

--- a/desktop/core/src/desktop/lib/rest/raz_http_client_test.py
+++ b/desktop/core/src/desktop/lib/rest/raz_http_client_test.py
@@ -31,22 +31,21 @@ class TestRazHttpClient():
 
   def test_get_file(self):
     with patch('desktop.lib.rest.raz_http_client.AdlsRazClient.get_url') as raz_get_url:
-      with patch('desktop.lib.rest.raz_http_client.HttpClient.execute') as http_execute:
+      with patch('desktop.lib.rest.raz_http_client.HttpClient.execute') as raz_http_execute:
 
         raz_get_url.return_value = {
           'token': 'sv=2014-02-14&sr=b&sig=pJL%2FWyed41tptiwBM5ymYre4qF8wzrO05tS5MCjkutc%3D&st=2015-01-02T01%3A40%3A51Z&se=2015-01-02T02%3A00%3A51Z&sp=r'
         }
-        http_execute.return_value = 'my file content'
+        raz_http_execute.return_value = 'my_file_content'
 
         client = RazHttpClient(username='test', base_url='https://gethue.blob.core.windows.net')
-        f = client.execute(http_method='GET', path='/gethue/data/customer.csv')
+        f = client.execute(http_method='GET', path='/gethue/data/customer.csv', params={'action': 'getStatus'})
 
-        assert_equal('my file content', f)
-        raz_get_url.assert_called_with(action='GET', path='https://gethue.blob.core.windows.net/gethue/data/customer.csv', headers=None)
-        http_execute.assert_called_with(
+        assert_equal('my_file_content', f)
+        raz_get_url.assert_called_with(action='GET', path='https://gethue.blob.core.windows.net/gethue/data/customer.csv?action=getStatus', headers=None)
+        raz_http_execute.assert_called_with(
             http_method='GET',
-            path='/gethue/data/customer.csv?sv=2014-02-14&sr=b&sig=pJL%2FWyed41tptiwBM5ymYre4qF8wzrO05tS5MCjkutc%3D&st=2015-01-02T01%3A40%3A51Z&se=2015-01-02T02%3A00%3A51Z&sp=r',
-            params=None,
+            path='https://gethue.blob.core.windows.net/gethue/data/customer.csv?action=getStatus&sv=2014-02-14&sr=b&sig=pJL%2FWyed41tptiwBM5ymYre4qF8wzrO05tS5MCjkutc%3D&st=2015-01-02T01%3A40%3A51Z&se=2015-01-02T02%3A00%3A51Z&sp=r',
             data=None,
             headers=None,
             allow_redirects=False,


### PR DESCRIPTION
## What changes were proposed in this pull request?

- With extra params according to Azure APIs, the SAS token appending was not working properly.
- This fix will only append `?action=getStatus` only once and wont call `self._make_url(...)` again in the [base class `HttpClient`](https://github.com/cloudera/hue/blob/c843c7a8f7880663cabe17882e309eef068a5c88/desktop/core/src/desktop/lib/rest/http_client.py#L203).

## How was this patch tested?

- Fixing and running unit tests
