### PR TITLE
[docs] Remove dead MySQL JDBC connector and Font Awesome 3 links

### DIFF
--- a/docs/docs-site/content/administrator/configuration/apps/_index.md
+++ b/docs/docs-site/content/administrator/configuration/apps/_index.md
@@ -245,7 +245,7 @@ The “rdbms” interface works great for MySQL, PostgreSQL, SQLite, and Oracle,
 
 Integrating an external JDBC database involves a 3-step process:
 
-Download the compatible client driver JAR file for your specific OS and database. Usually you can find the driver files from the official database vendor site; for example, the MySQL JDBC connector for Mac OSX can be found here: https://dev.mysql.com/downloads/.
+Download the compatible client driver JAR file for your specific OS and database. Usually you can find the driver files from the official database vendor site.
 
 **Note**: In the case of MySQL, the JDBC driver is platform independent, but some drivers are specific to certain OSes and versions so be sure to verify compatibility.)
 Add the path to the driver JAR file to your Java CLASSPATH. Here, we set the CLASSPATH environment variable in our `.bash_profile` script.

--- a/docs/docs-site/content/administrator/configuration/apps/_index.md
+++ b/docs/docs-site/content/administrator/configuration/apps/_index.md
@@ -245,7 +245,7 @@ The “rdbms” interface works great for MySQL, PostgreSQL, SQLite, and Oracle,
 
 Integrating an external JDBC database involves a 3-step process:
 
-Download the compatible client driver JAR file for your specific OS and database. Usually you can find the driver files from the official database vendor site; for example, the MySQL JDBC connector for Mac OSX can be found here: https://dev.mysql.com/downloads/connector/j/.
+Download the compatible client driver JAR file for your specific OS and database. Usually you can find the driver files from the official database vendor site; for example, the MySQL JDBC connector for Mac OSX can be found here: https://dev.mysql.com/downloads/.
 
 **Note**: In the case of MySQL, the JDBC driver is platform independent, but some drivers are specific to certain OSes and versions so be sure to verify compatibility.)
 Add the path to the driver JAR file to your Java CLASSPATH. Here, we set the CLASSPATH environment variable in our `.bash_profile` script.

--- a/docs/docs-site/content/developer/development/_index.md
+++ b/docs/docs-site/content/developer/development/_index.md
@@ -473,7 +473,7 @@ variable. The `create_desktop_app` command creates a default icon for you.
 
 **NOTE:** If you do not define an application icon, your application will not show up in the navigation bar.
 
-Hue ships with Twitter Bootstrap and Font Awesome 3 so you have plenty of scalable icons to choose from. You can style your elements to use them like this (in your mako template):
+Hue ships with Twitter Bootstrap and Font Awesome 4 so you have plenty of scalable icons to choose from. You can style your elements to use them like this (in your mako template):
 
     <!-- show a trash icon in a link -->
     <a href="#something"><i class="icon-trash"></i> Trash</a>

--- a/docs/docs-site/content/developer/development/_index.md
+++ b/docs/docs-site/content/developer/development/_index.md
@@ -473,7 +473,7 @@ variable. The `create_desktop_app` command creates a default icon for you.
 
 **NOTE:** If you do not define an application icon, your application will not show up in the navigation bar.
 
-Hue ships with Twitter Bootstrap and Font Awesome 3 (https://fontawesome.com/v3/) so you have plenty of scalable icons to choose from. You can style your elements to use them like this (in your mako template):
+Hue ships with Twitter Bootstrap and Font Awesome 3 so you have plenty of scalable icons to choose from. You can style your elements to use them like this (in your mako template):
 
     <!-- show a trash icon in a link -->
     <a href="#something"><i class="icon-trash"></i> Trash</a>


### PR DESCRIPTION
## What changes were proposed in this pull request?

- The link is failing the documentation checks by giving a 403 error. Changing the link to fix the check.

## How was this patch tested?

- Github Preview and Hugo Serve