### PR TITLE
[raz_adls] Add append and flush operation mapping

### DIFF
--- a/desktop/core/src/desktop/lib/raz/raz_client.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client.py
@@ -203,6 +203,9 @@ class RazClient(object):
     if method == 'HEAD':
       access_type = 'get-status' if params.get('action') == 'getStatus' else ''
 
+    if method == 'PATCH':
+      access_type = 'write' if params.get('action') == 'append' or params.get('action') == 'flush' else ''
+
     if method == 'DELETE':
       access_type = 'delete-recursive' if params.get('recursive') == 'true' else 'delete'
     

--- a/desktop/core/src/desktop/lib/raz/raz_client_test.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client_test.py
@@ -203,26 +203,6 @@ class RazClientTest(unittest.TestCase):
     assert_equal(response['access_type'], 'get-status')
     assert_equal(response['relative_path'], '/user/csso_hueuser')
 
-    # Create file
-    method = 'PUT'
-    relative_path = '/user/csso_hueuser/customers.csv'
-    url_params = {'resource': 'file'}
-
-    response = client.handle_adls_req_mapping(method, url_params, relative_path)
-
-    assert_equal(response['access_type'], 'create-file')
-    assert_equal(response['relative_path'], '/user/csso_hueuser/customers.csv')
-
-    # Create directory
-    method = 'PUT'
-    relative_path = '/user/csso_hueuser/test_dir'
-    url_params = {'resource': 'directory'}
-
-    response = client.handle_adls_req_mapping(method, url_params, relative_path)
-
-    assert_equal(response['access_type'], 'create-directory')
-    assert_equal(response['relative_path'], '/user/csso_hueuser/test_dir')
-
     # Delete path
     method = 'DELETE'
     relative_path = '/user/csso_hueuser/test_dir/customer.csv'
@@ -242,6 +222,46 @@ class RazClientTest(unittest.TestCase):
 
     assert_equal(response['access_type'], 'delete-recursive')
     assert_equal(response['relative_path'], '/user/csso_hueuser/test_dir')
+
+    # Create directory
+    method = 'PUT'
+    relative_path = '/user/csso_hueuser/test_dir'
+    url_params = {'resource': 'directory'}
+
+    response = client.handle_adls_req_mapping(method, url_params, relative_path)
+
+    assert_equal(response['access_type'], 'create-directory')
+    assert_equal(response['relative_path'], '/user/csso_hueuser/test_dir')
+
+    # Create file
+    method = 'PUT'
+    relative_path = '/user/csso_hueuser/customers.csv'
+    url_params = {'resource': 'file'}
+
+    response = client.handle_adls_req_mapping(method, url_params, relative_path)
+
+    assert_equal(response['access_type'], 'create-file')
+    assert_equal(response['relative_path'], '/user/csso_hueuser/customers.csv')
+
+    # Append
+    method = 'PATCH'
+    relative_path = '/user/csso_hueuser/customers.csv'
+    url_params = {'action': 'append'}
+
+    response = client.handle_adls_req_mapping(method, url_params, relative_path)
+
+    assert_equal(response['access_type'], 'write')
+    assert_equal(response['relative_path'], '/user/csso_hueuser/customers.csv')
+
+    # Flush
+    method = 'PATCH'
+    relative_path = '/user/csso_hueuser/customers.csv'
+    url_params = {'action': 'flush'}
+
+    response = client.handle_adls_req_mapping(method, url_params, relative_path)
+
+    assert_equal(response['access_type'], 'write')
+    assert_equal(response['relative_path'], '/user/csso_hueuser/customers.csv')
 
 
   def test_get_raz_client_s3(self):


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Required when creating file with data and also uploading should work out of the box now.

## Note

- Creating empty file --> calls create(), stats() --> working great.
- Creating file with data  --> calls create(), stats(), _append(), flush()
- create() needs mapping --> `create-file`
- Now this _append() and flush() , both of them works with mapping —> `create-file` and also with mapping --> `write`
- And upload needs them, so choosing the mapping `write` since it looks much more logical.

## How was this patch tested?

- Updating and running unit tests.
