### PR TITLE
Add x-forwarded-for header in hue's request to hive/impala

### DIFF
--- a/apps/beeswax/src/beeswax/server/hive_server2_lib.py
+++ b/apps/beeswax/src/beeswax/server/hive_server2_lib.py
@@ -677,6 +677,9 @@ class HiveServerClient(object):
 
     if self.query_server['server_name'] == 'beeswax': # All the time
       kwargs['configuration'].update({'hive.server2.proxy.user': user.username})
+      xff_header = json.loads(user.userprofile.json_data).get('HTTP-X-FORWARDED-FOR', None)
+      if xff_header:
+        kwargs['configuration'].update({'HTTP-X-FORWARDED-FOR': xff_header})
 
     if self.query_server['server_name'] == 'hplsql' or interpreter['dialect'] == 'hplsql': # All the time
       kwargs['configuration'].update({'hive.server2.proxy.user': user.username, 'set:hivevar:mode': 'HPLSQL'})
@@ -689,6 +692,9 @@ class HiveServerClient(object):
 
     if self.query_server.get('dialect') == 'impala' and self.query_server['SESSION_TIMEOUT_S'] > 0:
       kwargs['configuration'].update({'idle_session_timeout': str(self.query_server['SESSION_TIMEOUT_S'])})
+      xff_header = json.loads(user.userprofile.json_data).get('HTTP-X-FORWARDED-FOR', None)
+      if xff_header:
+        kwargs['configuration'].update({'HTTP-X-FORWARDED-FOR': xff_header})
 
     LOG.info('Opening %s thrift session for user %s' % (self.query_server['server_name'], user.username))
 

--- a/desktop/core/src/desktop/management/commands/rungunicornserver.py
+++ b/desktop/core/src/desktop/management/commands/rungunicornserver.py
@@ -151,6 +151,7 @@ def argprocessing(args=[], options={}):
 def rungunicornserver(args=[], options={}):
   gunicorn_options = {
       'accesslog': "-",
+      'access_log_format': "%({x-forwarded-for}i)s %(h)s %(l)s %(u)s %(t)s '%(r)s' %(s)s %(b)s '%(f)s' '%(a)s'",
       'backlog': 2048,
       'bind': [options['bind_addr']],
       'ca_certs': conf.SSL_CACERTS.get(),     # CA certificates file

--- a/desktop/core/src/desktop/middleware.py
+++ b/desktop/core/src/desktop/middleware.py
@@ -948,4 +948,8 @@ class MultipleProxyMiddleware:
         if ',' in request.META[field]:
           parts = request.META[field].split(',')
           request.META[field] = parts[-1].strip()
+
+    if 'HTTP_X_FORWARDED_FOR' not in request.META and 'REMOTE_ADDR' in request.META:
+      request.META['HTTP_X_FORWARDED_FOR'] = request.META['REMOTE_ADDR']
+
     return self.get_response(request)

--- a/tools/container/huelb/hue_httpd_template
+++ b/tools/container/huelb/hue_httpd_template
@@ -12,7 +12,7 @@ ErrorLog "${HUE_LOG_DIR}/httpd_error_log"
 LogLevel warn
 
 <IfModule log_config_module>
-  LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+  LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
   LogFormat "%h %l %u %t \"%r\" %>s %b" common
   CustomLog "${HUE_LOG_DIR}/httpd_access_log" common
 </IfModule>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added {x-forwarded-for} header to log client's IP address in hue load balancer and gunicorn logs. 
Added {x-forwarded-for} header to Thrift call made from hue to hive/impala.

## How was this patch tested?
Manual tests - Logs show up on cdw and 7.1.8 clusters.
HTTP-X-FORWARDED-FOR header is logged in Hive logs (which implies Hue has sent the XFF header to hive). 

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
