### PR TITLE
Remove impyla from pip install. It fix hue's impala import issue

### DIFF
--- a/tools/docker/hue/Dockerfile
+++ b/tools/docker/hue/Dockerfile
@@ -69,8 +69,6 @@ RUN ./build/env/bin/pip install --no-cache-dir \
   flower==0.9.7 \
   # Contains fix for SparkSql show tables \
   git+https://github.com/gethue/PyHive \
-  # pyhive \
-  impyla==0.17.0 \
   #ksql \
   git+https://github.com/bryanyang0528/ksql-python \
   pydruid \


### PR DESCRIPTION
## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
