### PR TITLE
[core] Remove port from database setting for Oracle RAC

### DIFF
--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -423,6 +423,11 @@ else:
     "CONN_MAX_AGE": desktop.conf.DATABASE.CONN_MAX_AGE.get(),
   }
 
+  if desktop.conf.DATABASE.ENGINE.get() == 'django.db.backends.oracle' and \
+     'PORT=' in desktop.conf.DATABASE.NAME.get():
+    # remove port number for Oracle RAC, and the port number is in description string
+    del default_db["PORT"]
+
 DATABASES = {
   'default': default_db
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When Hue use Django to connect to Oracle database with RAC mode, a full DSN string is expected. And removing port from Django database setting makes it connect via the DSN string.

Example of a full DSN string:
```
(DESCRIPTION=(LOAD_BALANCE=off)(FAILOVER=on)(CONNECT_TIMEOUT=5)(TRANSPORT_CONNECT_TIMEOUT=3)(RETRY_COUNT=3)(ADDRESS=(PROTOCOL=TCP)(HOST=<hostname>)(PORT=<port>))(CONNECT_DATA=(SERVICE_NAME=<service name>)))
```

## How was this patch tested?

- Tested on a cluster with Oracle RAC setup.

