### PR TITLE
Fix aws region attribute in values.yaml

### DIFF
--- a/tools/kubernetes/helm/hue/values.yaml
+++ b/tools/kubernetes/helm/hue/values.yaml
@@ -71,7 +71,7 @@ ingress:
 aws:
   accessKeyId: ""
   secretAccessKey: ""
-  awsRegion: "us-east-1"
+  region: "us-east-1"
 hive:
   site: |
     <!--


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Fix aws region attribute in values.yaml

## How was this patch tested?
- Manual

There seems to be a typo in helm chart values.yaml.
configmap-hue yaml has a .Values.aws.**region**

please review.