### PR TITLE
[raz] Refactor RAZ ADLS req according to ADLS Gen 2 URI

### DIFF
--- a/desktop/core/src/desktop/lib/raz/raz_client.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client.py
@@ -166,8 +166,7 @@ class RazClient(object):
             return dict([(i.key, i.value) for i in signed_response.signer_generated_headers])
 
   def _make_adls_request(self, request_data, path, resource_path):
-    storage_account = path.netloc.split('.')[0]
-    container, relative_path = resource_path.split('/', 1)
+    container, storage_account = path.netloc.split('.', 1)[0].split('@')
 
     request_data.update({
       "clientType": "adls",
@@ -175,7 +174,7 @@ class RazClient(object):
         "resource": {
           "storageaccount": storage_account,
           "container": container,
-          "relativepath": relative_path,
+          "relativepath": resource_path,
         },
         "resourceOwner": "",
         "action": "read",

--- a/desktop/core/src/desktop/lib/raz/raz_client_test.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client_test.py
@@ -102,7 +102,7 @@ class RazClientTest(unittest.TestCase):
     self.raz_token = "mock_RAZ_token"
 
     self.s3_path = 'https://gethue-test.s3.amazonaws.com/gethue/data/customer.csv'
-    self.adls_path = 'https://gethuestorageaccount.blob.core.windows.net/demo-gethue-container/demo-dir1/customer.csv'
+    self.adls_path = 'https://data@gethuedevstorage.dfs.core.windows.net/data/user/sso_hueuser?action=getStatus'
 
   def test_get_raz_client_adls(self):
     with patch('desktop.lib.raz.raz_client.RazToken') as RazToken:
@@ -163,9 +163,9 @@ class RazClientTest(unittest.TestCase):
             'context': {}, 
             'operation': {
               'resource': {
-                'storageaccount': 'gethuestorageaccount', 
-                'container': 'demo-gethue-container', 
-                'relativepath': 'demo-dir1/customer.csv'
+                'storageaccount': 'gethuedevstorage', 
+                'container': 'data', 
+                'relativepath': 'data/user/sso_hueuser'
               }, 
               'resourceOwner': '', 
               'action': 'read', 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- According to ADLS Gen 2 URI.
- `abfs://<containername>@<accountname>.dfs.core.windows.net/<file.path>/`

## How was this patch tested?

- Updating and running unit tests.
- Needs E2E testing with RAZ.
