### PR TITLE
[core] Implement Hue SAML LOGOUT URL for CDP. Redirect the client to …

### DIFF
--- a/desktop/core/src/desktop/templates/common_header_footer_components.mako
+++ b/desktop/core/src/desktop/templates/common_header_footer_components.mako
@@ -409,14 +409,8 @@ else:
     var isLoginRequired = false;
     $(document).ajaxComplete(function (event, xhr, settings) {
       if (xhr.responseText === '/* login required */') {
-        if (window.SAML_LOGOUT_URL) {
-          var logoutForm = $('<form action="' + window.SAML_LOGOUT_URL + '" method="POST"></form>');
-
-          if (window.SAML_REDIRECT_URL) {
-            var logoutRedirect = $('<input name="logoutRedirect" type="hidden" value="' + window.SAML_REDIRECT_URL + '" />');
-            logoutRedirect.appendTo(logoutForm);
-          }
-          logoutForm.appendTo('body').submit();
+        if (window.SAML_LOGOUT_URL && window.SAML_REDIRECT_URL) {
+          setTimeout(function () { window.location.href = "/accounts/logout" }, 2000);
         }
 
         var isAutoLogout = settings.url == '/desktop/debug/is_idle';

--- a/desktop/libs/libsaml/src/libsaml/backend.py
+++ b/desktop/libs/libsaml/src/libsaml/backend.py
@@ -24,6 +24,7 @@ import json
 import logging
 
 from django.contrib.auth import logout as auth_logout
+from django.http import HttpResponse
 from djangosaml2.backends import Saml2Backend as _Saml2Backend
 from djangosaml2.views import logout as saml_logout
 from libsaml import conf


### PR DESCRIPTION
…logout URL when idle session timeout has expired

(cherry picked from commit 7bb577ac2a0dca33b07c1734063e70f82c322e36)

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
