### PR TITLE
Hue [py3] Improve Hue container build script to "UBI8/Python3.…

### DIFF
--- a/tools/container/base/hue/Dockerfile
+++ b/tools/container/base/hue/Dockerfile
@@ -1,71 +1,53 @@
-FROM registry.access.redhat.com/ubi7/ubi as base-ubi-7
+FROM registry.access.redhat.com/ubi8/ubi as base-ubi-8
 
 LABEL description="Hue Project https://github.com/cloudera/hue"
 
 # Set the environment variable
 ENV NAME="basehue"
 
-# Required for building Hue
-#RUN yum install -y \
-#      ant \
-#      curl \
-#      gcc \
-#      gcc-c++ \
-#      git \
-#      java-1.8.0-openjdk-devel \
-#      maven \
-#      make \
-#      mysql-devel \
-#      nc \
-#      sudo \
-#      tar \
-#      vim-enhanced
-#
-
 # Required libraries for running Hue
 RUN set -eux; \
       yum install -y \
-        asciidoc \
         bzip2-devel \
+        curl \
+        cyrus-sasl \
         cyrus-sasl-devel \
         cyrus-sasl-gssapi \
         cyrus-sasl-plain \
         gettext \
-        gmp-devel \
+        gmp \
         java-1.8.0-openjdk-devel \
         krb5-devel \
         krb5-libs \
         krb5-workstation \
         libffi-devel \
-        libtidy \
         libxml2-devel \
         libxslt-devel \
         ncurses-devel \
         nmap-ncat \
+        procps-ng \
+        python38 \
+        python38-devel \
+        rsync \
         openldap-devel \
         openssl \
         openssl-devel \
-        postgresql \
-        postgresql-libs \
-        python-devel \
-        python-setuptools \
-        readline-devel \
         sqlite-devel \
         sudo \
-        swig \
         which \
         xmlsec1 \
         xmlsec1-openssl \
         zlib-devel
 
-RUN set -eux; easy_install supervisor pip
-
-RUN curl -s https://files.pythonhosted.org/packages/a1/92/a27986cb7b4bddc7d57781a0e1163d683110907edfca1db3fbce25536492/psycopg2_binary-2.8.3-cp27-cp27mu-manylinux1_x86_64.whl -o /tmp/psycopg2_binary-2.8.3-cp27-cp27mu-manylinux1_x86_64.whl
-
-RUN set -eux ; \
-      curl -sL https://rpm.nodesource.com/setup_10.x | bash - \
+RUN set -eux; \
+      /usr/bin/pip3.8 install supervisor \
+      && curl -s https://files.pythonhosted.org/packages/45/78/4621eb7085162bc4d2252ad92af1cc5ccacbd417a50e2ee74426331aad18/psycopg2_binary-2.9.3-cp38-cp38-musllinux_1_1_x86_64.whl -o /tmp/psycopg2_binary-2.9.3-cp38-cp38-musllinux_1_1_x86_64.whl \
+      && dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+      && yum install -y postgresql11 \
+      && curl -sL https://rpm.nodesource.com/setup_14.x | bash - \
         && yum install -y nodejs \
-        && yum clean all -y
+        && yum clean all -y  \
+        && rm -rf /var/cache/yum
 
 # kubernetes pod health check
 COPY healthz.sh /

--- a/tools/container/base/huelb/Dockerfile
+++ b/tools/container/base/huelb/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi7/ubi as base-ubi-7
+FROM registry.access.redhat.com/ubi8/ubi as base-ubi-8
 
 LABEL description="Hue Project https://github.com/cloudera/hue"
 
@@ -11,7 +11,9 @@ RUN set -eux; \
         httpd \
         httpd-tools \
         gettext \
-        nmap-ncat
+        nmap-ncat && \
+      yum clean all -y && \
+      rm -rf /var/cache/yum
 
 # kubernetes pod health check
 COPY healthz.sh /

--- a/tools/container/build.sh
+++ b/tools/container/build.sh
@@ -2,75 +2,56 @@
 
 set -ex
 
+# Time marker for both stderr and stdout
+date; date 1>&2
+
 WORK_DIR=$(dirname $(readlink -f $0))
+. ${WORK_DIR}/common.sh
+
 HUE_SRC=$(realpath $WORK_DIR/../..)
 BUILD_DIR=$(realpath $HUE_SRC/../containerbuild$GBN)
+
 HUE_DIR=$WORK_DIR/hue
 APACHE_DIR=$WORK_DIR/huelb
 BASEHUE_DIR=$WORK_DIR/base/hue
 BASEHUELB_DIR=$WORK_DIR/base/huelb
-HUEBASE_VERSION=huebase_ubi:7.5.2
-HUELBBASE_VERSION=huelb_httpd_ubi:2.4
 COMPILEHUE_DIR=$WORK_DIR/compile/hue
-COMPILEHUE_VERSION=huecompile_ubi:7.5.2
-HUEUSER="hive"
-CONTAINER=$(uuidgen | cut -d"-" -f5)
-CONTAINER_HUE_SRC=/root/hue
+
+COMPILEHUE_VERSION=huecompile_ubi:$DOCKERHUEBASE_VERSION
+HUEBASE_VERSION=huebase_ubi:$DOCKERHUEBASE_VERSION
+HUELBBASE_VERSION=huelb_httpd_ubi:$DOCKERHUELB_VERSION
+
+CONTAINER_HUE_SRC=/root/${HUEUSER}
 CONTAINER_HUE_OPT=/opt
 
-if [ -z "$REGISTRY" ]; then
-  REGISTRY=${REGISTRY:-"docker.io/hortonworks"}
-fi
-
-compile_hue() {
+# This step is performed inside the docker(compile step)
+compile_py3hue() {
+  export HUE_HOME="/opt/${HUEUSER}"
   mkdir -p $CONTAINER_HUE_OPT
   cd $CONTAINER_HUE_SRC
-  PREFIX=$CONTAINER_HUE_OPT make install
-  cd $CONTAINER_HUE_OPT/hue
+  INSTALL_DIR=${HUE_HOME} make install
+  cd $CONTAINER_HUE_OPT/${HUEUSER}
   APPS=$(find apps -maxdepth 2 -name "src" -type d|cut -d"/" -f2|sort| sed 's/[^ ]* */apps\/&/g')
   ./build/env/bin/python tools/app_reg/app_reg.py --install $APPS --relative-paths
-  bash tools/relocatable.sh
 }
 
+# Compile the bits in the docker and copy it out
 docker_hue_compile() {
-  export HUE_USER="hive"
   export HUE_CONF="/etc/hue"
   export HUE_HOME="/opt/${HUEUSER}"
   export HUE_CONF_DIR="${HUE_CONF}/conf"
   export HUE_LOG_DIR="/var/log/${HUEUSER}"
-  export UUID_GEN=$(uuidgen | cut -d"-" -f5)
+  export CONTAINER=$(uuidgen | cut -d"-" -f5)
 
   mkdir -p $BUILD_DIR
   docker run -dt --name $CONTAINER $COMPILEHUE_VERSION /bin/bash
   docker container cp $HUE_SRC $CONTAINER:$CONTAINER_HUE_SRC
-  docker container exec $CONTAINER $CONTAINER_HUE_SRC/tools/container/build.sh compile_hue
-  docker container cp $CONTAINER:$CONTAINER_HUE_OPT/hue $BUILD_DIR
+  docker container exec $CONTAINER $CONTAINER_HUE_SRC/tools/py3container/buildpy3.sh compile_py3hue
+  docker container cp $CONTAINER:$CONTAINER_HUE_OPT/${HUEUSER} $BUILD_DIR
   docker container stop $CONTAINER
 }
 
-find_git_state() {
-  cd $HUE_SRC
-  export GBRANCH=$(git ls-remote  --get-url)"/commits/"$(git rev-parse --abbrev-ref HEAD)
-  export GSHA=$(git ls-remote  --get-url)"/commit/"$(git rev-list --no-walk HEAD)
-  export VERSION=$(grep "VERSION=" VERSION | cut -d"=" -f2 | cut -d'"' -f2)
-}
-
-subst_var() {
-  file_name=$1
-  if [[ -e $file_name ]]; then
-    if [[ "$file_name" == *"_template" ]]; then
-      out_name="${file_name::-9}.conf"
-    fi
-  fi
-
-  eval "cat <<EOF
-$(<$file_name)
-EOF
-" | tee $out_name 2> /dev/null
-}
-
 docker_hue_build() {
-  export HUE_USER="hive"
   export HUE_CONF="/etc/hue"
   export HUE_HOME="/opt/${HUEUSER}"
   export HUE_CONF_DIR="${HUE_CONF}/conf"
@@ -78,12 +59,12 @@ docker_hue_build() {
   export UUID_GEN=$(uuidgen | cut -d"-" -f5)
 
   cd $HUE_DIR
-  cp -a $BUILD_DIR/hue $HUE_DIR
-  rm -f $HUE_DIR/hue/desktop/conf/*
+  cp -a $BUILD_DIR/${HUEUSER} $HUE_DIR
+  rm -f $HUE_DIR/${HUEUSER}/desktop/conf/*
 
   # Reduce Hue container size
-  rm -rf $HUE_DIR/hue/node_modules
-  rm -rf $HUE_DIR/hue/desktop/core/ext-eggs
+  rm -rf $HUE_DIR/${HUEUSER}/node_modules
+  rm -rf $HUE_DIR/${HUEUSER}/desktop/core/ext-eggs
 
   for f in $(find $HUE_DIR/supervisor-files -name "*_template"); do
     subst_var $f
@@ -101,14 +82,13 @@ docker_hue_build() {
 }
 
 docker_huelb_build() {
-  export HUE_USER="hive"
   export HUE_CONF="/etc/hue"
   export HUE_HOME="/opt/${HUEUSER}"
   export HUE_CONF_DIR="${HUE_CONF}/conf"
   export HUE_LOG_DIR="/var/log/${HUEUSER}"
 
   cd $APACHE_DIR
-  cp -a $BUILD_DIR/hue/build/static $APACHE_DIR
+  cp -a $BUILD_DIR/${HUEUSER}/build/static $APACHE_DIR
 
   for f in $(find $APACHE_DIR -name "*_template"); do
     subst_var $f
@@ -150,35 +130,74 @@ build_huecompilebase() {
 }
 
 pull_base_images() {
-  set +e
-
   docker pull ${REGISTRY}/$HUEBASE_VERSION
-  if [[ $? != 0 ]]; then
+  if [[ $? -ne 0 ]]; then
     build_huebase
   fi
   docker tag ${REGISTRY}/$HUEBASE_VERSION $HUEBASE_VERSION
 
   docker pull ${REGISTRY}/$HUELBBASE_VERSION
-  if [[ $? != 0 ]]; then
+  if [[ $? -ne 0 ]]; then
     build_huelbbase
   fi
   docker tag ${REGISTRY}/$HUELBBASE_VERSION $HUELBBASE_VERSION
 
   docker pull ${REGISTRY}/$COMPILEHUE_VERSION
-  if [[ $? != 0 ]]; then
+  if [[ $? -ne 0 ]]; then
     build_huecompilebase
   fi
   docker tag ${REGISTRY}/$COMPILEHUE_VERSION $COMPILEHUE_VERSION
-
-  set -e
 }
 
-if [[ $1 == "compile_hue" ]]; then
-  compile_hue
-else
+rebuild_base_images() {
+  docker pull registry.access.redhat.com/ubi8/ubi:latest
+  build_huebase
+  build_huelbbase
+  build_huecompilebase
+}
+
+hue_containers_build() {
+  if [ $REBUILD_BASE -gt 0 ]; then
+    rebuild_base_images
+  fi
   pull_base_images
   find_git_state
+
+  # compile hue code in compile container
   docker_hue_compile
+
+  # package compiled hue code in runtime container
   docker_hue_build
   docker_huelb_build
+}
+
+wait_for_parallel_jobs() {
+  EXIT=0
+  jobs -l
+  for job in `jobs -p`; do
+    echo $job
+    wait $job || let "EXIT+=1"
+  done
+
+  if [[ "$EXIT" == "0" ]]; then
+    exit 0
+  else
+    exit 1
+  fi
+}
+
+if [[ $1 == "compile_py3hue" ]]; then
+  compile_py3hue
+else
+  # Perform Hue Code Compilation and Docker packaging
+  hue_containers_build
+
+  # Perform any other container build process
+  #extra_container_build=$(find_extra_container_to_build)
+  #if test -n "$extra_container_build"; then
+  #  $extra_container_build
+  #fi
+
+  # Wait for the parallel jobs to finish
+  wait_for_parallel_jobs
 fi

--- a/tools/container/common.sh
+++ b/tools/container/common.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+DOCKERHUEBASE_VERSION=8.5.1
+DOCKERHUELB_VERSION=2.5.1
+REBUILD_BASE=1
+
+HUEUSER="hive"
+CONTAINER=$(uuidgen | cut -d"-" -f5)
+
+find_git_state() {
+  cd $HUE_SRC
+  export GBRANCH=$(git ls-remote  --get-url)"/commits/"$(git rev-parse --abbrev-ref HEAD)
+  export GSHA=$(git ls-remote  --get-url)"/commit/"$(git rev-list --no-walk HEAD)
+  export VERSION=$(grep "VERSION=" VERSION | cut -d"=" -f2 | cut -d'"' -f2)
+  echo "GBRANCH=$GBRANCH" >> hue.version
+  echo "GSHA=$GSHA" >> hue.version
+  echo "VERSION=$VERSION" >> hue.version
+  echo "GBN=$GBN" >> hue.version
+}
+
+find_extra_container_to_build() {
+  cd $HUE_SRC
+  workdir=""
+  projects=$(find $HUE_SRC -path "*/tools/container/build.sh")
+  skip_dir=$(dirname $(readlink -f build.sh))
+  for proj in $(find $HUE_SRC -path "*/tools/container/build.sh"); do
+    if [[ "$proj" != "$skip_dir/build.sh" ]] && [[ "$proj" != "$HUE_SRC/tools/container/build.sh" ]]; then
+      workdir=${proj}
+    fi
+  done
+  echo $workdir
+}
+
+subst_var() {
+  file_name=$1
+  if [[ -e $file_name ]]; then
+    if [[ "$file_name" == *"_template" ]]; then
+      out_name="${file_name::-9}.conf"
+    fi
+  fi
+
+  eval "cat <<EOF
+$(<$file_name)
+EOF
+" | tee $out_name 2> /dev/null
+}
+
+if [ -z "$REGISTRY" ]; then
+  REGISTRY=${REGISTRY:-"docker.io/hortonworks"}
+fi

--- a/tools/container/compile/hue/Dockerfile
+++ b/tools/container/compile/hue/Dockerfile
@@ -1,17 +1,17 @@
-FROM registry.access.redhat.com/ubi7/ubi as base-ubi-7
+FROM registry.access.redhat.com/ubi8/ubi as base-ubi-8
 
 LABEL description="Hue Project https://github.com/cloudera/hue"
 
 # Set the environment variable
 ENV NAME="basehue"
+ENV PYTHON_VER=python3.8
 
 # Required for building Hue
 RUN set -eux; \
     yum install -y \
-      ant \
-      asciidoc \
-      bzip2-devel \
+      bzip2-devel  \
       curl \
+      cyrus-sasl \
       cyrus-sasl-devel \
       cyrus-sasl-gssapi \
       cyrus-sasl-plain \
@@ -19,44 +19,34 @@ RUN set -eux; \
       gcc-c++ \
       gettext \
       git \
-      gmp-devel \
-      java-1.8.0-openjdk-devel \
+      java-11-openjdk-devel \
       krb5-devel \
       krb5-libs \
       krb5-workstation \
       libffi-devel \
-      libtidy \
       libxml2-devel \
       libxslt-devel \
       make \
       maven \
-      mysql-devel \
       nc \
       ncurses-devel \
       nmap-ncat \
       openldap-devel \
       openssl \
       openssl-devel \
-      postgresql \
-      postgresql-libs \
-      python-devel \
-      python-setuptools \
-      readline-devel \
+      python38 \
+      python38-devel \
+      rsync \
       sqlite-devel \
       sudo \
-      swig \
       tar \
       which \
       xmlsec1 \
       xmlsec1-openssl \
       zlib-devel
 
-RUN set -eux; easy_install supervisor pip
-
-RUN curl -s https://files.pythonhosted.org/packages/a1/92/a27986cb7b4bddc7d57781a0e1163d683110907edfca1db3fbce25536492/psycopg2_binary-2.8.3-cp27-cp27mu-manylinux1_x86_64.whl -o /tmp/psycopg2_binary-2.8.3-cp27-cp27mu-manylinux1_x86_64.whl
-
-RUN set -eux ; \
-      curl -sL https://rpm.nodesource.com/setup_10.x | bash - \
+RUN set -eux; \
+      curl -sL https://rpm.nodesource.com/setup_14.x | bash - \
         && yum install -y nodejs \
         && yum clean all -y
 

--- a/tools/container/hue/Dockerfile
+++ b/tools/container/hue/Dockerfile
@@ -26,13 +26,11 @@ ENV NAME="hue" \
 # create hue user
 RUN groupadd -g 1000 ${HUEUSER} && useradd -g 1000 -d ${HUE_HOME} -s /bin/bash -u 1000 ${HUEUSER}
 
-COPY hue ${HUE_HOME}
-COPY hue.sh ${HUE_HOME}/hue.sh
-
-RUN chown -R ${HUEUSER}:${HUEUSER} ${HUE_HOME}
+COPY --chown=${HUEUSER}:${HUEUSER} ${HUEUSER} ${HUE_HOME}
+COPY --chown=${HUEUSER}:${HUEUSER} hue.sh ${HUE_HOME}/hue.sh
 
 # Install psycopg2-binary
-RUN $HUE_BIN/pip install /tmp/psycopg2_binary-2.8.3-cp27-cp27mu-manylinux1_x86_64.whl
+RUN $HUE_BIN/python3.8 -m pip install --upgrade pip --force && $HUE_BIN/pip install psycopg2-binary
 
 # Setup directory structure
 RUN mkdir -p ${HUE_LOG_DIR} && chown -R ${HUEUSER}:${HUEUSER} ${HUE_LOG_DIR}
@@ -42,8 +40,7 @@ RUN mkdir -p ${HUE_CONF} && chown -R ${HUEUSER}:${HUEUSER} ${HUE_CONF}
 RUN echo "${HUEUSER} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${HUEUSER} && \
     chmod 0440 /etc/sudoers.d/${HUEUSER}
 
-COPY hueconf ${HUE_CONF}/conf
-RUN chown -R ${HUEUSER}:${HUEUSER} ${HUE_CONF}/conf
+COPY --chown=${HUEUSER}:${HUEUSER} hueconf ${HUE_CONF}/conf
 
 RUN ln -s ${HUE_CONF}/conf/log.conf ${HUE_HOME}/desktop/conf/log.conf; \
     ln -s ${HUE_CONF}/conf/log4j.properties ${HUE_HOME}/desktop/conf/log4j.properties
@@ -58,4 +55,4 @@ RUN chown -R ${HUEUSER}:${HUEUSER} /etc/supervisord.conf && chown -R ${HUEUSER}:
 EXPOSE 8888 9111
 
 WORKDIR ${HUE_HOME}
-CMD ["/usr/bin/supervisord","-c","/etc/supervisord.conf"]
+CMD ["/usr/local/bin/supervisord","-c","/etc/supervisord.conf"]

--- a/tools/container/hue/hueconf/hue.ini
+++ b/tools/container/hue/hueconf/hue.ini
@@ -1,5 +1,6 @@
 [desktop]
 allowed_hosts="*"
+use_x_forwarded_host=true
 secret_key_script=/bin/echo cloudera
 cluster_id=d6cb3d9f-953b-46ff-9dc4-ab2a9331f0db
 app_blacklist=filebrowser,oozie,search,hbase,security,metastore,pig,sqoop,spark

--- a/tools/container/hue/supervisor-files/etc/supervisord_template
+++ b/tools/container/hue/supervisor-files/etc/supervisord_template
@@ -1,10 +1,10 @@
 [unix_http_server]
-file=/var/log/${HUE_USER}/supervisord.sock
+file=/var/log/${HUEUSER}/supervisord.sock
 username=${UUID_GEN}
 password=${UUID_GEN}
 
 [supervisord]
-pidfile=/var/log/${HUE_USER}/supervisord.pid
+pidfile=/var/log/${HUEUSER}/supervisord.pid
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/tools/container/hue/supervisor-files/hue_ktrenewer_template
+++ b/tools/container/hue/supervisor-files/hue_ktrenewer_template
@@ -7,9 +7,9 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-environment=DESKTOP_LOG_DIR="/var/log/${HUE_USER}",PYTHON_EGG_CACHE="$HUE_CONF_DIR/.python-eggs"
-user=${HUE_USER}
-group=${HUE_USER}
+environment=DESKTOP_LOG_DIR="/var/log/${HUEUSER}",PYTHON_EGG_CACHE="$HUE_CONF_DIR/.python-eggs"
+user=${HUEUSER}
+group=${HUEUSER}
 exitcodes=0,2
 autorestart=false
 startsecs=20

--- a/tools/container/hue/supervisor-files/hue_server_template
+++ b/tools/container/hue/supervisor-files/hue_server_template
@@ -7,9 +7,9 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-environment=DESKTOP_LOG_DIR="/var/log/${HUE_USER}",PYTHON_EGG_CACHE="${HUE_CONF_DIR}/.python-eggs",SERVER_SOFTWARE="apache"
-user=${HUE_USER}
-group=${HUE_USER}
+environment=DESKTOP_LOG_DIR="/var/log/${HUEUSER}",PYTHON_EGG_CACHE="${HUE_CONF_DIR}/.python-eggs",SERVER_SOFTWARE="apache"
+user=${HUEUSER}
+group=${HUEUSER}
 exitcodes=0,2
 autorestart=false
 startsecs=20

--- a/tools/container/huelb/Dockerfile
+++ b/tools/container/huelb/Dockerfile
@@ -28,14 +28,12 @@ RUN groupadd -g 1000 ${HUEUSER} && useradd -g 1000 -d ${HUE_HOME} -s /bin/bash -
 RUN mkdir -p ${HUE_LOG_DIR} && chown -R ${HUEUSER}:${HUEUSER} ${HUE_LOG_DIR}
 RUN echo "Include /etc/httpd/conf.d/hue_httpd.conf" >> /etc/httpd/conf/httpd.conf
 
-COPY static ${HUE_HOME}/build/static
-COPY hue_httpd.conf /etc/httpd/conf.d/hue_httpd.conf
-COPY hue.conf /etc/httpd/conf.d/hue.conf
-COPY run_httpd.sh ${HUE_HOME}
+COPY --chown=${HUEUSER}:${HUEUSER} static ${HUE_HOME}/build/static
+COPY --chown=${HUEUSER}:${HUEUSER} hue_httpd.conf /etc/httpd/conf.d/hue_httpd.conf
+COPY --chown=${HUEUSER}:${HUEUSER} hue.conf /etc/httpd/conf.d/hue.conf
+COPY --chown=${HUEUSER}:${HUEUSER} run_httpd.sh ${HUE_HOME}
 RUN sed -i "s|Listen 80|Listen 8080|g" /etc/httpd/conf/httpd.conf && sed -i "s|User apache|User hive|g" /etc/httpd/conf/httpd.conf && sed -i "s|Group apache|Group hive|g" /etc/httpd/conf/httpd.conf
-RUN chown -R ${HUEUSER}:${HUEUSER} ${HUE_HOME}/build/static \
-      /etc/httpd/conf.d/hue* \
-      ${HUE_HOME}/run_httpd.sh && chmod -v +x ${HUE_HOME}/run_httpd.sh
+RUN chmod -v +x ${HUE_HOME}/run_httpd.sh
 RUN mkdir -p /run && chown -R ${HUEUSER}:${HUEUSER} /run && mkdir -p /tmp/httpd && chown -R ${HUEUSER}:${HUEUSER} /tmp/httpd && chown -R ${HUEUSER}:${HUEUSER} /etc/httpd && chown -R ${HUEUSER}:${HUEUSER} /var/log && chown -R ${HUEUSER}:${HUEUSER} /etc/httpd/logs
 
 EXPOSE 8080

--- a/tools/container/huelb/hue_httpd_template
+++ b/tools/container/huelb/hue_httpd_template
@@ -37,6 +37,7 @@ Alias /static ${HUE_HOME}/build/static
 
 Header add Set-Cookie "ROUTEID=.%{BALANCER_WORKER_ROUTE}e; path=/" env=BALANCER_ROUTE_CHANGED
 ProxyPreserveHost Off
+ProxyAddHeaders On
 ProxyPass /static !
 ProxyPass / balancer://hue/ stickysession=ROUTEID
 
@@ -44,6 +45,6 @@ SetEnv proxy-initial-not-pooled 1
 ProxyTimeout 900
 
 AllowEncodedSlashes NoDecode
-User ${HUE_USER}
-Group ${HUE_USER}
+User ${HUEUSER}
+Group ${HUEUSER}
 Include /etc/httpd/conf.d/hue.conf


### PR DESCRIPTION
…8" version.

- Upgrade UBI8 based packages
- Pin Python Version to python3.8
- Upgrade nodesource version to 14.x
- Install psycopg2-binary python package
- Generate self-signed certificate using CNAME instead of FQDN
- Perform COPY/chown command in Dockerfile which resulted reduced docker image size
- Added ProxyAddHeaders flag in apache config file

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
