### PR TITLE
GH-2370 Hue Login Failed attempt should not expose bind_dn into the Login screen

### DIFF
--- a/apps/useradmin/src/useradmin/ldap_access.py
+++ b/apps/useradmin/src/useradmin/ldap_access.py
@@ -191,7 +191,7 @@ class LdapConnection(object):
       msg = "Can\'t contact LDAP server"
     else:
       if bind_user:
-        msg = "Failed to bind to LDAP server as user %s" % bind_user
+        msg = "Failed to bind to LDAP server"
       else:
         msg = "Failed to bind to LDAP server anonymously"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

#2370  - Hue Login Failed attempt should not expose bind_dn into the Login screen

## How was this patch tested?

-Tested Manually