### PR TITLE
[core] upgrading ipython to latest version

### DIFF
--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -31,7 +31,7 @@ eventlet==0.31.0
 future==0.18.2
 greenlet==0.4.15
 gunicorn==19.9.0
-ipython==7.16.3  # Last Python 3.6
+ipython==8.1.1  # Python >= 3.8
 jaeger-client==4.3.0
 jdcal==1.0.1
 kazoo==2.8.0


### PR DESCRIPTION
## What changes were proposed in this pull request?

- ipython 7.16.3 to 8.1.1
- ipdb[0.13.9] requires ipython>=7.17.0

## How was this patch tested?

- running ./build/env/bin/hue shell
