### PR TITLE
Incorrect password allows to log into Hue when using pam_use_pwd_modu…

### DIFF
--- a/desktop/core/src/desktop/auth/backend.py
+++ b/desktop/core/src/desktop/auth/backend.py
@@ -594,7 +594,7 @@ class LdapBackend(object):
       LOG.warning("LDAP was not properly configured: %s", detail)
       return None
 
-    if AUTH.PAM_USE_PWD_MODULE.get():
+    if AUTH.PAM_USE_PWD_MODULE.get() and user is not None:
       LOG.debug('Setting LDAP username to %s using PAM pwd module for user %s' % (getpwnam(username).pw_name, username))
       pam_user = getpwnam(username).pw_name
       try:


### PR DESCRIPTION
…le with LDAP as a backend

Jira: CDPD-31058

Performed internal testing and identified that the user after auth failure comes out as None which was not checked this was causing successful login even though there was a failure at LDAP with invalid credentials.