### PR TITLE
[backend/gunicorn] add configs for request header limits

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -94,6 +94,11 @@ http_500_debug_mode=false
 # This is available for the Impala service only currently. It is highly recommended to only point to a series of coordinator-only nodes only.
 # enable_smart_thrift_pool=false
 
+# Limits for request headers
+## limit_request_field_size=8190
+## limit_request_fields=100
+## limit_request_line=4094
+
 # Filename of SSL Certificate
 ## ssl_certificate=
 

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -99,6 +99,11 @@
   # This is available for the Impala service only currently. It is highly recommended to only point to a series of coordinator-only nodes only.
   # enable_smart_thrift_pool=false
 
+  # Limits for request headers
+  ## limit_request_field_size=8190
+  ## limit_request_fields=100
+  ## limit_request_line=4094
+
   # Filename of SSL Certificate
   ## ssl_certificate=
 

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -205,6 +205,27 @@ X_FRAME_OPTIONS = Config(
   type=str,
   default="SAMEORIGIN")
 
+LIMIT_REQUEST_FIELD_SIZE = Config(
+  key="limit_request_field_size",
+  help=_("This property specifies the maximum allowed size of an HTTP request header field."),
+  default=8190,
+  type=int
+)
+
+LIMIT_REQUEST_FIELDS = Config(
+  key="limit_request_fields",
+  help=_("This property specifies the maximum number of HTTP headers fields in a request."),
+  default=100,
+  type=int
+)
+
+LIMIT_REQUEST_LINE = Config(
+  key="limit_request_line",
+  help=_("This property specifies the maximum size of HTTP request line in bytes."),
+  default=4094,
+  type=int
+)
+
 SSL_CERTIFICATE = Config(
   key="ssl_certificate",
   help=_("Filename of SSL Certificate"),

--- a/desktop/core/src/desktop/management/commands/rungunicornserver.py
+++ b/desktop/core/src/desktop/management/commands/rungunicornserver.py
@@ -138,9 +138,9 @@ def rungunicornserver():
       'initgroups': None,
       'keepalive': 120,                       # seconds to wait for requests on a keep-alive connection.
       'keyfile': ssl_keyfile,                 # SSL key file
-      'limit_request_field_size': None,
-      'limit_request_fields': None,
-      'limit_request_line': None,
+      'limit_request_field_size': conf.LIMIT_REQUEST_FIELD_SIZE.get(),
+      'limit_request_fields': conf.LIMIT_REQUEST_FIELDS.get(),
+      'limit_request_line': conf.LIMIT_REQUEST_LINE.get(),
       'logconfig': None,
       'loglevel': 'info',
       'max_requests': 1200,                   # The maximum number of requests a worker will process before restarting.


### PR DESCRIPTION
The request header limits were hard-coded to None, resulting in gunicorn picking its own defaults. This commit extracts the three header related gunicorn params to conf while keeping the defaults. With this change, it is now possible to override the defaults.

Steps to reproduce:
1. Navigate to hue directly (without any load-balancer).
2. Keep the developer console of the browser open.
3. Select one of the GET server requests, such as `/api/editor/autocomplete/default/` and "Copy -> Copy as cURL".
4. Run the curl command from the console and it should go fine.
5. Now, edit the curl command to add a new test cookie with a 10k+ size value.
6. This request will fail.

Steps to verify:
1. Update the hue.ini to add the following 
    > [desktop]
    >   limit_request_field_size=0
    >   limit_request_fields=32768
    >   limit_request_line=8190
3. Restart the hue-server. The above config with set the limits to the maximum values supported by gunicorn.
4. The curl command with large cookie should now pass.