### PR TITLE
[CVE][Py3] Bump django-celery-result to 2.4.0 to fix high severity CVE

### DIFF
--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -3,7 +3,7 @@ requests-gssapi==1.2.3
 asn1crypto==0.24.0
 avro-python3==1.8.2
 Babel==2.9.1
-celery[redis]==5.2.2
+celery[redis]==5.2.3
 cffi==1.15.0
 channels==3.0.3
 channels-redis==3.2.0
@@ -13,7 +13,7 @@ django-auth-ldap==2.3.0
 Django==3.2.15
 daphne==3.0.2
 django-celery-beat==2.2.1
-django-celery-results==2.2.0
+django-celery-results==2.4.0
 django-cors-headers==3.7.0
 django-crequest==2018.5.11
 django-debug-panel==0.8.3


### PR DESCRIPTION
- Celery is also bumped to 5.2.3 because django-celery-result has a dependency on it.
