### PR TITLE
[frontend] fix encoding when linking from assistpanel to Filebrowser

### DIFF
--- a/desktop/core/src/desktop/js/ko/components/assist/assistStorageEntry.js
+++ b/desktop/core/src/desktop/js/ko/components/assist/assistStorageEntry.js
@@ -248,11 +248,14 @@ class AssistStorageEntry {
   toggleOpen(data, event) {
     const self = this;
     if (self.definition.type === 'file') {
-      if (event.ctrlKey || event.metaKey || event.which === 2) {
-        window.open('/hue' + self.definition.url, '_blank');
-      } else {
-        huePubSub.publish('open.link', self.definition.url);
-      }
+      const browserTarget =
+        event.ctrlKey || event.metaKey || event.which === 2 ? '_blank' : undefined;
+
+      huePubSub.publish('open.filebrowserlink', {
+        pathPrefix: '/filebrowser/view=',
+        decodedPath: self.definition.path,
+        browserTarget
+      });
       return;
     }
     self.open(!self.open());

--- a/desktop/core/src/desktop/js/ko/components/assist/assistStorageEntry.test.js
+++ b/desktop/core/src/desktop/js/ko/components/assist/assistStorageEntry.test.js
@@ -16,6 +16,8 @@
 
 import $ from 'jquery';
 
+import huePubSub from 'utils/huePubSub';
+
 import AssistStorageEntry from './assistStorageEntry';
 import * as hueConfig from 'config/hueConfig';
 
@@ -79,5 +81,36 @@ describe('assistStorageEntry.js', () => {
 
     spy.mockRestore();
     spy.mockClear();
+  });
+
+  it('uses pubsub "open.filebrowserlink" with decoded path to open files in the filebrowser', async () => {
+    const publishSpy = jest.spyOn(huePubSub, 'publish');
+    const entry = new AssistStorageEntry({
+      parent: null,
+      definition: { type: 'file', path: '/%20 åäö' }
+    });
+    expect(entry.definition.type).toEqual('file');
+    const event = {};
+    entry.toggleOpen(undefined, event);
+    expect(publishSpy).toBeCalledWith('open.filebrowserlink', {
+      decodedPath: '/%20 åäö',
+      pathPrefix: '/filebrowser/view='
+    });
+  });
+
+  it('uses pubsub "open.filebrowserlink" with decoded path to open files in a new window', async () => {
+    const publishSpy = jest.spyOn(huePubSub, 'publish');
+    const entry = new AssistStorageEntry({
+      parent: null,
+      definition: { type: 'file', path: '/%20 åäö' }
+    });
+    expect(entry.definition.type).toEqual('file');
+    const event = { ctrlKey: true };
+    entry.toggleOpen(undefined, event);
+    expect(publishSpy).toBeCalledWith('open.filebrowserlink', {
+      decodedPath: '/%20 åäö',
+      pathPrefix: '/filebrowser/view=',
+      browserTarget: '_blank'
+    });
   });
 });

--- a/desktop/core/src/desktop/js/ko/components/assist/ko.assistStoragePanel.js
+++ b/desktop/core/src/desktop/js/ko/components/assist/ko.assistStoragePanel.js
@@ -30,9 +30,12 @@ const TEMPLATE = `
     <li><a href="javascript:void(0);" data-bind="click: function (data) { showContextPopover(data, { target: $parentContext.$contextSourceElement }, { left: -15, top: 2 }); }"><i class="fa fa-fw fa-info"></i> ${I18n(
       'Show details'
     )}</a></li>
-    <li><a href="javascript:void(0);" data-bind="hueLink: definition.url"><i class="fa fa-fw" data-bind="css: {'fa-folder-open-o': definition.type === 'dir', 'fa-file-text-o': definition.type === 'file'}"></i> ${I18n(
-      'Open in Browser'
-    )}</a></li>
+    <li>
+      <a href="javascript:void(0);" data-bind="click: ()=> {huePubSub.publish('open.filebrowserlink', { pathPrefix: '/filebrowser/view=', decodedPath: definition.path });}">
+        <i class="fa fa-fw" data-bind="css: {'fa-folder-open-o': definition.type === 'dir', 'fa-file-text-o': definition.type === 'file'}"></i> 
+        ${I18n('Open in Browser')}
+      </a>
+    </li>
     <!-- ko if: definition.type === 'file' -->
     <li><a href="javascript:void(0);" data-bind="click: openInImporter"><!-- ko template: { name: 'app-icon-template', data: { icon: 'importer' } } --><!-- /ko --> ${I18n(
       'Open in Importer'

--- a/desktop/core/src/desktop/js/onePageViewModel.js
+++ b/desktop/core/src/desktop/js/onePageViewModel.js
@@ -889,36 +889,44 @@ class OnePageViewModel {
       }
     });
 
-    huePubSub.subscribe('open.filebrowserlink', ({ pathPrefix, decodedPath, fileBrowserModel }) => {
-      if (pathPrefix.includes('download=')) {
-        // The download view on the backend requires the slashes not to
-        // be encoded in order for the file to be correctly named.
-        const encodedPath = encodeURIComponent(decodedPath).replaceAll('%2F', '/');
-        const possibleKnoxUrlPathPrefix = window.HUE_BASE_URL;
-        window.location = possibleKnoxUrlPathPrefix + pathPrefix + encodedPath;
-        return;
-      }
+    huePubSub.subscribe(
+      'open.filebrowserlink',
+      ({ pathPrefix, decodedPath, fileBrowserModel, browserTarget }) => {
+        if (pathPrefix.includes('download=')) {
+          // The download view on the backend requires the slashes not to
+          // be encoded in order for the file to be correctly named.
+          const encodedPath = encodeURIComponent(decodedPath).replaceAll('%2F', '/');
+          const possibleKnoxUrlPathPrefix = window.HUE_BASE_URL;
+          window.location = possibleKnoxUrlPathPrefix + pathPrefix + encodedPath;
+          return;
+        }
 
-      const appPrefix = '/hue';
-      const urlEncodedPercentage = '%25';
-      // Fix. The '%' character needs to be encoded twice due to a bug in the page library
-      // that decodes the url twice. Even when we don't directly call pag() we still need this
-      // fix since the user can reload the page which will trigger a call to page().
-      const pageFixedEncodedPath = encodeURIComponent(
-        decodedPath.replaceAll('%', urlEncodedPercentage)
-      );
-      const href = window.HUE_BASE_URL + appPrefix + pathPrefix + pageFixedEncodedPath;
+        const appPrefix = '/hue';
+        const urlEncodedPercentage = '%25';
+        // Fix. The '%' character needs to be encoded twice due to a bug in the page library
+        // that decodes the url twice. Even when we don't directly call page() we still need this
+        // fix since the user can reload the page which will trigger a call to page().
+        const pageFixedEncodedPath = encodeURIComponent(
+          decodedPath.replaceAll('%', urlEncodedPercentage)
+        );
+        const href = window.HUE_BASE_URL + appPrefix + pathPrefix + pageFixedEncodedPath;
 
-      // We don't want reload the entire filebrowser when navigating between folders
-      // and already on the listdir_components page.
-      if (fileBrowserModel) {
-        fileBrowserModel.targetPath(pathPrefix + encodeURIComponent(decodedPath));
-        window.history.pushState(null, '', href);
-        fileBrowserModel.retrieveData();
-      } else {
-        page(href);
+        if (browserTarget) {
+          window.open(href, browserTarget);
+          return;
+        }
+
+        // We don't want reload the entire filebrowser when navigating between folders
+        // and already on the listdir_components page.
+        if (fileBrowserModel) {
+          fileBrowserModel.targetPath(pathPrefix + encodeURIComponent(decodedPath));
+          window.history.pushState(null, '', href);
+          fileBrowserModel.retrieveData();
+        } else {
+          page(href);
+        }
       }
-    });
+    );
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Fix encoding when linking from assistpanel to Filebrowser by using the pubsub `open.filebrowserlink` and make sure all page-library workarounds are contain to one place only.
- added unit tests 

## How was this patch tested?

- manual testing
- passing unit tests

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
