### PR TITLE
Hue [py3] Enable HTTP_X_FORWARDED header detection

### DIFF
--- a/desktop/core/src/desktop/middleware.py
+++ b/desktop/core/src/desktop/middleware.py
@@ -923,3 +923,25 @@ class MimeTypeJSFileFixStreamingMiddleware(MiddlewareMixin):
       response['Content-Type'] = "application/javascript"
 
     return response
+
+class MultipleProxyMiddleware:
+  FORWARDED_FOR_FIELDS = [
+    'HTTP_X_FORWARDED_FOR',
+    'HTTP_X_FORWARDED_HOST',
+    'HTTP_X_FORWARDED_SERVER',
+  ]
+
+  def __init__(self, get_response):
+    self.get_response = get_response
+
+  def __call__(self, request):
+    """
+    Rewrites the proxy headers so that only the most
+    recent proxy is used.
+    """
+    for field in self.FORWARDED_FOR_FIELDS:
+      if field in request.META:
+        if ',' in request.META[field]:
+          parts = request.META[field].split(',')
+          request.META[field] = parts[-1].strip()
+    return self.get_response(request)

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -148,6 +148,7 @@ MIDDLEWARE = [
     'desktop.middleware.MetricsMiddleware',
     'desktop.middleware.EnsureSafeMethodMiddleware',
     'desktop.middleware.AuditLoggingMiddleware',
+    'desktop.middleware.MultipleProxyMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',


### PR DESCRIPTION
## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
