### PR TITLE
[ci] Remove ca-certificate upgrade and do `apt get update`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ jobs:
       - run:
           name: compile
           command: |
-            apt-get upgrade -y ca-certificates && apt-get update && apt-get install -y python3.6-dev libsnappy-dev asciidoc # This should not be needed as some point
+            apt-get update && apt-get install -y python3.6-dev libsnappy-dev asciidoc # This should not be needed as some point
 
             export PYTHON_VER=python3.6
             make apps


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Circle CI `build-py-36` is again failing for PRs but this time with the following error

```
Ign:1 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 distro-info-data all 0.37ubuntu0.12
Err:1 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 distro-info-data all 0.37ubuntu0.12
  404  Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/d/distro-info-data/distro-info-data_0.37ubuntu0.12_all.deb  404  Not Found [IP: 91.189.88.142 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?

```


