### PR TITLE
Revert eventlet from 0.31.0 back to 0.30.2 due to incompatible with g…

### DIFF
--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -27,7 +27,7 @@ django_prometheus==1.0.15
 django-webpack-loader==1.0.0
 djangorestframework-simplejwt==4.4.0  # For Python 3.6
 djangorestframework==3.12.2
-eventlet==0.31.0
+eventlet==0.30.2
 future==0.18.2
 greenlet==0.4.15
 gunicorn==19.9.0


### PR DESCRIPTION
…unicorn 19.9.0

## What changes were proposed in this pull request?

```
│ + /opt/hive/build/env/bin/hue rungunicornserver                                                                                                                                                                                    │
│                                                                                                                                                                                                                                    │
│ Error: class uri 'eventlet' invalid or not found:                                                                                                                                                                                  │
│                                                                                                                                                                                                                                    │
│ [Traceback (most recent call last):                                                                                                                                                                                                │
│   File "/opt/hive/build/env/lib/python3.8/site-packages/gunicorn/util.py", line 135, in load_class                                                                                                                                 │
│     mod = import_module('.'.join(components))                                                                                                                                                                                      │
│   File "/usr/lib64/python3.8/importlib/__init__.py", line 127, in import_module                                                                                                                                                    │
│     return _bootstrap._gcd_import(name[level:], package, level)                                                                                                                                                                    │
│   File "<frozen importlib._bootstrap>", line 1014, in _gcd_import                                                                                                                                                                  │
│   File "<frozen importlib._bootstrap>", line 991, in _find_and_load                                                                                                                                                                │
│   File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked                                                                                                                                                       │
│   File "<frozen importlib._bootstrap>", line 671, in _load_unlocked                                                                                                                                                                │
│   File "<frozen importlib._bootstrap_external>", line 783, in exec_module                                                                                                                                                          │
│   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed                                                                                                                                                     │
│   File "/opt/hive/build/env/lib/python3.8/site-packages/gunicorn/workers/geventlet.py", line 23, in <module>                                                                                                                       │
│     from eventlet.wsgi import ALREADY_HANDLED as EVENTLET_ALREADY_HANDLED                                                                                                                                                          │
│ ImportError: cannot import name 'ALREADY_HANDLED' from 'eventlet.wsgi' (/opt/hive/build/env/lib/python3.8/site-packages/eventlet/wsgi.py)                                                                                          │
│ ]
```
This is due to https://github.com/cloudera/hue/pull/2366. 

See more info: https://stackoverflow.com/questions/67409452/gunicorn-importerror-cannot-import-name-already-handled-from-eventlet-wsgi

Will bump up again when Gunicorn release the fix.


## How was this patch tested?

downgraded the eventlet and tested


