### PR TITLE
[gunicorn] Fix ManualTLS 7.1.8 cluster install fails as Hue service d…

### DIFF
--- a/desktop/core/src/desktop/management/commands/rungunicornserver.py
+++ b/desktop/core/src/desktop/management/commands/rungunicornserver.py
@@ -99,7 +99,7 @@ def rungunicornserver():
   # https://github.com/benoitc/gunicorn/issues/2410
   ssl_keyfile = None
   if conf.SSL_CERTIFICATE.get() and conf.SSL_PRIVATE_KEY.get():
-    ssl_password = str.encode(conf.get_ssl_password())
+    ssl_password = str.encode(conf.get_ssl_password()) if conf.get_ssl_password() is not None else None
     if ssl_password:
       with open(conf.SSL_PRIVATE_KEY.get(), 'r') as f:
         with tempfile.NamedTemporaryFile(dir=os.path.dirname(


### PR DESCRIPTION
…oesn't start

(cherry picked from commit 2650a6f5321aac46f85455885908af7f752786d4)

## What changes were proposed in this pull request?

- Bug fix

## How was this patch tested?

- Tested on internal CDH cluster

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
