### PR TITLE
[api_public] Skip rewrite request user for AnonymousUser

### DIFF
--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -56,7 +56,8 @@ def get_context_namespaces(request, interface):
 @api_view(["GET"])
 @permission_classes([AllowAny])
 def get_banners(request):
-  return desktop_api.get_banners(request)
+  django_request = get_django_request(request)
+  return desktop_api.get_banners(django_request)
 
 # Editor
 
@@ -386,7 +387,8 @@ def _patch_operation_id_request(django_request):
 def get_django_request(request):
   django_request = request._request
 
-  django_request.user = rewrite_user(django_request.user)
+  if hasattr(django_request, 'user') and not django_request.user.is_anonymous:
+    django_request.user = rewrite_user(django_request.user)
 
   # Workaround ClusterMiddleware not being applied
   if django_request.path.startswith('/api/') and django_request.fs is None:


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Since the banner API is being accessed without authentication, it is done via AnonymousUser. Anonymous user cannot be re-written with other UserProfile related attributes.

## How was this patch tested?

- Manually tested hitting the public API for locally running Hue
- Existing unit test