### PR TITLE
Add DELETE to suggestKeywords of generic parser (fixes  #2983)

### DIFF
--- a/desktop/core/src/desktop/js/parse/sql/generic/sqlParseSupport.js
+++ b/desktop/core/src/desktop/js/parse/sql/generic/sqlParseSupport.js
@@ -1005,6 +1005,7 @@ const initSqlParser = function (parser) {
     let keywords = [
       'ALTER',
       'CREATE',
+      'DELETE',
       'DESCRIBE',
       'DROP',
       'GRANT',


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add DELETE to suggestKeywords of generic parser to resolve #2983

## How was this patch tested?

No tests, as the change was simply to add DELETE to a keywords array.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
