### PR TITLE
[ui_analytics] prevent incorrect log calls to the backend and GA

### DIFF
--- a/desktop/core/src/desktop/js/utils/hueAnalytics.test.ts
+++ b/desktop/core/src/desktop/js/utils/hueAnalytics.test.ts
@@ -91,6 +91,65 @@ describe('hueAnalytics', () => {
     });
   });
 
+  it('should not log to backend or GA with incorrect parameters', () => {
+    const gtagSpy = jest.fn();
+    getLastKnownConfigMock.mockImplementation(() => {
+      return { hue_config: { collect_usage: true } };
+    });
+
+    windowSpy.mockImplementation(() => ({
+      DEV: false,
+      gtag: gtagSpy
+    }));
+
+    windowSpy.mockImplementation(() => ({}));
+
+    hueAnalytics.convert(null, 'action1');
+    hueAnalytics.convert(undefined, 'action1');
+    hueAnalytics.convert([], 'action1');
+    hueAnalytics.convert({}, 'action1');
+    hueAnalytics.convert(NaN, 'action1');
+    hueAnalytics.convert(1, 'action1');
+    hueAnalytics.convert(true, 'action1');
+    hueAnalytics.convert(new Date(), 'action1');
+    hueAnalytics.convert(BigInt(1), 'action1');
+    hueAnalytics.convert(Symbol(), 'action1');
+    hueAnalytics.convert('area1', null);
+    hueAnalytics.convert('area1', undefined);
+    hueAnalytics.convert('area1', []);
+    hueAnalytics.convert('area1', {});
+    hueAnalytics.convert('area1', NaN);
+    hueAnalytics.convert('area1', 1);
+    hueAnalytics.convert('area1', true);
+    hueAnalytics.convert('area1', new Date());
+    hueAnalytics.convert('area1', BigInt(1));
+    hueAnalytics.convert('area1', Symbol());
+
+    hueAnalytics.log(null, 'action1');
+    hueAnalytics.log(undefined, 'action1');
+    hueAnalytics.log([], 'action1');
+    hueAnalytics.log({}, 'action1');
+    hueAnalytics.log(NaN, 'action1');
+    hueAnalytics.log(1, 'action1');
+    hueAnalytics.log(true, 'action1');
+    hueAnalytics.log(new Date(), 'action1');
+    hueAnalytics.log(BigInt(1), 'action1');
+    hueAnalytics.log(Symbol(), 'action1');
+    hueAnalytics.log('area1', null);
+    hueAnalytics.log('area1', undefined);
+    hueAnalytics.log('area1', []);
+    hueAnalytics.log('area1', {});
+    hueAnalytics.log('area1', NaN);
+    hueAnalytics.log('area1', 1);
+    hueAnalytics.log('area1', true);
+    hueAnalytics.log('area1', new Date());
+    hueAnalytics.log('area1', BigInt(1));
+    hueAnalytics.log('area1', Symbol());
+
+    expect(gtagSpy).not.toHaveBeenCalled();
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+
   it('should use global listener to log clicks on element with attribute "data-hue-analytics"', () => {
     const gtagSpy = jest.fn();
     getLastKnownConfigMock.mockImplementation(() => {

--- a/desktop/core/src/desktop/views.py
+++ b/desktop/core/src/desktop/views.py
@@ -220,7 +220,11 @@ def log_js_error(request):
 
 def log_analytics(request):
   ai = AccessInfo(request)
-  ai.log(level=logging.INFO, msg='UI INTERACTION: ' + request.POST.get('area') + ' > ' + request.POST.get('action'))
+  area = request.POST.get('area')
+  action = request.POST.get('action')
+
+  if area is not None and action is not None:
+    ai.log(level=logging.INFO, msg='UI INTERACTION: ' + area + ' > ' + action)
 
   return JsonResponse({'status': 0})
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added checks in the frontend and backend to prevent incorrect UI analytics logging parameters.

## How was this patch tested?

- Manual testing calling `window.hueAnalytics.convert` and `window.hueAnalytics.log` functions from console
- Additional unit tests

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
