### PR TITLE
[sparksql] Store Livy session details in the UserProfile

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/spark_shell.py
+++ b/desktop/libs/notebook/src/notebook/connectors/spark_shell.py
@@ -362,7 +362,7 @@ class SparkApi(Api):
       finally:
         stored_session_info = self._get_session_info_from_user()
         if stored_session_info and session['id'] == stored_session_info['id']:
-          self._remove_info_session_from_user()
+          self._remove_session_info_from_user()
     else:
       return {'status': -1}
 
@@ -592,7 +592,7 @@ class SparkApi(Api):
     self.user.profile.save()
 
 
-  def _remove_info_session_from_user(self):
+  def _remove_session_info_from_user(self):
     self.user = rewrite_user(self.user)
     session_key = self._get_session_key()
 

--- a/desktop/libs/notebook/src/notebook/connectors/spark_shell_tests.py
+++ b/desktop/libs/notebook/src/notebook/connectors/spark_shell_tests.py
@@ -20,7 +20,10 @@ import sys
 from builtins import object
 from nose.tools import assert_equal, assert_true, assert_false, assert_raises
 
-from notebook.connectors.spark_shell import SparkApi, SESSIONS
+from desktop.lib.django_test_util import make_logged_in_client
+from useradmin.models import User
+
+from notebook.connectors.spark_shell import SparkApi
 
 if sys.version_info[0] > 2:
   from unittest.mock import patch, Mock
@@ -31,7 +34,9 @@ else:
 class TestSparkApi(object):
 
   def setUp(self):
-    self.user = 'hue_test'
+    self.client = make_logged_in_client(username="hue_test", groupname="default", recreate=True, is_superuser=False)
+    self.user = User.objects.get(username="hue_test")
+
     self.interpreter = {
         'name': 'livy',
         'options': {
@@ -94,8 +99,8 @@ class TestSparkApi(object):
               cores = p['value']
           assert_equal(cores, 2)
 
-          if SESSIONS.get(session_key):
-            del SESSIONS[session_key]
+          if self.api._get_session_info_from_user():
+            self.api._remove_info_session_from_user()
 
           # Case without user configuration. Expected 1 driverCores
           USE_DEFAULT_CONFIGURATION.get.return_value = True
@@ -110,9 +115,6 @@ class TestSparkApi(object):
               cores = p['value']
           assert_equal(cores, 1)
 
-          if SESSIONS.get(session_key):
-            del SESSIONS[session_key]
-
           # Case with no user configuration. Expected 1 driverCores
           USE_DEFAULT_CONFIGURATION.get.return_value = False
           session3 = self.api.create_session(lang=lang, properties=properties)
@@ -124,9 +126,6 @@ class TestSparkApi(object):
             if p['name'] == 'driverCores':
               cores = p['value']
           assert_equal(cores, 1)
-
-          if SESSIONS.get(session_key):
-            del SESSIONS[session_key]
 
 
   def test_create_session_plain(self):
@@ -152,9 +151,6 @@ class TestSparkApi(object):
       files_properties = [prop for prop in session['properties'] if prop['name'] == 'files']
       assert_true(files_properties, session['properties'])
       assert_equal(files_properties[0]['value'], [], session['properties'])
-
-      if SESSIONS.get(session_key):
-        del SESSIONS[session_key]
 
 
   def test_execute(self):

--- a/desktop/libs/notebook/src/notebook/connectors/spark_shell_tests.py
+++ b/desktop/libs/notebook/src/notebook/connectors/spark_shell_tests.py
@@ -100,7 +100,7 @@ class TestSparkApi(object):
           assert_equal(cores, 2)
 
           if self.api._get_session_info_from_user():
-            self.api._remove_info_session_from_user()
+            self.api._remove_session_info_from_user()
 
           # Case without user configuration. Expected 1 driverCores
           USE_DEFAULT_CONFIGURATION.get.return_value = True


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Global variable are not a good option to act as a caching option specially with gunicorn server. We can either use some caching service or store the session info in the Hue db to have atomicity in operations as a tradeoff with DB calls.
- Currently we are storing it in the user profile object and in future we can see for some cache service like Memcached or Redis.

## How was this patch tested?

- Manually tested