### PR TITLE
Upgrading protobuf python module to 3.20.3 version

### DIFF
--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -45,7 +45,7 @@ openpyxl==3.0.9
 pandas==1.4.2
 phoenixdb==1.2.0
 prompt-toolkit==2.0.10
-protobuf==3.17.0
+protobuf==3.20.3
 pyformance==0.3.2
 pylint==2.6.0
 pylint-django==2.3.0


### PR DESCRIPTION
(cherry picked from commit 51c4882b230b7b5b6273eee7faa13fe7e5865936)

## What changes were proposed in this pull request?

- To fix CVE-2022-1941

## How was this patch tested?

- manual

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
