### PR TITLE
[frontend] fix CVE-2021-44906 by upgrading selectize to remove old mi…

### DIFF
--- a/desktop/core/src/desktop/js/jquery/plugins/jquery.selectize.js
+++ b/desktop/core/src/desktop/js/jquery/plugins/jquery.selectize.js
@@ -1,5 +1,5 @@
 /*! selectize clear button plugin by Alexey Petushkov | https://github.com/mentatxx/selectize-plugin-clear | Apache License (v2) */
 
-import Selectize from 'selectize';
+import Selectize from '@selectize/selectize';
 
 window.Selectize = Selectize;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@gethue/sql-formatter": "4.0.3",
+        "@selectize/selectize": "^0.14.0",
         "antd": "^4.23.1",
         "axios": "0.24.0",
         "babel-preset-react-app": "^3.1.2",
@@ -48,7 +49,6 @@
         "removeNPMAbsolutePaths": "^1.0.4",
         "sanitize-html": "^2.7.2",
         "select2": "4.0.13",
-        "selectize": "0.12.6",
         "selectize-plugin-clear": "0.0.3",
         "sprintf-js": "1.1.2",
         "vue": "3.2.0",
@@ -2950,6 +2950,20 @@
       "integrity": "sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA==",
       "dev": true
     },
+    "node_modules/@selectize/selectize": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@selectize/selectize/-/selectize-0.14.0.tgz",
+      "integrity": "sha512-/CrMY4wrhQmkTNYwvhL3azsdmP9qi1BVlQK2oXhrLCA4GlyXSGX2bhHuPef+OOwhdPw0qmwzU4LqEcJeiY/bLQ==",
+      "engines": {
+        "node": "*"
+      },
+      "optionalDependencies": {
+        "jquery-ui": "^1.13.2"
+      },
+      "peerDependencies": {
+        "jquery": "^1.7.0 || ^2 || ^3"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -4235,11 +4249,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/ansicolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
     },
     "node_modules/antd": {
       "version": "4.23.1",
@@ -5889,18 +5898,6 @@
         }
       ]
     },
-    "node_modules/cardinal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
-      "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
-      "dependencies": {
-        "ansicolors": "~0.2.1",
-        "redeyed": "~1.0.0"
-      },
-      "bin": {
-        "cdl": "bin/cdl.js"
-      }
-    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -6515,11 +6512,6 @@
       "version": "2.6.17",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
       "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
-    },
-    "node_modules/csv-parse": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.0.tgz",
-      "integrity": "sha512-Zb4tGPANH4SW0LgC9+s9Mnequs9aqn7N3/pCqNbVjs2XhEF6yWNU2Vm4OGl1v2Go9nw8rXt87Cm2QN/o6Vpqgg=="
     },
     "node_modules/d3": {
       "version": "5.7.0",
@@ -9315,18 +9307,10 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/humanize": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/humanize/-/humanize-0.0.9.tgz",
-      "integrity": "sha1-GZT/rs3+nEQe0r2sdFK3u0yeQaQ=",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/i18next": {
-      "version": "21.9.2",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.9.2.tgz",
-      "integrity": "sha512-00fVrLQOwy45nm3OtC9l1WiLK3nJlIYSljgCt0qzTaAy65aciMdRy9GsuW+a2AtKtdg9/njUGfRH30LRupV7ZQ==",
+      "version": "21.10.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.10.0.tgz",
+      "integrity": "sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==",
       "funding": [
         {
           "type": "individual",
@@ -12645,14 +12629,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/microplugin": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/microplugin/-/microplugin-0.0.3.tgz",
-      "integrity": "sha1-H8Lhu3yeGegr2Eu6kTe75xJQ2M0=",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -13204,20 +13180,6 @@
       "bin": {
         "opener": "bin/opener-bin.js"
       }
-    },
-    "node_modules/optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dependencies": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      }
-    },
-    "node_modules/optimist/node_modules/minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
     },
     "node_modules/optionator": {
       "version": "0.9.1",
@@ -14788,26 +14750,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/redeyed": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
-      "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
-      "dependencies": {
-        "esprima": "~3.0.0"
-      }
-    },
-    "node_modules/redeyed/node_modules/esprima": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
-      "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k=",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -15295,21 +15237,6 @@
       "resolved": "https://registry.npmjs.org/select2/-/select2-4.0.13.tgz",
       "integrity": "sha512-1JeB87s6oN/TDxQQYCvS5EFoQyvV6eYMZZ0AeA4tdFDYWN3BAGZ8npr17UBFddU0lgAt3H0yjX3X6/ekOj1yjw=="
     },
-    "node_modules/selectize": {
-      "version": "0.12.6",
-      "resolved": "https://registry.npmjs.org/selectize/-/selectize-0.12.6.tgz",
-      "integrity": "sha512-bWO5A7G+I8+QXyjLfQUgh31VI4WKYagUZQxAXlDyUmDDNrFxrASV0W9hxCOl0XJ/XQ1dZEu3G9HjXV4Wj0yb6w==",
-      "dependencies": {
-        "microplugin": "0.0.3",
-        "sifter": "^0.5.1"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "peerDependencies": {
-        "jquery": "^1.7.0, ^2, ^3"
-      }
-    },
     "node_modules/selectize-plugin-clear": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/selectize-plugin-clear/-/selectize-plugin-clear-0.0.3.tgz",
@@ -15369,29 +15296,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/sifter": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/sifter/-/sifter-0.5.4.tgz",
-      "integrity": "sha512-t2yxTi/MM/ESup7XH5oMu8PUcttlekt269RqxARgnvS+7D/oP6RyA1x3M/5w8dG9OgkOyQ8hNRWelQ8Rj4TAQQ==",
-      "dependencies": {
-        "async": "^2.6.0",
-        "cardinal": "^1.0.0",
-        "csv-parse": "^4.6.5",
-        "humanize": "^0.0.9",
-        "optimist": "^0.6.1"
-      },
-      "bin": {
-        "sifter": "bin/sifter.js"
-      }
-    },
-    "node_modules/sifter/node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dependencies": {
-        "lodash": "^4.17.14"
       }
     },
     "node_modules/signal-exit": {
@@ -17759,14 +17663,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -19947,6 +19843,14 @@
       "integrity": "sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA==",
       "dev": true
     },
+    "@selectize/selectize": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@selectize/selectize/-/selectize-0.14.0.tgz",
+      "integrity": "sha512-/CrMY4wrhQmkTNYwvhL3azsdmP9qi1BVlQK2oXhrLCA4GlyXSGX2bhHuPef+OOwhdPw0qmwzU4LqEcJeiY/bLQ==",
+      "requires": {
+        "jquery-ui": "^1.13.2"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -21015,11 +20919,6 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
-    },
-    "ansicolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
     },
     "antd": {
       "version": "4.23.1",
@@ -22450,15 +22349,6 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001355.tgz",
       "integrity": "sha512-Sd6pjJHF27LzCB7pT7qs+kuX2ndurzCzkpJl6Qct7LPSZ9jn0bkOA8mdgMgmqnQAWLVOOGjLpc+66V57eLtb1g=="
     },
-    "cardinal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
-      "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
-      "requires": {
-        "ansicolors": "~0.2.1",
-        "redeyed": "~1.0.0"
-      }
-    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -22947,11 +22837,6 @@
       "version": "2.6.17",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
       "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
-    },
-    "csv-parse": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.0.tgz",
-      "integrity": "sha512-Zb4tGPANH4SW0LgC9+s9Mnequs9aqn7N3/pCqNbVjs2XhEF6yWNU2Vm4OGl1v2Go9nw8rXt87Cm2QN/o6Vpqgg=="
     },
     "d3": {
       "version": "5.7.0",
@@ -25088,15 +24973,10 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
     },
-    "humanize": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/humanize/-/humanize-0.0.9.tgz",
-      "integrity": "sha1-GZT/rs3+nEQe0r2sdFK3u0yeQaQ="
-    },
     "i18next": {
-      "version": "21.9.2",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.9.2.tgz",
-      "integrity": "sha512-00fVrLQOwy45nm3OtC9l1WiLK3nJlIYSljgCt0qzTaAy65aciMdRy9GsuW+a2AtKtdg9/njUGfRH30LRupV7ZQ==",
+      "version": "21.10.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.10.0.tgz",
+      "integrity": "sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==",
       "requires": {
         "@babel/runtime": "^7.17.2"
       }
@@ -27633,11 +27513,6 @@
         "picomatch": "^2.2.3"
       }
     },
-    "microplugin": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/microplugin/-/microplugin-0.0.3.tgz",
-      "integrity": "sha1-H8Lhu3yeGegr2Eu6kTe75xJQ2M0="
-    },
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -28066,22 +27941,6 @@
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
       "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "dev": true
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-        }
-      }
     },
     "optionator": {
       "version": "0.9.1",
@@ -29205,21 +29064,6 @@
         "strip-indent": "^3.0.0"
       }
     },
-    "redeyed": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
-      "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
-      "requires": {
-        "esprima": "~3.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
-          "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k="
-        }
-      }
-    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -29572,15 +29416,6 @@
       "resolved": "https://registry.npmjs.org/select2/-/select2-4.0.13.tgz",
       "integrity": "sha512-1JeB87s6oN/TDxQQYCvS5EFoQyvV6eYMZZ0AeA4tdFDYWN3BAGZ8npr17UBFddU0lgAt3H0yjX3X6/ekOj1yjw=="
     },
-    "selectize": {
-      "version": "0.12.6",
-      "resolved": "https://registry.npmjs.org/selectize/-/selectize-0.12.6.tgz",
-      "integrity": "sha512-bWO5A7G+I8+QXyjLfQUgh31VI4WKYagUZQxAXlDyUmDDNrFxrASV0W9hxCOl0XJ/XQ1dZEu3G9HjXV4Wj0yb6w==",
-      "requires": {
-        "microplugin": "0.0.3",
-        "sifter": "^0.5.1"
-      }
-    },
     "selectize-plugin-clear": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/selectize-plugin-clear/-/selectize-plugin-clear-0.0.3.tgz",
@@ -29629,28 +29464,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
-    },
-    "sifter": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/sifter/-/sifter-0.5.4.tgz",
-      "integrity": "sha512-t2yxTi/MM/ESup7XH5oMu8PUcttlekt269RqxARgnvS+7D/oP6RyA1x3M/5w8dG9OgkOyQ8hNRWelQ8Rj4TAQQ==",
-      "requires": {
-        "async": "^2.6.0",
-        "cardinal": "^1.0.0",
-        "csv-parse": "^4.6.5",
-        "humanize": "^0.0.9",
-        "optimist": "^0.6.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        }
-      }
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -31450,11 +31263,6 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@gethue/sql-formatter": "4.0.3",
+    "@selectize/selectize": "^0.14.0",
     "antd": "^4.23.1",
     "axios": "0.24.0",
     "babel-preset-react-app": "^3.1.2",
@@ -68,8 +69,7 @@
     "regenerator-runtime": "^0.13.3",
     "removeNPMAbsolutePaths": "^1.0.4",
     "sanitize-html": "^2.7.2",
-    "select2": "4.0.13",
-    "selectize": "0.12.6",
+    "select2": "4.0.13",    
     "selectize-plugin-clear": "0.0.3",
     "sprintf-js": "1.1.2",
     "vue": "3.2.0",


### PR DESCRIPTION
…nimist dependency

## What changes were proposed in this pull request?

The `selectize` package has not been updated for several years but a new version based on the same repo has been published under `@selectize/selectize`. This PR replaces the old selectize with the new package which does not contain the security issue.

## How was this patch tested?

- Manually tested that the Selectize component still works (tested in a few places not all occurences)
- Manually tested that the selectize-plugin-clear still worked
- Unit tests working

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
