### PR TITLE
[frontent] Support special and non ascii characters in file download

### DIFF
--- a/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
+++ b/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
@@ -1394,7 +1394,16 @@ else:
       };
 
       self.downloadFile = function () {
-        huePubSub.publish('open.link', self.selectedFile().url.replace("${url('filebrowser:filebrowser.views.view', path='')}", "${url('filebrowser:filebrowser_views_download', path='')}"));
+        const baseUrl = "${url('filebrowser:filebrowser_views_download', path='')}";
+      // If the hash characters aren't encoded the page library will
+      // split the path on the first occurence and the remaining string will not
+      // be part of the path. Question marks must also be encoded or the string after the first
+      // question mark will be interpreted as the url querystring.      
+        const partiallyEncodedFilePath = self.selectedFile().path.replaceAll('#', encodeURIComponent('#'))
+          .replaceAll('?', encodeURIComponent('?'));;
+        const fullUrl = baseUrl+partiallyEncodedFilePath;
+        
+        huePubSub.publish('open.link', fullUrl);
       };
 
       self.renameFile = function () {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added support for downloading files containing supported special characters and non ASCII characters in the filenames.
Support described in image below:

![image](https://user-images.githubusercontent.com/5167091/184102361-54547f31-157c-4e26-b75a-45772f1bee62.png)

## How was this patch tested?

Manual testing done on MacOS for HDFS, S3 and ABFS in the following browsers

- [x]  Safari
- [x]  Chrome
- [x]  Edge
- [x]  Firefox

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
