### PR TITLE
[importer] not calling guess format just after clicking importer icon

### DIFF
--- a/desktop/libs/indexer/src/indexer/templates/importer.mako
+++ b/desktop/libs/indexer/src/indexer/templates/importer.mako
@@ -2096,7 +2096,7 @@ ${ commonheader(_("Importer"), "indexer", user, request, "60px") | n,unicode }
       self.kafkaClusters = ko.observableArray(['localhost', 'demo.gethue.com']);
       self.kafkaSelectedCluster = ko.observable();
       self.kafkaSelectedCluster.subscribe(function(val) {
-        if (val) {
+        if (val && self.inputFormat() == 'stream') {
           wizard.guessFormat();
         }
       });


### PR DESCRIPTION
## What changes were proposed in this pull request?

- not calling guess format just after clicking importer icon if input format is not 'stream'

## How was this patch tested?

- We’ve tested it with flag off and remote file upload + flag on and then local file upload and remote file upload and it was working fine for all cases.
