### PR TITLE
[ui] Spark application history links not working when Knox is enabled

### DIFF
--- a/apps/jobbrowser/src/jobbrowser/templates/job_browser.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/job_browser.mako
@@ -3033,12 +3033,12 @@ ${ commonheader("Job Browser", "jobbrowser", user, request) | n,unicode }
               /*
                 Rewrite tracking url
                 Sample trackingUrl: http://<yarn>:8088/proxy/application_1652826179847_0003/
-                Knox URL: https://<knox-base>/yarn/cluster/app/application_1652826179847_0003
+                Knox URL: https://<knox-base>/yarnuiv2/redirect#/yarn-app/application_1652826179847_0003/attempts
               */
               var matches = item.value.match('(application_[0-9_]+)');
               if (matches && matches.length > 1) {
                 var applicationId = matches[1];
-                item.value = window.KNOX_BASE_URL + '/yarn/cluster/app/' + applicationId;
+                item.value = window.KNOX_BASE_URL + '/yarnuiv2/redirect#/yarn-app/' + applicationId + '/attempts';
               }
             }
             return;

--- a/apps/jobbrowser/src/jobbrowser/templates/job_browser.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/job_browser.mako
@@ -3027,7 +3027,7 @@ ${ commonheader("Job Browser", "jobbrowser", user, request) | n,unicode }
       };
 
       self._rewriteKnoxUrls = function (data) {
-        if (data.app.type === 'SPARK') {
+        if (data && data.app && data.app.type === 'SPARK' && data.app.properties && data.app.properties.metadata) {
           data.app.properties.metadata.forEach(function (item) {
             if (item.name === 'trackingUrl') {
               /*
@@ -3035,9 +3035,9 @@ ${ commonheader("Job Browser", "jobbrowser", user, request) | n,unicode }
                 Sample trackingUrl: http://<yarn>:8088/proxy/application_1652826179847_0003/
                 Knox URL: https://<knox-base>/yarn/cluster/app/application_1652826179847_0003
               */
-              const matches = item.value.match('(application_[0-9_]+)');
+              var matches = item.value.match('(application_[0-9_]+)');
               if (matches && matches.length > 1) {
-                const applicationId = matches[1];
+                var applicationId = matches[1];
                 item.value = window.KNOX_BASE_URL + '/yarn/cluster/app/' + applicationId;
               }
             }
@@ -3098,7 +3098,7 @@ ${ commonheader("Job Browser", "jobbrowser", user, request) | n,unicode }
 
         lastFetchJobRequest = self._fetchJob(function (data) {
           if (data.status == 0) {
-            if (window.KNOX_BASE_URL.length && window.KNOX_BASE_URL.length) {
+            if (window.KNOX_BASE_URL && window.KNOX_BASE_URL.length) {
               self._rewriteKnoxUrls(data);
             }
 

--- a/apps/jobbrowser/src/jobbrowser/templates/job_browser.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/job_browser.mako
@@ -3026,6 +3026,25 @@ ${ commonheader("Job Browser", "jobbrowser", user, request) | n,unicode }
         });
       };
 
+      self._rewriteKnoxUrls = function (data) {
+        if (data.app.type === 'SPARK') {
+          data.app.properties.metadata.forEach(function (item) {
+            if (item.name === 'trackingUrl') {
+              /*
+                Rewrite tracking url
+                Sample trackingUrl: http://<yarn>:8088/proxy/application_1652826179847_0003/
+                Knox URL: https://<knox-base>/yarn/cluster/app/application_1652826179847_0003
+              */
+              const matches = item.value.match('(application_[0-9_]+)');
+              if (matches && matches.length > 1) {
+                const applicationId = matches[1];
+                item.value = window.KNOX_BASE_URL + '/yarn/cluster/app/' + applicationId;
+              }
+            }
+            return;
+          });
+        }
+      }
       self.fetchJob = function () {
         // TODO: Remove cancelActiveRequest from apiHelper when in webpack
         vm.apiHelper.cancelActiveRequest(lastFetchJobRequest);
@@ -3079,6 +3098,10 @@ ${ commonheader("Job Browser", "jobbrowser", user, request) | n,unicode }
 
         lastFetchJobRequest = self._fetchJob(function (data) {
           if (data.status == 0) {
+            if (window.KNOX_BASE_URL.length && window.KNOX_BASE_URL.length) {
+              self._rewriteKnoxUrls(data);
+            }
+
             vm.interface(interface);
             vm.job(new Job(vm, data.app));
             if (window.location.hash !== '#!id=' + vm.job().id()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The spark application trackingUrl was pointing to the original url even
when Knox was enabled.

This change rewrites the trackingUrl with the knox url to the corresponding
YARN application url when Knox is enabled.

## How was this patch tested?
- Tested it by running the a spark job on Knox enabled cluster and
   verifying the generated knox url
- Tested it by running the a spark job on non-Knox enabled cluster
   and verified that the original url is displayed.

## Github Issue:  #2858