### PR TITLE
Webcomponent wrapper unmounted

### DIFF
--- a/desktop/core/src/desktop/js/vue/wrapper/index.ts
+++ b/desktop/core/src/desktop/js/vue/wrapper/index.ts
@@ -212,7 +212,7 @@ export default function wrap(
     }
 
     disconnectedCallback() {
-      callHooks(this._component, 'unmounted');
+      this._wrapper.unmount();
     }
   }
 


### PR DESCRIPTION
In our application `vue3-webcomponent-wrapper` triggers an error in `vue-i18n` when a web component is removed from the DOM. The problem seems to be, that `vue-i18n`'s unmounted method is unable to retrieve the current vue instance and thereby [fails with a syntax error](https://github.com/intlify/vue-i18n-next/blob/0da16ade4289d0b9b5e8eddaf9d1be53e4d0d0e9/packages/vue-i18n-core/src/mixins/next.ts#L129-L134). vue-i18n uses the `getCurrentInstance` method in their unmounted hook. The method seems to be [undocumented](https://stackoverflow.com/a/72209340/7451049) but works. The fact that vue3-webcomponent-wrapper [calls the `unmounted` methods manually](https://github.com/naltatis/hue/blob/89c23c4151d9b4ce451991b06e81b005b84edce1/desktop/core/src/desktop/js/vue/wrapper/utils.ts#L26-L32) seems to produce an issue here.

_Note: We might have the same issue with `callHooks(this._component, 'mounted');`. But since I was not able to produce an example running into this case I've only altered the `unmounted` case._

## What changes were proposed in this pull request?

Use the documented `app.unmount()` API instead of invoking the `unmounted` hooks of the component directly.

## How was this patch tested?

I've created this [Stackblitz](https://stackblitz.com/edit/vitejs-vite-tm1bzs) to reproduce the error and also show, that the patched version fixes it.

//cc @kazupon