### PR TITLE
Added '/' which was missed out when performing status check when ther…

### DIFF
--- a/desktop/libs/metadata/src/metadata/catalog/atlas_client.py
+++ b/desktop/libs/metadata/src/metadata/catalog/atlas_client.py
@@ -72,7 +72,7 @@ class AtlasApi(Api):
     atlas_servers = CATALOG.API_URL.get().replace("%20", "").replace("['", "").replace("']", "").replace("'", "").split(',')
 
     for atlas_server in atlas_servers:
-      atlas_url = atlas_server + 'api/atlas/admin/status'
+      atlas_url = atlas_server.strip().strip('/') + '/api/atlas/admin/status'
       response = requests.get(atlas_url)
       atlas_is_active = response.json()
 


### PR DESCRIPTION
…e is no slash '/' at the end of the url for Atlas server.

If the '/' at the end of atlas url is missing then the status check fail with no proper url.