### PR TITLE
[jb] Enable left assist jobbrowser when Query Store is present

### DIFF
--- a/apps/jobbrowser/src/jobbrowser/conf.py
+++ b/apps/jobbrowser/src/jobbrowser/conf.py
@@ -95,12 +95,6 @@ QUERY_STORE = ConfigSection(
   key="query_store",
   help=_("""Credentials for query store API."""),
   members=dict(
-    IS_ENABLED = Config(
-      key="is_enabled",
-      help=_("Enable Query Store backend for showing Hive queries information."),
-      type=coerce_bool,
-      default=False
-    ),
     SERVER_URL=Config(
       key="server_url",
       default='http://localhost:8080/',

--- a/apps/jobbrowser/src/jobbrowser/conf.py
+++ b/apps/jobbrowser/src/jobbrowser/conf.py
@@ -95,6 +95,12 @@ QUERY_STORE = ConfigSection(
   key="query_store",
   help=_("""Credentials for query store API."""),
   members=dict(
+    IS_ENABLED = Config(
+      key="is_enabled",
+      help=_("Enable Query Store backend for showing Hive queries information."),
+      type=coerce_bool,
+      default=False
+    ),
     SERVER_URL=Config(
       key="server_url",
       default='http://localhost:8080/',

--- a/desktop/core/src/desktop/models.py
+++ b/desktop/core/src/desktop/models.py
@@ -2043,9 +2043,9 @@ class ClusterConfig(object):
 
     if 'jobbrowser' in self.apps:
       from hadoop.cluster import get_default_yarncluster  # Circular loop
-      from jobbrowser.conf import ENABLE_HIVE_QUERY_BROWSER
+      from jobbrowser.conf import ENABLE_HIVE_QUERY_BROWSER, QUERY_STORE
 
-      if get_default_yarncluster() or ENABLE_HIVE_QUERY_BROWSER.get():
+      if get_default_yarncluster() or ENABLE_HIVE_QUERY_BROWSER.get() or QUERY_STORE.IS_ENABLED.get():
         interpreters.append({
           'type': 'yarn',
           'displayName': _('Jobs'),

--- a/desktop/core/src/desktop/models.py
+++ b/desktop/core/src/desktop/models.py
@@ -2043,9 +2043,9 @@ class ClusterConfig(object):
 
     if 'jobbrowser' in self.apps:
       from hadoop.cluster import get_default_yarncluster  # Circular loop
-      from jobbrowser.conf import ENABLE_HIVE_QUERY_BROWSER, QUERY_STORE
+      from jobbrowser.conf import ENABLE_HIVE_QUERY_BROWSER, ENABLE_QUERIES_LIST
 
-      if get_default_yarncluster() or ENABLE_HIVE_QUERY_BROWSER.get() or QUERY_STORE.IS_ENABLED.get():
+      if get_default_yarncluster() or ENABLE_HIVE_QUERY_BROWSER.get() or ENABLE_QUERIES_LIST.get():
         interpreters.append({
           'type': 'yarn',
           'displayName': _('Jobs'),


### PR DESCRIPTION
## What changes were proposed in this pull request?

- We should not use the `enable_hive_query_browser` flag as it is not fully completed feature.
- Jobs left assist should be enabled when there is no Hive Query browser mentioned above and YarnRM, else when the Jobbrowser is not blacklisted, then also it wont be accessible in the case of Hive VWs.
- So, when Hive VWs uses Query Store, now left Jobbrowser tab is accessible in which user can find details about Hive queries under `Queries` tab.