### PR TITLE
[frontend] Prepend the base url to the href in the hueLink binding

### DIFF
--- a/desktop/core/src/desktop/js/ko/bindings/ko.hueLink.js
+++ b/desktop/core/src/desktop/js/ko/bindings/ko.hueLink.js
@@ -48,7 +48,10 @@ ko.bindingHandlers.hueLink = {
   update: function (element, valueAccessor) {
     const url = ko.unwrap(valueAccessor());
     if (url) {
-      $(element).attr('href', '/hue' + (url.indexOf('/') === 0 ? url : '/' + url));
+      $(element).attr(
+        'href',
+        window.HUE_BASE_URL + '/hue' + (url.indexOf('/') === 0 ? url : '/' + url)
+      );
     } else {
       $(element).attr('href', 'javascript: void(0);');
     }


### PR DESCRIPTION
This takes care of an issue where right-click and choosing "Open in a new tab" doesn't take the base url into account.

cmd/ctrl-click works as that is handled by the click event handler on the element (init function of the binding)

Manually tested
