### PR TITLE
[docker] Revert protobuf change and set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python in Py3 image

### DIFF
--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -44,6 +44,7 @@ nose==1.3.7
 openpyxl==3.0.9
 pandas==1.4.2
 prompt-toolkit==2.0.10
+protobuf==3.17.0
 pyformance==0.3.2
 pylint==2.6.0
 pylint-django==2.3.0
@@ -73,7 +74,6 @@ git+https://github.com/gethue/django-mako.git
 werkzeug==2.0.1  # Should remove it here and from devtools.mk
 django-utils-six==2.0
 six==1.16.0
-protobuf==3.17.0
 -e file:///${ROOT}/desktop/core/ext-py3/requests-2.27.1
 -e file:///${ROOT}/desktop/core/ext-py3/boto-2.49.0
 -e file:///${ROOT}/desktop/core/ext-py3/django-axes-5.13.0

--- a/tools/docker/hue/Dockerfile
+++ b/tools/docker/hue/Dockerfile
@@ -42,6 +42,7 @@ RUN pip3 install --upgrade --no-cache-dir setuptools virtualenv pip && \
   rm -r /hue/desktop/conf/* && \
   cp -r /hue/desktop/conf.dist/* /hue/desktop/conf/ && \
   cd /hue && \
+  PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python \
   PREFIX=/usr/share ROOT=/usr/share/hue PYTHON_VER=python3.8 make install && \
   chown -R hue /usr/share/hue && \
   npm cache clean --force && \


### PR DESCRIPTION
## What changes were proposed in this pull request?

- When the docker image is building, it is picking up the latest protobuf pypi package for python3 because of some other dependency package.
- We are setting PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python as a workaround for image not able to run.
