### PR TITLE
[jwt] Bump PyJWT package to 2.4.0 to fix high severity CVE

### DIFF
--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -57,7 +57,7 @@ python-ldap==3.1.0
 python-oauth2==1.1.0
 pytidylib==0.3.2
 pytz==2021.3
-PyJWT==1.7.1
+PyJWT==2.4.0
 PyYAML==5.4.1
 requests-kerberos==0.12.0
 rsa==4.7

--- a/desktop/core/src/desktop/auth/api_authentications.py
+++ b/desktop/core/src/desktop/auth/api_authentications.py
@@ -52,6 +52,9 @@ class JwtAuthentication(authentication.BaseAuthentication):
 
     LOG.debug('JwtAuthentication: got access token from %s: %s' % (request.path, access_token))
 
+    decode_options = {
+      'verify_signature': AUTH.JWT.VERIFY.get(),
+    }
     public_key_pem = ''
     if AUTH.JWT.VERIFY.get():
       public_key_pem = self._handle_public_key(access_token)
@@ -63,7 +66,7 @@ class JwtAuthentication(authentication.BaseAuthentication):
         issuer=AUTH.JWT.ISSUER.get(),
         audience=AUTH.JWT.AUDIENCE.get(),
         algorithms=["RS256"],
-        verify=AUTH.JWT.VERIFY.get()
+        options=decode_options
       )
     except jwt.DecodeError:
       LOG.error('JwtAuthentication: Invalid token')

--- a/desktop/core/src/desktop/auth/api_authentications_tests.py
+++ b/desktop/core/src/desktop/auth/api_authentications_tests.py
@@ -38,6 +38,13 @@ else:
 
 
 class TestJwtAuthentication():
+
+  @classmethod
+  def setUpClass(cls):
+    if sys.version_info[0] < 3:
+      raise SkipTest
+
+
   def setUp(self):
     self.client = make_logged_in_client(username="test_user", groupname="default", recreate=True, is_superuser=False)
     self.user = rewrite_user(User.objects.get(username="test_user"))

--- a/desktop/core/src/desktop/auth/api_authentications_tests.py
+++ b/desktop/core/src/desktop/auth/api_authentications_tests.py
@@ -199,7 +199,7 @@ class TestJwtAuthentication():
             issuer=AUTH.JWT.ISSUER.get(),
             audience=AUTH.JWT.AUDIENCE.get(),
             algorithms=['RS256'],
-            verify=True
+            options={'verify_signature': True}
           )
           assert_equal(user, self.user)
         finally:


### PR DESCRIPTION


## What changes were proposed in this pull request?

- Dependabot alerted CVE for PyJWT package: https://github.com/cloudera/hue/pull/2865
- For this, we had to change the verify JWT token flag code when decoding the token and update UTs.

## How was this patch tested?

- Successfully running unit tests.