### PR TITLE
[frontend] fix modal overflow for sharing saved sql queries

### DIFF
--- a/desktop/core/src/desktop/js/ko/components/doc/__snapshots__/ko.shareDocModal.test.js.snap
+++ b/desktop/core/src/desktop/js/ko/components/doc/__snapshots__/ko.shareDocModal.test.js.snap
@@ -6,7 +6,7 @@ exports[`ko.shareDocModal.js should render component 1`] = `
       <button type=\\"button\\" class=\\"close\\" data-dismiss=\\"modal\\" aria-label=\\"Close\\"><span aria-hidden=\\"true\\">×</span></button>
       <h2 class=\\"modal-title\\">Sharing - <span data-bind=\\"text: documentName\\"></span></h2>
     </div>
-    <div class=\\"modal-body\\" style=\\"overflow: visible; height: 240px\\">
+    <div class=\\"modal-body\\" style=\\"overflow: visible;\\">
       <!-- ko with: document --><!-- /ko -->
     </div>
     <div class=\\"modal-footer\\">

--- a/desktop/core/src/desktop/js/ko/components/doc/ko.shareDocModal.js
+++ b/desktop/core/src/desktop/js/ko/components/doc/ko.shareDocModal.js
@@ -35,7 +35,7 @@ const TEMPLATE = `
       <button type="button" class="close" data-dismiss="modal" aria-label="${ I18n('Close') }"><span aria-hidden="true">&times;</span></button>
       <h2 class="modal-title">${ I18n('Sharing') } - <span data-bind="text: documentName"></span></h2>
     </div>
-    <div class="modal-body" style="overflow: visible; height: 240px">
+    <div class="modal-body" style="overflow: visible;">
       <!-- ko with: document -->
         <!-- ko with: definition -->
           <!-- ko component: {
@@ -45,16 +45,16 @@ const TEMPLATE = `
               docDefinition: $data
             }
           } --><!-- /ko -->
-          <div class="row-fluid" data-bind="visible: !$parent.hasErrors()" style="max-height: 114px;" id="scrolldiv">
+          <div class="row-fluid" data-bind="visible: !$parent.hasErrors()"  id="scrolldiv">
             <div class="span6">
               <h4 class="muted" style="margin-top: 0">${ I18n('Read') }</h4>
               <div data-bind="visible: (perms.read.users.length == 0 && perms.read.groups.length == 0)">${ I18n('The document is not shared for read.') }</div>
-              <ul class="unstyled airy" data-bind="foreach: perms.read.users">
+              <ul class="unstyled airy" style="max-height: 20vh; overflow-x:auto;" data-bind="foreach: perms.read.users">
                 <li>
                   <span class="badge badge-info" data-bind="css: { 'badge-left' : $parents[1].fileEntry.canModify() }"><i class="fa fa-user"></i> <span data-bind="text: $parents[1].prettifyUsernameById(id), attr:{'data-id': id}"></span></span><span class="badge badge-right trash-share" data-bind="visible: $parents[1].fileEntry.canModify(), click: function() { $parents[1].removeUserReadShare($data) }"> <i class="fa fa-times"></i></span>
                 </li>
               </ul>
-              <ul class="unstyled airy" data-bind="foreach: perms.read.groups">
+              <ul class="unstyled airy" style="max-height: 20vh; overflow-x:auto;" data-bind="foreach: perms.read.groups">
                 <li>
                   <span class="badge badge-info" data-bind="css: { 'badge-left' : $parents[1].fileEntry.canModify() }"><i class="fa fa-users"></i> ${ I18n('Group') } &quot;<span data-bind="text: name"></span>&quot;</span><span class="badge badge-right trash-share" data-bind="visible: $parents[1].fileEntry.canModify(), click: function() { $parents[1].removeGroupReadShare($data) }"> <i class="fa fa-times"></i></span>
                 </li>
@@ -64,7 +64,7 @@ const TEMPLATE = `
             <div class="span6">
               <h4 class="muted" style="margin-top: 0">${ I18n('Modify') }</h4>
               <div data-bind="visible: (perms.write.users.length == 0 && perms.write.groups.length == 0)">${ I18n('The document is not shared for modify.') }</div>
-              <ul class="unstyled airy" data-bind="foreach: perms.write.users">
+              <ul class="unstyled airy" style="max-height: 20vh; overflow-x:auto;" data-bind="foreach: perms.write.users">
                 <li>
                   <span class="badge badge-info badge-left" data-bind="css: { 'badge-left' : $parents[1].fileEntry.canModify() }">
                     <i class="fa fa-user">
@@ -77,7 +77,7 @@ const TEMPLATE = `
                   </span>
                 </li>
               </ul>
-              <ul class="unstyled airy" data-bind="foreach: perms.write.groups">
+              <ul class="unstyled airy" style="max-height: 20vh; overflow-x:auto;" data-bind="foreach: perms.write.groups">
                 <li>
                   <span class="badge badge-info badge-left" data-bind="css: { 'badge-left' : $parents[1].fileEntry.canModify() }">
                     <i class="fa fa-users"></i> ${ I18n('Group') } &quot;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removed the fixed height of the modal body and a div in the body that caused the overflow to happen already for a small selection. The modal will now grow with its content like normal bootstrap modals. The panels for selected users and groups will grow with each selected item until they reach 20% of the viewport and then get individual scrollbars.

## How was this patch tested?

Manual testing in chrome by adding multiple users/groups (actually by manually modifying the DOM in the browser since my cluster only had 3 users and 1 group).

Few selections scenario:
![image](https://user-images.githubusercontent.com/5167091/195698204-e181e863-bb5d-4423-a226-f5e728785db6.png)

Scenario with many users selected with read access:
![image](https://user-images.githubusercontent.com/5167091/195698453-08390372-b85f-48f5-b67f-c3a9625c8ec5.png)

Extreme scenario, many groups and users selected for different access:
![image](https://user-images.githubusercontent.com/5167091/195698739-cc4fbd8d-7823-4f3a-8e71-14b3f1d72533.png)



Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
