### PR TITLE
[frontend] replace location popover with link to filebrowser

### DIFF
--- a/apps/metastore/src/metastore/templates/metastore.mako
+++ b/apps/metastore/src/metastore/templates/metastore.mako
@@ -263,11 +263,16 @@ ${ components.menubar(is_embeddable) }
       ${_('and stored in')}
       <!-- ko if: details.properties.format === 'kudu' -->
         <div>${_('Kudu')}</div>
+      <!-- /ko -->
+      <!-- ko if: details.properties.format !== 'kudu' -->
+        <!-- ko if: hdfs_link -->
+          <div>          
+            <a data-bind="hueLink: hdfs_link, attr: { title: $parent.catalogEntry.getHdfsFilePath() }" target="_blank" >${_('location')}</a>
+          </div>
         <!-- /ko -->
-        <!-- ko if: details.properties.format !== 'kudu' -->
-        <div>
-          <a href="javascript: void(0);" data-bind="storageContextPopover: { path: hdfs_link.replace('/filebrowser/view=', ''), offset: { left: 5 } }"> ${_('location')}</a>
-        </div>
+        <!-- ko ifnot: hdfs_link -->
+          <div>${_('unknown location')}</div>
+        <!-- /ko -->
       <!-- /ko -->
     </div>
     <!-- /ko -->
@@ -480,12 +485,14 @@ ${ components.menubar(is_embeddable) }
             <div>${ _('Owner') }</div>
             <div><span data-bind="text: owner_name ? owner_name : '${ _ko('None') }'"></span> <span data-bind="visible: owner_type">(<span data-bind="text: owner_type"></span>)</span></div>
           </div>
-          <div class="metastore-property">
-            <div>${ _('Location') }</div>
-            <div>
-              <a href="javascript: void(0);" data-bind="storageContextPopover: { path: hdfs_link.replace('/filebrowser/view=', ''), offset: { left: 5 } }"> ${_('Location')}</a>
+          <!-- ko if: hdfs_link  -->
+            <div class="metastore-property">
+              <div>${ _('Location') }</div>
+              <div>              
+                <a data-bind="hueLink: hdfs_link, attr: { title: $parent.catalogEntry.getHdfsFilePath() }" target="_blank" >${_('location')}</a>
+              </div>
             </div>
-          </div>
+          <!-- /ko -->
         </div>
       </div>
       <!-- ko with: parameters -->

--- a/desktop/core/src/desktop/js/catalog/DataCatalogEntry.ts
+++ b/desktop/core/src/desktop/js/catalog/DataCatalogEntry.ts
@@ -1414,6 +1414,11 @@ export default class DataCatalogEntry {
     return false;
   }
 
+  getHdfsFilePath(): string {
+    const hdfs_link = this.analysis?.hdfs_link || '';
+    return hdfs_link.replace('/filebrowser/view=', '');
+  }
+
   /**
    * Returns true if the entry is an Iceberg table
    */

--- a/desktop/core/src/desktop/js/catalog/dataCatalogEntry.test.ts
+++ b/desktop/core/src/desktop/js/catalog/dataCatalogEntry.test.ts
@@ -69,7 +69,7 @@ describe('dataCatalogEntry.ts', () => {
           partition_keys: [],
           cols: [{ name: 'i', type: 'int', comment: '' }],
           path_location: 'test',
-          hdfs_link: '/test',
+          hdfs_link: '/filebrowser/view=/warehouse/tablespace/managed/hive/sample_07',
           is_view: false,
           properties: [],
           details: {
@@ -92,6 +92,13 @@ describe('dataCatalogEntry.ts', () => {
 
       await entry.getAnalysis();
       expect(entry.isIcebergTable()).toBeTruthy();
+    });
+
+    it('should return the hdfs path based on the hdfs_link', async () => {
+      emptyAnalysisApiSpy();
+      const entry = await getEntry('someDb.someTable');
+      await entry.getAnalysis();
+      expect(entry.getHdfsFilePath()).toEqual('/warehouse/tablespace/managed/hive/sample_07');
     });
 
     it('rejects a cachedOnly request if there is no previous promise', async () => {


### PR DESCRIPTION
## What changes were proposed in this pull request?

### Context
The file location popover in the table browser failed to load while the same path could be opened in the file browser.  As @Akhilsnaik suggested in a related internal jira the issue is probably that the popover recursively checks for parent directory listing permissions while the file browser doesn't. After discussion with @JohanAhlen we decided to replace the location popover with a link to the file browser instead of changing the underlying loadDeep strategy due the to risk of introducing regressions.  

- Removed location popover for tables and databases in the Table browser
- Tables in the Table browser will now show a link to the file browser if there is a hdfs_link available and if there is no hdfs_link the text 'unknown location' will be shown
- Databases in the Table browser only show a link to the file browser if there is a hdfs_link available, otherwise nothing. 

## How was this patch tested?
- Tested partially using unit tests
- Manual testing in the following browsers:
  - [x] Chrome
  - [x] Safari 
  - [x] Edge (for Mac)
  - [x] Firefox
  



Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
