### PR TITLE
[phoenix] get_view_names() returning empty list

### DIFF
--- a/desktop/core/ext-py/phoenixdb-1.1.0/phoenixdb/sqlalchemy_phoenix.py
+++ b/desktop/core/ext-py/phoenixdb-1.1.0/phoenixdb/sqlalchemy_phoenix.py
@@ -153,8 +153,8 @@ class PhoenixDialect(DefaultDialect):
     def get_view_names(self, connection, schema=None, **kw):
         if schema is None:
             schema = ''
-        return connection.connect().connection.meta().get_tables(schemaPattern=schema,
-                                                                 typeList=('VIEW'))
+        views = connection.connect().connection.meta().get_tables(schemaPattern=schema, typeList=('VIEW',))
+        return [view['TABLE_NAME'] for view in views]
 
     def get_columns(self, connection, table_name, schema=None, **kw):
         if schema is None:

--- a/desktop/core/ext-py/phoenixdb-1.1.0/phoenixdb/tests/test_sqlalchemy.py
+++ b/desktop/core/ext-py/phoenixdb-1.1.0/phoenixdb/tests/test_sqlalchemy.py
@@ -68,6 +68,7 @@ class SQLAlchemyTest(unittest.TestCase):
                 connection.execute(text('create table ALCHEMY_TEST (ID integer primary key)'))
                 connection.execute(text('create table A.ALCHEMY_TEST_A (ID_A integer primary key)'))
                 connection.execute(text('create table B.ALCHEMY_TEST_B (ID_B integer primary key)'))
+                connection.execute(text('create view ALCHEMY_TEST_VIEW as select * from ALCHEMY_TEST'))
 
                 self.assertEqual(inspector.get_schema_names(), ['', 'A', 'B', 'SYSTEM'])
 
@@ -76,6 +77,8 @@ class SQLAlchemyTest(unittest.TestCase):
                 self.assertEqual(inspector.get_table_names('A'), ['ALCHEMY_TEST_A'])
                 self.assertEqual(inspector.get_table_names('B'), ['ALCHEMY_TEST_B'])
 
+                self.assertEqual(inspector.get_view_names(), ['ALCHEMY_TEST_VIEW'])
+                
                 self.assertEqual(inspector.get_columns('ALCHEMY_TEST').pop()['name'], 'ID')
                 self.assertEqual(
                     inspector.get_columns('ALCHEMY_TEST', '').pop()['name'], 'ID')
@@ -87,6 +90,7 @@ class SQLAlchemyTest(unittest.TestCase):
                 self.assertTrue(engine.has_table('ALCHEMY_TEST_A', 'A'))
                 self.assertFalse(engine.has_table('ALCHEMY_TEST', 'A'))
             finally:
+                connection.execute('drop view if exists ALCHEMY_TEST_VIEW')
                 connection.execute('drop table if exists ALCHEMY_TEST')
                 connection.execute('drop table if exists A.ALCHEMY_TEST_A')
                 connection.execute('drop table if exists B.ALCHEMY_TEST_B')


### PR DESCRIPTION
## What changes were proposed in this pull request?

- get_view_names() returning view list -> https://github.com/apache/phoenix-queryserver/pull/91

## How was this patch tested?

- Manually and added tests like added in above PR
