### PR TITLE
Atlas add basic search option and set search cluster to 'cm' as default

### DIFF
--- a/desktop/libs/metadata/src/metadata/catalog/atlas_client.py
+++ b/desktop/libs/metadata/src/metadata/catalog/atlas_client.py
@@ -191,8 +191,13 @@ class AtlasApi(Api):
     }
 
     try:
-      atlas_response = self._root.get('/v2/search/dsl?query=%s' % dsl_query, headers=self.__headers,
-                                      params=self.__params)
+      if CATALOG.ENABLE_BASIC_SEARCH.get():
+        atlas_response = self._root.get('/v2/search/basic?query=%s' % dsl_query, headers=self.__headers,
+                                       params=self.__params)
+      else:
+        atlas_response = self._root.get('/v2/search/dsl?query=%s' % dsl_query, headers=self.__headers,
+                                       params=self.__params)
+
       if not 'entities' in atlas_response or len(atlas_response['entities']) < 1:
         raise CatalogEntityDoesNotExistException('Could not find entity with query: %s' % dsl_query)
 
@@ -370,7 +375,10 @@ class AtlasApi(Api):
         else:
           atlas_dsl_query = 'from %s where qualifiedName like \'%s*\' limit %s' % (atlas_type, parentPath, limit)
 
-      atlas_response = self._root.get('/v2/search/dsl?query=%s' % atlas_dsl_query)
+      if CATALOG.ENABLE_BASIC_SEARCH.get():
+        atlas_response = self._root.get('/v2/search/basic?query=%s' % atlas_dsl_query)
+      else:
+        atlas_response = self._root.get('/v2/search/dsl?query=%s' % atlas_dsl_query)
 
       # Adapt Atlas entities to Navigator structure in the results
       if 'entities' in atlas_response:

--- a/desktop/libs/metadata/src/metadata/conf.py
+++ b/desktop/libs/metadata/src/metadata/conf.py
@@ -320,7 +320,13 @@ CATALOG = ConfigSection(
     SEARCH_CLUSTER=Config(
       key="search_cluster",
       help=_t("Limits found entities to a specific cluster."),
-      default=None
+      default='cm'
+    ),
+    ENABLE_BASIC_SEARCH=Config(
+      key="enable_basic_search",
+      help=_t("Limits found entities to a specific cluster."),
+      default=False,
+      type=coerce_bool
     ),
     FETCH_SIZE_SEARCH_INTERACTIVE=Config(
       key="fetch_size_search_interactive",


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added basic search functionality for Atlas using a configuration and also set the default value for search_cluster to cm.

Internal Jira: CDPD-19430

## How was this patch tested?
Tested this manually on a CDP cluster where I can see both DSL and Basic search worked when config is enabled as they both have similar constructs.