### PR TITLE
[ui] Improve yarn config check for skipping job names in log div

### DIFF
--- a/desktop/core/src/desktop/js/apps/notebook/snippet.js
+++ b/desktop/core/src/desktop/js/apps/notebook/snippet.js
@@ -2576,9 +2576,14 @@ class Snippet {
                     job.percentJob = ko.observable(job.percentJob);
                   }
                   const config = getLastKnownConfig();
-                  if (config && config['hue_config'] && config['hue_config']['is_yarn_enabled']) {
-                    self.jobs.push(job);
+                  // Yarn job names start with 'application' and we skip them if yarn config is not present.
+                  if (
+                    job.name.startsWith('application') &&
+                    !(config && config['hue_config'] && config['hue_config']['is_yarn_enabled'])
+                  ) {
+                    return;
                   }
+                  self.jobs.push(job);
                 } else if (typeof job.percentJob !== 'undefined') {
                   for (let i = 0; i < _found.length; i++) {
                     _found[i].percentJob(job.percentJob);


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Previous logic failed for other job names if config is not present, now we only skip yarn jobs which start with 'application' if the config is not present. This will allow Impala job browser links to be shown in the log div.

## How was this patch tested?

- Tested manually with both Hive and Impala by running select and insert queries and meanwhile toggling on/off the yarn config for different scenarios.