### PR TITLE
[interpreters] Dialect field should not have spaces

### DIFF
--- a/desktop/core/src/desktop/js/apps/tableBrowser/metastoreTable.js
+++ b/desktop/core/src/desktop/js/apps/tableBrowser/metastoreTable.js
@@ -29,7 +29,7 @@ import I18n from 'utils/i18n';
 let contextPopoverTimeout = -1;
 
 export const DIALECT_HIVE = 'hive';
-export const DIALECT_SPARK = 'spark sql';
+export const DIALECT_SPARK = 'sparksql';
 
 class MetastoreTable {
   /**

--- a/desktop/core/src/desktop/js/apps/tableBrowser/metastoreTable.test.js
+++ b/desktop/core/src/desktop/js/apps/tableBrowser/metastoreTable.test.js
@@ -112,7 +112,7 @@ describe('metastoreTable.js', () => {
     expect(metastoreHiveTable.enableImport()).toEqual(true);
   });
 
-  it('should not enable import when the dialect is spark sql', async () => {
+  it('should not enable import when the dialect is sparksql', async () => {
     const metastoreTable = new MetastoreTable(
       generateOptions({ catalogEntry: { getDialect: () => DIALECT_SPARK } })
     );

--- a/desktop/libs/notebook/src/notebook/api_tests.py
+++ b/desktop/libs/notebook/src/notebook/api_tests.py
@@ -645,7 +645,7 @@ def test_get_interpreters_to_show():
       }),
       ('spark', {
           'name': 'Scala', 'displayName': 'Scala', 'interface': 'livy', 'type': 'spark', 'is_sql': False, 'options': {},
-          'dialect_properties': {}, 'is_catalog': False, 'category': 'editor', 'dialect': 'scala'
+          'dialect_properties': {}, 'is_catalog': False, 'category': 'editor', 'dialect': 'spark'
       }),
       ('pig', {
           'name': 'Pig', 'displayName': 'Pig', 'interface': 'pig', 'type': 'pig', 'is_sql': False, 'options': {},
@@ -672,7 +672,7 @@ def test_get_interpreters_to_show():
       }),
       ('spark', {
           'name': 'Scala', 'displayName': 'Scala', 'interface': 'livy', 'type': 'spark', 'is_sql': False, 'options': {},
-          'dialect_properties': {}, 'is_catalog': False, 'category': 'editor', 'dialect': 'scala'
+          'dialect_properties': {}, 'is_catalog': False, 'category': 'editor', 'dialect': 'spark'
       })
     ))
 

--- a/desktop/libs/notebook/src/notebook/conf.py
+++ b/desktop/libs/notebook/src/notebook/conf.py
@@ -141,7 +141,7 @@ def get_ordered_interpreters(user=None):
       "type": i['type'],
       "interface": i['interface'],
       "options": i['options'],
-      'dialect': i.get('dialect', i['name']).lower(),
+      'dialect': i.get('dialect', i['type']).lower(),
       'dialect_properties': i.get('dialect_properties') or {},  # Empty when connectors off
       'category': i.get('category', 'editor'),
       "is_sql": i.get('is_sql') or \


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Do not use name since it can be flaky and customizable, intead type field looks more reliable.
- Changed dialect for SparkSQL.

