### PR TITLE
Impala table import is failing when beeswax max_number_of_sessions != 0

### DIFF
--- a/apps/impala/src/impala/server.py
+++ b/apps/impala/src/impala/server.py
@@ -69,6 +69,11 @@ class ImpalaDaemonApiException(Exception):
 
 
 class ImpalaServerClient(HiveServerClient):
+  def __init__(self, query_server, user):
+    super(ImpalaServerClient, self).__init__(query_server, user)
+    self.max_number_of_sessions = 1
+    self.has_close_sessions = False
+    self.has_session_pool = False
 
   def get_exec_summary(self, operation_handle, session_handle):
     """


### PR DESCRIPTION
## What changes were proposed in this pull request?
Reset max_number_of_sessions, has_close_sessions & has_session_pool in ImpalaServerClient

## How was this patch tested?
Manually tested in a real cluster
