### PR TITLE
[jobbrowser] Pass cookie info to query_store

### DIFF
--- a/apps/jobbrowser/src/jobbrowser/apis/query_store.py
+++ b/apps/jobbrowser/src/jobbrowser/apis/query_store.py
@@ -67,11 +67,13 @@ def _create_query_store_client(request, content_type='application/json; charset=
   headers = {
     'x-do-as': request.user.username,
     'X-Requested-By': 'das',
-    'Content-Type': content_type
+    'Content-Type': content_type,
+    'Cookie': request.environ.get('HTTP_COOKIE')
   }
 
   client = HttpClient(QUERY_STORE.SERVER_URL.get())
   client.set_headers(headers)
+  client.set_verify(False)
 
   if USE_SASL.get():
     client.set_kerberos_auth()


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Pass cookie info to query_store
- Disable SSL verify

## How was this patch tested?

- Manually tested
