### PR TITLE
[ui] Check for yarn config when adding application job ids

### DIFF
--- a/desktop/core/src/desktop/js/apps/notebook/snippet.js
+++ b/desktop/core/src/desktop/js/apps/notebook/snippet.js
@@ -31,7 +31,7 @@ import { getStatementsParser } from 'parse/utils';
 import { SHOW_EVENT as SHOW_GIST_MODAL_EVENT } from 'ko/components/ko.shareGistModal';
 import { cancelActiveRequest } from 'api/apiUtils';
 import { ACTIVE_SNIPPET_CONNECTOR_CHANGED_EVENT } from 'apps/editor/events';
-import { findEditorConnector, getConfig } from 'config/hueConfig';
+import { findEditorConnector, getLastKnownConfig } from 'config/hueConfig';
 import {
   ASSIST_GET_DATABASE_EVENT,
   ASSIST_GET_SOURCE_EVENT,
@@ -2575,12 +2575,10 @@ class Snippet {
                   } else {
                     job.percentJob = ko.observable(job.percentJob);
                   }
-
-                  getConfig().then(config => {
-                    if (config['hue_config']['is_yarn_enabled']) {
-                      self.jobs.push(job);
-                    }
-                  });
+                  const config = getLastKnownConfig();
+                  if (config && config['hue_config'] && config['hue_config']['is_yarn_enabled']) {
+                    self.jobs.push(job);
+                  }
                 } else if (typeof job.percentJob !== 'undefined') {
                   for (let i = 0; i < _found.length; i++) {
                     _found[i].percentJob(job.percentJob);

--- a/desktop/core/src/desktop/js/apps/notebook/snippet.js
+++ b/desktop/core/src/desktop/js/apps/notebook/snippet.js
@@ -31,7 +31,7 @@ import { getStatementsParser } from 'parse/utils';
 import { SHOW_EVENT as SHOW_GIST_MODAL_EVENT } from 'ko/components/ko.shareGistModal';
 import { cancelActiveRequest } from 'api/apiUtils';
 import { ACTIVE_SNIPPET_CONNECTOR_CHANGED_EVENT } from 'apps/editor/events';
-import { findEditorConnector } from 'config/hueConfig';
+import { findEditorConnector, getConfig } from 'config/hueConfig';
 import {
   ASSIST_GET_DATABASE_EVENT,
   ASSIST_GET_SOURCE_EVENT,
@@ -2575,7 +2575,12 @@ class Snippet {
                   } else {
                     job.percentJob = ko.observable(job.percentJob);
                   }
-                  self.jobs.push(job);
+
+                  getConfig().then(config => {
+                    if (config['hue_config']['is_yarn_enabled']) {
+                      self.jobs.push(job);
+                    }
+                  });
                 } else if (typeof job.percentJob !== 'undefined') {
                   for (let i = 0; i < _found.length; i++) {
                     _found[i].percentJob(job.percentJob);


### PR DESCRIPTION
## What changes were proposed in this pull request?

- If there is no yarn config in Hue backend, we should not show the `application_id` on the UI for some Hive queries which use Tez.

## How was this patch tested?

- Manually

Before:
<img width="930" alt="Screenshot 2022-05-09 at 5 50 28 PM" src="https://user-images.githubusercontent.com/42064744/167408595-f7c2b88d-ea08-4a7a-967f-5169c2b701ad.png">


After:
<img width="941" alt="Screenshot 2022-05-09 at 5 46 54 PM" src="https://user-images.githubusercontent.com/42064744/167408149-6ea7e2d4-26c8-4198-bf28-7a08b3072ac2.png">

