### PR TITLE
[left assist] adding download option in left for the documents

### DIFF
--- a/desktop/core/src/desktop/js/ko/components/assist/ko.assistDocumentsPanel.js
+++ b/desktop/core/src/desktop/js/ko/components/assist/ko.assistDocumentsPanel.js
@@ -53,6 +53,9 @@ const TEMPLATE = `
       'Share'
     )}</a></li>
     <!-- /ko -->
+    <li><a href="javascript: void(0);" data-bind="click: contextMenuDownload"><i class="fa fa-fw fa-download"></i> ${I18n(
+      'Download'
+    )}</a></li>
   </script>
 
   <script type="text/html" id="assist-document-header-actions">


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Download button added in the left assist for the the documents

## How was this patch tested?

- Manually
