### PR TITLE
[frontend] add iceberg indicator to table browser

### DIFF
--- a/apps/metastore/src/metastore/templates/metastore.mako
+++ b/apps/metastore/src/metastore/templates/metastore.mako
@@ -250,6 +250,9 @@ ${ components.menubar(is_embeddable) }
           </a>
         </span>
         ${ _('Table') }
+        <!-- ko if: $parent.catalogEntry.isIcebergTable() -->
+          <i class="fa muted fa-snowflake-o" title="${ _('Iceberg table') }"></i>
+        <!-- /ko -->
       <!-- /ko -->
     </div>
     <!-- ko ifnot: $parent.catalogEntry.isView() -->


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Added "iceberg" icon after table detail in the table browser if the table is of type iceberg.

## How was this patch tested?
- Tested partially using unit tests
- Manual testing in the following browsers:
  - [x] Chrome
  - [x] Safari 
  - [x] Edge (for Mac)
  - [x] Firefox
  
![image](https://user-images.githubusercontent.com/5167091/168592373-3e259085-430e-48ce-a90c-05ecfb38414a.png)

## Test instructions
1. Open the Impala editor
2. Add a new iceberg table using "CREATE TABLE TempIceberg (i INT, t TIMESTAMP, j BIGINT) STORED AS ICEBERG;"
3. Go to the table browser and open the table
4. Verify that it has "iceberg" icon as shown in the screenshot 
5. Open another table and verify that the icon is not present there

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
