### PR TITLE
[backend/file-browser] Force cache validation for file download

### DIFF
--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -203,6 +203,7 @@ def download(request, path):
     setattr(response, 'redirect_override', True)
   else:
     response = StreamingHttpResponse(file_reader(fh), content_type=content_type)
+    response["Cache-Control"] = 'no-cache' # Browsers must not cache files but always download
     response["Last-Modified"] = http_date(stats['mtime'])
     response["Content-Length"] = stats['size']
     response['Content-Disposition'] = request.GET.get('disposition', 'attachment; filename="' + stats['name'] + '"') \


### PR DESCRIPTION
In the files-download, we were always setting the 'Last-Modified' header for the downloaded files. Since, we were not providing the expiration, the browser was not being forced to verify for a new versions and are free to use their own heuristics. See the Caching RFC for more details https://www.rfc-editor.org/rfc/rfc7234#section-4.2.2

This commit adds the 'must-revalidate' to force the browsers to verify the files everytime.