### PR TITLE
Hue - After upgrading thrift-0.16.0 version, Hue gets following error,

### DIFF
--- a/desktop/core/ext-py/thrift-0.16.0/src/transport/TSocket.py
+++ b/desktop/core/ext-py/thrift-0.16.0/src/transport/TSocket.py
@@ -94,6 +94,10 @@ class TSocket(TSocketBase):
                 if exc.errno in (errno.EWOULDBLOCK, errno.EAGAIN):
                     return True
                 return False
+            except ValueError as e:
+                logger.debug(e)
+                # SSLSocket fails on recv with non-zero flags; fallback to the old behavior
+                return True
         finally:
             self.handle.settimeout(original_timeout)
 

--- a/desktop/core/ext-py/thrift-0.16.0/test/test_socket.py
+++ b/desktop/core/ext-py/thrift-0.16.0/test/test_socket.py
@@ -25,6 +25,7 @@ class TSocketTest(unittest.TestCase):
             acc.start()
 
             sock = TSocket(host="localhost", port=acc.port)
+            self.assertFalse(sock.isOpen())
             sock.open()
             sock.setTimeout(timeout)
 

--- a/desktop/core/ext-py/thrift-0.16.0/test/test_sslsocket.py
+++ b/desktop/core/ext-py/thrift-0.16.0/test/test_sslsocket.py
@@ -158,7 +158,9 @@ class TSSLSocketTest(unittest.TestCase):
     def _assert_connection_success(self, server, path=None, **client_args):
         with self._connectable_client(server, path=path, **client_args) as (acc, client):
             try:
+                self.assertFalse(client.isOpen())
                 client.open()
+                self.assertTrue(client.isOpen())
                 client.write(b"hello")
                 self.assertEqual(client.read(5), b"there")
                 self.assertTrue(acc.client is not None)


### PR DESCRIPTION
non-zero flags not allowed in calls to recv

(cherry picked from commit 9b1bc2802208f3fc401ded40ffb676f20083fc5a)

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
