### PR TITLE
[oozie] Fix rerun workflow URL when Knox is enabled

### DIFF
--- a/apps/oozie/src/oozie/templates/dashboard/rerun_coord_popup.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/rerun_coord_popup.mako
@@ -99,7 +99,7 @@
     $('#submit-rerun-form${ SUFFIX }').submit(function (e) {
       $.ajax({
         type: "POST",
-        url: '${ action }',
+        url: window.HUE_BASE_URL + '${ action }', // window.HUE_BASE_URL is empty string when Knox is not enabled
         data: $('#submit-rerun-form${ SUFFIX }').serialize(),
         success: function (data) {
           huePubSub.publish('submit.rerun.popup.return${ SUFFIX }', data);

--- a/apps/oozie/src/oozie/templates/dashboard/rerun_workflow_popup.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/rerun_workflow_popup.mako
@@ -109,7 +109,7 @@
         $('#submit-rerun-form${ SUFFIX }').submit(function (e) {
           $.ajax({
             type: "POST",
-            url: '${ action }',
+            url: window.HUE_BASE_URL + '${ action }', // window.HUE_BASE_URL is empty string when Knox is not enabled
             data: $('#submit-rerun-form${ SUFFIX }').serialize(),
             success: function (data) {
               huePubSub.publish('submit.rerun.popup.return${ SUFFIX }', data);


### PR DESCRIPTION
## What changes were proposed in this pull request?

When Knox is enabled, window.HUE_BASE_URL is not append at front because app_path is HDFS URL already contains HUE_BASE_URL. This fix is adding window.HUE_BASE_URL at the front of rerun URL. When Knox is not enabled, window.HUE_BASE_URL is an empty string.

## How was this patch tested?

tested on Knox enabled cluster and non-Knox cluster

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
