### PR TITLE
[jwt] Bump djangorestframework-simplejwt to 5.2.0

### DIFF
--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -25,7 +25,7 @@ django-nose==1.4.7
 django_opentracing==1.1.0
 django_prometheus==1.0.15
 django-webpack-loader==1.0.0
-djangorestframework-simplejwt==4.4.0  # For Python 3.6
+djangorestframework-simplejwt==5.2.0
 djangorestframework==3.12.2
 eventlet==0.30.2
 future==0.18.2


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Required for error: `AttributeError: 'str' object has no attribute 'decode'`
- This error comes when trying to use Hue public API via Hue's JWT access token.
- Version 4.7+ contains the fix so we upgraded to the latest. This was required because we upgraded PyJWT to 2.4.0 due to CVE.

## How was this patch tested?

- Manually tested the Hue public API flow.