### PR TITLE
[api] Add user home directory in /get_filesystems API

### DIFF
--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -43,6 +43,20 @@ def error_handler(view_fn):
 
 @error_handler
 def get_filesystems(request):
+  response = {}
+
+  filesystems = {}
+  for k in fsmanager.get_filesystems(request.user):
+    filesystems[k] = True
+
+  response['status'] = 0
+  response['filesystems'] = filesystems
+
+  return JsonResponse(response)
+
+
+@error_handler
+def get_filesystems_with_home_dirs(request): # Using as a public API only for now
   filesystems = []
   user_home_dir = ''
 
@@ -55,9 +69,8 @@ def get_filesystems(request):
       user_home_dir = get_home_dir_for_abfs(request.user)
 
     filesystems.append({
-      fs: {
-        'user_home_directory': user_home_dir,
-      }
+      'file_system': fs,
+      'user_home_directory': user_home_dir,
     })
 
   return JsonResponse(filesystems, safe=False)

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -43,7 +43,6 @@ def error_handler(view_fn):
 
 @error_handler
 def get_filesystems(request):
-  response = {}
   filesystems = []
   user_home_dir = ''
 
@@ -61,5 +60,4 @@ def get_filesystems(request):
       }
     })
 
-  response['filesystems'] = filesystems
-  return JsonResponse(response)
+  return JsonResponse(filesystems, safe=False)

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -21,7 +21,8 @@ from desktop.lib.django_util import JsonResponse
 from desktop.lib import fsmanager
 from desktop.lib.i18n import smart_unicode
 
-from aws.conf import has_s3_access
+from azure.abfs.__init__ import get_home_dir_for_abfs
+from aws.s3.s3fs import get_s3_home_directory
 
 
 LOG = logging.getLogger(__name__)
@@ -43,12 +44,22 @@ def error_handler(view_fn):
 @error_handler
 def get_filesystems(request):
   response = {}
+  filesystems = []
+  user_home_dir = ''
 
-  filesystems = {}
-  for k in fsmanager.get_filesystems(request.user):
-    filesystems[k] = True
+  for fs in fsmanager.get_filesystems(request.user):
+    if fs == 'hdfs':
+      user_home_dir = request.user.get_home_directory()
+    elif fs == 's3a':
+      user_home_dir = get_s3_home_directory(request.user)
+    elif fs == 'abfs':
+      user_home_dir = get_home_dir_for_abfs(request.user)
 
-  response['status'] = 0
+    filesystems.append({
+      fs: {
+        'user_home_directory': user_home_dir,
+      }
+    })
+
   response['filesystems'] = filesystems
-
   return JsonResponse(response)

--- a/apps/filebrowser/src/filebrowser/urls.py
+++ b/apps/filebrowser/src/filebrowser/urls.py
@@ -61,5 +61,5 @@ urlpatterns = [
 
 # API
 urlpatterns += [
-  re_path(r'^api/get_filesystems/?', filebrowser_api.get_filesystems, name='get_filesystems'),
+  re_path(r'^api/get_filesystems/?', filebrowser_api.get_filesystems_with_home_dirs, name='get_filesystems'),
 ]

--- a/apps/filebrowser/src/filebrowser/urls.py
+++ b/apps/filebrowser/src/filebrowser/urls.py
@@ -61,5 +61,5 @@ urlpatterns = [
 
 # API
 urlpatterns += [
-  re_path(r'^api/get_filesystems/?', filebrowser_api.get_filesystems_with_home_dirs, name='get_filesystems'),
+  re_path(r'^api/get_filesystems/?', filebrowser_api.get_filesystems, name='get_filesystems'),
 ]

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -192,7 +192,7 @@ def analyze_table(request, dialect, database, table, columns=None):
 @api_view(["POST"])
 def storage_get_filesystems(request):
   django_request = get_django_request(request)
-  return filebrowser_api.get_filesystems(django_request)
+  return filebrowser_api.get_filesystems_with_home_dirs(django_request)
 
 @api_view(["GET"])
 def storage_view(request, path):


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Improve the current /get_filesystem API to add user home directory for each filesystem.
- Remove response status code for cleaner API.

### Sample response:
```json
[{"file_system": "hdfs", "user_home_directory": "/user/demo"}, {"file_system": "s3a", "user_home_directory": "s3a://<some_s3_path>"}, {"file_system": "abfs", "user_home_directory": "abfs://<some_abfs_path>"}]
```

## How was this patch tested?

- Manually tested in local Hue setup.
