### PR TITLE
[hplsql] replace connector_name beeswax to hive

### DIFF
--- a/apps/beeswax/src/beeswax/server/hive_server2_lib.py
+++ b/apps/beeswax/src/beeswax/server/hive_server2_lib.py
@@ -666,7 +666,8 @@ class HiveServerClient(object):
         'username': user.username,  # If SASL or LDAP, it gets the username from the authentication mechanism since it dependents on it.
         'configuration': {},
     }
-    interpreter = get_interpreter(connector_type=self.query_server['server_name'], user=self.user)
+    connector_type = 'hive' if self.query_server['server_name'] == 'beeswax' else self.query_server['server_name']
+    interpreter = get_interpreter(connector_type=connector_type, user=self.user)
 
     if self.impersonation_enabled:
       kwargs.update({'username': DEFAULT_USER})


### PR DESCRIPTION
## What changes were proposed in this pull request?

- replacing connector_name beeswax to hive

## How was this patch tested?

- Manually
