### PR TITLE
Update _index.md

### DIFF
--- a/docs/docs-site/content/administrator/installation/dependencies/_index.md
+++ b/docs/docs-site/content/administrator/installation/dependencies/_index.md
@@ -152,11 +152,11 @@ This is a verified step-by-step guide on how to get Hue up and running on a fres
 
 3. Install postgres (unless you prefer something else)
 
-   `brew install postgres`
+   `brew install postgresql@14`
 
 4. Start Postgres
 
-   `brew services start postgresql`
+   `brew services start postgresql@14`
 
 5. Create the hue database and set permissions
 


### PR DESCRIPTION
While trying to install hue found out that the command 'brew install postgre' does not work since postgresql is deprecated. Hence I am updating the commands for the gethue installation dependencies documentation.

## What changes were proposed in this pull request?

- Changed the command to 'brew install postgresql@14' and ' brew services start postgresql@14'


