### PR TITLE
[frontend] Replace ENABLE_NOTEBOOK_2 with ENABLE_HUE_5

### DIFF
--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -1785,6 +1785,13 @@ EDITOR_AUTOCOMPLETE_TIMEOUT = Config(
   help=_('Timeout value in ms for autocomplete of columns, tables, values etc. 0 = disabled.')
 )
 
+ENABLE_HUE_5 = Config(
+  key="enable_hue_5",
+  help=_("Feature flag to enable Hue 5."),
+  type=coerce_bool,
+  default=False
+)
+
 USE_NEW_EDITOR = Config( # To remove in Hue 4
   key='',
   default=True,

--- a/desktop/core/src/desktop/js/apps/editor/components/resultChart/ko.resultChart.js
+++ b/desktop/core/src/desktop/js/apps/editor/components/resultChart/ko.resultChart.js
@@ -863,7 +863,7 @@ class ResultChart extends DisposableComponent {
   }
 
   prepopulateChart() {
-    if (!window.ENABLE_NOTEBOOK_2) {
+    if (!window.ENABLE_HUE_5) {
       const type = this.chartType();
       hueAnalytics.log('notebook', 'chart/' + type);
     }

--- a/desktop/core/src/desktop/js/apps/editor/notebook.test.js
+++ b/desktop/core/src/desktop/js/apps/editor/notebook.test.js
@@ -34,14 +34,14 @@ describe('notebook.js', () => {
     }
   };
 
-  const previousEnableNotebook2 = window.ENABLE_NOTEBOOK_2;
+  const previousEnableHue5 = window.ENABLE_HUE_5;
 
   beforeAll(() => {
-    window.ENABLE_NOTEBOOK_2 = true;
+    window.ENABLE_HUE_5 = true;
   });
 
   afterAll(() => {
-    window.ENABLE_NOTEBOOK_2 = previousEnableNotebook2;
+    window.ENABLE_HUE_5 = previousEnableHue5;
   });
 
   beforeEach(() => {

--- a/desktop/core/src/desktop/js/apps/editor/snippet.js
+++ b/desktop/core/src/desktop/js/apps/editor/snippet.js
@@ -60,7 +60,7 @@ import {
 } from 'ko/components/assist/events';
 import { EXECUTABLE_UPDATED_TOPIC } from './execution/events';
 
-// TODO: Remove for ENABLE_NOTEBOOK_2. Temporary here for debug
+// TODO: Remove together with ENABLE_HUE_5. Temporary here for debug
 window.SqlExecutable = SqlExecutable;
 window.Executor = Executor;
 
@@ -879,7 +879,7 @@ export default class Snippet {
 
   handleAjaxError(data, callback) {
     if (data.status === -2) {
-      // TODO: Session expired, check if handleAjaxError is used for ENABLE_NOTEBOOK_2
+      // TODO: Session expired, check if handleAjaxError is used for ENABLE_HUE_5
     } else if (data.status === -3) {
       // Statement expired
       this.status(STATUS.expired);

--- a/desktop/core/src/desktop/js/apps/editor/snippet.test.js
+++ b/desktop/core/src/desktop/js/apps/editor/snippet.test.js
@@ -34,14 +34,14 @@ describe('snippet.js', () => {
     }
   };
 
-  const previousEnableNotebook2 = window.ENABLE_NOTEBOOK_2;
+  const previousEnableHue5 = window.ENABLE_HUE_5;
 
   beforeAll(() => {
-    window.ENABLE_NOTEBOOK_2 = true;
+    window.ENABLE_HUE_5 = true;
   });
 
   afterAll(() => {
-    window.ENABLE_NOTEBOOK_2 = previousEnableNotebook2;
+    window.ENABLE_HUE_5 = previousEnableHue5;
   });
 
   beforeEach(() => {

--- a/desktop/core/src/desktop/js/apps/jobBrowser/components/impalaQueries/query-details/QueryDetails.vue
+++ b/desktop/core/src/desktop/js/apps/jobBrowser/components/impalaQueries/query-details/QueryDetails.vue
@@ -81,7 +81,7 @@
 
   import I18n from 'utils/i18n';
 
-  declare const ENABLE_NOTEBOOK_2: boolean;
+  declare const ENABLE_HUE_5: boolean;
 
   export default defineComponent({
     components: {
@@ -118,7 +118,7 @@
         });
 
         huePubSub.subscribeOnce(
-          ENABLE_NOTEBOOK_2 ? 'ace.editor.focused' : 'set.current.app.view.model',
+          ENABLE_HUE_5 ? 'ace.editor.focused' : 'set.current.app.view.model',
           () =>
             setTimeout(() => {
               huePubSub.publish('editor.insert.at.cursor', {

--- a/desktop/core/src/desktop/js/apps/notebook/aceAutocompleteWrapper.js
+++ b/desktop/core/src/desktop/js/apps/notebook/aceAutocompleteWrapper.js
@@ -39,7 +39,7 @@ class AceAutocompleteWrapper {
         timeout: options.timeout
       });
     };
-    if (window.ENABLE_NOTEBOOK_2) {
+    if (window.ENABLE_HUE_5) {
       self.snippet.dialect.subscribe(() => {
         initializeAutocompleter();
       });

--- a/desktop/core/src/desktop/js/apps/notebook/app.js
+++ b/desktop/core/src/desktop/js/apps/notebook/app.js
@@ -41,7 +41,7 @@ const HUE_PUB_SUB_EDITOR_ID =
   window.location.pathname.indexOf('notebook') > -1 ? 'notebook' : 'editor';
 
 huePubSub.subscribe('app.dom.loaded', app => {
-  if ((app === 'editor' && !window.ENABLE_NOTEBOOK_2) || app === 'notebook') {
+  if ((app === 'editor' && !window.ENABLE_HUE_5) || app === 'notebook') {
     window.MAIN_SCROLLABLE = '.page-content';
 
     let isLeftNavOpen = false;

--- a/desktop/core/src/desktop/js/hue.js
+++ b/desktop/core/src/desktop/js/hue.js
@@ -128,7 +128,7 @@ $(document).ready(async () => {
   ko.applyBindings(sidePanelViewModel, $('.left-panel')[0]);
   ko.applyBindings(sidePanelViewModel, $('#leftResizer')[0]);
   ko.applyBindings(sidePanelViewModel, $('.right-panel')[0]);
-  if (!window.ENABLE_NOTEBOOK_2) {
+  if (!window.ENABLE_HUE_5) {
     ko.applyBindings(sidePanelViewModel, $('.context-panel')[0]);
   }
 

--- a/desktop/core/src/desktop/js/onePageViewModel.js
+++ b/desktop/core/src/desktop/js/onePageViewModel.js
@@ -59,7 +59,7 @@ class OnePageViewModel {
           waitForObservable(viewModel.selectedNotebook, () => {
             if (viewModel.editorType() !== type) {
               viewModel.selectedNotebook().selectedSnippet(type);
-              if (!window.ENABLE_NOTEBOOK_2) {
+              if (!window.ENABLE_HUE_5) {
                 viewModel.editorType(type);
               }
               viewModel.newNotebook(type);
@@ -597,7 +597,7 @@ class OnePageViewModel {
                   self.isLoadingEmbeddable(true);
                   viewModel
                     .openNotebook(getUrlParameter('editor'))
-                    [window.ENABLE_NOTEBOOK_2 ? 'finally' : 'always'](() => {
+                    [window.ENABLE_HUE_5 ? 'finally' : 'always'](() => {
                       self.isLoadingEmbeddable(false);
                     });
                 });
@@ -691,11 +691,9 @@ class OnePageViewModel {
           if (notebookId !== '') {
             self.getActiveAppViewModel(viewModel => {
               self.isLoadingEmbeddable(true);
-              viewModel
-                .openNotebook(notebookId)
-                [window.ENABLE_NOTEBOOK_2 ? 'finally' : 'always'](() => {
-                  self.isLoadingEmbeddable(false);
-                });
+              viewModel.openNotebook(notebookId)[window.ENABLE_HUE_5 ? 'finally' : 'always'](() => {
+                self.isLoadingEmbeddable(false);
+              });
             });
           } else {
             self.getActiveAppViewModel(viewModel => {

--- a/desktop/core/src/desktop/templates/global_js_constants.mako
+++ b/desktop/core/src/desktop/templates/global_js_constants.mako
@@ -20,8 +20,9 @@
   from desktop import conf
   from desktop.auth.backend import is_admin, is_hue_admin
   from desktop.conf import APP_SWITCHER_ALTUS_BASE_URL, APP_SWITCHER_MOW_BASE_URL, CUSTOM_DASHBOARD_URL, \
-      DISPLAY_APP_SWITCHER, IS_K8S_ONLY, IS_MULTICLUSTER_ONLY, USE_DEFAULT_CONFIGURATION, USE_NEW_ASSIST_PANEL, \
-      VCS, ENABLE_GIST, ENABLE_LINK_SHARING, has_channels, has_connectors, ENABLE_UNIFIED_ANALYTICS, RAZ
+      DISPLAY_APP_SWITCHER, ENABLE_HUE_5, IS_K8S_ONLY, IS_MULTICLUSTER_ONLY, USE_DEFAULT_CONFIGURATION,\
+      USE_NEW_ASSIST_PANEL, VCS, ENABLE_GIST, ENABLE_LINK_SHARING, has_channels, has_connectors,\
+      ENABLE_UNIFIED_ANALYTICS, RAZ
   from desktop.models import hue_version, _get_apps, get_cluster_config, _handle_user_dir_raz
 
   from beeswax.conf import DOWNLOAD_BYTES_LIMIT, DOWNLOAD_ROW_LIMIT, LIST_PARTITIONS_LIMIT, CLOSE_SESSIONS
@@ -35,7 +36,7 @@
       get_catalog_url, get_optimizer_mode
   from metastore.conf import ENABLE_NEW_CREATE_TABLE
   from metastore.views import has_write_access
-  from notebook.conf import ENABLE_NOTEBOOK_2, ENABLE_QUERY_ANALYSIS, ENABLE_QUERY_BUILDER, ENABLE_QUERY_SCHEDULING, ENABLE_SQL_INDEXER, \
+  from notebook.conf import ENABLE_QUERY_ANALYSIS, ENABLE_QUERY_BUILDER, ENABLE_QUERY_SCHEDULING, ENABLE_SQL_INDEXER, \
       get_ordered_interpreters, SHOW_NOTEBOOKS
   from django.utils.translation import get_language
 
@@ -105,7 +106,7 @@
 
   window.ENABLE_DOWNLOAD = '${ conf.ENABLE_DOWNLOAD.get() }' === 'True';
   window.ENABLE_NEW_CREATE_TABLE = '${ hasattr(ENABLE_NEW_CREATE_TABLE, 'get') and ENABLE_NEW_CREATE_TABLE.get()}' === 'True';
-  window.ENABLE_NOTEBOOK_2 = '${ ENABLE_NOTEBOOK_2.get() }' === 'True';
+  window.ENABLE_HUE_5 = '${ ENABLE_HUE_5.get() }' === 'True';
   window.ENABLE_PREDICT = '${ OPTIMIZER.ENABLE_PREDICT.get() }' === 'True';
   window.ENABLE_SQL_INDEXER = '${ ENABLE_SQL_INDEXER.get() }' === 'True';
 

--- a/desktop/core/src/desktop/templates/hue.mako
+++ b/desktop/core/src/desktop/templates/hue.mako
@@ -18,7 +18,7 @@
   import sys
 
   from desktop import conf
-  from desktop.conf import IS_MULTICLUSTER_ONLY, has_multi_clusters
+  from desktop.conf import ENABLE_HUE_5, IS_MULTICLUSTER_ONLY, has_multi_clusters
   from desktop.views import _ko, commonshare, login_modal
   from desktop.lib.i18n import smart_unicode
   from desktop.models import PREFERENCE_IS_WELCOME_TOUR_SEEN, hue_version, get_cluster_config
@@ -28,7 +28,6 @@
   from filebrowser.conf import SHOW_UPLOAD_BUTTON
   from indexer.conf import ENABLE_NEW_INDEXER
   from metadata.conf import has_optimizer, OPTIMIZER
-  from notebook.conf import ENABLE_NOTEBOOK_2
 
   from desktop.auth.backend import is_admin
   from webpack_loader.templatetags.webpack_loader import render_bundle
@@ -215,7 +214,7 @@ ${ hueIcons.symbols() }
       }"><div class="resize-bar"></div></div>
 
       <div class="page-content">
-        <!-- ko if: window.ENABLE_NOTEBOOK_2 -->
+        <!-- ko if: window.ENABLE_HUE_5 -->
         <!-- ko component: 'session-panel' --><!-- /ko -->
         <!-- /ko -->
         <!-- ko hueSpinner: { spin: isLoadingEmbeddable, center: true, size: 'xlarge', blackout: true } --><!-- /ko -->
@@ -280,7 +279,7 @@ ${ hueIcons.symbols() }
           }
         }" style="display: none;"></div>
 
-      %if not ENABLE_NOTEBOOK_2.get():
+      %if not ENABLE_HUE_5.get():
       <div class="context-panel" data-bind="slideVisible: contextPanelVisible">
         <div class="margin-top-10 padding-left-10 padding-right-10">
           <h4 class="margin-bottom-30"><i class="fa fa-cogs"></i> ${_('Session')}</h4>

--- a/desktop/libs/notebook/src/notebook/conf.py
+++ b/desktop/libs/notebook/src/notebook/conf.py
@@ -219,13 +219,6 @@ ENABLE_QUERY_BUILDER = Config(
   default=False
 )
 
-ENABLE_NOTEBOOK_2 = Config(
-  key="enable_notebook_2",
-  help=_t("Feature flag to enable Notebook 2."),
-  type=coerce_bool,
-  default=False
-)
-
 # Note: requires Oozie app
 ENABLE_QUERY_SCHEDULING = Config(
   key="enable_query_scheduling",

--- a/desktop/libs/notebook/src/notebook/decorators.py
+++ b/desktop/libs/notebook/src/notebook/decorators.py
@@ -27,13 +27,14 @@ from django.http import Http404
 from django.utils.functional import wraps
 
 from dashboard.models import extract_solr_exception_message
+from desktop.conf import ENABLE_HUE_5
 from desktop.lib.django_util import JsonResponse
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.i18n import smart_unicode
 from desktop.lib.rest.http_client import RestException
 from desktop.models import Document2, Document, FilesystemException
 
-from notebook.conf import check_has_missing_permission, ENABLE_NOTEBOOK_2
+from notebook.conf import check_has_missing_permission
 from notebook.connectors.base import QueryExpired, QueryError, SessionExpired, AuthenticationRequired, OperationTimeout, \
   OperationNotSupported
 from notebook.models import _get_editor_type
@@ -120,7 +121,7 @@ def api_error_handler(f):
     except SessionExpired as e:
       response['status'] = -2
     except QueryExpired as e:
-      if ENABLE_NOTEBOOK_2.get():
+      if ENABLE_HUE_5.get():
         response['query_status'] = {'status': 'expired'}
         response['status'] = 0
       else:

--- a/desktop/libs/notebook/src/notebook/tasks.py
+++ b/desktop/libs/notebook/src/notebook/tasks.py
@@ -39,14 +39,13 @@ from django.http import FileResponse, HttpRequest
 from beeswax.data_export import DataAdapter
 from desktop.auth.backend import rewrite_user
 from desktop.celery import app
-from desktop.conf import TASK_SERVER
+from desktop.conf import ENABLE_HUE_5, TASK_SERVER
 from desktop.lib import export_csvxls, fsmanager
 from desktop.models import Document2
 from desktop.settings import CACHES_CELERY_KEY, CACHES_CELERY_QUERY_RESULT_KEY
 from useradmin.models import User
 
 from notebook.api import _get_statement
-from notebook.conf import ENABLE_NOTEBOOK_2
 from notebook.connectors.base import get_api, QueryExpired, ExecutionWrapper, QueryError
 from notebook.models import make_notebook, MockedDjangoRequest, Notebook
 from notebook.sql_utils import get_current_statement
@@ -492,7 +491,7 @@ def _cleanup(notebook, snippet):
   caches[CACHES_CELERY_KEY].delete(_fetch_progress_key(notebook, snippet))
 
 def _get_query_key(notebook, snippet):
-  if ENABLE_NOTEBOOK_2.get():
+  if ENABLE_HUE_5.get():
     if snippet.get('executable'):
       query_key = snippet['executable']['id']
     elif snippet.get('executor'):

--- a/desktop/libs/notebook/src/notebook/views.py
+++ b/desktop/libs/notebook/src/notebook/views.py
@@ -29,7 +29,7 @@ from django.views.decorators.http import require_POST
 from beeswax.data_export import DOWNLOAD_COOKIE_AGE
 from beeswax.management.commands import beeswax_install_examples
 from desktop.auth.decorators import admin_required
-from desktop.conf import ENABLE_DOWNLOAD, USE_NEW_EDITOR
+from desktop.conf import ENABLE_DOWNLOAD, ENABLE_HUE_5, USE_NEW_EDITOR
 from desktop.lib import export_csvxls
 from desktop.lib.connectors.models import Connector
 from desktop.lib.django_util import render, JsonResponse
@@ -39,7 +39,7 @@ from desktop.models import Document2, Document, FilesystemException, _get_gist_d
 from desktop.views import serve_403_error
 from metadata.conf import has_optimizer, has_catalog, has_workload_analytics
 
-from notebook.conf import get_ordered_interpreters, ENABLE_NOTEBOOK_2, SHOW_NOTEBOOKS, EXAMPLES
+from notebook.conf import get_ordered_interpreters, SHOW_NOTEBOOKS, EXAMPLES
 from notebook.connectors.base import Notebook, _get_snippet_name, get_interpreter
 from notebook.connectors.spark_shell import SparkApi
 from notebook.decorators import check_editor_access_permission, check_document_access_permission, check_document_modify_permission
@@ -142,7 +142,7 @@ def editor(request, is_mobile=False, is_embeddable=False):
     editor_type = _get_editor_type(editor_id)
 
   template = 'editor.mako'
-  if ENABLE_NOTEBOOK_2.get():
+  if ENABLE_HUE_5.get():
     template = 'editor2.mako'
   elif is_mobile:
     template = 'editor_m.mako'
@@ -207,7 +207,7 @@ def browse(request, database, table, partition_spec=None):
         namespace=namespace,
         compute=compute
     )
-    return render('editor2.mako' if ENABLE_NOTEBOOK_2.get() else 'editor.mako', request, {
+    return render('editor2.mako' if ENABLE_HUE_5.get() else 'editor.mako', request, {
         'notebooks_json': json.dumps([editor.get_data()]),
         'options_json': json.dumps({
             'languages': get_ordered_interpreters(request.user),
@@ -294,7 +294,7 @@ def execute_and_watch(request):
   else:
     raise PopupException(_('Action %s is unknown') % action)
 
-  return render('editor2.mako' if ENABLE_NOTEBOOK_2.get() else 'editor.mako', request, {
+  return render('editor2.mako' if ENABLE_HUE_5.get() else 'editor.mako', request, {
       'notebooks_json': json.dumps([editor.get_data()]),
       'options_json': json.dumps({
           'languages': [{"name": "%s SQL" % editor_type.title(), "type": editor_type}],

--- a/docs/docs-site/content/administrator/configuration/connectors/_index.md
+++ b/docs/docs-site/content/administrator/configuration/connectors/_index.md
@@ -32,13 +32,11 @@ Read about [how to build your own parser](/developer/development/#sql-parsers) i
 
 ### Connectors
 
-Admins can configure the connectors via the UI or [API](/developer/api/rest/#connectors). This feature requires Editor v2 and is quite functional despite not being offically released and on by default.
+Admins can configure the connectors via the UI or [API](/developer/api/rest/#connectors). This feature requires the Hue 5 feature flag set and is quite functional despite not being officially released and on by default.
 
     [desktop]
     enable_connectors=true
-
-    [notebook]
-    enable_notebook_2=true
+    enable_hue_5=true
 
 **NOTE:** After enabling the above flags, if a `django.db.utils.OperationalError: (1054, "Unknown column 'useradmin_huepermission.connector_id' in 'field list'")` error comes, then try **changing the DB name** in the hue.ini under `[[database]]` because there is no upgrade path and run the migrate command `./build/env/bin/hue migrate`.
 

--- a/docs/gethue/content/en/posts/2020-09-15-sql-querying-improvements-phoenix-flink-sparksql-erd.md
+++ b/docs/gethue/content/en/posts/2020-09-15-sql-querying-improvements-phoenix-flink-sparksql-erd.md
@@ -221,11 +221,9 @@ The query execution has been rewritten for better stability and running more tha
 
 Here is how to enable it in the `hue.ini`.
 
-    [notebook]
-    enable_notebook_2=true
-
     [desktop]
     enable_connectors=true
+    enable_hue_5=true
 
 **Note** [https://demo.gethue.com/](https://demo.gethue.com/) has the new Editor enabled
 

--- a/docs/gethue/content/en/posts/2020-10-20-querying-live-streams-of-data-with-flink-sql.md
+++ b/docs/gethue/content/en/posts/2020-10-20-querying-live-streams-of-data-with-flink-sql.md
@@ -115,8 +115,8 @@ More improvements are on the way, in particular in the SQL autocomplete and Edit
 
 In case you have an existing Hue Editor and want to point to the Flink, just activate it via this config change:
 
-    [notebook]
-    enable_notebook_2=true
+    [desktop]
+    enable_hue_5=true
 
     [[interpreters]]
 

--- a/docs/gethue/content/en/posts/2020-10-20-querying-live-streams-of-data-with-kafka-sql.md
+++ b/docs/gethue/content/en/posts/2020-10-20-querying-live-streams-of-data-with-kafka-sql.md
@@ -105,8 +105,8 @@ More improvements are on the way, in particular in the SQL autocomplete and Edit
 
 In case you have an existing Hue Editor and want to point to the ksqlDB, just activate it via this config change:
 
-    [notebook]
-    enable_notebook_2=true
+    [desktop]
+    enable_hue_5=true
 
     [[interpreters]]
 

--- a/docs/gethue/content/jp/posts/2020-09-15-sql-querying-improvements-phoenix-flink-sparksql-erd.md
+++ b/docs/gethue/content/jp/posts/2020-09-15-sql-querying-improvements-phoenix-flink-sparksql-erd.md
@@ -217,11 +217,9 @@ Hive 4 は SQL 構文による[スケジューリングクエリ](https://cwiki.
 
 `hue.ini` で有効にする方法は次のとおりです。
 
-    [notebook]
-    enable_notebook_2=true
-
     [desktop]
     enable_connectors=true
+    enable_hue_5=true
 
 **注** [https://demo.gethue.com/](https://demo.gethue.com/) では新しいエディタが有効になっています。
 

--- a/docs/gethue/content/jp/posts/2020-10-20-querying-live-streams-of-data-with-flink-sql.md
+++ b/docs/gethue/content/jp/posts/2020-10-20-querying-live-streams-of-data-with-flink-sql.md
@@ -112,8 +112,8 @@ categories:
 
 既存の Hue Editor をお持ちで ksqlDB を指定したい場合は、この設定変更で有効にしてください:
 
-    [notebook]
-    enable_notebook_2=true
+    [desktop]
+    enable_hue_5=true
 
     [[interpreters]]
 

--- a/docs/gethue/content/jp/posts/2020-10-20-querying-live-streams-of-data-with-kafka-sql.md
+++ b/docs/gethue/content/jp/posts/2020-10-20-querying-live-streams-of-data-with-kafka-sql.md
@@ -104,8 +104,8 @@ categories:
 
 既存の Hue Editor をお持ちで ksqlDB を指定したい場合は、この設定変更で有効にしてください:
 
-    [notebook]
-    enable_notebook_2=true
+    [desktop]
+    enable_hue_5=true
 
     [[interpreters]]
 


### PR DESCRIPTION
The scope of Hue 5 has grown beyond editor/notebook v2 and instead of introducing additional feature flags I've renamed the old one and moved it up in the desktop section of the config.

The ENABLE_HUE_5 flag can be used for any features that we intend to deliver in Hue 5 only.

Manually tested with flag on and off.