### PR TITLE
Hue ID Broker HA improvement

### DIFF
--- a/desktop/core/src/desktop/lib/idbroker/conf.py
+++ b/desktop/core/src/desktop/lib/idbroker/conf.py
@@ -53,7 +53,7 @@ def _handle_idbroker_ha(fs=None):
       id_broker_addr_list = id_broker_addr.split(',')
       for id_broker_addr in id_broker_addr_list:
         try:
-          response = requests.get(id_broker_addr + 'dt/knoxtoken/api/v1/token', auth=HTTPKerberosAuth(), verify=False)
+          response = requests.get(id_broker_addr.rstrip('/') + '/dt/knoxtoken/api/v1/token', auth=HTTPKerberosAuth(), verify=False)
         except Exception as e:
           if 'Name or service not known' in str(e):
             LOG.warn('IDBroker %s is not available for use' % id_broker_addr)


### PR DESCRIPTION
Previous commit for helped to address the issue if there were multiple id brokers in the core-site.  But with the new information it seems like the information which is added automatically to the core-site was missing the ending '/' which is causing the same issue,  this fix would address that.

## What changes were proposed in this pull request?
Added rstrip and placed '/dt' instead just 'dt'

## How was this patch tested?
Manually