### PR TITLE
[saml] Fix key_file has no attribute 'strip' when resp assertion signed

### DIFF
--- a/desktop/core/ext-py/pysaml2-4.9.0/src/saml2/sigver.py
+++ b/desktop/core/ext-py/pysaml2-4.9.0/src/saml2/sigver.py
@@ -1436,7 +1436,7 @@ class SecurityContext(object):
         :param enctext: The encrypted text as a string
         :return: The decrypted text
         """
-        if key_file is None or len(key_file.strip()) == 0:
+        if key_file is None or len(key_file) == 0:
             key_file = self.key_file
         if passphrase is None:
             passphrase = self.key_file_passphrase


### PR DESCRIPTION
## What changes were proposed in this pull request?

After enable response and assertion is signed, SAML login got this error:
```
Traceback:

File "/opt/cloudera/parcels/CDH-7.1.7-1.cdh7.1.7.p0.15945976/lib/hue/build/env/lib/python2.7/site-packages/Django-1.11.29-py2.7.egg/django/core/handlers/exception.py" in inner
  41.             response = get_response(request)

File "/opt/cloudera/parcels/CDH-7.1.7-1.cdh7.1.7.p0.15945976/lib/hue/build/env/lib/python2.7/site-packages/Django-1.11.29-py2.7.egg/django/core/handlers/base.py" in _legacy_get_response
  249.             response = self._get_response(request)

File "/opt/cloudera/parcels/CDH-7.1.7-1.cdh7.1.7.p0.15945976/lib/hue/build/env/lib/python2.7/site-packages/Django-1.11.29-py2.7.egg/django/core/handlers/base.py" in _get_response
  187.                 response = self.process_exception_by_middleware(e, request)

File "/opt/cloudera/parcels/CDH-7.1.7-1.cdh7.1.7.p0.15945976/lib/hue/build/env/lib/python2.7/site-packages/Django-1.11.29-py2.7.egg/django/core/handlers/base.py" in _get_response
  185.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/opt/cloudera/parcels/CDH-7.1.7-1.cdh7.1.7.p0.15945976/lib/hue/build/env/lib/python2.7/site-packages/Django-1.11.29-py2.7.egg/django/utils/decorators.py" in inner
  185.                     return func(*args, **kwargs)

File "/opt/cloudera/parcels/CDH-7.1.7-1.cdh7.1.7.p0.15945976/lib/hue/build/env/lib/python2.7/site-packages/Django-1.11.29-py2.7.egg/django/views/decorators/http.py" in inner
  40.             return func(request, *args, **kwargs)

File "/opt/cloudera/parcels/CDH-7.1.7-1.cdh7.1.7.p0.15945976/lib/hue/build/env/lib/python2.7/site-packages/Django-1.11.29-py2.7.egg/django/views/decorators/csrf.py" in wrapped_view
  58.         return view_func(*args, **kwargs)

File "/opt/cloudera/parcels/CDH-7.1.7-1.cdh7.1.7.p0.15945976/lib/hue/build/env/lib/python2.7/site-packages/djangosaml2-0.16.11-py2.7.egg/djangosaml2/views.py" in assertion_consumer_service
  271.         response = client.parse_authn_request_response(xmlstr, BINDING_HTTP_POST, outstanding_queries)

File "/opt/cloudera/parcels/CDH-7.1.7-1.cdh7.1.7.p0.15945976/lib/hue/build/env/lib/python2.7/site-packages/pysaml2-4.9.0-py2.7.egg/saml2/client_base.py" in parse_authn_request_response
  714.                                         binding, **kwargs)

File "/opt/cloudera/parcels/CDH-7.1.7-1.cdh7.1.7.p0.15945976/lib/hue/build/env/lib/python2.7/site-packages/pysaml2-4.9.0-py2.7.egg/saml2/entity.py" in _parse_response
  1199.             response = response.verify(keys)

File "/opt/cloudera/parcels/CDH-7.1.7-1.cdh7.1.7.p0.15945976/lib/hue/build/env/lib/python2.7/site-packages/pysaml2-4.9.0-py2.7.egg/saml2/response.py" in verify
  1051.         if self.parse_assertion(keys):

File "/opt/cloudera/parcels/CDH-7.1.7-1.cdh7.1.7.p0.15945976/lib/hue/build/env/lib/python2.7/site-packages/pysaml2-4.9.0-py2.7.egg/saml2/response.py" in parse_assertion
  950.                     decr_text = self.sec.decrypt_keys(decr_text, keys)

File "/opt/cloudera/parcels/CDH-7.1.7-1.cdh7.1.7.p0.15945976/lib/hue/build/env/lib/python2.7/site-packages/pysaml2-4.9.0-py2.7.egg/saml2/sigver.py" in decrypt_keys
  1424.             dectext = self.decrypt(enctext, key_file=key_files, id_attr=id_attr, passphrase=passphrase)

File "/opt/cloudera/parcels/CDH-7.1.7-1.cdh7.1.7.p0.15945976/lib/hue/build/env/lib/python2.7/site-packages/pysaml2-4.9.0-py2.7.egg/saml2/sigver.py" in decrypt
  1439.         if key_file is None or len(key_file.strip()) == 0:

Exception Type: AttributeError at /saml2/acs/
Exception Value: 'list' object has no attribute 'strip'
```

## How was this patch tested?

in Okta SAML advanced setting: enable response and assertion is signed and upload cert file

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
