### PR TITLE
[api] Port create directory filebrowser API to public

### DIFF
--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -209,6 +209,11 @@ def storage_upload_file(request):
   django_request = get_django_request(request)
   return filebrowser_views.upload_file(django_request)
 
+@api_view(["POST"])
+def storage_mkdir(request):
+  django_request = get_django_request(request)
+  return filebrowser_views.mkdir(django_request)
+
 
 # Importer
 

--- a/desktop/core/src/desktop/api_public_urls.py
+++ b/desktop/core/src/desktop/api_public_urls.py
@@ -95,6 +95,7 @@ urlpatterns += [
   re_path(r'^storage/view=(?P<path>.*)$', api_public.storage_view, name='storage_view'),
   re_path(r'^storage/download=(?P<path>.*)$', api_public.storage_download, name='storage_download'),
   re_path(r'^storage/upload/file/?$', api_public.storage_upload_file, name='storage_upload_file'),
+  re_path(r'^storage/mkdir$', api_public.storage_mkdir, name='storage_mkdir'),
 ]
 
 urlpatterns += [


### PR DESCRIPTION
## What changes were proposed in this pull request?

- `/api/storage/mkdir` is the public API for create directory operation for Hue filebrowser.

## How was this patch tested?

- Tested manually 