### PR TITLE
Empty feature fails to clear .trash

### DIFF
--- a/desktop/core/src/desktop/lib/fs/proxyfs.py
+++ b/desktop/core/src/desktop/lib/fs/proxyfs.py
@@ -81,7 +81,8 @@ class ProxyFS(object):
         return True
       user = rewrite_user(User.objects.get(username=self.getuser()))
       return user.is_authenticated and user.is_active and \
-        (is_admin(user) or not filebrowser_action or user.has_hue_permission(action=filebrowser_action, app="filebrowser") or RAZ.IS_ENABLED.get())
+        (is_admin(user) or not filebrowser_action or
+         user.has_hue_permission(action=filebrowser_action, app="filebrowser") or RAZ.IS_ENABLED.get())
 
     except User.DoesNotExist:
       LOG.exception('proxyfs.has_access()')
@@ -217,7 +218,7 @@ class ProxyFS(object):
     return fs.mktemp(subdir=subdir, prefix=prefix, basedir=basedir)
 
   def purge_trash(self):
-    fs = self._get_fs()  # Only webhdfs supports trash.
+    fs = self._get_fs(None)  # Only webhdfs supports trash.
     if fs and hasattr(fs, 'purge_trash'):
       fs.purge_trash()
 


### PR DESCRIPTION
Jira: CDPD-41667

## What changes were proposed in this pull request?
Added  self._get_fs(None) so a path is not requested when clearing trash with Empty Trash feature.

## How was this patch tested?
Manually by uploading files and deleting them and then going to .Trash folder and using the option Empty Trash