### PR TITLE
[frontend] Hide import button for transactional hive tables

### DIFF
--- a/apps/metastore/src/metastore/templates/metastore.mako
+++ b/apps/metastore/src/metastore/templates/metastore.mako
@@ -902,7 +902,7 @@ ${ components.menubar(is_embeddable) }
                         <a class="btn btn-default" data-bind="attr: { 'href': '/metastore/table/'+ catalogEntry.path.join('/') + '/read' }" title="${_('Browse Data')}"><i class="fa fa-play fa-fw"></i> ${_('Browse Data')}</a>
                       % endif
                       % if has_write_access:
-                        <a href="javascript: void(0);" class="btn btn-default" data-bind="click: showImportData, visible: $root.source().type !== 'sparksql' && tableDetails() && !catalogEntry.isView()" title="${_('Import Data')}"><i class="fa fa-upload fa-fw"></i> ${_('Import')}</a>
+                        <a href="javascript: void(0);" class="btn btn-default" data-bind="click: showImportData, visible: enableImport($root.source().type)" title="${_('Import Data')}"><i class="fa fa-upload fa-fw"></i> ${_('Import')}</a>
                       % endif
                       % if has_write_access:
                         <a href="#dropSingleTable" data-toggle="modal" class="btn btn-default" data-bind="attr: { 'title' : tableDetails() && catalogEntry.isView() ? '${_('Drop View')}' : '${_('Drop Table')}' }"><i class="fa fa-times fa-fw"></i> ${_('Drop')}</a>

--- a/desktop/core/src/desktop/js/apps/tableBrowser/metastoreTable.js
+++ b/desktop/core/src/desktop/js/apps/tableBrowser/metastoreTable.js
@@ -28,8 +28,8 @@ import I18n from 'utils/i18n';
 
 let contextPopoverTimeout = -1;
 
-export const TABLE_SOURCE_TYPE_HIVE = 'hive';
-export const TABLE_SOURCE_TYPE_SPARK = 'sparksql';
+export const DIALECT_HIVE = 'hive';
+export const DIALECT_SPARK = 'spark sql';
 
 class MetastoreTable {
   /**
@@ -394,12 +394,13 @@ class MetastoreTable {
     this.catalogEntry.clearCache();
   }
 
-  enableImport(sourceType) {
+  enableImport() {
     const detailsLoaded = !!this.tableDetails();
+    const dialect = this.catalogEntry.getDialect();
     const isView = this.catalogEntry.isView();
     const isTransactionalHive =
-      sourceType === TABLE_SOURCE_TYPE_HIVE && this.catalogEntry.isTransactionalTable();
-    const isSpark = sourceType === TABLE_SOURCE_TYPE_SPARK;
+      dialect === DIALECT_HIVE && this.catalogEntry.isTransactionalTable();
+    const isSpark = dialect === DIALECT_SPARK;
 
     return detailsLoaded && !(isSpark || isView || isTransactionalHive);
   }

--- a/desktop/core/src/desktop/js/apps/tableBrowser/metastoreTable.js
+++ b/desktop/core/src/desktop/js/apps/tableBrowser/metastoreTable.js
@@ -28,6 +28,9 @@ import I18n from 'utils/i18n';
 
 let contextPopoverTimeout = -1;
 
+export const TABLE_SOURCE_TYPE_HIVE = 'hive';
+export const TABLE_SOURCE_TYPE_SPARK = 'sparksql';
+
 class MetastoreTable {
   /**
    * @param {Object} options
@@ -389,6 +392,16 @@ class MetastoreTable {
     this.partitions.loaded(false);
     // Clear will publish when done
     this.catalogEntry.clearCache();
+  }
+
+  enableImport(sourceType) {
+    const detailsLoaded = !!this.tableDetails();
+    const isView = this.catalogEntry.isView();
+    const isTransactionalHive =
+      sourceType === TABLE_SOURCE_TYPE_HIVE && this.catalogEntry.isTransactionalTable();
+    const isSpark = sourceType === TABLE_SOURCE_TYPE_SPARK;
+
+    return detailsLoaded && !(isSpark || isView || isTransactionalHive);
   }
 
   showImportData() {

--- a/desktop/core/src/desktop/js/apps/tableBrowser/metastoreTable.test.js
+++ b/desktop/core/src/desktop/js/apps/tableBrowser/metastoreTable.test.js
@@ -1,0 +1,124 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { merge } from 'lodash';
+
+import {
+  default as MetastoreTable,
+  TABLE_SOURCE_TYPE_HIVE,
+  TABLE_SOURCE_TYPE_SPARK
+} from './metastoreTable';
+
+describe('metastoreTable.js', () => {
+  const generateOptions = customOptions => {
+    const defaultOptions = {
+      catalogEntry: {
+        hasResolvedComment: () => false,
+        isModel: () => false,
+        isTransactionalTable: () => false,
+        isView: () => false,
+        getAnalysis: () =>
+          Promise.resolve({
+            details: {
+              stats: {}
+            },
+            partition_keys: []
+          }),
+        getComment: () => Promise.resolve(''),
+        getConnector: () => ({
+          buttonName: '',
+          displayName: '',
+          id: 'connectorA',
+          page: '',
+          tooltip: '',
+          type: ''
+        }),
+        getSample: () =>
+          Promise.resolve({
+            data: [],
+            meta: []
+          }),
+        getTopJoins: () => Promise.resolve({})
+      },
+      database: {
+        catalogEntry: {
+          loadNavigatorMetaForChildren: () => Promise.resolve({})
+        }
+      },
+      navigatorEnabled: false,
+      sqlAnalyzerEnabled: false
+    };
+
+    return merge({}, defaultOptions, customOptions);
+  };
+
+  it('should enable import when analysis is loaded', async () => {
+    const metastoreTable = new MetastoreTable(generateOptions({}));
+    const sourceType = 'sql';
+    await metastoreTable.fetchDetails();
+    expect(metastoreTable.enableImport(sourceType)).toEqual(true);
+  });
+
+  it('should not enable import before there is an analysis loaded', async () => {
+    const resolve = () => ({
+      details: {
+        stats: {}
+      },
+      partition_keys: []
+    });
+    const unresolvedPromise = new Promise(resolve, () => {});
+    const metastoreTable = new MetastoreTable(
+      generateOptions({ catalogEntry: { getAnalysis: () => unresolvedPromise } })
+    );
+    const sourceType = 'sql';
+
+    await metastoreTable.fetchDetails();
+    expect(metastoreTable.enableImport(sourceType)).toEqual(false);
+  });
+
+  it('should not enable import when the table is a view', async () => {
+    const metastoreTable = new MetastoreTable(
+      generateOptions({ catalogEntry: { isView: () => true } })
+    );
+    const sourceType = 'sql';
+    await metastoreTable.fetchDetails();
+    expect(metastoreTable.enableImport(sourceType)).toEqual(false);
+  });
+
+  it('should not enable import when the table is transactional and source type Hive', async () => {
+    const metastoreTransactionalHiveTable = new MetastoreTable(
+      generateOptions({ catalogEntry: { isTransactionalTable: () => true } })
+    );
+    await metastoreTransactionalHiveTable.fetchDetails();
+    expect(metastoreTransactionalHiveTable.enableImport(TABLE_SOURCE_TYPE_HIVE)).toEqual(false);
+
+    const metastoreTransactionalTable = new MetastoreTable(
+      generateOptions({ catalogEntry: { isTransactionalTable: () => true } })
+    );
+    await metastoreTransactionalTable.fetchDetails();
+    expect(metastoreTransactionalTable.enableImport('sql')).toEqual(true);
+
+    const metastoreHiveTable = new MetastoreTable(generateOptions());
+    await metastoreHiveTable.fetchDetails();
+    expect(metastoreHiveTable.enableImport(TABLE_SOURCE_TYPE_HIVE)).toEqual(true);
+  });
+
+  it('should not enable import when the source type is sparksql', async () => {
+    const metastoreTable = new MetastoreTable(generateOptions());
+    await metastoreTable.fetchDetails();
+    expect(metastoreTable.enableImport(TABLE_SOURCE_TYPE_SPARK)).toEqual(false);
+  });
+});

--- a/desktop/core/src/desktop/js/catalog/DataCatalogEntry.ts
+++ b/desktop/core/src/desktop/js/catalog/DataCatalogEntry.ts
@@ -1426,6 +1426,10 @@ export default class DataCatalogEntry {
     return this.analysis?.details?.stats?.table_type === 'ICEBERG';
   }
 
+  isTransactionalTable(): boolean {
+    return this.analysis?.details?.stats?.transactional === 'true';
+  }
+
   /**
    * Returns true if the entry is a view. It will be accurate once the source meta has been loaded.
    */


### PR DESCRIPTION
Move logic from mako template and create unit tests

## What changes were proposed in this pull request?

- add additional condition for showing the import button
- refactor out logic from mako template into `metastoreTable.js`
- add isTransactionalTable() function to `dataCatalogEntry.ts`
- create relevant unit tests

## How was this patch tested?

- Unit tests for new and existing conditions
- Manual testing in chrome for additional condition:

1. Create transactional hive table
```
CREATE TABLE trans(id tinyint, name string)
 TBLPROPERTIES ("transactional"="true");
```
2. Go to table browser and view the trans table and make sure there is no import button shown
![image](https://user-images.githubusercontent.com/5167091/176519061-4c0d84fd-0453-40de-ae1c-08922ed1a506.png)

3. Create non transactional hive table
```
CREATE TABLE nontrans(id tinyint, name string)
 TBLPROPERTIES ("transactional"="false");
```

4. Go to table browser and view the nontrans table and make sure there is no import button shown
![image](https://user-images.githubusercontent.com/5167091/176519332-d0df3ec5-0cb4-488e-bd03-0826211a9008.png)


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
