### PR TITLE
[editor] Update has_result_set from check_status response for public API

### DIFF
--- a/desktop/libs/notebook/src/notebook/api.py
+++ b/desktop/libs/notebook/src/notebook/api.py
@@ -300,6 +300,7 @@ def _check_status(request, notebook=None, snippet=None, operation_id=None):
           nb['snippets'][0]['status'] = status
           if has_result_set is not None:
             nb['snippets'][0]['has_result_set'] = has_result_set
+            nb['snippets'][0]['result']['handle']['has_result_set'] = has_result_set
           nb_doc.update_data(nb)
           nb_doc.save()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

public API call fetch_result_data is checking has_result_set from snippet/result/handle. If execute_statement get has_result_set is false, then we should update has_result_set after running check status.

## How was this patch tested?

tested real cluster.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
