### PR TITLE
[docker] Add few kerberos packages in py3 Dockerfile

### DIFF
--- a/tools/docker/hue/Dockerfile
+++ b/tools/docker/hue/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update -y && apt-get install -y \
   libsasl2-modules-gssapi-mit \
   libsasl2-dev \
   libkrb5-dev \
+  krb5-config \
+  krb5-user \
   libxml2-dev \
   libxslt-dev \
   libmysqlclient-dev \


### PR DESCRIPTION
## What changes were proposed in this pull request?

- 'krb5-config', 'krb5-user' packages were missed when the py2 and py3 Dockerfiles were swapped
