### PR TITLE
[frontent] fix to upload files with non ascii names on macos

### DIFF
--- a/desktop/core/src/desktop/js/ext/fileuploader.custom.js
+++ b/desktop/core/src/desktop/js/ext/fileuploader.custom.js
@@ -1256,8 +1256,8 @@ qq.extend(qq.UploadHandlerXhr.prototype, {
             }
         };
 
-        var formData = new FormData();
-        formData.append(params.fileFieldLabel, file);
+        var formData = new FormData();        
+        formData.append(params.fileFieldLabel, file, file.name.normalize('NFC'));
         formData.append('dest', params.dest);
 
         // Encoding is needed to support folder names with some special 


### PR DESCRIPTION
## Context
Here is what I think is happening: Uploading a file via the web browser on MacOS will use the decomposed unicode normalization (NFD) for the filename which in turn will cause the Hue server's upload to HDFS to fail. It does not matter if the Hue server is running on MacOS or not. I haven't found any information about unicode normalization for HDFS clusters and I'm not sure if that is dependent on the underlying cluster OS or not, but from what I can gather it seems that MacOS is the odd bird here by using NFD. 

## What changes were proposed in this pull request?
- Normalize the file name using NFC before completing the XMLHttpRequest. 

## How was this patch tested?
- Tested by uploading files with non ASCII characters like 'åäl' and 'Tжейко' in the filename from different web browsers on MacOS.
- I also tested normalizing the string to NFC twice to simulate when the file name already is in NFC 

## Additional testing required
- Test the upload of files with non ASCII characters from Windows and Linux/Unix. 

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
