### PR TITLE
[localization] skipping the fuzzy translation

### DIFF
--- a/Makefile.sdk
+++ b/Makefile.sdk
@@ -194,7 +194,7 @@ distclean:: clean
 .PHONY: compile-locale
 compile-locale:
 	$(PYBABEL) extract . -F babel.cfg -k _ -k _t -o $(LOCALE_ROOT)/en_US.pot --copyright-holder="Cloudera, Inc" --project="Hue" --version=""
-	$(PYBABEL) update -D django -i $(LOCALE_ROOT)/en_US.pot -d $(LOCALE_ROOT)
+	$(PYBABEL) update -D django -i $(LOCALE_ROOT)/en_US.pot -d $(LOCALE_ROOT) -N  # skipping the fuzzy translation
 	$(PYBABEL) compile -D django -d $(LOCALE_ROOT)
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

-  Skipping the fuzzy translation as after babel==2.5.2, pybabel compile exiting the code if errors were encountered.
- And we can't resolve the fuzzy translation manually we need some clients as previously we were having for localization.

## How was this patch tested?

- Checked with `make locales`

