### PR TITLE
[jb] Use Hive Querybrowser feature flag to wrap models

### DIFF
--- a/apps/jobbrowser/src/jobbrowser/models.py
+++ b/apps/jobbrowser/src/jobbrowser/models.py
@@ -34,7 +34,7 @@ from desktop.conf import REST_CONN_TIMEOUT
 from desktop.lib import i18n
 from desktop.lib.view_util import format_duration_in_millis, location_to_url
 
-from jobbrowser.conf import DISABLE_KILLING_JOBS
+from jobbrowser.conf import DISABLE_KILLING_JOBS, ENABLE_HIVE_QUERY_BROWSER
 
 if sys.version_info[0] > 2:
   from django.utils.translation import gettext as _
@@ -79,110 +79,112 @@ def can_kill_job(self, user):
 
   return user.username == self.user
 
+# Wrapping the incomplete Hive QueryBrowser models with the feature flag
+if ENABLE_HIVE_QUERY_BROWSER.get():
 
-# You'll have to do the following manually to clean this up:
-#   * Rearrange models' order
-#   * Make sure each model has one field with primary_key=True
-#   * Make sure each ForeignKey has `on_delete` set to the desired behavior.
-#   * Remove `managed = False` lines if you wish to allow Django to create, modify, and delete the table
-# Feel free to rename the models, but don't rename db_table values or field names.
+  # You'll have to do the following manually to clean this up:
+  #   * Rearrange models' order
+  #   * Make sure each model has one field with primary_key=True
+  #   * Make sure each ForeignKey has `on_delete` set to the desired behavior.
+  #   * Remove `managed = False` lines if you wish to allow Django to create, modify, and delete the table
+  # Feel free to rename the models, but don't rename db_table values or field names.
 
-class HiveQuery(models.Model):
-  # (mysql.E001) MySQL does not allow unique CharFields to have a max_length > 255.
-  # query_id = models.CharField(unique=True, max_length=512, blank=True, null=True)
-  id = models.IntegerField(unique=True, blank=True, null=False, primary_key=True)
-  query_id = models.CharField(unique=True, max_length=255, blank=True, null=True)
-  query = models.TextField(blank=True, null=True)
-  query_fts = models.TextField(blank=True, null=True)  # This field type is a guess.
-  start_time = models.BigIntegerField(blank=True, null=True)
-  end_time = models.BigIntegerField(blank=True, null=True)
-  elapsed_time = models.BigIntegerField(blank=True, null=True)
-  status = models.CharField(max_length=32, blank=True, null=True)
-  queue_name = models.CharField(max_length=767, blank=True, null=True)
-  user_id = models.CharField(max_length=256, blank=True, null=True)
-  request_user = models.CharField(max_length=256, blank=True, null=True)
-  cpu_time = models.BigIntegerField(blank=True, null=True)
-  physical_memory = models.BigIntegerField(blank=True, null=True)
-  virtual_memory = models.BigIntegerField(blank=True, null=True)
-  data_read = models.BigIntegerField(blank=True, null=True)
-  data_written = models.BigIntegerField(blank=True, null=True)
-  operation_id = models.CharField(max_length=512, blank=True, null=True)
-  client_ip_address = models.CharField(max_length=64, blank=True, null=True)
-  hive_instance_address = models.CharField(max_length=512, blank=True, null=True)
-  hive_instance_type = models.CharField(max_length=512, blank=True, null=True)
-  session_id = models.CharField(max_length=512, blank=True, null=True)
-  log_id = models.CharField(max_length=512, blank=True, null=True)
-  thread_id = models.CharField(max_length=512, blank=True, null=True)
-  execution_mode = models.CharField(max_length=16, blank=True, null=True)
-  databases_used = models.TextField(blank=True, null=True)  # This field type is a guess.
-  tables_read = models.TextField(blank=True, null=True)  # This field type is a guess.
-  tables_written = models.TextField(blank=True, null=True)  # This field type is a guess.
-  domain_id = models.CharField(max_length=512, blank=True, null=True)
-  llap_app_id = models.CharField(max_length=512, blank=True, null=True)
-  used_cbo = models.CharField(max_length=16, blank=True, null=True)
-  first_task_started_time = models.BigIntegerField(blank=True, null=True)
-  waiting_time = models.BigIntegerField(blank=True, null=True)
-  resource_utilization = models.BigIntegerField(blank=True, null=True)
-  version = models.SmallIntegerField(blank=True, null=True)
-  created_at = models.DateTimeField(blank=True, null=True)
+  class HiveQuery(models.Model):
+    # (mysql.E001) MySQL does not allow unique CharFields to have a max_length > 255.
+    # query_id = models.CharField(unique=True, max_length=512, blank=True, null=True)
+    id = models.IntegerField(unique=True, blank=True, null=False, primary_key=True)
+    query_id = models.CharField(unique=True, max_length=255, blank=True, null=True)
+    query = models.TextField(blank=True, null=True)
+    query_fts = models.TextField(blank=True, null=True)  # This field type is a guess.
+    start_time = models.BigIntegerField(blank=True, null=True)
+    end_time = models.BigIntegerField(blank=True, null=True)
+    elapsed_time = models.BigIntegerField(blank=True, null=True)
+    status = models.CharField(max_length=32, blank=True, null=True)
+    queue_name = models.CharField(max_length=767, blank=True, null=True)
+    user_id = models.CharField(max_length=256, blank=True, null=True)
+    request_user = models.CharField(max_length=256, blank=True, null=True)
+    cpu_time = models.BigIntegerField(blank=True, null=True)
+    physical_memory = models.BigIntegerField(blank=True, null=True)
+    virtual_memory = models.BigIntegerField(blank=True, null=True)
+    data_read = models.BigIntegerField(blank=True, null=True)
+    data_written = models.BigIntegerField(blank=True, null=True)
+    operation_id = models.CharField(max_length=512, blank=True, null=True)
+    client_ip_address = models.CharField(max_length=64, blank=True, null=True)
+    hive_instance_address = models.CharField(max_length=512, blank=True, null=True)
+    hive_instance_type = models.CharField(max_length=512, blank=True, null=True)
+    session_id = models.CharField(max_length=512, blank=True, null=True)
+    log_id = models.CharField(max_length=512, blank=True, null=True)
+    thread_id = models.CharField(max_length=512, blank=True, null=True)
+    execution_mode = models.CharField(max_length=16, blank=True, null=True)
+    databases_used = models.TextField(blank=True, null=True)  # This field type is a guess.
+    tables_read = models.TextField(blank=True, null=True)  # This field type is a guess.
+    tables_written = models.TextField(blank=True, null=True)  # This field type is a guess.
+    domain_id = models.CharField(max_length=512, blank=True, null=True)
+    llap_app_id = models.CharField(max_length=512, blank=True, null=True)
+    used_cbo = models.CharField(max_length=16, blank=True, null=True)
+    first_task_started_time = models.BigIntegerField(blank=True, null=True)
+    waiting_time = models.BigIntegerField(blank=True, null=True)
+    resource_utilization = models.BigIntegerField(blank=True, null=True)
+    version = models.SmallIntegerField(blank=True, null=True)
+    created_at = models.DateTimeField(blank=True, null=True)
 
-  class Meta:
-    managed = False
-    db_table = 'hive_query'
-
-
-class QueryDetails(models.Model):
-  hive_query = models.ForeignKey(HiveQuery, on_delete=models.CASCADE, unique=True, blank=True, null=True)
-  explain_plan_raw = models.TextField(blank=True, null=True)  # This field type is a guess.
-  configuration_raw = models.TextField(blank=True, null=True)  # This field type is a guess.
-  perf = models.TextField(blank=True, null=True)  # This field type is a guess.
-  configuration_compressed = models.BinaryField(blank=True, null=True)
-  explain_plan_compressed = models.BinaryField(blank=True, null=True)
-
-  class Meta:
-    managed = False
-    db_table = 'query_details'
+    class Meta:
+      managed = False
+      db_table = 'hive_query'
 
 
-class DagInfo(models.Model):
-  # (mysql.E001) MySQL does not allow unique CharFields to have a max_length > 255.
-  # dag_id = models.CharField(unique=True, max_length=512, blank=True, null=True)
-  dag_id = models.CharField(unique=True, max_length=255, blank=True, null=True)
-  dag_name = models.CharField(max_length=512, blank=True, null=True)
-  application_id = models.CharField(max_length=512, blank=True, null=True)
-  init_time = models.BigIntegerField(blank=True, null=True)
-  start_time = models.BigIntegerField(blank=True, null=True)
-  end_time = models.BigIntegerField(blank=True, null=True)
-  time_taken = models.BigIntegerField(blank=True, null=True)
-  status = models.CharField(max_length=64, blank=True, null=True)
-  am_webservice_ver = models.CharField(max_length=16, blank=True, null=True)
-  am_log_url = models.CharField(max_length=512, blank=True, null=True)
-  queue_name = models.CharField(max_length=64, blank=True, null=True)
-  caller_id = models.CharField(max_length=512, blank=True, null=True)
-  caller_type = models.CharField(max_length=128, blank=True, null=True)
-  hive_query = models.ForeignKey('HiveQuery', on_delete=models.CASCADE, blank=True, null=True)
-  created_at = models.DateTimeField(blank=True, null=True)
-  source_file = models.TextField(blank=True, null=True)
+  class QueryDetails(models.Model):
+    hive_query = models.ForeignKey(HiveQuery, on_delete=models.CASCADE, unique=True, blank=True, null=True)
+    explain_plan_raw = models.TextField(blank=True, null=True)  # This field type is a guess.
+    configuration_raw = models.TextField(blank=True, null=True)  # This field type is a guess.
+    perf = models.TextField(blank=True, null=True)  # This field type is a guess.
+    configuration_compressed = models.BinaryField(blank=True, null=True)
+    explain_plan_compressed = models.BinaryField(blank=True, null=True)
 
-  class Meta:
-    managed = False
-    db_table = 'dag_info'
+    class Meta:
+      managed = False
+      db_table = 'query_details'
 
 
-class DagDetails(models.Model):
-  dag_info = models.ForeignKey('DagInfo', on_delete=models.CASCADE, unique=True, blank=True, null=True)
-  hive_query = models.ForeignKey('HiveQuery', on_delete=models.CASCADE, blank=True, null=True)
-  dag_plan_raw = models.TextField(blank=True, null=True)  # This field type is a guess.
-  vertex_name_id_mapping_raw = models.TextField(blank=True, null=True)  # This field type is a guess.
-  diagnostics = models.TextField(blank=True, null=True)
-  counters_raw = models.TextField(blank=True, null=True)  # This field type is a guess.
-  dag_plan_compressed = models.BinaryField(blank=True, null=True)
-  vertex_name_id_mapping_compressed = models.BinaryField(blank=True, null=True)
-  counters_compressed = models.BinaryField(blank=True, null=True)
+  class DagInfo(models.Model):
+    # (mysql.E001) MySQL does not allow unique CharFields to have a max_length > 255.
+    # dag_id = models.CharField(unique=True, max_length=512, blank=True, null=True)
+    dag_id = models.CharField(unique=True, max_length=255, blank=True, null=True)
+    dag_name = models.CharField(max_length=512, blank=True, null=True)
+    application_id = models.CharField(max_length=512, blank=True, null=True)
+    init_time = models.BigIntegerField(blank=True, null=True)
+    start_time = models.BigIntegerField(blank=True, null=True)
+    end_time = models.BigIntegerField(blank=True, null=True)
+    time_taken = models.BigIntegerField(blank=True, null=True)
+    status = models.CharField(max_length=64, blank=True, null=True)
+    am_webservice_ver = models.CharField(max_length=16, blank=True, null=True)
+    am_log_url = models.CharField(max_length=512, blank=True, null=True)
+    queue_name = models.CharField(max_length=64, blank=True, null=True)
+    caller_id = models.CharField(max_length=512, blank=True, null=True)
+    caller_type = models.CharField(max_length=128, blank=True, null=True)
+    hive_query = models.ForeignKey('HiveQuery', on_delete=models.CASCADE, blank=True, null=True)
+    created_at = models.DateTimeField(blank=True, null=True)
+    source_file = models.TextField(blank=True, null=True)
 
-  class Meta:
-    managed = False
-    db_table = 'dag_details'
+    class Meta:
+      managed = False
+      db_table = 'dag_info'
+
+
+  class DagDetails(models.Model):
+    dag_info = models.ForeignKey('DagInfo', on_delete=models.CASCADE, unique=True, blank=True, null=True)
+    hive_query = models.ForeignKey('HiveQuery', on_delete=models.CASCADE, blank=True, null=True)
+    dag_plan_raw = models.TextField(blank=True, null=True)  # This field type is a guess.
+    vertex_name_id_mapping_raw = models.TextField(blank=True, null=True)  # This field type is a guess.
+    diagnostics = models.TextField(blank=True, null=True)
+    counters_raw = models.TextField(blank=True, null=True)  # This field type is a guess.
+    dag_plan_compressed = models.BinaryField(blank=True, null=True)
+    vertex_name_id_mapping_compressed = models.BinaryField(blank=True, null=True)
+    counters_compressed = models.BinaryField(blank=True, null=True)
+
+    class Meta:
+      managed = False
+      db_table = 'dag_details'
 
 
 class LinkJobLogs(object):


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Incomplete implementation of the db models for separate Hive Querybrowser just like Impala tab in Jobbrowser.
- Using the `enable_hive_query_browser` flag to wrap it up.
- This removes the warnings when running the Django server.
- Also helps in successful dump database in Hue: https://github.com/cloudera/hue/discussions/2634

