### PR TITLE
[dashboard] adding 'allow_unsecure_html' config flag

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -1166,6 +1166,9 @@ tls=no
 # Activate the tree widget (to drill down fields as dimensions, alpha).
 ## has_tree_widget=false
 
+# Setting this value to true opens up for possible xss attacks.
+## allow_unsecure_html=false
+
 [[engines]]
 
 #  [[[solr]]]

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -1149,6 +1149,9 @@
   # Activate the tree widget (to drill down fields as dimensions, alpha).
   ## has_tree_widget=false
 
+  # Setting this value to true opens up for possible xss attacks.
+  ## allow_unsecure_html=false
+
   [[engines]]
 
     #  [[[solr]]]

--- a/desktop/libs/dashboard/src/dashboard/conf.py
+++ b/desktop/libs/dashboard/src/dashboard/conf.py
@@ -84,6 +84,12 @@ HAS_TREE_WIDGET = Config(
   type=coerce_bool
 )
 
+ALLOW_UNSECURE_HTML = Config(
+  key="allow_unsecure_html",
+  help=_t("Setting this value to true opens up for possible xss attacks."),
+  type=coerce_bool,
+  default=False
+)
 
 def get_properties():
   if ENGINES.get():

--- a/desktop/libs/dashboard/src/dashboard/templates/common_search.mako
+++ b/desktop/libs/dashboard/src/dashboard/templates/common_search.mako
@@ -20,7 +20,7 @@ import sys
 from desktop import conf
 from desktop.views import commonheader, commonfooter, _ko, commonshare
 
-from dashboard.conf import USE_GRIDSTER, USE_NEW_ADD_METHOD, HAS_REPORT_ENABLED, HAS_WIDGET_FILTER, HAS_TREE_WIDGET
+from dashboard.conf import USE_GRIDSTER, USE_NEW_ADD_METHOD, HAS_REPORT_ENABLED, HAS_WIDGET_FILTER, HAS_TREE_WIDGET, ALLOW_UNSECURE_HTML
 
 if sys.version_info[0] > 2:
   from django.utils.translation import gettext as _
@@ -1057,7 +1057,11 @@ ${ dashboard.layout_skeleton(suffix='search') }
         </thead>
         <tbody data-bind="foreach: {data: $root.results, as: 'doc'}" class="result-tbody">
           <tr data-bind="style: {'backgroundColor': $index() % 2 == 0 ? '#FFF': '#F6F6F6'}">
+          % if ALLOW_UNSECURE_HTML.get():
+            <td><div data-bind="htmlUnsecure: content" style="margin-bottom: -20px"></div></td>
+          % else:
             <td><div data-bind="html: content" style="margin-bottom: -20px"></div></td>
+          % endif
           </tr>
           <tr>
             <td class="show-details-icon pointer" data-bind="click: toggleDocDetails">


### PR DESCRIPTION
## What changes were proposed in this pull request?

- adding config flag to allow configuring unsecured HTML in Hue Dashboards
-  setting this value to true opens up for possible xss attacks.