### PR TITLE
Improve hive service discovery behavior, and select a hive server efficiently for load balancing.

### DIFF
--- a/apps/beeswax/src/beeswax/server/dbms.py
+++ b/apps/beeswax/src/beeswax/server/dbms.py
@@ -151,8 +151,8 @@ def get(user, query_server=None, cluster=None):
 
 
 def select_hive_server(hiveservers, activeEndpoint=None):
-  servers = map(lambda server: {'host': server[0], 'port': server[1]},
-                     [server.split(';')[0].split('=')[1].split(":") for server in hiveservers])
+  servers = list(map(lambda server: {'host': server[0], 'port': server[1]},
+                     [server.split(';')[0].split('=')[1].split(":") for server in hiveservers]))
   return ((next(iter(filter(lambda server: server == activeEndpoint, servers)), None) if activeEndpoint else None)
           or next(iter(filter(lambda server: platform.node() in server['host'], servers)), None)
           or servers[abs(hash(platform.node())) % len(servers)])

--- a/apps/beeswax/src/beeswax/server/dbms_tests.py
+++ b/apps/beeswax/src/beeswax/server/dbms_tests.py
@@ -156,7 +156,7 @@ class TestGetQueryServerConfig():
               exists=Mock(return_value=True),
               # Bug "TypeError: expected string or buffer" if False, to add a new test case and fix
               get_children=Mock(
-                return_value=map(lambda h: "serverUri={0}:{1};version=xxx;sequence=xxx".format(h, '10000'), hosts)
+                return_value=list(map(lambda h: "serverUri={0}:{1};version=xxx;sequence=xxx".format(h, '10000'), hosts))
               )
             )
 
@@ -175,7 +175,7 @@ class TestGetQueryServerConfig():
 
   def test_get_dbms_after_cache_expiration(self):
     hosts = ['hive-llap-1.gethue.com', 'hive-llap-2.gethue.com', 'hive-llap-3.gethue.com', 'hive-llap-4.gethue.com']
-    znodes = lambda hh: map(lambda h: "serverUri={0}:{1};version=xxx;sequence=xxx".format(h, '10000'), hh)
+    znodes = lambda hh: list(map(lambda h: "serverUri={0}:{1};version=xxx;sequence=xxx".format(h, '10000'), hh))
     with patch('beeswax.conf.HIVE_DISCOVERY_HS2.get') as HIVE_DISCOVERY_HS2:
       with patch('beeswax.conf.HIVE_DISCOVERY_HIVESERVER2_ZNODE.get') as HIVE_DISCOVERY_HIVESERVER2_ZNODE:
         with patch('beeswax.server.dbms.KazooClient') as KazooClient:

--- a/apps/beeswax/src/beeswax/tests.py
+++ b/apps/beeswax/src/beeswax/tests.py
@@ -2804,6 +2804,9 @@ class MockDbms(object):
   def get_state(self, handle):
     return 0
 
+  def get_query_server_config(self):
+    return {}
+
 class TestWithMockedServer(object):
 
   def setUp(self):


### PR DESCRIPTION
## What changes were proposed in this pull request?

- an improvement : In multiple hue/hive instance environment, hive connections from all hue instances are established to the same hive server. it causes load imbalance and hive service may not available, when # of connections  reaches maximum of hive thrift thread pool. This pr introduces a new method for hive selection to make connections evenly distributed across all hive servers.
- a minor bug fix : when a cache for hive service discovery is expired due to timeout([default: 5min](https://docs.djangoproject.com/en/4.0/ref/settings/#timeout)), and a hive server currently connected is not available, new connections to available hive servers might not be established properly.
- one more (minor) change : Hue doesn't try to make new connections and sessions to available hive servers, when it receives abnormal response for open session requests. this behavior is different from hive's one. In hive client side, [when not-success response received from hive server, clients tries to open sessions to other hive servers](https://github.com/apache/hive/blob/18501dd2e6f0c68038600b4dc69b7197a7827cbd/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java#L1195)(in service discovery mode).

## How was this patch tested?

- unit tests(added a new test in dbms_test.py) + manual tests
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
