### PR TITLE
[hplsql] hplsql editor name HPL/SQL and placeholder

### DIFF
--- a/desktop/core/src/desktop/js/apps/editor/components/aceEditor/AceEditor.vue
+++ b/desktop/core/src/desktop/js/apps/editor/components/aceEditor/AceEditor.vue
@@ -542,7 +542,13 @@
 
         const createPlaceholderElement = (): HTMLElement => {
           const element = document.createElement('div');
-          element.innerText = I18n('Example: SELECT * FROM tablename, or press CTRL + space');
+          if (connector.dialect === 'hplsql') {
+            element.innerText = I18n(
+              'Example: CREATE PROCEDURE name AS SELECT * FROM tablename limit 10 GO'
+            );
+          } else {
+            element.innerText = I18n('Example: SELECT * FROM tablename, or press CTRL + space');
+          }
           element.style.marginLeft = '6px';
           element.classList.add('ace_invisible');
           element.classList.add('ace_emptyMessage');

--- a/desktop/core/src/desktop/models.py
+++ b/desktop/core/src/desktop/models.py
@@ -1849,6 +1849,15 @@ class ClusterConfig(object):
     }
 
 
+  def displayName(self, dialect, name):
+    if ENABLE_UNIFIED_ANALYTICS.get() and dialect == 'hive':
+      return 'Unified Analytics'
+    elif name.lower() == 'hplsql':
+      return 'HPL/SQL'
+    else:
+      return name
+
+
   def _get_editor(self):
     interpreters = []
 
@@ -1860,7 +1869,7 @@ class ClusterConfig(object):
           'name': interpreter['name'],
           'type': interpreter['type'],  # Connector v1
           'id': interpreter['type'],
-        'displayName': 'Unified Analytics' if ENABLE_UNIFIED_ANALYTICS.get() and interpreter['dialect'] == 'hive' else interpreter['name'],
+          'displayName': self.displayName(interpreter['dialect'], interpreter['name']),
           'buttonName': _('Query'),
           'tooltip': _('%s Query') % interpreter['type'].title(),
           'optimizer': get_optimizer_mode(),


### PR DESCRIPTION
## What changes were proposed in this pull request?

- For notebook2 editor name changed to "HPL/SQL" and added placeholder for hplsql dialect

## How was this patch tested?

- ss
<img width="245" alt="Screenshot 2022-01-20 at 3 53 20 PM" src="https://user-images.githubusercontent.com/36241930/150320485-b91392f1-379d-43cc-87a0-f8f4e0455f10.png">

