### PR TITLE
[sparksql] Only close livy session of particular dialect per user

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/spark_shell.py
+++ b/desktop/libs/notebook/src/notebook/connectors/spark_shell.py
@@ -343,7 +343,7 @@ class SparkApi(Api):
       if stored_session_info and self._check_session(stored_session_info):
         session = stored_session_info
       else:
-        raise Exception(_("Session error. Please create new session and try again."))
+        raise PopupException(_("Session error. Please create new session and try again."))
     
     return session
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Currently, all Livy sessions except the cached session were getting closed when trying to go to some other dialect with Livy as interface.
- With this fix, we will only close unused session per user for particular dialect. 
- For example, if user A is on SparkSQL, then it should only close all unused session for user A for SparkSQL only.

## How was this patch tested?

- Manually tested