### PR TITLE
[backend] Pull hue_image_version from hue config

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -194,6 +194,14 @@ http_500_debug_mode=false
 # ^\/.*$,^http:\/\/www.mydomain.com\/.*$
 ## redirect_whitelist=^(\/[a-zA-Z0-9]+.*|\/)$
 
+# Image version/ Build version of Hue
+# hue_image_version="2022.2.2.1"
+## hue_image_version=
+
+# Name of the Hue host
+# hue_host="hue-hive-1"
+## hue_host=
+
 # Comma separated list of apps to not load at server startup.
 # e.g.: pig,zookeeper
 ## app_blacklist=

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -199,6 +199,14 @@
   # ^\/.*$,^http:\/\/www.mydomain.com\/.*$
   ## redirect_whitelist=^(\/[a-zA-Z0-9]+.*|\/)$
 
+  # Image version/ Build version of Hue
+  # hue_image_version="2022.2.2.1"
+  ## hue_image_version=
+
+  # Name of the Hue host
+  # hue_host="hue-hive-1"
+  ## hue_host=
+
   # Comma separated list of apps to not load at server startup.
   # e.g.: pig,zookeeper
   ## app_blacklist=

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -205,6 +205,18 @@ X_FRAME_OPTIONS = Config(
   type=str,
   default="SAMEORIGIN")
 
+HUE_IMAGE_VERSION = Config(
+  key="hue_image_version",
+  help=_("Image version of Hue"),
+  type=str,
+  default="")
+
+HUE_HOST_NAME = Config(
+  key="hue_host",
+  help=_("Name of Hue host selected"),
+  type=str,
+  default="")
+
 LIMIT_REQUEST_FIELD_SIZE = Config(
   key="limit_request_field_size",
   help=_("This property specifies the maximum allowed size of an HTTP request header field."),

--- a/desktop/core/src/desktop/models.py
+++ b/desktop/core/src/desktop/models.py
@@ -51,7 +51,8 @@ from useradmin.organization import _fitered_queryset
 from desktop import appmanager
 from desktop.auth.backend import is_admin
 from desktop.conf import get_clusters, IS_MULTICLUSTER_ONLY, ENABLE_ORGANIZATIONS, ENABLE_PROMETHEUS, \
-    has_connectors, TASK_SERVER, APP_BLACKLIST, COLLECT_USAGE, ENABLE_SHARING, ENABLE_CONNECTORS, ENABLE_UNIFIED_ANALYTICS, RAZ
+    has_connectors, TASK_SERVER, APP_BLACKLIST, COLLECT_USAGE, ENABLE_SHARING, ENABLE_CONNECTORS, ENABLE_UNIFIED_ANALYTICS, RAZ, \
+    HUE_IMAGE_VERSION, HUE_HOST_NAME
 from desktop.lib import fsmanager
 from desktop.lib.connectors.api import _get_installed_connectors
 from desktop.lib.connectors.models import Connector
@@ -79,8 +80,7 @@ SAMPLE_USER_OWNERS = ['hue', 'sample']
 
 UTC_TIME_FORMAT = "%Y-%m-%dT%H:%M"
 HUE_VERSION = None
-SELECTED_HUE_VW = None
-HUE_IMAGE_VERSION = None
+IMAGE_VERSION = None
 
 
 def uuid_default():
@@ -95,55 +95,25 @@ def hue_version():
   return HUE_VERSION
 
 def hue_image_version():
-  global HUE_IMAGE_VERSION
+  global IMAGE_VERSION
 
-  if HUE_IMAGE_VERSION is None:
+  if IMAGE_VERSION is None:
     p = get_run_root('cloudera', 'cdh_version.properties')
     if os.path.exists(p):
       build_version = _version_from_properties(open(p))
       if build_version:
-        HUE_IMAGE_VERSION = '%s' % (build_version)
+        IMAGE_VERSION = '%s' % (build_version)
 
-    elif os.getenv('HUE_CONF_DIR') and os.path.exists(os.getenv('HUE_CONF_DIR')):
-      cdw_path = os.getenv('HUE_CONF_DIR') + '/zhue.ini'
-      if os.path.exists(cdw_path):
-        hue_img_version = _version_from_hue_conf(open(cdw_path))
-        if hue_img_version:
-          HUE_IMAGE_VERSION = '%s' % (hue_img_version)
+    else:
+      IMAGE_VERSION = HUE_IMAGE_VERSION.get()
 
-  return HUE_IMAGE_VERSION
+  return IMAGE_VERSION
 
-def selected_hue_vw():
-  global SELECTED_HUE_VW
-
-  if SELECTED_HUE_VW is None:
-    if os.getenv('HUE_CONF_DIR') and os.path.exists(os.getenv('HUE_CONF_DIR')):
-      cdw_path = os.getenv('HUE_CONF_DIR') + '/zhue.ini'
-      if os.path.exists(cdw_path):
-        selected_hue_vw_name = _vw_name_from_hue_conf(open(cdw_path))
-        if selected_hue_vw_name:
-          SELECTED_HUE_VW = '%s' % (selected_hue_vw_name)
-
-  return SELECTED_HUE_VW
+def name_of_hue_host():
+  return HUE_HOST_NAME.get()
 
 def _version_from_properties(f):
   return dict(line.strip().split('=') for line in f.readlines() if len(line.strip().split('=')) == 2).get('cloudera.cdh.release')
-
-def _version_from_hue_conf(f):
-  hue_img_version = ''
-  for line in f.readlines():
-    if 'hue_image_version' in line:
-      hue_img_version += line.split('=')[1].replace('"', '').strip()
-
-  return hue_img_version
-
-def _vw_name_from_hue_conf(f):
-  selected_hue_vw_name = ''
-  for line in f.readlines():
-    if 'selected_hue_vw' in line:
-      selected_hue_vw_name += line.split('=')[1].replace('"', '').strip()
-
-  return selected_hue_vw_name
 
 def get_sample_user_install(user):
   if ENABLE_ORGANIZATIONS.get():
@@ -1809,8 +1779,8 @@ class ClusterConfig(object):
     editors = app_config.get('editor')
     main_button_action = self.get_main_quick_action(app_config)
     img_version = hue_image_version()
-    hue_version1 = hue_version()
-    selected_hue_vw_name = selected_hue_vw()
+    version_of_hue = hue_version()
+    hue_host_name = name_of_hue_host()
 
     if main_button_action.get('is_sql'):
       default_sql_interpreter = main_button_action['type']
@@ -1835,9 +1805,9 @@ class ClusterConfig(object):
         'enable_sharing': ENABLE_SHARING.get(),
         'collect_usage': COLLECT_USAGE.get()
       },
-      'vw_name': selected_hue_vw_name,
+      'vw_name': hue_host_name,
       'img_version': img_version,
-      'hue_version': hue_version1
+      'hue_version': version_of_hue
     }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Improvement to https://github.com/cloudera/hue/pull/3221. Pulling the config from hue.ini rather than parsing the hue.ini file and reading configs from it. 

The Hue UI must display the virtual warehouse name(present in the case of CDW), and hue_image_version (from CDW/CDH) in the bottom left side of the sidebar. Making changes to get_config API to populate the following parameters ('vw_name', 'img_version' and 'hue_version' )

## How was this patch tested?
Manually Tested on a CDW and CDH hue editor. 


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
