### PR TITLE
[CVE] Remove pillow from Django 1.11.29 ext-py package

### DIFF
--- a/desktop/core/ext-py/Django-1.11.29/tests/requirements/base.txt
+++ b/desktop/core/ext-py/Django-1.11.29/tests/requirements/base.txt
@@ -4,7 +4,6 @@ docutils
 geoip2
 jinja2 >= 2.9.2
 numpy
-Pillow != 5.4.0
 PyYAML < 5.3
 # pylibmc/libmemcached can't be built on Windows.
 pylibmc; sys.platform != 'win32'


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Having couple of CVEs ranging from high to critical in the current version.
- Version suggested by dependabot (>=8.3.2) required Python 3.6 and above.
- Used in Django 1.11.29 tests so we can remove and ignore most probably

