### PR TITLE
[api] Also lookup for query in snippet in risk call

### DIFF
--- a/desktop/libs/metadata/src/metadata/optimizer_api.py
+++ b/desktop/libs/metadata/src/metadata/optimizer_api.py
@@ -32,6 +32,7 @@ from desktop.models import Document2
 from libsentry.privilege_checker import MissingSentryPrivilegeException
 from notebook.api import _get_statement
 from notebook.models import Notebook
+from notebook.sql_utils import get_current_statement
 
 from metadata.optimizer.base import get_api
 from metadata.optimizer.optimizer_client import NavOptException, _get_table_name, _clean_query
@@ -197,7 +198,11 @@ def query_risk(request):
 
   interface = request.POST.get('interface', OPTIMIZER.INTERFACE.get())
   connector = json.loads(request.POST.get('connector', '{}'))
-  query = json.loads(request.POST.get('query'))
+  if request.POST.get('query'):
+    query = json.loads(request.POST.get('query'))
+  else:
+    snippet = json.loads(request.POST.get('snippet'))
+    query = get_current_statement(snippet)
   source_platform = request.POST.get('sourcePlatform')
   db_name = request.POST.get('dbName')
 


### PR DESCRIPTION
Currently on demo.gethue:

[2021-08-28 12:04:01 +0000] [34] [DEBUG] POST /api/optimizer/query_risk/
[28/Aug/2021 05:04:01 -0700] optimizer_api ERROR    the JSON object must be str, bytes or bytearray, not 'NoneType'
Traceback (most recent call last):
  File "/usr/share/hue/desktop/libs/metadata/src/metadata/optimizer_api.py", line 60, in decorator
    return view_fn(*args, **kwargs)
  File "/usr/share/hue/desktop/libs/metadata/src/metadata/optimizer_api.py", line 200, in query_risk
    query = json.loads(request.POST.get('query'))
  File "/usr/lib/python3.6/json/__init__.py", line 348, in loads
    'not {!r}'.format(s.__class__.__name__))
TypeError: the JSON object must be str, bytes or bytearray, not 'NoneType'
