### PR TITLE
[jwt] Add USE_THRIFT_HTTP_JWT config in desktop/conf

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -306,6 +306,9 @@ http_500_debug_mode=false
 # Turn on the direct link sharing of saved document.
 ## enable_link_sharing=true
 
+# Use Thrift over HTTP for the transport mode with JWT as Bearer header.
+  ## use_thrift_http_jwt=false
+
 # Hue uses Localstorage to keep the users settings and database preferences.
 # Please make this value true in case local storage should not be used
 # default value is false

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -311,6 +311,9 @@
   # Turn on the direct link sharing of saved document.
   ## enable_link_sharing=true
 
+  # Use Thrift over HTTP for the transport mode with JWT as Bearer header.
+  ## use_thrift_http_jwt=false
+
   # Hue uses Localstorage to keep the users settings and database preferences.
   # Please make this value true in case local storage should not be used
   # default value is false

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -151,6 +151,9 @@ def is_python2():
   """Hue is running on Python 2."""
   return sys.version_info[0] == 2
 
+def is_jwt_authentication_enabled():
+  """JWT backend flag enabled or backend set in api auth explicitly"""
+  return AUTH.JWT.IS_ENABLED.get() or 'desktop.auth.api_authentications.JwtAuthentication' in AUTH.API_AUTH.get()
 
 USE_CHERRYPY_SERVER = Config(
   key="use_cherrypy_server",
@@ -2058,6 +2061,14 @@ ENABLE_LINK_SHARING = Config(
   type=coerce_bool,
   help=_('Turn on the direct link sharing of saved document.')
 )
+
+USE_THRIFT_HTTP_JWT = Config(
+  key="use_thrift_http_jwt",
+  help=_("Use Thrift over HTTP for the transport mode with JWT as Bearer header."),
+  type=coerce_bool,
+  dynamic_default=is_jwt_authentication_enabled
+)
+
 DISABLE_LOCAL_STORAGE = Config(
   key='disable_local_storage',
   default="false",


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add the USE_THRIFT_HTTP_JWT flag on `desktop/conf`.
- Takes default bool values from custom jwt `is_enabled` flag and `api_auth`.
