### PR TITLE
[core] Fix query history timestamp of installing example tables

### DIFF
--- a/apps/beeswax/src/beeswax/management/commands/beeswax_install_examples.py
+++ b/apps/beeswax/src/beeswax/management/commands/beeswax_install_examples.py
@@ -230,6 +230,7 @@ class SampleTable(object):
           status='ready',
           database=self.db_name,
           on_success_url='assist.db.refresh',
+          last_executed=int(self.request.ts * 1000) if self.request else -1,
           is_task=False,
       )
 
@@ -372,6 +373,7 @@ class SampleTable(object):
         status='ready',
         database=self.db_name,
         on_success_url='assist.db.refresh',
+        last_executed=int(self.request.ts * 1000) if self.request and hasattr(self.request, 'ts') else -1,
         is_task=False,
     )
     job.execute_and_wait(self.request)

--- a/apps/beeswax/src/beeswax/management/commands/beeswax_install_examples_tests.py
+++ b/apps/beeswax/src/beeswax/management/commands/beeswax_install_examples_tests.py
@@ -225,5 +225,6 @@ class TestTransactionalTables():
         statement="UPSERT INTO us_population VALUES ('CA', 'San Jose', 912332)",
         status='ready',
         database='default',
+        last_executed=-1,
         on_success_url='assist.db.refresh', is_task=False
       )


### PR DESCRIPTION
## What changes were proposed in this pull request?

Install example tables as superuser, but the time query history is showing 53 yrs old due to missing timestamp.

## How was this patch tested?

Run install Hive and Impala examples locally 

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
