### PR TITLE
[raz_adls] Add create and delete operations mapping

### DIFF
--- a/desktop/core/src/desktop/lib/raz/raz_client.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client.py
@@ -200,21 +200,22 @@ class RazClient(object):
 
 
   def handle_adls_req_mapping(self, method, params, relative_path):
-    access_type = ''
-
     if method == 'HEAD':
-      # Stats
-      if params.get('action') == 'getStatus':
-        access_type = 'get-status'
+      access_type = 'get-status' if params.get('action') == 'getStatus' else ''
+
+    if method == 'DELETE':
+      access_type = 'delete-recursive' if params.get('recursive') == 'true' else 'delete'
     
     if method == 'GET':
-      access_type = 'read'
-
-      # List
-      if params.get('resource') == 'filesystem':
-        if params.get('directory'):
-          relative_path += lib_urlunquote(params['directory'])
-          access_type = 'list'
+      access_type = 'list' if params.get('resource') == 'filesystem' else 'read'
+      if params.get('directory'):
+        relative_path += lib_urlunquote(params['directory'])
+    
+    if method == 'PUT':
+      if params.get('resource') == 'file':
+        access_type = 'create-file'
+      elif params.get('resource') == 'directory':
+        access_type = 'create-directory'
 
     return {'access_type': access_type, 'relative_path': relative_path}
 

--- a/desktop/core/src/desktop/lib/raz/raz_client_test.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client_test.py
@@ -203,6 +203,46 @@ class RazClientTest(unittest.TestCase):
     assert_equal(response['access_type'], 'get-status')
     assert_equal(response['relative_path'], '/user/csso_hueuser')
 
+    # Create file
+    method = 'PUT'
+    relative_path = '/user/csso_hueuser/customers.csv'
+    url_params = {'resource': 'file'}
+
+    response = client.handle_adls_req_mapping(method, url_params, relative_path)
+
+    assert_equal(response['access_type'], 'create-file')
+    assert_equal(response['relative_path'], '/user/csso_hueuser/customers.csv')
+
+    # Create directory
+    method = 'PUT'
+    relative_path = '/user/csso_hueuser/test_dir'
+    url_params = {'resource': 'directory'}
+
+    response = client.handle_adls_req_mapping(method, url_params, relative_path)
+
+    assert_equal(response['access_type'], 'create-directory')
+    assert_equal(response['relative_path'], '/user/csso_hueuser/test_dir')
+
+    # Delete path
+    method = 'DELETE'
+    relative_path = '/user/csso_hueuser/test_dir/customer.csv'
+    url_params = {}
+
+    response = client.handle_adls_req_mapping(method, url_params, relative_path)
+
+    assert_equal(response['access_type'], 'delete')
+    assert_equal(response['relative_path'], '/user/csso_hueuser/test_dir/customer.csv')
+
+    # Delete with recursive as true
+    method = 'DELETE'
+    relative_path = '/user/csso_hueuser/test_dir'
+    url_params = {'recursive': 'true'}
+
+    response = client.handle_adls_req_mapping(method, url_params, relative_path)
+
+    assert_equal(response['access_type'], 'delete-recursive')
+    assert_equal(response['relative_path'], '/user/csso_hueuser/test_dir')
+
 
   def test_get_raz_client_s3(self):
     with patch('desktop.lib.raz.raz_client.RazToken') as RazToken:


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Added mapping for create operations (create file and directory) and delete operations (only specific path or recursive).

## How was this patch tested?

- Updated and running unit tests.