### PR TITLE
[ci] Update apt cache before installing packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,6 +210,7 @@ commands:
 
             if [ -d /usr/share/hue ]; then
               # Running in gethue/hue Docker container
+              apt-get update
               apt-get install -y python3.8-dev python3.8-venv python3.8-distutils libsnappy-dev # This should not be needed as some point
               curl -sL https://bootstrap.pypa.io/get-pip.py | python3.8
             else


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hue PR build job failed https://app.circleci.com/pipelines/github/cloudera/hue/9379/workflows/eaeadec0-7b86-4dc8-a4c5-df11bc707fe6/jobs/16200

```
libsnappy-dev is already the newest version (1.1.7-1).
python3-distutils is already the newest version (3.6.9-1~18.04).
python3-distutils set to manually installed.
The following additional packages will be installed:
  libpython3.8 libpython3.8-dev libpython3.8-minimal libpython3.8-stdlib
  python-pip-whl python3.8 python3.8-minimal
Suggested packages:
  python3.8-doc binfmt-support
The following NEW packages will be installed:
  libpython3.8 libpython3.8-dev libpython3.8-minimal libpython3.8-stdlib
  python-pip-whl python3.8 python3.8-dev python3.8-minimal python3.8-venv
0 upgraded, 9 newly installed, 0 to remove and 20 not upgraded.
Need to get 62.7 MB of archives.
After this operation, 117 MB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 libpython3.8-minimal amd64 3.8.0-3ubuntu1~18.04.2 [704 kB]
Get:2 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 python3.8-minimal amd64 3.8.0-3ubuntu1~18.04.2 [1807 kB]
Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 libpython3.8-stdlib amd64 3.8.0-3ubuntu1~18.04.2 [1676 kB]
Get:4 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 libpython3.8 amd64 3.8.0-3ubuntu1~18.04.2 [1631 kB]
Get:5 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 libpython3.8-dev amd64 3.8.0-3ubuntu1~18.04.2 [54.4 MB]
Ign:6 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 python-pip-whl all 9.0.1-2.3~ubuntu1.18.04.6
Get:7 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 python3.8 amd64 3.8.0-3ubuntu1~18.04.2 [355 kB]
Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 python3.8-dev amd64 3.8.0-3ubuntu1~18.04.2 [510 kB]
Err:6 http://security.ubuntu.com/ubuntu bionic-updates/universe amd64 python-pip-whl all 9.0.1-2.3~ubuntu1.18.04.6
  404  Not Found [IP: 185.125.190.36 80]
Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 python3.8-venv amd64 3.8.0-3ubuntu1~18.04.2 [5304 B]
Fetched 61.1 MB in 3s (18.0 MB/s)        
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/universe/p/python-pip/python-pip-whl_9.0.1-2.3~ubuntu1.18.04.6_all.deb  404  Not Found [IP: 185.125.190.36 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?

Exited with code exit status 100

CircleCI received exit code 100
```

## How was this patch tested?

CI build job passed https://app.circleci.com/pipelines/github/cloudera/hue/9386/workflows/807ddcb5-20df-4324-bd2d-84b180a78ee2/jobs/16229

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
