### PR TITLE
Webcomponent Wrapper (re-)mount fix

### DIFF
--- a/desktop/core/src/desktop/js/vue/wrapper/index.ts
+++ b/desktop/core/src/desktop/js/vue/wrapper/index.ts
@@ -36,7 +36,6 @@ import {
   toVNodes,
   camelize,
   hyphenate,
-  callHooks,
   setInitialProps,
   createCustomEvent,
   convertAttributeValue
@@ -85,7 +84,7 @@ export default function wrap(
   }
 
   class CustomElement extends HTMLElement {
-    _wrapper: App;
+    _wrapper?: App;
     _component?: ComponentPublicInstance;
 
     _props!: KeyHash;
@@ -95,26 +94,8 @@ export default function wrap(
     constructor() {
       super();
 
-      const eventProxies = this.createEventProxies(<string[]>componentObj.emits);
-
       this._props = {};
       this._slotChildren = [];
-
-      // eslint-disable-next-line @typescript-eslint/no-this-alias
-      const self = this;
-      this._wrapper = createApp({
-        render() {
-          const props = Object.assign({}, self._props, eventProxies);
-          delete props.dataVApp;
-          return h(componentObj, props, () => self._slotChildren);
-        },
-        mounted() {
-          self._mounted = true;
-        },
-        unmounted() {
-          self._mounted = false;
-        }
-      });
 
       // Use MutationObserver to react to future attribute & slot content change
       const observer = new MutationObserver(mutations => {
@@ -191,28 +172,42 @@ export default function wrap(
     }
 
     connectedCallback() {
-      if (!this._component || !this._mounted) {
-        if (isInitialized) {
-          // initialize attributes
-          this.syncInitialAttributes();
-        }
-
-        // initialize children
-        this.syncSlots();
-
-        // Mount the component
-        this._component = this._wrapper.mount(this);
-      } else {
-        // Call mounted on re-insert
-        callHooks(this._component, 'mounted');
+      if (isInitialized) {
+        // initialize attributes
+        this.syncInitialAttributes();
       }
+
+      const eventProxies = this.createEventProxies(<string[]>componentObj.emits);
+
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      const self = this;
+      this._wrapper = createApp({
+        render() {
+          const props = Object.assign({}, self._props, eventProxies);
+          delete props.dataVApp;
+          return h(componentObj, props, () => self._slotChildren);
+        },
+        mounted() {
+          self._mounted = true;
+        },
+        unmounted() {
+          self._mounted = false;
+        }
+      });
+
+      // initialize children
+      this.syncSlots();
+
+      // Mount the component
+      this._component = this._wrapper.mount(this);
+
       if (options?.connectedCallback) {
         options.connectedCallback.bind(this)();
       }
     }
 
     disconnectedCallback() {
-      this._wrapper.unmount();
+      this._wrapper?.unmount();
     }
   }
 

--- a/desktop/core/src/desktop/js/vue/wrapper/utils.ts
+++ b/desktop/core/src/desktop/js/vue/wrapper/utils.ts
@@ -1,4 +1,4 @@
-import { ComponentPublicInstance, VNode } from 'vue';
+import { VNode } from 'vue';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type KeyHash = { [key: string]: any };
@@ -19,18 +19,6 @@ export function setInitialProps(propsList: string[]): KeyHash {
     res[key] = undefined;
   });
   return res;
-}
-
-export function callHooks(vm: ComponentPublicInstance | undefined, hook: string): void {
-  if (vm) {
-    let hooks = vm.$options[hook] || [];
-    if (!Array.isArray(hooks)) {
-      hooks = [hooks];
-    }
-    hooks.forEach((hook: () => void): void => {
-      hook.call(vm);
-    });
-  }
 }
 
 export function createCustomEvent(name: string, args: unknown[]): CustomEvent {


### PR DESCRIPTION
In https://github.com/cloudera/hue/pull/3102 I provided a fix for the broken unmount behaviour and mentioned that we might also have an issue in the mount case. Now we ran into exactly this issue. This PR includes the fix for the case where you create a custom element, attach it to the DOM, remove and then re-add it. In our application we have situations where the host app (also Vue) decides to briefly remove a web component from the DOM and reattaches it a few moments later.

I've isolated the issue in this [Stackblitz](https://stackblitz.com/edit/vitejs-vite-syzsx9?file=src%2Fmain.js). The problem seems to be, that it's not possible to unmount and then re-mount a Vue 3 Application. Once it's unmounted you have to recreate it.

## What changes were proposed in this pull request?

- `connectedCallback` now always creates a Vue instance and mounts it. Before creation was done once in the constructor.

## How was this patch tested?

Here you can find a side by side comparison of the current and patched version of the webcomponent wrapper. In the current version it's not possible to reattach the component to the DOM once it has been removed.
https://stackblitz.com/edit/vitejs-vite-syzsx9?file=src%2Fmain.js