### PR TITLE
[UI][left-assist] Fix file browsing when remote_storage_home path is set

### DIFF
--- a/desktop/core/src/desktop/js/api/apiHelper.js
+++ b/desktop/core/src/desktop/js/api/apiHelper.js
@@ -415,7 +415,7 @@ class ApiHelper {
   fetchAbfsPath(options) {
     let url =
       URLS.ABFS_API_PREFIX +
-      encodeURI(options.pathParts.join('/')) +
+      options.pathParts.join('/') +
       '?format=json&sortby=name&descending=false&pagesize=' +
       (options.pageSize || 500) +
       '&pagenum=' +
@@ -603,10 +603,9 @@ class ApiHelper {
    * @param {string} [options.filter]
    */
   fetchS3Path(options) {
-    options.pathParts.shift(); // remove the trailing /
     let url =
       URLS.S3_API_PREFIX +
-      encodeURI(options.pathParts.join('/')) +
+      options.pathParts.join('/') +
       '?format=json&sortby=name&descending=false&pagesize=' +
       (options.pageSize || 500) +
       '&pagenum=' +


### PR DESCRIPTION
## What changes were proposed in this pull request?

- The `.shift()` method is not removing the trailing slash. Just like the ABFS code section, we might not need this for S3. Only ADLS or HDFS sections might need it.

- When the remote_storage_home path is set in the config, the URI in API call is getting double-encoded and failing. We need to see why this is happening for this scenario. When remote_storage_home is not set, then it is working fine.

## How was this patch tested?

- Tested manually in local Hue setup