### PR TITLE
[frontend] Create a separate upstream GitHub CI workflow for UI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,13 +109,6 @@ commands:
 
             cp -r ~/repo/docs .
 
-      - run:
-          name: run commit title format check
-          command: |
-            cd ~/repo
-
-            ./tools/ci/check_for_commit_message.sh
-
       # Run documentation lint
       - run:
           name: run documentation lints
@@ -146,44 +139,6 @@ commands:
             /usr/share/hue/build/env/bin/pip install pylint==1.7.5 pylint-django==0.7.2 configparser==4.0.2
             ./tools/ci/check_for_python_lint.sh /usr/share/hue
 
-      - run:
-          name: run js lint
-          command: |
-            cd /usr/share/hue
-            cp ~/repo/.prettierrc .
-            cp ~/repo/.eslint* .
-            cp ~/repo/tools . -r
-
-            npm run lint
-
-      - run:
-          name: run style lint
-          command: |
-            cd /usr/share/hue
-
-            npm run style-lint
-
-      - run:
-          name: run npm version checker
-          command: |
-            cd /usr/share/hue
-
-            npm run check-pinned-versions
-
-      - run:
-          name: run npm license checker
-          command: |
-            cd /usr/share/hue
-
-            npm run check-license
-
-      - run:
-          name: run npm absolute path detection
-          command: |
-            cd /usr/share/hue
-
-            npm run check-absolute-paths
-
       # Run tests
       - run:
           name: run python API tests
@@ -191,16 +146,6 @@ commands:
             cd /usr/share/hue
 
             PYTHONWARNINGS=always ./build/env/bin/hue test unit --with-xunit --with-cover
-
-      - run:
-          name: run js tests
-          command: |
-            cd /usr/share/hue
-
-            # https://jestjs.io/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server
-            sed -i 's/"test": "jest"/"test": "jest --runInBand"/g' package.json
-
-            npm run test
 
       - store_artifacts:
           path: test-reports

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -1,0 +1,33 @@
+name: Cleanup caches by a branch
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+          
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys. 
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/commitflow-ui.yml
+++ b/.github/workflows/commitflow-ui.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
     branches:
     - master
-    # paths:
-    #   - '**.js' // this workflow will run when a pull request includes a change to a JavaScript file (.js)
+    paths:
+      - '**.js'
 
 jobs:
   build:

--- a/.github/workflows/commitflow-ui.yml
+++ b/.github/workflows/commitflow-ui.yml
@@ -9,12 +9,13 @@ on:
     - master
     paths:
       - '**.js'
+      - '**.jsx'
+      - '**.ts'
+      - '**.tsx'
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/commitflow-ui.yml
+++ b/.github/workflows/commitflow-ui.yml
@@ -12,10 +12,14 @@ on:
       - '**.jsx'
       - '**.ts'
       - '**.tsx'
+      - '**.less'
+      - '**.scss'
+      - '**.vue'
+      - 'package*.json'
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -23,38 +27,32 @@ jobs:
     - name: Caching npm with setup node
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 14
         cache: 'npm'
 
-    - name: Install npm
+    - name: Install npm dependencies
       run: npm ci
 
     - name: run commit title format check
-      run: |
-        ./tools/ci/check_for_commit_message.sh 
+      run: ./tools/ci/check_for_commit_message.sh 
 
-    - name : run npm version checker
-      run: |
-        npm run check-pinned-versions
+    - name: run npm version checker
+      run: npm run check-pinned-versions
 
     - name: run npm license checker
-      run: |
-        npm run check-license
+      run: npm run check-license
 
     - name: run npm absolute path detection
-      run: |
-        npm run check-absolute-paths
+      run: npm run check-absolute-paths
 
     - name: run js lint
-      run: |
-        npm run lint
+      run: npm run lint
 
     - name: run style lint
-      run: |
-        npm run style-lint
+      run: npm run style-lint
 
     - name: run js tests
-      run : |
+      run: |
         # https://jestjs.io/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server
         sed -i 's/"test": "jest"/"test": "jest --runInBand"/g' package.json
 

--- a/.github/workflows/commitflow-ui.yml
+++ b/.github/workflows/commitflow-ui.yml
@@ -1,0 +1,60 @@
+name: UI CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+    # paths:
+    #   - '**.js' // this workflow will run when a pull request includes a change to a JavaScript file (.js)
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Caching npm with setup node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+        cache: 'npm'
+
+    - name: Install npm
+      run: npm ci
+
+    - name: run commit title format check
+      run: |
+        ./tools/ci/check_for_commit_message.sh 
+
+    - name : run npm version checker
+      run: |
+        npm run check-pinned-versions
+
+    - name: run npm license checker
+      run: |
+        npm run check-license
+
+    - name: run npm absolute path detection
+      run: |
+        npm run check-absolute-paths
+
+    - name: run js lint
+      run: |
+        npm run lint
+
+    - name: run style lint
+      run: |
+        npm run style-lint
+
+    - name: run js tests
+      run : |
+        # https://jestjs.io/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server
+        sed -i 's/"test": "jest"/"test": "jest --runInBand"/g' package.json
+
+        npm run test

--- a/.github/workflows/commitflow.yml
+++ b/.github/workflows/commitflow.yml
@@ -77,7 +77,6 @@ jobs:
         npm run webpack-workers
         ./build/env/bin/hue collectstatic --noinput
 
-
     # - name: run documentation lints
     #   run: |
     #     cd $GITHUB_WORKSPACE
@@ -105,33 +104,6 @@ jobs:
     #     /usr/share/hue/build/env/bin/pip install pylint==1.7.5 pylint-django==0.7.2 configparser==4.0.2
     #     ./tools/ci/check_for_python_lint.sh /usr/share/hue
 
-    - name: run js lint
-      run: |
-        cp .prettierrc /usr/share/hue
-        cp .eslint* /usr/share/hue
-        cp tools /usr/share/hue -r
-
-        cd /usr/share/hue
-        npm run lint
-
-    - name: run npm license checker
-      run: |
-        cd /usr/share/hue
-
-        npm run check-license
-
-    - name: run style lint
-      run: |
-        cd /usr/share/hue
-
-        npm run style-lint
-
-    - name: run npm absolute path detection
-      run: |
-        cd /usr/share/hue
-
-        npm run check-absolute-paths
-
     # Run tests
     - name: run python API tests
       run: |
@@ -139,11 +111,3 @@ jobs:
 
         PYTHONWARNINGS=always ./build/env/bin/hue test unit --with-xunit --with-cover
 
-    - name: run js tests
-      run : |
-        cd /usr/share/hue
-
-        # https://jestjs.io/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server
-        sed -i 's/"test": "jest"/"test": "jest --runInBand"/g' package.json
-
-        npm run test

--- a/desktop/core/src/desktop/js/reactComponents/createRootElements.js
+++ b/desktop/core/src/desktop/js/reactComponents/createRootElements.js
@@ -31,7 +31,7 @@ async function render(name, props, root) {
 }
 
 export async function createReactComponents(selector) {
-  // Find all DOM containers
+  // Find all DOM containers .
   document.querySelectorAll(`${selector} [data-reactcomponent]`).forEach(domContainer => {
     const componentName = domContainer.dataset['reactcomponent'];
     const rawPropDataset = domContainer.dataset.props ? JSON.parse(domContainer.dataset.props) : {};

--- a/desktop/core/src/desktop/js/reactComponents/createRootElements.js
+++ b/desktop/core/src/desktop/js/reactComponents/createRootElements.js
@@ -31,7 +31,7 @@ async function render(name, props, root) {
 }
 
 export async function createReactComponents(selector) {
-  // Find all DOM containers .
+  // Find all DOM containers.
   document.querySelectorAll(`${selector} [data-reactcomponent]`).forEach(domContainer => {
     const componentName = domContainer.dataset['reactcomponent'];
     const rawPropDataset = domContainer.dataset.props ? JSON.parse(domContainer.dataset.props) : {};


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Create a separate github workflow with the following:
        Check out code
        Run commit title format check
        Prepare NPM (node/npm versions, caching etc)
        Run JS package.json version checker
        Run JS license checker
        Run NPM Absolute path detection
        Run JS lints
        Run Style lints
        Run JS tests
- When a cache is created by a workflow run triggered on a pull request, the cache is created for the merge ref (refs/pull/.../merge). Because of this, the cache will have a limited scope and can only be restored by re-runs of the pull request. It cannot be restored by the base branch or other pull requests targeting that base branch which could lead to **cache thrashing** when there are multiple PRs open. Hence added the clean up cache workflow that would be triggered when the PR is closed.

## How was this patch tested?

- Tested locally using https://github.com/nektos/act
