### PR TITLE
[frontend] fix to upload files to folders with non ascii names for s3…

### DIFF
--- a/desktop/core/src/desktop/js/ext/fileuploader.custom.js
+++ b/desktop/core/src/desktop/js/ext/fileuploader.custom.js
@@ -29,6 +29,35 @@ import $ from 'jquery';
 // Helper functions
 //
 
+const splitProtocolAndPathName = (fullUrl) => {
+    // The path name can contain one or more questionmarks (?) that are NOT specifying 
+    // the search/query start for these urls so we use a custom regex instead of URL() to parse.
+    const splitRegex = /^(\w*:)?(.*)$/i;
+    const [match, protocol, pathName] = splitRegex.exec(fullUrl);
+    return [protocol ?? '', pathName ]
+}
+
+const isUnicodeAlphaNumeric = /^[\p{L}\p{N}]*$/u;
+const encodeUploadPath = (char) => {            
+    const needsEncoding = !isUnicodeAlphaNumeric.test(char) && char !== '/' && char !== '?';
+    return needsEncoding ? encodeURIComponent(char) : char;
+}
+
+/**
+ * Fixes encoding issues with the destination folder url.
+ * Some special non-alphanumeric characters like plus (+) and ampersand (&) needs encoding
+ * while the slash (/) which represents a directory and question mark (?) should not be encoded. 
+ * Alphanumeric characters that are non ASCII (e.g. åäö) should not be encoded since that
+ * will fail if the target is s3 or abfs.     
+ * @param {string} destination The "destination url" used for the filesystem. Might not be a valid url.
+ */
+const fixUploadDestination = (destination) => {
+    const decodedDestination = decodeURIComponent(destination);
+    const [protocol, path] = splitProtocolAndPathName(decodedDestination);
+    const updatedPath = [...path].map(encodeUploadPath).join('');
+    return `${protocol}${updatedPath}`;        
+}
+
 
 let qq = {};
 
@@ -1260,9 +1289,7 @@ qq.extend(qq.UploadHandlerXhr.prototype, {
         formData.append(params.fileFieldLabel, file, file.name.normalize('NFC'));
         formData.append('dest', params.dest);
 
-        // Encoding is needed to support folder names with some special 
-        // non alfanumeric characters like plus (+) and ampersand (&)
-        var destination = encodeURIComponent(params.dest);
+        const destination = fixUploadDestination(params.dest);
         var action = this._options.action + "?dest=" + destination;
         xhr.open("POST", action, true);
         xhr.send(formData);


### PR DESCRIPTION
… and abfs

## What changes were proposed in this pull request?

Allow uploading to folders that have non-ascii characters in their name for S3 and ABFS. This is done by being more selective in what gets encoded in the destination folder path:

  - Some special non-alphanumeric characters like plus (+) and ampersand (&) needs encoding 
  - the slash (/) which represents a directory and question mark (?) should not be encoded
  - Alphanumeric characters that are non ASCII (e.g. åäö) should not be encoded since that will fail if the target is s3 or abfs. 

## How was this patch tested?

Manually tested on MacOS with 

- [x] Chrome 
- [x] Safari
- [x] Firefox
- [x] Edge


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
