### PR TITLE
[sparksql] Clean unused session from /fetch_result_data call also

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/spark_shell.py
+++ b/desktop/libs/notebook/src/notebook/connectors/spark_shell.py
@@ -234,6 +234,12 @@ class SparkApi(Api):
     session = self._handle_session_health_check(session)
 
     response = self._fetch_result(api, session, cell, start_over)
+
+    # Close unused sessions if there are any.
+    # Clean here since /fetch_result_data is called only once after the /execute call
+    if self._get_session_info_from_user():
+      self._close_unused_sessions()
+
     return response
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- /fetch_result_data is called only once after /execute call (unlike /check_status or /get_logs).
- We can leverage the call for cleaning up any unused sessions specially the dead ones which are created after cancelling the executed query statement and retrying.

## How was this patch tested?

- Manually tested