### PR TITLE
Set non-root default user for Hue images

### DIFF
--- a/tools/container/hue/Dockerfile
+++ b/tools/container/hue/Dockerfile
@@ -23,8 +23,11 @@ ENV NAME="hue" \
     PATH=$PATH:${HUE_BIN} \
     SUPERVISOR_VERSION=4.0.2
 
-# create hue user
-RUN groupadd -g 1000 ${HUEUSER} && useradd -g 1000 -d ${HUE_HOME} -s /bin/bash -u 1000 ${HUEUSER}
+# Switch to non-root default user
+RUN yum install -y microdnf && \
+    microdnf install -y shadow-utils findutils && \
+    groupadd -g 1000 ${HUEUSER} && \
+    useradd -g 1000 -d ${HUE_HOME} -s /bin/bash -u 1000 ${HUEUSER}
 
 COPY --chown=${HUEUSER}:${HUEUSER} ${HUEUSER} ${HUE_HOME}
 COPY --chown=${HUEUSER}:${HUEUSER} hue.sh ${HUE_HOME}/hue.sh
@@ -57,5 +60,8 @@ RUN rm -rf ${HUE_HOME}/build/env/lib/python3.8/site-packages/pip/_vendor/chardet
 
 EXPOSE 8888 9111
 
+# Switch to non-root default user
+USER hive
+ENV USER hive
 WORKDIR ${HUE_HOME}
 CMD ["/usr/local/bin/supervisord","-c","/etc/supervisord.conf"]

--- a/tools/container/huelb/Dockerfile
+++ b/tools/container/huelb/Dockerfile
@@ -22,8 +22,11 @@ ENV NAME="hue" \
     PATH=$PATH:${HUE_BIN} \
     SUPERVISOR_VERSION=4.0.2
 
-# create hue user
-RUN groupadd -g 1000 ${HUEUSER} && useradd -g 1000 -d ${HUE_HOME} -s /bin/bash -u 1000 ${HUEUSER}
+# Switch to non-root default user
+RUN yum install -y microdnf && \
+    microdnf install -y shadow-utils findutils && \
+    groupadd -g 1000 ${HUEUSER} && \
+    useradd -g 1000 -d ${HUE_HOME} -s /bin/bash -u 1000 ${HUEUSER}
 
 RUN mkdir -p ${HUE_LOG_DIR} && chown -R ${HUEUSER}:${HUEUSER} ${HUE_LOG_DIR}
 RUN echo "Include /etc/httpd/conf.d/hue_httpd.conf" >> /etc/httpd/conf/httpd.conf
@@ -40,5 +43,8 @@ EXPOSE 8080
 # https://httpd.apache.org/docs/2.4/stopping.html#gracefulstop
 STOPSIGNAL SIGINT
 
+# Switch to non-root default user
+USER hive
+ENV USER hive
 WORKDIR ${HUE_HOME}
 CMD ["run_httpd.sh"]


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Setting non-root login for Hue and Hue LB image.

## How was this patch tested?

- docker image inspect --format '{{json .Config.User}}' HUE_IMAGE_NAME
- docker image inspect --format '{{json .Config.User}}' HUELB_IMAGE_NAME
- Checked user id at hue terminal login in kubernetes env.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
