### PR TITLE
[frontend] Add knox prefix to download url

### DIFF
--- a/desktop/core/src/desktop/js/onePageViewModel.js
+++ b/desktop/core/src/desktop/js/onePageViewModel.js
@@ -894,7 +894,8 @@ class OnePageViewModel {
         // The download view on the backend requires the slashes not to
         // be encoded in order for the file to be correctly named.
         const encodedPath = encodeURIComponent(decodedPath).replaceAll('%2F', '/');
-        window.location = pathPrefix + encodedPath;
+        const possibleKnoxUrlPathPrefix = window.HUE_BASE_URL;
+        window.location = possibleKnoxUrlPathPrefix + pathPrefix + encodedPath;
         return;
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Modify the single point file download function to include knox prefix in the url

## How was this patch tested?

- Manually locally to make sure it works when knox is not present
- On a datahub test cluster with knox present by directly modifying the js file in the browser to use the same fix

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
