### PR TITLE
Change impersonation to use principal_username broke phoenixdb

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
+++ b/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
@@ -271,7 +271,7 @@ class SqlAlchemyApi(Api):
     }
     CONNECTIONS[guid] = cache
 
-    response =  {
+    response = {
       'sync': False,
       'has_result_set': result.cursor != None,
       'modified_row_count': 0,
@@ -343,7 +343,7 @@ class SqlAlchemyApi(Api):
   @query_error_handler
   def progress(self, notebook, snippet, logs=''):
     progress = 50
-    if self.options['url'].startswith('presto://') | self.options['url'].startswith('trino://') :
+    if self.options['url'].startswith('presto://') | self.options['url'].startswith('trino://'):
       guid = snippet['result']['handle']['guid']
       handle = CONNECTIONS.get(guid)
       stats = None

--- a/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
+++ b/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
@@ -196,6 +196,7 @@ class SqlAlchemyApi(Api):
           self.options.pop('connect_args')
       )
 
+    # phoenixdb does not support impersonation using principal_username parameter
     if self.options.get('has_impersonation') and not driver_name.startswith("phoenix"):
       self.options.setdefault('connect_args', {}).setdefault('principal_username', self.user.username)
 

--- a/desktop/libs/notebook/src/notebook/connectors/sql_alchemy_tests.py
+++ b/desktop/libs/notebook/src/notebook/connectors/sql_alchemy_tests.py
@@ -244,6 +244,29 @@ class TestApi(object):
                                        connect_args={'principal_username': 'test'},
                                        pool_pre_ping=True)
 
+  def test_create_engine_with_impersonation_phoenix(self):
+    interpreter = {
+      'name': 'hive',
+      'options': {
+        'url': 'phoenix://hue:8080/hue',
+        'session': {},
+        'has_impersonation': False  # Off
+      }
+    }
+
+    with patch('notebook.connectors.sql_alchemy.create_engine') as create_engine:
+      engine = SqlAlchemyApi(self.user, interpreter)._create_engine()
+
+      create_engine.assert_called_with('phoenix://hue:8080/hue', pool_pre_ping=False)
+
+
+    interpreter['options']['has_impersonation'] = True  # On
+
+    with patch('notebook.connectors.sql_alchemy.create_engine') as create_engine:
+      engine = SqlAlchemyApi(self.user, interpreter)._create_engine()
+
+      create_engine.assert_called_with('phoenix://test@hue:8080/hue', pool_pre_ping=False)
+
 
   def test_explain(self):
 

--- a/desktop/libs/notebook/src/notebook/connectors/sql_alchemy_tests.py
+++ b/desktop/libs/notebook/src/notebook/connectors/sql_alchemy_tests.py
@@ -246,7 +246,7 @@ class TestApi(object):
 
   def test_create_engine_with_impersonation_phoenix(self):
     interpreter = {
-      'name': 'hive',
+      'name': 'phoenix',
       'options': {
         'url': 'phoenix://hue:8080/hue',
         'session': {},


### PR DESCRIPTION
## What changes were proposed in this pull request?

For Phoenix driver use the old method if has_impersonation is set to true

## How was this patch tested?

Tested my change on a cluster with HUE + Phoenix.
Added a unit test as well.
