### PR TITLE
[indexer] Check whether impala conf is present or not

### DIFF
--- a/desktop/libs/indexer/src/indexer/indexers/sql.py
+++ b/desktop/libs/indexer/src/indexer/indexers/sql.py
@@ -55,6 +55,11 @@ try:
 except ImportError as e:
   LOG.warning('Hive and HiveServer2 interfaces are not enabled')
 
+try:
+  from impala import conf as impala_conf
+except ImportError as e:
+  LOG.warning("Impala app is not enabled")
+  impala_conf = None
 
 class SQLIndexer(object):
 
@@ -170,7 +175,7 @@ class SQLIndexer(object):
         user_scratch_dir = self.fs.get_home_dir() + '/.scratchdir/%s' % str(uuid.uuid4()) # Make sure it's unique.
         self.fs.do_as_user(self.user, self.fs.mkdir, user_scratch_dir, 0o0777)
         self.fs.do_as_user(self.user, self.fs.rename, source['path'], user_scratch_dir)
-        if editor_type == 'impala' and USER_SCRATCH_DIR_PERMISSION.get():
+        if editor_type == 'impala' and impala_conf and impala_conf.USER_SCRATCH_DIR_PERMISSION.get():
           self.fs.do_as_user(self.user, self.fs.chmod, user_scratch_dir, 0o0777, True)
         source_path = user_scratch_dir + '/' + source['path'].split('/')[-1]
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- When trying to run the latest docker image we are getting the following error:

```
  File "/usr/share/hue/desktop/core/src/desktop/urls.py", line 50, in <module>
    for pattern in self.url_patterns:
  File "/usr/share/hue/build/env/lib/python3.8/site-packages/django/utils/functional.py", line 48, in __get__
    from desktop import api_public_urls
  File "/usr/share/hue/desktop/core/src/desktop/api_public_urls.py", line 20, in <module>
    from desktop import api_public
    res = instance.__dict__[self.name] = self.func(instance)
  File "/usr/share/hue/desktop/core/src/desktop/api_public.py", line 25, in <module>
  File "/usr/share/hue/build/env/lib/python3.8/site-packages/django/urls/resolvers.py", line 602, in url_patterns
    from indexer import api3 as indexer_api3
  File "/usr/share/hue/desktop/libs/indexer/src/indexer/api3.py", line 64, in <module>
    from indexer.indexers.sql import _create_database, _create_table, _create_table_from_local
  File "/usr/share/hue/desktop/libs/indexer/src/indexer/indexers/sql.py", line 35, in <module>
    from impala.conf import USER_SCRATCH_DIR_PERMISSION
ModuleNotFoundError: No module named 'impala.conf'
    patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
  File "/usr/share/hue/build/env/lib/python3.8/site-packages/django/utils/functional.py", line 48, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/usr/share/hue/build/env/lib/python3.8/site-packages/django/urls/resolvers.py", line 595, in urlconf_module
    return import_module(self.urlconf_name)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 848, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/usr/share/hue/desktop/core/src/desktop/urls.py", line 50, in <module>
    from desktop import api_public_urls
  File "/usr/share/hue/desktop/core/src/desktop/api_public_urls.py", line 20, in <module>
    from desktop import api_public
  File "/usr/share/hue/desktop/core/src/desktop/api_public.py", line 25, in <module>
    from indexer import api3 as indexer_api3
  File "/usr/share/hue/desktop/libs/indexer/src/indexer/api3.py", line 64, in <module>
    from indexer.indexers.sql import _create_database, _create_table, _create_table_from_local
  File "/usr/share/hue/desktop/libs/indexer/src/indexer/indexers/sql.py", line 35, in <module>
    from impala.conf import USER_SCRATCH_DIR_PERMISSION
ModuleNotFoundError: No module named 'impala.conf'
[01/Aug/2022 14:24:10 ] supervisor   WARNING  Exit code for /usr/share/hue/build/env/bin/hue runcpserver: 1
[01/Aug/2022 14:24:10 ] supervisor   ERROR    Process /usr/share/hue/build/env/bin/hue runcpserver has restarted more than 3 times in the last 6 seconds
[01/Aug/2022 14:24:10 ] supervisor   WARNING  Exit code for /usr/share/hue/build/env/bin/hue kt_renewer: 1
[01/Aug/2022 14:24:10 ] supervisor   ERROR    Process /usr/share/hue/build/env/bin/hue kt_renewer has restarted more than 3 times in the last 6 seconds
[01/Aug/2022 14:24:11 ] supervisor   WARNING  Supervisor shutting down!
[01/Aug/2022 14:24:11 ] supervisor   WARNING  Waiting for children to exit for 5 seconds...
[01/Aug/2022 14:24:11 ] supervisor   ERROR    Exception in supervisor main loop
Traceback (most recent call last):
  File "/usr/share/hue/desktop/core/src/desktop/supervisor.py", line 385, in main
    wait_loop(sups, options)
  File "/usr/share/hue/desktop/core/src/desktop/supervisor.py", line 402, in wait_loop
    shutdown(sups)  # shutdown() exits the process
  File "/usr/share/hue/desktop/core/src/desktop/supervisor.py", line 218, in shutdown
    sys.exit(1)
SystemExit: 1
[01/Aug/2022 14:24:11 ] supervisor   WARNING  Supervisor shutting down!
[01/Aug/2022 14:24:11 ] supervisor   WARNING  Waiting for children to exit for 5 seconds...
harsh.gupta@harsh ~ %
```