### PR TITLE
Hue [core] Adding supervisor conf for Hue log listener command.

### DIFF
--- a/tools/container/hue/supervisor-files/hue_loglistener_template
+++ b/tools/container/hue/supervisor-files/hue_loglistener_template
@@ -1,0 +1,18 @@
+[program:hue_loglistener]
+directory=${HUE_HOME}
+command="${HUE_HOME}/desktop/core/src/desktop/loglistener.py"
+autostart=true
+startretries=3
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+environment=DESKTOP_LOG_DIR="/var/log/${HUEUSER}",PYTHON_EGG_CACHE="$HUE_CONF_DIR/.python-eggs"
+user=${HUEUSER}
+group=${HUEUSER}
+exitcodes=0,2
+autorestart=false
+startsecs=20
+stopwaitsecs=30
+killasgroup=true
+# rlimits


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add supervisor.conf file for the recently introduced hue log listener command

## How was this patch tested?

- manually, after docker creation

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
