### PR TITLE
[assist] Prevent automatic opening of unknown tables in the right assist

### DIFF
--- a/desktop/core/src/desktop/js/ko/components/assist/ko.assistEditorContextPanel.js
+++ b/desktop/core/src/desktop/js/ko/components/assist/ko.assistEditorContextPanel.js
@@ -291,7 +291,10 @@ class AssistEditorContextPanel {
       }
       window.clearTimeout(loadEntriesTimeout);
       if (this.activeTables().length === 1) {
-        this.activeTables()[0].open(true);
+        const singleTable = this.activeTables()[0];
+        if (!singleTable.hasErrors()) {
+          singleTable.open(true);
+        }
       } else {
         loadEntriesTimeout = window.setTimeout(() => {
           this.activeTables().every(table => {


### PR DESCRIPTION
This takes care of an issue where the right assist is causing autocomplete API calls for tables that don't exist.

Tested manually to reproduce and after the fix to verify.