### PR TITLE
[frontend] Add shortcut key for toggling side panels

### DIFF
--- a/desktop/core/src/desktop/js/hue.js
+++ b/desktop/core/src/desktop/js/hue.js
@@ -61,6 +61,7 @@ import 'components/sidebar/HueSidebarWebComponent';
 import 'components/assist/AssistPanelWebComponent';
 
 import 'ko/components/assist/assistViewModel';
+import { BOTH_ASSIST_TOGGLE_EVENT } from 'ko/components/assist/events';
 import OnePageViewModel from 'onePageViewModel';
 import SidePanelViewModel from 'sidePanelViewModel';
 import TopNavViewModel from 'topNavViewModel';
@@ -174,4 +175,11 @@ $(document).ready(async () => {
   });
 
   $('.page-content').jHueScrollUp();
+});
+
+// Framework independent global keyboard shortcuts
+document.addEventListener('keydown', e => {
+  if (e.key === '.' && (e.metaKey || e.ctrlKey)) {
+    huePubSub.publish(BOTH_ASSIST_TOGGLE_EVENT);
+  }
 });

--- a/desktop/core/src/desktop/js/ko/components/assist/events.js
+++ b/desktop/core/src/desktop/js/ko/components/assist/events.js
@@ -16,6 +16,7 @@
 
 export const SHOW_LEFT_ASSIST_EVENT = 'left.assist.show';
 export const SHOW_RIGHT_ASSIST_EVENT = 'right.assist.show';
+export const BOTH_ASSIST_TOGGLE_EVENT = 'both.assists.toggle';
 
 export const ASSIST_IS_DB_PANEL_READY_EVENT = 'assist.is.db.panel.ready';
 export const ASSIST_DB_PANEL_IS_READY_EVENT = 'assist.db.panel.is.ready';

--- a/desktop/core/src/desktop/js/sidePanelViewModel.js
+++ b/desktop/core/src/desktop/js/sidePanelViewModel.js
@@ -20,7 +20,11 @@ import * as ko from 'knockout';
 import hueAnalytics from 'utils/hueAnalytics';
 import huePubSub from 'utils/huePubSub';
 import { ACTIVE_SNIPPET_CONNECTOR_CHANGED_EVENT } from 'apps/editor/events';
-import { SHOW_LEFT_ASSIST_EVENT, SHOW_RIGHT_ASSIST_EVENT } from 'ko/components/assist/events';
+import {
+  SHOW_LEFT_ASSIST_EVENT,
+  SHOW_RIGHT_ASSIST_EVENT,
+  BOTH_ASSIST_TOGGLE_EVENT
+} from 'ko/components/assist/events';
 import { getFromLocalStorage, setInLocalStorage } from 'utils/storageUtils';
 import defer from 'utils/timing/defer';
 
@@ -132,6 +136,16 @@ class SidePanelViewModel {
         self.assistWithoutStorage(false);
       });
     };
+
+    huePubSub.subscribe(BOTH_ASSIST_TOGGLE_EVENT, () => {
+      const hideBoth = self.rightAssistVisible() || self.leftAssistVisible();
+      if (hideBoth) {
+        hideAssists(true, true);
+      } else {
+        self.leftAssistVisible(true);
+        self.rightAssistVisible(true);
+      }
+    });
 
     huePubSub.subscribe('both.assists.hide', preventStorage => {
       hideAssists(true, true, preventStorage);

--- a/desktop/core/src/desktop/js/sidePanelViewModel.test.js
+++ b/desktop/core/src/desktop/js/sidePanelViewModel.test.js
@@ -18,7 +18,7 @@ import SidePanelViewModel from './sidePanelViewModel';
 import huePubSub from 'utils/huePubSub';
 import { BOTH_ASSIST_TOGGLE_EVENT } from 'ko/components/assist/events';
 import hueAnalytics from 'utils/hueAnalytics';
-import * as all from 'utils/storageUtils';
+import * as storageUtils from 'utils/storageUtils';
 
 describe('SidePanelViewModel', () => {
   beforeAll(() => {
@@ -30,16 +30,16 @@ describe('SidePanelViewModel', () => {
   });
 
   it('Should hide the assistspanels on BOTH_ASSIST_TOGGLE_EVENT when visible', () => {
-    jest.spyOn(all, 'getFromLocalStorage').mockImplementation(() => true);
-    jest.spyOn(all, 'setInLocalStorage').mockImplementation(() => {});
+    jest.spyOn(storageUtils, 'getFromLocalStorage').mockImplementation(() => true);
+    jest.spyOn(storageUtils, 'setInLocalStorage').mockImplementation(() => {});
     const sidePanelViewModel = new SidePanelViewModel();
     expect(sidePanelViewModel.rightAssistVisible()).toBeTruthy();
     expect(sidePanelViewModel.leftAssistVisible()).toBeTruthy();
-    expect(all.setInLocalStorage).not.toHaveBeenCalledWith(
+    expect(storageUtils.setInLocalStorage).not.toHaveBeenCalledWith(
       'assist.left_assist_panel_visible',
       false
     );
-    expect(all.setInLocalStorage).not.toHaveBeenCalledWith(
+    expect(storageUtils.setInLocalStorage).not.toHaveBeenCalledWith(
       'assist.right_assist_panel_visible',
       false
     );
@@ -47,22 +47,28 @@ describe('SidePanelViewModel', () => {
     huePubSub.publish(BOTH_ASSIST_TOGGLE_EVENT);
     expect(sidePanelViewModel.rightAssistVisible()).toBeFalsy();
     expect(sidePanelViewModel.leftAssistVisible()).toBeFalsy();
-    expect(all.setInLocalStorage).toHaveBeenCalledWith('assist.left_assist_panel_visible', false);
-    expect(all.setInLocalStorage).toHaveBeenCalledWith('assist.right_assist_panel_visible', false);
+    expect(storageUtils.setInLocalStorage).toHaveBeenCalledWith(
+      'assist.left_assist_panel_visible',
+      false
+    );
+    expect(storageUtils.setInLocalStorage).toHaveBeenCalledWith(
+      'assist.right_assist_panel_visible',
+      false
+    );
   });
 
   it('Should show the assistspanels on BOTH_ASSIST_TOGGLE_EVENT when hidden', () => {
-    jest.spyOn(all, 'getFromLocalStorage').mockImplementation(() => false);
-    jest.spyOn(all, 'setInLocalStorage').mockImplementation(() => {});
+    jest.spyOn(storageUtils, 'getFromLocalStorage').mockImplementation(() => false);
+    jest.spyOn(storageUtils, 'setInLocalStorage').mockImplementation(() => {});
     const sidePanelViewModel = new SidePanelViewModel();
 
     expect(sidePanelViewModel.rightAssistVisible()).toBeFalsy();
     expect(sidePanelViewModel.leftAssistVisible()).toBeFalsy();
-    expect(all.setInLocalStorage).not.toHaveBeenCalledWith(
+    expect(storageUtils.setInLocalStorage).not.toHaveBeenCalledWith(
       'assist.left_assist_panel_visible',
       true
     );
-    expect(all.setInLocalStorage).not.toHaveBeenCalledWith(
+    expect(storageUtils.setInLocalStorage).not.toHaveBeenCalledWith(
       'assist.right_assist_panel_visible',
       true
     );
@@ -70,7 +76,13 @@ describe('SidePanelViewModel', () => {
     huePubSub.publish(BOTH_ASSIST_TOGGLE_EVENT);
     expect(sidePanelViewModel.rightAssistVisible()).toBeTruthy();
     expect(sidePanelViewModel.leftAssistVisible()).toBeTruthy();
-    expect(all.setInLocalStorage).toHaveBeenCalledWith('assist.left_assist_panel_visible', true);
-    expect(all.setInLocalStorage).toHaveBeenCalledWith('assist.right_assist_panel_visible', true);
+    expect(storageUtils.setInLocalStorage).toHaveBeenCalledWith(
+      'assist.left_assist_panel_visible',
+      true
+    );
+    expect(storageUtils.setInLocalStorage).toHaveBeenCalledWith(
+      'assist.right_assist_panel_visible',
+      true
+    );
   });
 });

--- a/desktop/core/src/desktop/js/sidePanelViewModel.test.js
+++ b/desktop/core/src/desktop/js/sidePanelViewModel.test.js
@@ -1,0 +1,76 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SidePanelViewModel from './SidePanelViewModel';
+import huePubSub from 'utils/huePubSub';
+import { BOTH_ASSIST_TOGGLE_EVENT } from 'ko/components/assist/events';
+import hueAnalytics from 'utils/hueAnalytics';
+import * as all from 'utils/storageUtils';
+
+describe('SidePanelViewModel', () => {
+  beforeAll(() => {
+    jest.spyOn(hueAnalytics, 'convert').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Should hide the assistspanels on BOTH_ASSIST_TOGGLE_EVENT when visible', () => {
+    jest.spyOn(all, 'getFromLocalStorage').mockImplementation(() => true);
+    jest.spyOn(all, 'setInLocalStorage').mockImplementation(() => {});
+    const sidePanelViewModel = new SidePanelViewModel();
+    expect(sidePanelViewModel.rightAssistVisible()).toBeTruthy();
+    expect(sidePanelViewModel.leftAssistVisible()).toBeTruthy();
+    expect(all.setInLocalStorage).not.toHaveBeenCalledWith(
+      'assist.left_assist_panel_visible',
+      false
+    );
+    expect(all.setInLocalStorage).not.toHaveBeenCalledWith(
+      'assist.right_assist_panel_visible',
+      false
+    );
+
+    huePubSub.publish(BOTH_ASSIST_TOGGLE_EVENT);
+    expect(sidePanelViewModel.rightAssistVisible()).toBeFalsy();
+    expect(sidePanelViewModel.leftAssistVisible()).toBeFalsy();
+    expect(all.setInLocalStorage).toHaveBeenCalledWith('assist.left_assist_panel_visible', false);
+    expect(all.setInLocalStorage).toHaveBeenCalledWith('assist.right_assist_panel_visible', false);
+  });
+
+  it('Should show the assistspanels on BOTH_ASSIST_TOGGLE_EVENT when hidden', () => {
+    jest.spyOn(all, 'getFromLocalStorage').mockImplementation(() => false);
+    jest.spyOn(all, 'setInLocalStorage').mockImplementation(() => {});
+    const sidePanelViewModel = new SidePanelViewModel();
+
+    expect(sidePanelViewModel.rightAssistVisible()).toBeFalsy();
+    expect(sidePanelViewModel.leftAssistVisible()).toBeFalsy();
+    expect(all.setInLocalStorage).not.toHaveBeenCalledWith(
+      'assist.left_assist_panel_visible',
+      true
+    );
+    expect(all.setInLocalStorage).not.toHaveBeenCalledWith(
+      'assist.right_assist_panel_visible',
+      true
+    );
+
+    huePubSub.publish(BOTH_ASSIST_TOGGLE_EVENT);
+    expect(sidePanelViewModel.rightAssistVisible()).toBeTruthy();
+    expect(sidePanelViewModel.leftAssistVisible()).toBeTruthy();
+    expect(all.setInLocalStorage).toHaveBeenCalledWith('assist.left_assist_panel_visible', true);
+    expect(all.setInLocalStorage).toHaveBeenCalledWith('assist.right_assist_panel_visible', true);
+  });
+});

--- a/desktop/core/src/desktop/js/sidePanelViewModel.test.js
+++ b/desktop/core/src/desktop/js/sidePanelViewModel.test.js
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import SidePanelViewModel from './SidePanelViewModel';
+import SidePanelViewModel from './sidePanelViewModel';
 import huePubSub from 'utils/huePubSub';
 import { BOTH_ASSIST_TOGGLE_EVENT } from 'ko/components/assist/events';
 import hueAnalytics from 'utils/hueAnalytics';

--- a/desktop/core/src/desktop/templates/common_notebook_ko_components.mako
+++ b/desktop/core/src/desktop/templates/common_notebook_ko_components.mako
@@ -882,7 +882,10 @@ else:
         },{
           id: 'settings',
           label: '${ _('Settings')}',
-          shortcuts: [{ shortcut: 'Ctrl - ,', macShortcut: 'Command - ,', description: '${ _('Show the settings menu where you can control autocomplete behaviour, syntax checker, dark theme and various editor settings.')}' }]
+          shortcuts: [
+            { shortcut: 'Ctrl-,', macShortcut: 'Command-,', description: '${ _('Show the settings menu where you can control autocomplete behaviour, syntax checker, dark theme and various editor settings.')}'},
+            { shortcut: 'Ctrl-.', macShortcut: 'Command-.', description: '${ _('Show or hide the assist panels.')}' }
+            ]
         }];
 
         self.query = ko.observable('');


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Added the shortcut key to toggle the visibility of the side panels (win: ctrl + . & mac: cmd + . )
- Updated shortcut docs
- Added new unit tests

## How was this patch tested?

- Tested using unit tests
- Manual testing in the following browsers:
  - [x] Chrome
  - [x] Safari 
  - [x] Edge (for Mac)
  - [x] Firefox

Note! Not tested on windows. Waiting for WMware licence.

## Test instructions
1. Open the editor
2. Press cmd + . (if your are one a mac) 
3. Verify that both assist panels are hidden
4. Press cmd + . (if your are one a mac) 
5. Verify that both assist panels are showing again and that they still are showing content
6. Hide one of the assist panels by using the mouse and clicking the panels chevron icon
7. Press cmd + . (if your are one a mac) 
8. Verify that both assist panels are hidden
9. etc...

## Screenshots
![image](https://user-images.githubusercontent.com/5167091/165716598-9fde1a7f-e951-442a-9b9e-528643d55106.png)

after hitting cmd + .

![image](https://user-images.githubusercontent.com/5167091/165716896-322ef124-ed28-414b-80de-6575a9cf3873.png)


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
