### PR TITLE
[py3] Fix error when start Hue shell on command line

### DIFF
--- a/desktop/core/src/desktop/manage_entry.py
+++ b/desktop/core/src/desktop/manage_entry.py
@@ -110,7 +110,7 @@ def entry():
     else:
       from ConfigParser import NoOptionError, RawConfigParser
 
-    config = RawConfigParser()
+    config = RawConfigParser(strict=False) if sys.version_info[0] > 2 else RawConfigParser()
     config.read(cm_config_file)
     try:
       cm_agent_run_dir = config.get('General', 'agent_wide_credential_cache_location')
@@ -162,7 +162,8 @@ def entry():
       print("If the above does not work, make sure Hue has been started on this server.")
 
     if not envline == None:
-      empty, environment = envline.split("environment=")
+      # spliting envline by "environment=" won't work since new key cdp_environment was added
+      environment = envline.replace("environment=", "")
       for envvar in environment.split(","):
         include_env_vars = ("HADOOP_C", "PARCEL", "SCM_DEFINES", "LD_LIBRARY")
         if any(include_env_var in envvar for include_env_var in include_env_vars):
@@ -186,9 +187,11 @@ def entry():
       JAVA_HOME = "UNKNOWN"
 
       if locate_java is not None:
-        for line in iter(locate_java.stdout.readline, ''):
-          if 'JAVA_HOME' in line:
-            JAVA_HOME = line.rstrip().split('=')[1]
+        for line in iter(locate_java.stdout.readline, b''):
+          if b'JAVA_HOME' in line:
+            JAVA_HOME = line.rstrip().split(b'=')[1]
+            if sys.version_info[0] > 2 and type(JAVA_HOME) == bytes:
+              JAVA_HOME = JAVA_HOME.decode("utf-8")
 
       if JAVA_HOME != "UNKNOWN":
         os.environ["JAVA_HOME"] = JAVA_HOME


### PR DESCRIPTION
## What changes were proposed in this pull request?

After swich Python3.8, there is error reading config file with duplicate section. And also there bytes to string conversion issue.

```
[root@yn-2 hue]# build/env/bin/hue shell --cm-managed
Traceback (most recent call last):
  File "build/env/bin/hue", line 36, in <module>
    sys.exit(load_entry_point('desktop', 'console_scripts', 'hue')())
  File "/opt/cloudera/parcels/CDH-7.1.8-1.cdh7.1.8.p0.30052893/lib/hue/desktop/core/src/desktop/manage_entry.py", line 114, in entry
    config.read(cm_config_file)
  File "/usr/local/lib/python3.8/configparser.py", line 697, in read
    self._read(fp, filename)
  File "/usr/local/lib/python3.8/configparser.py", line 1067, in _read
    raise DuplicateSectionError(sectname, fpname,
configparser.DuplicateSectionError: While reading from '/etc/cloudera-scm-agent/config.ini' [line 285]: section 'Security' already exists
```

## How was this patch tested?

tested on cluster command prompt

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
