### PR TITLE
[jwt] Add request path to help debug API calls

### DIFF
--- a/desktop/core/src/desktop/auth/api_authentications.py
+++ b/desktop/core/src/desktop/auth/api_authentications.py
@@ -34,20 +34,20 @@ class JwtAuthentication(authentication.BaseAuthentication):
     authorization_header = request.META.get('HTTP_AUTHORIZATION')
 
     if not authorization_header:
-      LOG.debug('JwtAuthentication: no authorization header')
+      LOG.debug('JwtAuthentication: no authorization header from %s' % request.path)
       return None
 
     header, access_token = authorization_header.split(' ')
 
     if header != 'Bearer':
-      LOG.debug('JwtAuthentication: no Bearer header')
+      LOG.debug('JwtAuthentication: no Bearer header from %s' % request.path)
       return None
 
     if not access_token:
-      LOG.debug('JwtAuthentication: no Bearer value')
+      LOG.debug('JwtAuthentication: no Bearer value from %s' % request.path)
       return None
 
-    LOG.debug('JwtAuthentication: got access token %s' % access_token)
+    LOG.debug('JwtAuthentication: got access token from %s: %s' % (request.path, access_token))
 
     try:
       payload = jwt.decode(


### PR DESCRIPTION
## What changes were proposed in this pull request?

After using external JWT auth service, it was working. But there are a few logs shows error "no authorization header." Simply add the request.path in the log to help which API call throws error.

## How was this patch tested?

Tested locally with/wo jwt token to see if the path get logged for cURL commands.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
