### PR TITLE
[importer] Fixing only headers CSV file table creation in Local File importer on Impala

### DIFF
--- a/apps/beeswax/data/tables/onlyheader.csv
+++ b/apps/beeswax/data/tables/onlyheader.csv
@@ -1,0 +1,1 @@
+"date(1)","hour.1","minute","dep","arr","dep_delay","arr_delay","carrier","flight","dest","plane","cancelled","time","dist"

--- a/desktop/libs/indexer/src/indexer/indexers/sql_tests.py
+++ b/desktop/libs/indexer/src/indexer/indexers/sql_tests.py
@@ -900,8 +900,7 @@ def test_create_table_from_local_impala():
       ],
       'sourceType': 'impala'
     }
-    request = MockRequest(fs=MockFs())
-    sql = SQLIndexer(user=request.user, fs=request.fs).create_table_from_local_file(source, destination).get_str()
+    sql = SQLIndexer(user=Mock(), fs=Mock()).create_table_from_local_file(source, destination).get_str()
 
     statement = '''USE default;
 
@@ -930,6 +929,77 @@ INSERT INTO default.test1_tmp VALUES \
 ('2011-12-14 12:00:00', '16', '13', '1613', '1731', '8', '-4', 'WN', '33', 'SAN', 'N707SA', '1', '185', '1313'), \
 ('2011-12-14 12:00:00', '11', '45', '1145', '1257', '5', '-13', 'WN', '1212', 'SAN', 'N279WN', '0', '183', '1313'), \
 ('2011-12-14 12:00:00', '20', '16', '2016', '2112', '36', '32', 'WN', '207', 'SAT', 'N929WN', '0', '44', '192');
+
+CREATE TABLE IF NOT EXISTS default.test1
+AS SELECT
+  CAST ( `date` AS timestamp ) `date`,
+  CAST ( `hour` AS bigint ) `hour`,
+  CAST ( `minute` AS bigint ) `minute`,
+  CAST ( `dep` AS bigint ) `dep`,
+  CAST ( `arr` AS bigint ) `arr`,
+  CAST ( `dep_delay` AS bigint ) `dep_delay`,
+  CAST ( `arr_delay` AS bigint ) `arr_delay`,
+  CAST ( `carrier` AS string ) `carrier`,
+  CAST ( `flight` AS bigint ) `flight`,
+  CAST ( `dest` AS string ) `dest`,
+  CAST ( `plane` AS string ) `plane`,
+  CAST ( CAST ( `cancelled` AS TINYINT ) AS boolean ) `cancelled`,
+  CAST ( `time` AS bigint ) `time`,
+  CAST ( `dist` AS bigint ) `dist`
+FROM  default.test1_tmp;
+
+DROP TABLE IF EXISTS default.test1_tmp;'''
+
+    assert_equal(statement, sql)
+
+
+def test_create_table_only_header_file_local_impala():
+  with patch('indexer.indexers.sql.get_interpreter') as get_interpreter:
+    get_interpreter.return_value = {'Name': 'Impala', 'dialect': 'impala'}
+    source = {
+      'path': BASE_DIR + '/apps/beeswax/data/tables/onlyheader.csv',
+      'sourceType': 'impala',
+      'format': {'hasHeader': True}
+    }
+    destination = {
+      'name': 'default.test1',
+      'columns': [
+        {'name': 'date', 'type': 'timestamp', 'keep': True},
+        {'name': 'hour', 'type': 'bigint', 'keep': True},
+        {'name': 'minute', 'type': 'bigint', 'keep': True},
+        {'name': 'dep', 'type': 'bigint', 'keep': True},
+        {'name': 'arr', 'type': 'bigint', 'keep': True},
+        {'name': 'dep_delay', 'type': 'bigint', 'keep': True},
+        {'name': 'arr_delay', 'type': 'bigint', 'keep': True},
+        {'name': 'carrier', 'type': 'string', 'keep': True},
+        {'name': 'flight', 'type': 'bigint', 'keep': True},
+        {'name': 'dest', 'type': 'string', 'keep': True},
+        {'name': 'plane', 'type': 'string', 'keep': True},
+        {'name': 'cancelled', 'type': 'boolean', 'keep': True},
+        {'name': 'time', 'type': 'bigint', 'keep': True},
+        {'name': 'dist', 'type': 'bigint', 'keep': True},
+      ],
+      'sourceType': 'impala'
+    }
+    sql = SQLIndexer(user=Mock(), fs=Mock()).create_table_from_local_file(source, destination).get_str()
+
+    statement = '''USE default;
+
+CREATE TABLE IF NOT EXISTS default.test1_tmp (
+  `date` string,
+  `hour` string,
+  `minute` string,
+  `dep` string,
+  `arr` string,
+  `dep_delay` string,
+  `arr_delay` string,
+  `carrier` string,
+  `flight` string,
+  `dest` string,
+  `plane` string,
+  `cancelled` string,
+  `time` string,
+  `dist` string);
 
 CREATE TABLE IF NOT EXISTS default.test1
 AS SELECT


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Separating the insert sql from create sql
- Now we will be able to create the only header tables.

## How was this patch tested?

- Manually
- Unit test
