### PR TITLE
[frontend] use encoded tags for complex db types when copying result to clipboard

### DIFF
--- a/desktop/core/src/desktop/js/utils/hueUtils.ts
+++ b/desktop/core/src/desktop/js/utils/hueUtils.ts
@@ -38,6 +38,7 @@ import stripHtmlFromFunctions from './html/stripHtmlForFunctions';
 import deleteAllEmptyStringKeys from './string/deleteAllEmptyStringKeys';
 import equalIgnoreCase from './string/equalIgnoreCase';
 import parseHivePseudoJson from './string/parseHivePseudoJson';
+import isComplexDBTypeDefinition from './string/isComplexDBTypeDefinition';
 import UUID from './string/UUID';
 
 import waitForObservable from './timing/waitForObservable';
@@ -77,6 +78,7 @@ export default {
   isOverflowing,
   logError,
   parseHivePseudoJson,
+  isComplexDBTypeDefinition,
   removeURLParameter,
   replaceURL,
   scrollbarWidth,

--- a/desktop/core/src/desktop/js/utils/string/isComplexDBTypeDefinition.test.js
+++ b/desktop/core/src/desktop/js/utils/string/isComplexDBTypeDefinition.test.js
@@ -1,0 +1,63 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import isComplexDBTypeDefinition from './isComplexDBTypeDefinition';
+
+describe('hue.utils.js', () => {
+  describe('isComplexDBTypeDefinition', () => {
+    beforeEach(() => {});
+
+    it('returns true for complex DB type definitions', () => {
+      expect(isComplexDBTypeDefinition('map<string,array<string>>')).toEqual(true);
+      expect(isComplexDBTypeDefinition('MAP<string,array<string>>')).toEqual(true);
+      expect(isComplexDBTypeDefinition('array<string>')).toEqual(true);
+      expect(isComplexDBTypeDefinition('ARRAY<string>')).toEqual(true);
+      expect(isComplexDBTypeDefinition('struct<f1:bigint,f2:bigint>')).toEqual(true);
+      expect(isComplexDBTypeDefinition('STRUCT<f1:bigint,f2:bigint>')).toEqual(true);
+      expect(
+        isComplexDBTypeDefinition('uniontype<int, double, array<string>, struct<a:int,b:string>>')
+      ).toEqual(true);
+      expect(
+        isComplexDBTypeDefinition('UNIONTYPE<int, double, array<string>, struct<a:int,b:string>>')
+      ).toEqual(true);
+    });
+
+    it('returns false for other strings', () => {
+      expect(isComplexDBTypeDefinition('<string,array<string>>')).toEqual(false);
+      expect(isComplexDBTypeDefinition('<b>test</b>')).toEqual(false);
+      expect(isComplexDBTypeDefinition('<string>')).toEqual(false);
+      expect(isComplexDBTypeDefinition('xxx<f1:bigint,f2:bigint>')).toEqual(false);
+      expect(isComplexDBTypeDefinition('map')).toEqual(false);
+      expect(isComplexDBTypeDefinition('MAP')).toEqual(false);
+      expect(isComplexDBTypeDefinition('ARRAY')).toEqual(false);
+      expect(isComplexDBTypeDefinition('array')).toEqual(false);
+      expect(isComplexDBTypeDefinition('struc')).toEqual(false);
+      expect(isComplexDBTypeDefinition('STRUCT')).toEqual(false);
+      expect(isComplexDBTypeDefinition('uniontype')).toEqual(false);
+      expect(isComplexDBTypeDefinition('UNIONTYPE')).toEqual(false);
+    });
+
+    it('returns false for all non string based input', () => {
+      expect(isComplexDBTypeDefinition(12)).toEqual(false);
+      expect(isComplexDBTypeDefinition(-12)).toEqual(false);
+      expect(isComplexDBTypeDefinition({})).toEqual(false);
+      expect(isComplexDBTypeDefinition(undefined)).toEqual(false);
+      expect(isComplexDBTypeDefinition(new Date())).toEqual(false);
+      expect(isComplexDBTypeDefinition(null)).toEqual(false);
+      expect(isComplexDBTypeDefinition([])).toEqual(false);
+    });
+  });
+});

--- a/desktop/core/src/desktop/js/utils/string/isComplexDBTypeDefinition.ts
+++ b/desktop/core/src/desktop/js/utils/string/isComplexDBTypeDefinition.ts
@@ -1,0 +1,23 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Complex data type definitions used by Hive
+const complexTypes = /^(map|struct|array|uniontype)<.*>$/i;
+
+const isComplexDBTypeDefinition = (dataType: string | number): boolean =>
+  typeof dataType === 'string' ? complexTypes.test(dataType) : false;
+
+export default isComplexDBTypeDefinition;

--- a/desktop/core/src/desktop/templates/common_notebook_ko_components.mako
+++ b/desktop/core/src/desktop/templates/common_notebook_ko_components.mako
@@ -407,8 +407,10 @@ else:
               result += '</tr>';
               data.forEach(function (row) {
                 result += '<tr>';
-                for (var i = 1; i < row.length; i++) { // Skip the row number column
-                  result += '<td>' + hueUtils.html2text(row[i]) + '</td>';
+                for (var i = 1; i < row.length; i++) { // Skip the row number column              
+                  var htmlDecodedValue = hueUtils.html2text(row[i]);
+                  var needsToStayEncoded = hueUtils.isComplexDBTypeDefinition(htmlDecodedValue)
+                  result += '<td>' + ( needsToStayEncoded ? row[i] : htmlDecodedValue) + '</td>';
                 }
                 result += '</tr>';
               });


### PR DESCRIPTION
## Context
The copy to clipboard creates a new simple HTML table using the DOM with all the values and then copies that into the clipboard. Query result values can contain '<' and '>' and since they will not be encoded when using copy to clipboard HTML strings will be rendered without the tags, e.g. the value `<h1>hello</h1> `will be rendered as the text `hello` only in the copied data. I'm not sure if this is by design or a side affect of the implementation strategy used but I didn't not want to risk a regression by changing that. The problem here is that a value representing a complex data type definition like 'map<string,array<string>>' must remain encoded for the current copy-as-html-table-approach to work so I limited this fix to the rendering of complex data type definitions used by Hive.

An alternative approach, that I first looked into, would be to skip creating a new DOM table all together and just produce the copied data using tabs and line breaks, BUT I found that there already was such a fix at some point and that it later had been reverted for reasons unknown to me.

## What changes were proposed in this pull request?
- Added check to see if values should stay encoded when copying to clipboard
- Added util function isComplexDBTypeDefinition based on regex
- Added unit tests

## How was this patch tested?
Tested with unit tests and manually e2e by creating a Hive table with complex data types and making sure their definition could be copied to the clipboard, e.g.
1. Create the table
```
CREATE TABLE complex_types_tables(
  map_test MAP <STRING, array <STRING>>,
  struct_test STRUCT <f1: BIGINT, f2: BIGINT>,
  array_test ARRAY <string>,
  uniontype_test UNIONTYPE<int, double, array<string>, struct<a:int,b:string>>
);
```
2. List the types
`DESCRIBE complex_types_tables; `
3. From the results tab click "Exports results" and select "Clipboard"
4. Paste into a document that only support plain text, e.g. a txt-file, and make sure the data is displayed in a tabular format using line breaks and tabs.
![image](https://user-images.githubusercontent.com/5167091/173544954-0a1a4b3a-cb98-4ada-b2aa-32fdef2d9496.png)

5. Paste it into a document that supports inserting HTML-tables and make sure a table is generated:
![image](https://user-images.githubusercontent.com/5167091/173545604-c84a6fa2-711d-42c2-908b-7751701dd034.png)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
