### PR TITLE
[frontend] - unmount react root on DOM node disposal

### DIFF
--- a/desktop/core/src/desktop/js/ko/bindings/ko.reactWrapper.js
+++ b/desktop/core/src/desktop/js/ko/bindings/ko.reactWrapper.js
@@ -36,7 +36,7 @@ ko.bindingHandlers.reactWrapper = (() => {
       const props = getProps(allBindings);
 
       // The component's react root should only be created once per DOM
-      // load so we pass it along via the bindingContext to be reused in the KO update call
+      // load so we pass it along via the bindingContext to be reused in the KO update call.
       const reactRoot = createRoot(el);
       el.__KO_React_root = reactRoot;
       loadComponent(componentName).then(Component => {

--- a/desktop/core/src/desktop/js/ko/bindings/ko.reactWrapper.js
+++ b/desktop/core/src/desktop/js/ko/bindings/ko.reactWrapper.js
@@ -36,12 +36,17 @@ ko.bindingHandlers.reactWrapper = (() => {
       const props = getProps(allBindings);
 
       // The component's react root should only be created once per DOM
-      // load so we pass it along via the bindingContext to be reused in the
+      // load so we pass it along via the bindingContext to be reused in the KO update call
       const reactRoot = createRoot(el);
       el.__KO_React_root = reactRoot;
       loadComponent(componentName).then(Component => {
         reactRoot.render(createElement(Component, props));
       });
+
+      // Since the react component is a root component we need to handle the
+      // unmounting explicitly if the dom node is disposed by Knockout, e.g. via "ko if:"
+      ko.utils.domNodeDisposal.addDisposeCallback(el, () => reactRoot.unmount());
+
       // Tell Knockout that it does not need to update the children
       // of this component, since that is now handled by React
       return { controlsDescendantBindings: true };


### PR DESCRIPTION
## What changes were proposed in this pull request?
Since Knockout can modify the DOM and remove elements that contain react _root_ components we need to make sure those components are explicitly unmounted so that any clean up code they use is actually being executed.

## How was this patch tested?

Manual testing using a test react component. In the mako file:

```
  <!-- ko if: someChangingCondition -->
    <Test data-bind="reactWrapper: 'Test', props: {}"></Test>
  <!-- /ko -->
```
and in the functional Test component we use a side effect that has a clean up call:

 ```
useEffect(() => {
    return () => {
      console.log('Cleaning up');
    };
  }, []);
```
 

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
