### PR TITLE
When Impala editor is not installed, then the importer fails to get t…

### DIFF
--- a/desktop/libs/indexer/src/indexer/indexers/sql.py
+++ b/desktop/libs/indexer/src/indexer/indexers/sql.py
@@ -170,7 +170,7 @@ class SQLIndexer(object):
         user_scratch_dir = self.fs.get_home_dir() + '/.scratchdir/%s' % str(uuid.uuid4()) # Make sure it's unique.
         self.fs.do_as_user(self.user, self.fs.mkdir, user_scratch_dir, 0o0777)
         self.fs.do_as_user(self.user, self.fs.rename, source['path'], user_scratch_dir)
-        if USER_SCRATCH_DIR_PERMISSION.get():
+        if editor_type == 'impala' and USER_SCRATCH_DIR_PERMISSION.get():
           self.fs.do_as_user(self.user, self.fs.chmod, user_scratch_dir, 0o0777, True)
         source_path = user_scratch_dir + '/' + source['path'].split('/')[-1]
 


### PR DESCRIPTION
…he USER_SCRATCH_DIR_PERMISSION from impala conf.

Jira: CDPD-41666

## What changes were proposed in this pull request?
Added a condition to check the editor type before allowing it to enter the if condition

## How was this patch tested?
This was tested manually by disabling impala editor to see if Hive importer worked and enabled impala editor to see if importer from impala editor worked.