### PR TITLE
[raz] Check py version before unicode type check for non-ascii dir creation

### DIFF
--- a/desktop/core/src/desktop/lib/raz/raz_client.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client.py
@@ -245,7 +245,7 @@ class RazClient(object):
     # In GET operations with non-ascii chars, only the non-ascii part is URL encoded.
     # We need to unquote the path fully before making a signed request for RAZ.
     if method == 'GET' and 'prefix' in url_params and '%' in url_params['prefix']:
-      if isinstance(url_params['prefix'], unicode) and sys.version_info[0] < 3:
+      if sys.version_info[0] < 3 and isinstance(url_params['prefix'], unicode):
         url_params['prefix'] = url_params['prefix'].encode()
 
       url_params['prefix'] = lib_urlunquote(url_params['prefix'])


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Checking python version first and then the type of prefix if its unicode or not.
- This is required because python3 doesn't recognize unicode keyword, it is only done via python2.
- So checking the python version first will short-circuit the if condition because it will be False beforehand for py3 and type check of prefix for unicode will not happen.
