### PR TITLE
Hue [py3] Enable SAML certificate creation with passphrase support.

### DIFF
--- a/desktop/core/ext-py3/pysaml2-5.0.0/src/saml2/config.py
+++ b/desktop/core/ext-py3/pysaml2-5.0.0/src/saml2/config.py
@@ -32,6 +32,7 @@ COMMON_ARGS = [
     "entityid",
     "xmlsec_binary",
     "key_file",
+    "key_file_passphrase",
     "cert_file",
     "encryption_keypairs",
     "additional_cert_files",
@@ -194,6 +195,7 @@ class Config(object):
         self.xmlsec_path = []
         self.debug = False
         self.key_file = None
+        self.key_file_passphrase = None
         self.cert_file = None
         self.encryption_keypairs = None
         self.additional_cert_files = None


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Enable SAML certificate creation with passphrase support
 
## How was this patch tested?

- Tested on DWX server. Checked SAML login works.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
