### PR TITLE
Disabling lint check for /ext-py3 folder

### DIFF
--- a/tools/ci/check_for_python_lint.sh
+++ b/tools/ci/check_for_python_lint.sh
@@ -22,6 +22,7 @@ FOUND_ISSUE=-1
 
 files=`git diff --name-only origin/master --diff-filter=b | egrep .py$ | \
   grep -v /ext-py/ | \
+  grep -v /ext-py3/ | \
   grep -v wsgiserver.py | \
   grep -v /migrations/ | \
   grep -v apps/oozie/src/oozie/tests.py | \


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Disabling lint check for /ext-py3 folder


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
