### PR TITLE
[sparksql] Close unused Livy sessions to free up resources

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/spark_shell_tests.py
+++ b/desktop/libs/notebook/src/notebook/connectors/spark_shell_tests.py
@@ -218,6 +218,11 @@ class TestSparkApi(object):
         'meta': 'test_meta'
       }
     )
+    self.api.create_session = Mock(
+      return_value={
+        'id': 'test_id'
+      }
+    )
 
     response = self.api.get_sample_data(snippet, 'test_db', 'test_table', 'test_column')
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Close unused Livy sessions to free up resources

Other improvements include:
 - Check for stale value when caching session value for particular user.
 - Create session in /sampla_data also  if required to fix table browser corner case when switching to editor.
 - Update UTs