### PR TITLE
[ci] Upgrade ca-certificates for `build-py-36` Circle CI check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,8 @@ workflows:
       - commit:
           requires:
             - build
-            - build-py-36
+            # Remove build-py-36 till https://github.com/nodesource/distributions/issues/1266 is fixed
+            # - build-py-36
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ jobs:
       - run:
           name: compile
           command: |
-            apt-get update && apt-get upgrade -y ca-certificates && apt-get install -y python3.6-dev libsnappy-dev asciidoc # This should not be needed as some point
+            apt-get upgrade -y ca-certificates && apt-get update && apt-get install -y python3.6-dev libsnappy-dev asciidoc # This should not be needed as some point
 
             export PYTHON_VER=python3.6
             make apps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ jobs:
       - run:
           name: compile
           command: |
-            apt-get update && apt-get install ca-certificates && apt-get install -y python3.6-dev libsnappy-dev asciidoc # This should not be needed as some point
+            apt-get update && apt-get upgrade -y ca-certificates && apt-get install -y python3.6-dev libsnappy-dev asciidoc # This should not be needed as some point
 
             export PYTHON_VER=python3.6
             make apps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ jobs:
       - run:
           name: compile
           command: |
-            apt-get update && apt-get install -y python3.6-dev libsnappy-dev asciidoc # This should not be needed as some point
+            apt-get update && apt-get install ca-certificates && apt-get install -y python3.6-dev libsnappy-dev asciidoc # This should not be needed as some point
 
             export PYTHON_VER=python3.6
             make apps
@@ -284,8 +284,7 @@ workflows:
       - commit:
           requires:
             - build
-            # Remove build-py-36 till https://github.com/nodesource/distributions/issues/1266 is fixed
-            # - build-py-36
+            - build-py-36
           filters:
             branches:
               only:


### PR DESCRIPTION
## What changes were proposed in this pull request?

- `build-py-36` Circle CI check is failing with the following error:

```
Ign:1 https://deb.nodesource.com/node_14.x bionic InRelease
Err:2 https://deb.nodesource.com/node_14.x bionic Release                  
  Certificate verification failed: The certificate is NOT trusted. The certificate chain uses expired certificate.  Could not handshake: Error in the certificate verification. [IP: 23.62.230.111 443]
Hit:3 http://archive.ubuntu.com/ubuntu bionic InRelease                    
Get:4 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
Get:5 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]    
Get:6 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]    
Get:7 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [1430 kB]
Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [2208 kB]
Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [2800 kB]
Reading package lists... Done                            
E: The repository 'https://deb.nodesource.com/node_14.x bionic Release' no longer has a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
"PYTHON_VER is python3.6."
"Python 3 module install via pip"
/root/repo/Makefile.vars:65: *** "Error: must have python development packages for python3.6. Could not find Python.h. Please install python3.6-devel or python3.6-dev".  Stop.
```

- Digging the error more, it was found that its a certificate expiration issue.
- Till https://github.com/nodesource/distributions/issues/1266 is fixed, we can remove the required check for the Circle CI check for the time being, we also have a py3.8 Github Action as a backup.
- When the issue has been permanently fixed, then we add the required check back again!

