### PR TITLE
Hue [core] Hue needs to run under UBI8 docker.

### DIFF
--- a/tools/container/hue/Dockerfile
+++ b/tools/container/hue/Dockerfile
@@ -46,6 +46,7 @@ RUN echo "${HUEUSER} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${HUEUSER} && \
 COPY --chown=${HUEUSER}:${HUEUSER} hueconf ${HUE_CONF}/conf
 
 RUN ln -s ${HUE_CONF}/conf/log.conf ${HUE_HOME}/desktop/conf/log.conf; \
+    ln -s ${HUE_CONF}/conf/gunicorn_log.conf ${HUE_HOME}/desktop/conf/gunicorn_log.conf \
     ln -s ${HUE_CONF}/conf/log4j.properties ${HUE_HOME}/desktop/conf/log4j.properties
 
 # supervisor stuff
@@ -53,6 +54,7 @@ RUN mkdir -p /etc/supervisor.d/ && chmod +w /etc/supervisor.d && mkdir -p /var/l
 ADD supervisor-files/etc/supervisord.conf /etc/supervisord.conf
 ADD supervisor-files/hue_server.conf /etc/supervisor.d/
 ADD supervisor-files/hue_ktrenewer.conf /etc/supervisor.d/
+ADD supervisor-files/hue_loglistener.conf /etc/supervisor.d/
 RUN chown -R ${HUEUSER}:${HUEUSER} /etc/supervisord.conf && chown -R ${HUEUSER}:${HUEUSER} /etc/supervisor.d
 
 # Remove chardet package

--- a/tools/container/hue/hueconf/gunicorn_log.conf
+++ b/tools/container/hue/hueconf/gunicorn_log.conf
@@ -1,0 +1,115 @@
+########################################
+# Definition for the different objects
+# - FOR DEVELOPMENT ONLY -
+#
+# Directories where log files are kept must already exist.
+# That's why we pick /tmp.
+#
+# The loggers are configured to write to the log files ONLY.
+# Developers may set the DESKTOP_DEBUG environment variable to
+# enable stderr logging output.
+########################################
+
+[logger_root]
+handlers=logfile,errorlog
+
+[logger_access]
+handlers=accesslog
+qualname=access
+
+[logger_django_auth_ldap]
+handlers=accesslog
+qualname=django_auth_ldap
+
+[logger_kazoo_client]
+level=INFO
+handlers=errorlog
+qualname=kazoo.client
+
+[logger_djangosaml2]
+level=INFO
+handlers=errorlog
+qualname=djangosaml2
+
+[logger_requests_packages_urllib3_connectionpool]
+level=DEBUG
+handlers=errorlog
+qualname=requests.packages.urllib3.connectionpool
+
+[logger_django_db]
+level=DEBUG
+handlers=errorlog
+qualname=django.db.backends
+
+[logger_boto]
+level=ERROR
+handlers=errorlog
+qualname=boto
+
+[logger_gunicorn.error]
+level=INFO
+handlers=errorlog
+propagate=1
+qualname=gunicorn.error
+
+[logger_gunicorn.access]
+level=INFO
+handlers=accesslog
+propagate=0
+qualname=gunicorn.access
+
+[handler_stderr]
+class=StreamHandler
+formatter=default
+level=DEBUG
+args=(sys.stderr,)
+
+[handler_stdout]
+class=StreamHandler
+formatter=default
+level=DEBUG
+args=(sys.stdout,)
+
+[handler_accesslog]
+class=handlers.RotatingFileHandler
+level=INFO
+propagate=True
+formatter=access
+args=('%LOG_DIR%/access.log', 'a', 5000000, 5)
+
+[handler_errorlog]
+class=handlers.RotatingFileHandler
+level=ERROR
+formatter=default
+args=('%LOG_DIR%/error.log', 'a', 5000000, 5)
+
+[handler_logfile]
+class=handlers.RotatingFileHandler
+# Choices are DEBUG, INFO, WARNING, ERROR, CRITICAL
+level=DEBUG
+formatter=default
+args=('%LOG_DIR%/rungunicornserver.log', 'a', 5000000, 5)
+
+[formatter_default]
+class=logging.Formatter
+format=[%(asctime)s] %(module)-12s %(levelname)-8s %(message)s
+datefmt=%d/%b/%Y %H:%M:%S %z
+
+[formatter_access]
+class=logging.Formatter
+format=[%(asctime)s] %(levelname)-8s %(message)s
+datefmt=%d/%b/%Y %H:%M:%S %z
+
+
+########################################
+# A summary of loggers, handlers and formatters
+########################################
+
+[loggers]
+keys=root,access,django_auth_ldap,kazoo_client,requests_packages_urllib3_connectionpool,djangosaml2,django_db,boto,gunicorn.error,gunicorn.access
+
+[handlers]
+keys=stderr,logfile,accesslog,errorlog,stdout
+
+[formatters]
+keys=default,access

--- a/tools/container/hue/hueconf/log.conf
+++ b/tools/container/hue/hueconf/log.conf
@@ -9,107 +9,28 @@
 # Developers may set the DESKTOP_DEBUG environment variable to
 # enable stderr logging output.
 ########################################
-
 [logger_root]
-handlers=logfile,errorlog
-
-[logger_access]
-handlers=accesslog
-qualname=access
-
-[logger_django_auth_ldap]
-handlers=accesslog
-qualname=django_auth_ldap
-
-[logger_kazoo_client]
-level=INFO
-handlers=errorlog
-qualname=kazoo.client
-
-[logger_djangosaml2]
-level=INFO
-handlers=errorlog
-qualname=djangosaml2
-
-[logger_requests_packages_urllib3_connectionpool]
-level=DEBUG
-handlers=errorlog
-qualname=requests.packages.urllib3.connectionpool
-
-[logger_django_db]
-level=DEBUG
-handlers=errorlog
-qualname=django.db.backends
-
-[logger_boto]
-level=ERROR
-handlers=errorlog
-qualname=boto
-
-[logger_gunicorn.error]
-level=INFO
-handlers=errorlog
-propagate=1
-qualname=gunicorn.error
-
-[logger_gunicorn.access]
-level=INFO
-handlers=accesslog
-propagate=0
-qualname=gunicorn.access
-
-[handler_stderr]
-class=StreamHandler
-formatter=default
-level=DEBUG
-args=(sys.stderr,)
-
-[handler_stdout]
-class=StreamHandler
-formatter=default
-level=DEBUG
-args=(sys.stdout,)
-
-[handler_accesslog]
-class=handlers.RotatingFileHandler
-level=INFO
-propagate=True
-formatter=access
-args=('%LOG_DIR%/access.log', 'a', 1000000, 3)
-
-[handler_errorlog]
-class=handlers.RotatingFileHandler
-level=ERROR
-formatter=default
-args=('%LOG_DIR%/error.log', 'a', 1000000, 3)
+handlers=logfile
 
 [handler_logfile]
-class=handlers.RotatingFileHandler
-# Choices are DEBUG, INFO, WARNING, ERROR, CRITICAL
 level=DEBUG
+class=handlers.SocketHandler
 formatter=default
-args=('%LOG_DIR%/%PROC_NAME%.log', 'a', 1000000, 3)
+args=("/tmp/hue.uds",None,)
 
 [formatter_default]
 class=desktop.log.formatter.Formatter
 format=[%(asctime)s] %(module)-12s %(levelname)-8s %(message)s
 datefmt=%d/%b/%Y %H:%M:%S %z
 
-[formatter_access]
-class=desktop.log.formatter.Formatter
-format=[%(asctime)s] %(levelname)-8s %(message)s
-datefmt=%d/%b/%Y %H:%M:%S %z
-
-
 ########################################
 # A summary of loggers, handlers and formatters
 ########################################
-
 [loggers]
-keys=root,access,django_auth_ldap,kazoo_client,requests_packages_urllib3_connectionpool,djangosaml2,django_db,boto,gunicorn.error,gunicorn.access
+keys=root
 
 [handlers]
-keys=stderr,logfile,accesslog,errorlog,stdout
+keys=logfile
 
 [formatters]
-keys=default,access
+keys=default


### PR DESCRIPTION
Keeping docker image up to date with Hue logfile server-related changes.

## What changes were proposed in this pull request?

- put required log.conf files in docker images.
 
## How was this patch tested?

- manually

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
