### PR TITLE
[frontent] use executable.id to compare executables in charts of edit…

### DIFF
--- a/desktop/core/src/desktop/js/apps/editor/components/resultChart/ko.resultChart.js
+++ b/desktop/core/src/desktop/js/apps/editor/components/resultChart/ko.resultChart.js
@@ -584,7 +584,7 @@ class ResultChart extends DisposableComponent {
     };
 
     this.subscribe(EXECUTABLE_RESULT_UPDATED_TOPIC, executionResult => {
-      if (this.activeExecutable() === executionResult.executable) {
+      if (this.activeExecutable()?.id === executionResult?.executable?.id) {
         handleResultChange();
       }
     });


### PR DESCRIPTION
…or v2

## What changes were proposed in this pull request?

- Compare on id instead of object when rendering charts in v2 editor

## How was this patch tested?

- Manually by executing a query and clicking the chart tab
- Clicking on different statements in the editor will update the chart accordingly

![image](https://user-images.githubusercontent.com/5167091/209148698-855b15f2-1288-4ddd-b600-84edc35d16fd.png)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
