### PR TITLE
GH-2511 Hue Document tab is using different timestamp 

### DIFF
--- a/desktop/core/src/desktop/models.py
+++ b/desktop/core/src/desktop/models.py
@@ -77,7 +77,7 @@ SAMPLE_USER_ID = 1100713
 SAMPLE_USER_INSTALL = 'hue'
 SAMPLE_USER_OWNERS = ['hue', 'sample']
 
-UTC_TIME_FORMAT = "%Y-%m-%dT%H:%MZ"
+UTC_TIME_FORMAT = "%Y-%m-%dT%H:%M"
 HUE_VERSION = None
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

#2511 - GH-2511 Hue Document tab is using different timestamp 

## How was this patch tested?

-Tested Manually in the Opensource Master
The Time shown is correct now.

![Screenshot 2021-08-31 at 2 59 08 PM](https://user-images.githubusercontent.com/18462803/131478554-91e1bb7c-280c-4fad-9b1b-9b4e8ecbb406.png)

