### PR TITLE
[backend] mask server response header due to security vulnerabilities

### DIFF
--- a/desktop/core/src/desktop/management/commands/rungunicornserver.py
+++ b/desktop/core/src/desktop/management/commands/rungunicornserver.py
@@ -116,6 +116,10 @@ def rungunicornserver():
     else:
       ssl_keyfile = conf.SSL_PRIVATE_KEY.get()
 
+  # Hide server name = gunicorn and mask it to apache
+  gunicorn.SERVER_SOFTWARE = 'apache'
+  os.environ['SERVER_SOFTWARE'] = gunicorn.SERVER_SOFTWARE
+
   options = {
       'accesslog': "-",
       'backlog': 2048,


### PR DESCRIPTION
## What changes were proposed in this pull request?
The Server name response header contains gunicorn version, mask it to apache due to security issues. 

Github issue raised: https://github.com/cloudera/hue/issues/3209

- (Please fill in changes proposed in this fix)

## How was this patch tested?
Patch was tested on CDH cluster. Verified the Server response header 'Server: apache'.
Attaching screenshot
<img width="573" alt="Screen Shot 2023-03-08 at 3 37 25 PM" src="https://user-images.githubusercontent.com/33496652/223878442-0fa0b412-7bad-41f5-8646-8f2fb878650d.png">


