### PR TITLE
Hue [py3] Fixing b64encode string issue

### DIFF
--- a/desktop/core/src/desktop/lib/raz/raz_client.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client.py
@@ -255,7 +255,10 @@ class RazClient(object):
         time_offset=0
     )
     raz_req_serialized = raz_req.SerializeToString()
-    signed_request = base64.b64encode(raz_req_serialized)
+    if sys.version_info[0] > 2:
+      signed_request = base64.b64encode(raz_req_serialized).decode('utf-8')
+    else:
+      signed_request = base64.b64encode(raz_req_serialized)
 
     request_headers["Accept-Encoding"] = "gzip,deflate"
     request_data["context"] = {

--- a/desktop/core/src/desktop/lib/raz/raz_client_test.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client_test.py
@@ -339,6 +339,13 @@ class RazClientTest(unittest.TestCase):
 
             resp = client.check_access(method='GET', url=self.s3_path)
 
+            if sys.version_info[0] > 2:
+              signed_request = 'CiRodHRwczovL2dldGh1ZS10ZXN0LnMzLmFtYXpvbmF3cy5jb20Q' \
+                'ATIYZ2V0aHVlL2RhdGEvY3VzdG9tZXIuY3N2OABCAnMzSgJzMw=='
+            else:
+              signed_request = b'CiRodHRwczovL2dldGh1ZS10ZXN0LnMzLmFtYXpvbmF3cy5jb20Q' \
+                b'ATIYZ2V0aHVlL2RhdGEvY3VzdG9tZXIuY3N2OABCAnMzSgJzMw=='
+
             requests_post.assert_called_with(
               'https://raz.gethue.com:8080/api/authz/s3/access?delegation=mock_RAZ_token', 
               headers={'Content-Type': 'application/json', 'Accept-Encoding': 'gzip,deflate'}, 
@@ -355,8 +362,7 @@ class RazClientTest(unittest.TestCase):
                 'sessionId': '',
                 'accessTime': '',
                 'context': {
-                  'S3_SIGN_REQUEST': b'CiRodHRwczovL2dldGh1ZS10ZXN0LnMzLmFtYXpvbmF3cy5jb20Q' \
-                    b'ATIYZ2V0aHVlL2RhdGEvY3VzdG9tZXIuY3N2OABCAnMzSgJzMw=='
+                  'S3_SIGN_REQUEST': signed_request
                 }
               },
               verify=False


### PR DESCRIPTION
(cherry picked from commit 61f095c03c46e72f4c3e8feedae3f24f662abb66)

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
