### PR TITLE
[celery] upgrading celery and virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ ifeq ($(PYTHON_VER),python2.7)
 	@$(SYS_PYTHON) $(VIRTUAL_BOOTSTRAP) $(VIRTUALENV_OPTS) --system-site-packages $(BLD_DIR_ENV)
 else ifeq ($(PYTHON_VER),python3.8)
 	@$(SYS_PYTHON) -m pip install --upgrade pip==22.2.2
-	@$(SYS_PIP) install virtualenv==20.16.5 virtualenv-make-relocatable==0.0.1
+	@$(SYS_PIP) install virtualenv==20.19.0 virtualenv-make-relocatable==0.0.1
 	@if [[ "ppc64le" == $(PPC64LE) ]]; then \
 	  $(SYS_PYTHON) -m venv $(BLD_DIR_ENV); \
 	 fi

--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -3,7 +3,7 @@ requests-gssapi==1.2.3
 asn1crypto==0.24.0
 avro-python3==1.8.2
 Babel==2.9.1
-celery[redis]==5.2.3
+celery[redis]==5.2.7
 cffi==1.15.0
 channels==3.0.3
 channels-redis==3.2.0


### PR DESCRIPTION
## What changes were proposed in this pull request?

- celery 5.2.3 requires setuptools<59.7.0,>=59.1.1 and these versions have CVE-2022-40897 hence we are upgrading celery to 5.2.7 (latest)
-  virtualenv 20.16.5 was restricting setuptools to 65.3.0 [PR](https://github.com/pypa/virtualenv/pull/2405/files ) hence need to upgrade to latest.  
