### PR TITLE
[ui] Avoid displaying service connectivity error in a popup

### DIFF
--- a/desktop/core/src/desktop/js/jquery/plugins/jquery.notify.js
+++ b/desktop/core/src/desktop/js/jquery/plugins/jquery.notify.js
@@ -54,7 +54,11 @@ Plugin.prototype.show = function () {
   _this.options.message = _this.options.message.replace(/(<([^>]+)>)/gi, ''); // escape HTML messages
   _this.options.message = deXSS(_this.options.message); // escape XSS messages
 
-  if (/^(504|upstream connect error|Gateway Time-out)/.test(_this.options.message.trim())) {
+  if (
+    /^(504|upstream connect error|Gateway Time-out|Service connectivity error)/.test(
+      _this.options.message.trim()
+    )
+  ) {
     console.warn(_this.options.message);
     return;
   }

--- a/desktop/core/src/desktop/static/desktop/js/jquery.notify.js
+++ b/desktop/core/src/desktop/static/desktop/js/jquery.notify.js
@@ -48,7 +48,11 @@
     var _this = this;
     var MARGIN = 4;
 
-    if (/^(504|upstream connect error|Gateway Time-out)/.test(_this.options.message.trim())) {
+    if (
+      /^(504|upstream connect error|Gateway Time-out|Service connectivity error)/.test(
+        _this.options.message.trim()
+      )
+    ) {
       console.warn(_this.options.message);
       return;
     }


### PR DESCRIPTION
Similar to #2002 and #2006, some error will happen occasionally and will confuse the users. Note this error happens when Knox gateway run out of replay buffer. And this happens one of ten same call like get_logs or check_status.