### PR TITLE
[filebrowser] Check for abfs:// in remote_storage_home and remove RAZ check

### DIFF
--- a/desktop/libs/azure/src/azure/abfs/__init__.py
+++ b/desktop/libs/azure/src/azure/abfs/__init__.py
@@ -182,10 +182,10 @@ def get_home_dir_for_abfs(user=None):
   except:
     remote_home_abfs = 'abfs://'
 
-  # Check from remote_storage_home config only for RAZ env
-  if RAZ.IS_ENABLED.get() and hasattr(REMOTE_STORAGE_HOME, 'get') and REMOTE_STORAGE_HOME.get():
+  if hasattr(REMOTE_STORAGE_HOME, 'get') and REMOTE_STORAGE_HOME.get() and REMOTE_STORAGE_HOME.get().startswith('abfs://'):
     remote_home_abfs = REMOTE_STORAGE_HOME.get()
-    remote_home_abfs = _handle_user_dir_raz(user, remote_home_abfs)
+
+  remote_home_abfs = _handle_user_dir_raz(user, remote_home_abfs)
 
   return remote_home_abfs
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- RAZ check is done when handling user directories, so this method is much cleaner now.

## How was this patch tested?

- Manually tested in local Hue setup. Needs to be tested E2E in Raz cluster setup.