### PR TITLE
[fb] Prevent decoding of already decoded path in the File Browser

### DIFF
--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -144,9 +144,10 @@ def index(request):
 
 
 def _normalize_path(path):
-  decoded_path = unquote_url(path)
-  if path != decoded_path:
-    path = decoded_path
+  # Prevent decoding of already decoded path, every path contains a '/' which would be encoded to %2F, hence
+  # if / is present it means that it's already been decoded.
+  if '/' not in path:
+    path = unquote_url(path)
 
   # Check if protocol missing / and add it back (e.g. Kubernetes ingress can strip double slash)
   if path.startswith('abfs:/') and not path.startswith('abfs://'):


### PR DESCRIPTION
Currently decoding happens at least twice in views.py when requesting to view a folder, this causes an issue when files are stored with actual encoded values in the name.

An example is if a folder exists in hdfs with the name 'some%20folder', the UI would encode it and request 'some%2520folder' (% becomes %25), which if decoded once would be correct, 'some%20folder', but if it's done twice the resulting name would be 'some folder' with a space instead of %20 which is incorrect.

We can safely assume that each path contains a '/' char, so we can use that to check if a path has already been decoded. An encoded path would never contain a '/' as it would be %2F.

Tested both through the UI and with unit tests.