### PR TITLE
[sparksql] Change snippet type from 'sql to 'sparksql'

### DIFF
--- a/desktop/libs/notebook/src/notebook/conf.py
+++ b/desktop/libs/notebook/src/notebook/conf.py
@@ -146,7 +146,7 @@ def get_ordered_interpreters(user=None):
       'category': i.get('category', 'editor'),
       "is_sql": i.get('is_sql') or \
           i['interface'] in ["hiveserver2", "rdbms", "jdbc", "solr", "sqlalchemy", "ksql", "flink"] or \
-          i['type'] == 'sql',
+          i['type'] in ["sql", "sparksql"],
       "is_catalog": i['interface'] in ["hms",],
     }
     for i in interpreters

--- a/desktop/libs/notebook/src/notebook/connectors/spark_shell.py
+++ b/desktop/libs/notebook/src/notebook/connectors/spark_shell.py
@@ -424,6 +424,8 @@ class SparkApi(Api):
     api = self.get_api()
     all_sessions = {}
 
+    session_type = 'sql' if session_type == 'sparksql' else session_type
+
     try:
       all_sessions = api.get_sessions()
     except Exception as e:


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Changing the snippet type from `sql` to `sparksql` for SparkSQL support.
- Type as `sql` looks too generic and can cause maintainability issues for other dialects.
- Users need to add the following config now for `[notebook]`:

```
[notebook]
[[interpreters]]
[[[sparksql]]]
name=Spark SQL
interface=livy
```

## How was this patch tested?

- Manually testing all Sparksql editor operations.
