### PR TITLE
Hue [core] Hue needs to run under UBI8 docker. version 2

### DIFF
--- a/tools/container/hue/Dockerfile
+++ b/tools/container/hue/Dockerfile
@@ -46,7 +46,7 @@ RUN echo "${HUEUSER} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${HUEUSER} && \
 COPY --chown=${HUEUSER}:${HUEUSER} hueconf ${HUE_CONF}/conf
 
 RUN ln -s ${HUE_CONF}/conf/log.conf ${HUE_HOME}/desktop/conf/log.conf; \
-    ln -s ${HUE_CONF}/conf/gunicorn_log.conf ${HUE_HOME}/desktop/conf/gunicorn_log.conf \
+    ln -s ${HUE_CONF}/conf/gunicorn_log.conf ${HUE_HOME}/desktop/conf/gunicorn_log.conf; \
     ln -s ${HUE_CONF}/conf/log4j.properties ${HUE_HOME}/desktop/conf/log4j.properties
 
 # supervisor stuff


### PR DESCRIPTION
fixing typo

## What changes were proposed in this pull request?

- fixing typo

## How was this patch tested?

- manually

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
