### PR TITLE
[knox] Disabled the MultipleProxyMiddleware for py2

### DIFF
--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -803,6 +803,8 @@ MODULES_TO_PATCH = (
 
 if sys.version_info[0] > 2:
   MIDDLEWARE.append('axes.middleware.AxesMiddleware')  # AxesMiddleware should be the last middleware in the MIDDLEWARE list.
+else:
+  MIDDLEWARE.remove('desktop.middleware.MultipleProxyMiddleware')
 
 try:
   import hashlib


### PR DESCRIPTION
The middleware is needed only on py3 and is interfering when authenticating with knox. We are stripping out the gateway host's header information and that is why it is failing the match with proxy_hosts config.