### PR TITLE
GH-2373 disable local_infile in RDBS mysql client by default 

### DIFF
--- a/desktop/libs/librdbms/src/librdbms/server/mysql_lib.py
+++ b/desktop/libs/librdbms/src/librdbms/server/mysql_lib.py
@@ -116,7 +116,8 @@ class MySQLClient(BaseRDMSClient):
       'user': self.query_server['username'],
       'passwd': self.query_server['password'] or '',  # MySQL can accept an empty password
       'host': self.query_server['server_host'],
-      'port': self.query_server['server_port']
+      'port': self.query_server['server_port'],
+      'local_infile': False
     }
 
     if self.query_server['options']:

--- a/desktop/libs/librdbms/src/librdbms/server/mysql_lib.py
+++ b/desktop/libs/librdbms/src/librdbms/server/mysql_lib.py
@@ -28,7 +28,7 @@ except ImportError as e:
 # lexicographic ordering in this check because then (1, 2, 1, 'gamma')
 # inadvertently passes the version test.
 version = Database.version_info
-if (version < (1,2,1) or (version[:3] == (1, 2, 1) and
+if (version < (1, 2, 1) or (version[:3] == (1, 2, 1) and
         (len(version) < 5 or version[3] != 'final' or version[4] < 2))):
   from django.core.exceptions import ImproperlyConfigured
   raise ImproperlyConfigured("MySQLdb-1.2.1p2 or newer is required; you have %s" % Database.__version__)

--- a/desktop/libs/librdbms/src/librdbms/server/mysql_lib.py
+++ b/desktop/libs/librdbms/src/librdbms/server/mysql_lib.py
@@ -19,10 +19,10 @@ import logging
 import sys
 
 try:
-    import MySQLdb as Database
+  import MySQLdb as Database
 except ImportError as e:
-    from django.core.exceptions import ImproperlyConfigured
-    raise ImproperlyConfigured("Error loading MySQLdb module: %s" % e)
+  from django.core.exceptions import ImproperlyConfigured
+  raise ImproperlyConfigured("Error loading MySQLdb module: %s" % e)
 
 # We want version (1, 2, 1, 'final', 2) or later. We can't just use
 # lexicographic ordering in this check because then (1, 2, 1, 'gamma')
@@ -30,8 +30,8 @@ except ImportError as e:
 version = Database.version_info
 if (version < (1,2,1) or (version[:3] == (1, 2, 1) and
         (len(version) < 5 or version[3] != 'final' or version[4] < 2))):
-    from django.core.exceptions import ImproperlyConfigured
-    raise ImproperlyConfigured("MySQLdb-1.2.1p2 or newer is required; you have %s" % Database.__version__)
+  from django.core.exceptions import ImproperlyConfigured
+  raise ImproperlyConfigured("MySQLdb-1.2.1p2 or newer is required; you have %s" % Database.__version__)
 
 from MySQLdb.converters import FIELD_TYPE
 
@@ -168,7 +168,8 @@ class MySQLClient(BaseRDMSClient):
     cursor = self.connection.cursor()
     query = 'SHOW TABLES'
     if table_names:
-      clause = ' OR '.join(["`Tables_in_%(database)s` LIKE '%%%(table)s%%'" % {'database': database, 'table': table} for table in table_names])
+      clause = ' OR '.join(["`Tables_in_%(database)s` LIKE '%%%(table)s%%'" % {'database': database, 'table': table}
+      for table in table_names])
       query += ' FROM `%(database)s` WHERE (%(clause)s)' % {'database': database, 'clause': clause}
     cursor.execute(query)
     self.connection.commit()


### PR DESCRIPTION
## What changes were proposed in this pull request?

- #2373  -  disable local_infile in RDBS mysql client by default 
Currently Hue is using mysql-connector-python via SQLAlchemy and its having the value of local_infile as True which is causing the #2373 , we should disable it so that there is no security risk of accessing files of hue server via any fake SQL server

Reference : https://mysql.wisborg.dk/2019/02/07/mysql-connector-python-8-0-15-allow_local_infile-disabled-by-default/
## How was this patch tested?

-  Tested Manually.
