### PR TITLE
[jwt] Fix thrift_util to use the right user

### DIFF
--- a/apps/beeswax/src/beeswax/server/hive_server2_lib.py
+++ b/apps/beeswax/src/beeswax/server/hive_server2_lib.py
@@ -30,7 +30,7 @@ from TCLIService.ttypes import TOpenSessionReq, TGetTablesReq, TFetchResultsReq,
   TGetCrossReferenceReq, TGetPrimaryKeysReq
 
 from desktop.lib import python_util, thrift_util
-from desktop.conf import DEFAULT_USER
+from desktop.conf import DEFAULT_USER, USE_THRIFT_HTTP_JWT
 
 from beeswax import conf as beeswax_conf, hive_site
 from beeswax.hive_site import hiveserver2_use_ssl
@@ -592,7 +592,7 @@ class HiveServerClient(object):
       validate = beeswax_conf.SSL.VALIDATE.get()
       timeout = beeswax_conf.SERVER_CONN_TIMEOUT.get()
 
-    if auth_username:
+    if auth_username and not USE_THRIFT_HTTP_JWT.get():
       username = auth_username
       password = auth_password
     else:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Get a wrong user 'hue' at https://github.com/cloudera/hue/blob/56a6c734b04679ad4c009d71d959d4d6325855d4/desktop/core/src/desktop/lib/thrift_util.py#L344. 

Added a condition to use the right user instead 'hue'.

## How was this patch tested?

Test Impala call via local dev to a DC cluster and capture tcpdump for port 28000.

![image](https://user-images.githubusercontent.com/106372/132765497-9a0c2f45-f098-435d-bfad-377f4b1f892d.png)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
