### PR TITLE
Fix Error loading MySQLdb module issue

### DIFF
--- a/tools/docker/hue/Dockerfile
+++ b/tools/docker/hue/Dockerfile
@@ -80,7 +80,9 @@ RUN ./build/env/bin/pip install --no-cache-dir \
   # sqlalchemy-clickhouse depend on infi.clickhouse_orm
   # install after sqlalchemy-clickhouse and version == 1.0.4
   # otherwise Code: 516, Authentication failed will display
-  infi.clickhouse_orm==1.0.4
+  infi.clickhouse_orm==1.0.4 \
+  # Fix Error loading MySQLdb module issue when launching hue with mysql engine
+  mysqlclient
 
 USER hue
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Fix the issue [Error loading MySQLDB module](https://github.com/cloudera/hue/issues/2759) when building the hue docker image

## How was this patch tested?

- rerun the `docker build` command to rebuild the gethue/hue image without any exception


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
