### PR TITLE
Export all does not work as Hive managed table location cannot be changed

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py
+++ b/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py
@@ -650,15 +650,13 @@ class HS2Api(Api):
     hql = '''
 DROP TABLE IF EXISTS `%(table)s`;
 
-CREATE TABLE `%(table)s` ROW FORMAT DELIMITED
+CREATE EXTERNAL TABLE `%(table)s` ROW FORMAT DELIMITED
      FIELDS TERMINATED BY '\\t'
      ESCAPED BY '\\\\'
      LINES TERMINATED BY '\\n'
      STORED AS TEXTFILE LOCATION '%(location)s'
      AS
 %(hql)s;
-
-ALTER TABLE `%(table)s` SET TBLPROPERTIES('EXTERNAL'='TRUE');
 
 DROP TABLE IF EXISTS `%(table)s`;
     ''' % {


### PR DESCRIPTION
Jira: CDPD-40785

## What changes were proposed in this pull request?
Making the table external at the time of table creation instead of setting the table to external post creating the table.

## How was this patch tested?
Manual test case performed both on Impala and Hive editors.