### PR TITLE
[frontend] fix issues related to file path encoding in file browser

### DIFF
--- a/apps/filebrowser/src/filebrowser/templates/display.mako
+++ b/apps/filebrowser/src/filebrowser/templates/display.mako
@@ -242,7 +242,14 @@ ${ fb_components.menubar() }
       mode: viewModel.mode()
     };
 
-    $.getJSON(_baseUrl, params, function (data) {
+    // Singel quotes (') encoded as Unicode Hex Character
+    // will cause the $.getJSON call to produce an incorrect url, 
+    // so we remove the encoding and use plain single quotes.
+    let contentUrl = _baseUrl.replaceAll('&#x27;', "'");
+    // Entity encoded ampersand doesn't work in file or folder names and
+    // needs to be replaced with '&'
+    contentUrl = contentUrl.replaceAll('&amp;', "&");
+    $.getJSON(contentUrl, params, function (data) {
       var _html = "";
 
       viewModel.file(ko.mapping.fromJS(data, { 'ignore': ['view.contents', 'view.xxd'] }));

--- a/apps/filebrowser/src/filebrowser/templates/fb_components.mako
+++ b/apps/filebrowser/src/filebrowser/templates/fb_components.mako
@@ -68,7 +68,7 @@ else:
               <a data-bind="text: label, click: show, attr: {'href': '${url('filebrowser:filebrowser.views.view', path=urlencode(''))}' + url}"></a><span class="divider">/</span>
             </li
           ></ul>
-          <input id="hueBreadcrumbText" type="text" style="display:none" data-bind="value: currentPath" autocomplete="off" class="input-xxlarge" />
+          <input id="hueBreadcrumbText" type="text" style="display:none" data-bind="value: currentDecodedPath" autocomplete="off" class="input-xxlarge" />          
         </li>
         % if is_trash_enabled:
         <li class="pull-right">
@@ -86,9 +86,10 @@ else:
           % for breadcrumb_item in breadcrumbs:
             <% label, f_url = breadcrumb_item['label'], breadcrumb_item['url'] %>
             %if label[-1] == '/':
-            <li><a data-bind="hueLink: '${'/filebrowser/view=' + f_url}'"><span class="divider">${label}</span></a></li>
+            ## Backticks are used as quotes to handle single quote in f_url
+            <li><a data-bind="hueLink: `${'/filebrowser/view=' + f_url}`"><span class="divider">${label}</span></a></li>
             %else:
-            <li><a data-bind="hueLink: '${'/filebrowser/view=' + f_url}'">${label}</a><span class="divider">/</span></li>
+            <li><a data-bind="hueLink: `${'/filebrowser/view=' + f_url}`">${label}</a><span class="divider">/</span></li>
             %endif
           % endfor
           </ul>

--- a/desktop/core/src/desktop/js/ext/fileuploader.custom.js
+++ b/desktop/core/src/desktop/js/ext/fileuploader.custom.js
@@ -1260,7 +1260,10 @@ qq.extend(qq.UploadHandlerXhr.prototype, {
         formData.append(params.fileFieldLabel, file);
         formData.append('dest', params.dest);
 
-        var action = this._options.action + "?dest=" + params.dest;
+        // Encoding is needed to support folder names with some special 
+        // non alfanumeric characters like plus (+) and ampersand (&)
+        var destination = encodeURIComponent(params.dest);
+        var action = this._options.action + "?dest=" + destination;
         xhr.open("POST", action, true);
         xhr.send(formData);
     },


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is aimed at fixing frontend bugs related to the non ascii and non alphanumerical characters in file and folder names. 

Changes to the Filebrowser app:
- Current path correctly displayed when editing the path
- Destination folder path correctly displayed in upload modal when uploading files
- Single quotes supported in file name when viewing file
- Ampersand supported in file and folder names
- hash character in file name supported when viewing file
- plus character supported in file name

## How was this patch tested?

The following characters and strings where tested for the different operations related to the file browser

![image](https://user-images.githubusercontent.com/5167091/172627116-95f38dac-8a2a-41be-bdda-4b29dd3893fb.png)

Manual testing done on MacOS for

- [x]  Safari
- [x] Chrome
- [x] Edge
- [x] Firefox


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
