### PR TITLE
Fixed NoneType Error

### DIFF
--- a/apps/beeswax/src/beeswax/server/hive_server2_lib.py
+++ b/apps/beeswax/src/beeswax/server/hive_server2_lib.py
@@ -728,7 +728,7 @@ class HiveServerClient(object):
 
     # HS2 does not return properties in TOpenSessionResp
     # TEZ returns properties, but we need the configuration to detect engine
-    properties = session.get_properties()
+    properties = session.get_properties() or {}
     if not properties or self.query_server['server_name'] == 'beeswax':
       configuration = self.get_configuration(session=session)
       properties.update(configuration)


### PR DESCRIPTION
The problem `AttributeError: 'Nonetype' object has not attribute 'update'` was throwed when I execute query with HS2, Maybe we should ensure the attribute "properties" is not "none", thus I add the empty dict to replace 'Nonetype' if the properties is none.