### PR TITLE
[raz] Retry some failed ABFS calls once again

### DIFF
--- a/desktop/core/src/desktop/lib/rest/raz_http_client.py
+++ b/desktop/core/src/desktop/lib/rest/raz_http_client.py
@@ -81,7 +81,7 @@ class RazHttpClient(HttpClient):
     except Exception as e:
       LOG.debug('ABFS Exception: ' + str(e))
 
-      # Only retrying idempotent operations once.
+      # Only retrying safe operations once.
       if http_method in ('HEAD', 'GET') and e.code == 403: 
         LOG.debug('Retrying same operation again for path: %s' % path)
         retry -= 1

--- a/desktop/core/src/desktop/lib/rest/raz_http_client.py
+++ b/desktop/core/src/desktop/lib/rest/raz_http_client.py
@@ -82,8 +82,8 @@ class RazHttpClient(HttpClient):
       LOG.debug('ABFS Exception: ' + str(e))
 
       # Only retrying idempotent operations once.
-      if http_method in ('HEAD', 'GET'): 
-        LOG.debug('Retrying same operation again for path %s' % path)
+      if http_method in ('HEAD', 'GET') and e.code == 403: 
+        LOG.debug('Retrying same operation again for path: %s' % path)
         retry -= 1
         return self.execute(
             http_method=http_method, 
@@ -99,6 +99,9 @@ class RazHttpClient(HttpClient):
             timeout=timeout, 
             retry=retry
         )
+      else:
+        # Re-raise all other exceptions to be handled later for other operations such as rename.
+        raise e
 
   def get_sas_token(self, http_method, username, url, params=None, headers=None):
     raz_client = AdlsRazClient(username=username)


### PR DESCRIPTION
## What does this PR do?

- Sometimes correct ABFS calls with correct params and having a SAS token from RAZ failed with a 403 signature mismatch error intermittently.
- This gives a bad user experience for someone browsing the ABFS file browser.
- We are now retrying such operation for one more time as a workaround time so that they execute successfully (since this issue is intermittent). 
- However, the real reason of call failure might be because of some problem with the generated SAS token from RAZ.

## How was this tested?

- Tested E2E manually in a live cluster.