### PR TITLE
[frontent] add support for % in file and folder names

### DIFF
--- a/apps/filebrowser/src/filebrowser/templates/display.mako
+++ b/apps/filebrowser/src/filebrowser/templates/display.mako
@@ -400,7 +400,9 @@ ${ fb_components.menubar() }
       // split the path on the first occurence and the remaining string will not
       // be part of the path. Question marks must also be encoded or the string after the first
       // question mark will be interpreted as the url querystring.
-      const partiallyEncodedFilePath = correctedFilePath.replaceAll('#', encodeURIComponent('#'))
+      // Percentage character must be double encoded due to the page library that decodes the url twice
+      const doubleUrlEncodedPercentage = '%2525';
+      const partiallyEncodedFilePath = correctedFilePath.replaceAll('%', doubleUrlEncodedPercentage).replaceAll('#', encodeURIComponent('#'))
         .replaceAll('?', encodeURIComponent('?'));
       const baseUrl = "${url('filebrowser:filebrowser_views_download', path='')}";
       const fullUrl = baseUrl+partiallyEncodedFilePath;

--- a/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
+++ b/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
@@ -1393,7 +1393,7 @@ else:
           // Fix. The '%' character needs to be encoded twice due to a bug in the page library
           // that decodes the url twice
           
-          if(file.path.includes('%') && !file.path.includes(urlEncodedPercentage)) {            
+          if (file.path.includes('%') && !file.path.includes(urlEncodedPercentage)) {            
             url = url.replaceAll(urlEncodedPercentage, encodeURIComponent(urlEncodedPercentage));
           }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added fixes needed to support percentage (%) in file and folder names. 

## How was this patch tested?
Tested manually for HDFS, S3 and ABFS

See updated sheet with supported characters
https://docs.google.com/spreadsheets/d/1SEghz9AJDEthIxScIcQ95nGU2Xh8oQ7U-FLwWiRZ8gs/edit?usp=sharing

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
