### PR TITLE
[ozone] Add service_id in ofs path and update UI

### DIFF
--- a/apps/filebrowser/src/filebrowser/templates/listdir.mako
+++ b/apps/filebrowser/src/filebrowser/templates/listdir.mako
@@ -61,12 +61,12 @@ ${ fb_components.menubar() }
         <div class="btn-toolbar" style="display: inline; vertical-align: middle">
           <div id="ch-dropdown" class="btn-group" style="vertical-align: middle">
             <button class="btn dropdown-toggle" title="${_('Actions')}" data-toggle="dropdown"
-            data-bind="visible: !inTrash(), enable: selectedFiles().length > 0 && ((!isS3() && !isABFS()) || (isS3() && !isS3Root()) || (isABFS() && !isABFSRoot()))">
+            data-bind="visible: !inTrash(), enable: selectedFiles().length > 0 && ((!isS3() && !isABFS() && !isOFS()) || (isS3() && !isS3Root()) || (isABFS() && !isABFSRoot()) || (isOFS() && !isOFSRoot()))">
               <i class="fa fa-cog"></i> ${_('Actions')}
               <span class="caret" style="line-height: 15px"></span>
             </button>
             <ul class="dropdown-menu" style="top: auto">
-              <li><a data-hue-analytics="filebrowser:actions-menu/rename-click" href="javascript: void(0)" title="${_('Rename')}" data-bind="visible: !inTrash() && selectedFiles().length == 1 && !isOFSRoot() && !isOFSVol(), click: renameFile,
+              <li><a data-hue-analytics="filebrowser:actions-menu/rename-click" href="javascript: void(0)" title="${_('Rename')}" data-bind="visible: !inTrash() && selectedFiles().length == 1 && !isOFSServiceID() && !isOFSVol(), click: renameFile,
               enable: selectedFiles().length == 1 && isCurrentDirSelected().length == 0"><i class="fa fa-fw fa-font"></i>
               ${_('Rename')}</a></li>
               <li><a data-hue-analytics="filebrowser:actions-menu/move-click" href="javascript: void(0)" title="${_('Move')}" data-bind="click: move, enable: selectedFiles().length > 0 &&
@@ -171,25 +171,25 @@ ${ fb_components.menubar() }
           <!-- /ko -->
           <!-- ko ifnot: isS3() || isABFS() -->
           <div id="upload-dropdown" class="btn-group" style="vertical-align: middle">
-            <a data-hue-analytics="filebrowser:upload-btn-click" href="javascript: void(0)" class="btn upload-link dropdown-toggle" title="${_('Upload')}" data-bind="click: uploadFile, visible: !inTrash(), css: {'disabled': isS3() && isS3Root() || isABFS() && isABFSRoot() || (isOFS() && (isOFSRoot() || isOFSVol()))}">
+            <a data-hue-analytics="filebrowser:upload-btn-click" href="javascript: void(0)" class="btn upload-link dropdown-toggle" title="${_('Upload')}" data-bind="click: uploadFile, visible: !inTrash(), css: {'disabled': isS3() && isS3Root() || isABFS() && isABFSRoot() || (isOFS() && (isOFSRoot() || isOFSServiceID() || isOFSVol()))}">
               <i class="fa fa-arrow-circle-o-up"></i> ${_('Upload')}
             </a>
           </div>
           <!-- /ko -->
           % endif
           <div class="btn-group" style="vertical-align: middle">
-            <a href="javascript: void(0)" data-toggle="dropdown" class="btn dropdown-toggle" data-bind="visible: !inTrash()">
+            <a href="javascript: void(0)" data-toggle="dropdown" class="btn dropdown-toggle" data-bind="visible: !inTrash(), css: {'disabled': isOFSRoot()}">
               <i class="fa fa-plus-circle"></i> ${_('New')}
               <span class="caret"></span>
             </a>
             <ul class="dropdown-menu pull-right" style="top: auto">
-              <li data-bind="visible: !isS3() && !isABFS() && !isOFS() || isS3() && !isS3Root() || isABFS() && !isABFSRoot() || isOFS() && !isOFSRoot() && !isOFSVol()"><a data-hue-analytics="filebrowser:new-file-btn-click" href="javascript: void(0)" class="create-file-link" title="${_('File')}"><i class="fa fa-file-o"></i> ${_('File')}</a></li>
+              <li data-bind="visible: !isS3() && !isABFS() && !isOFS() || isS3() && !isS3Root() || isABFS() && !isABFSRoot() || isOFS() && !isOFSServiceID() && !isOFSVol()"><a data-hue-analytics="filebrowser:new-file-btn-click" href="javascript: void(0)" class="create-file-link" title="${_('File')}"><i class="fa fa-file-o"></i> ${_('File')}</a></li>
               <li><a href="javascript: void(0)" class="create-directory-link" title="${_('Directory')}">
                 <i class="fa fa-folder"></i>
-                <span data-bind="visible: !isS3() && !isABFS() && !isOFS() || isS3() && !isS3Root() || isABFS() && !isABFSRoot() || isOFS() && !isOFSRoot() && !isOFSVol()">${_('Directory')}</span>
+                <span data-bind="visible: !isS3() && !isABFS() && !isOFS() || isS3() && !isS3Root() || isABFS() && !isABFSRoot() || isOFS() && !isOFSServiceID() && !isOFSVol()">${_('Directory')}</span>
                 <span data-bind="visible: (isS3() && isS3Root()) || (isOFS() && isOFSVol())">${_('Bucket')}</span>
                 <span data-bind="visible: isABFS() && isABFSRoot()">${_('File System')}</span>
-                <span data-bind="visible: isOFS() && isOFSRoot()">${_('Volume')}</span>
+                <span data-bind="visible: isOFS() && isOFSServiceID()">${_('Volume')}</span>
               </a></li>
             </ul>
           </div>

--- a/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
+++ b/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
@@ -461,7 +461,7 @@ else:
     <div id="createDirectoryModal" class="modal hide fade">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="${ _('Close') }"><span aria-hidden="true">&times;</span></button>
-        <!-- ko if: (!isS3() && !isABFS() && !isOFS()) || (isS3() && !isS3Root()) || (isABFS() && !isABFSRoot()) || (isOFS() && !isOFSRoot() && !isOFSVol())  -->
+        <!-- ko if: (!isS3() && !isABFS() && !isOFS()) || (isS3() && !isS3Root()) || (isABFS() && !isABFSRoot()) || (isOFS() && !isOFSServiceID() && !isOFSVol())  -->
         <h2 class="modal-title">${_('Create Directory')}</h2>
         <!-- /ko -->
         <!-- ko if: (isS3() && isS3Root()) || (isOFS() && isOFSVol()) -->
@@ -470,13 +470,13 @@ else:
         <!-- ko if: isABFS() && isABFSRoot() -->
         <h2 class="modal-title">${_('Create File System')}</h2>
         <!-- /ko -->
-        <!-- ko if: isOFS() && isOFSRoot() -->
+        <!-- ko if: isOFS() && isOFSServiceID() -->
         <h2 class="modal-title">${_('Create Volume')}</h2>
         <!-- /ko -->
       </div>
       <div class="modal-body">
         <label>
-          <!-- ko if: (!isS3() && !isABFS() && !isOFS()) || (isS3() && !isS3Root()) || (isABFS() && !isABFSRoot()) || (isOFS() && !isOFSRoot() && !isOFSVol()) -->
+          <!-- ko if: (!isS3() && !isABFS() && !isOFS()) || (isS3() && !isS3Root()) || (isABFS() && !isABFSRoot()) || (isOFS() && !isOFSServiceID() && !isOFSVol()) -->
           ${_('Directory Name')}
           <!-- /ko -->
           <!-- ko if: (isS3() && isS3Root()) || (isOFS() && isOFSVol()) -->
@@ -485,7 +485,7 @@ else:
           <!-- ko if: isABFS() && isABFSRoot() -->
           ${_('File System Name')}
           <!-- /ko -->
-          <!-- ko if: isOFS() && isOFSRoot() -->
+          <!-- ko if: isOFS() && isOFSServiceID() -->
           ${_('Volume Name')}
           <!-- /ko -->
           <input id="newDirectoryNameInput" name="name" value="" type="text" class="input-xlarge"/></label>
@@ -587,12 +587,12 @@ else:
   <!-- actions context menu -->
   <ul class="context-menu dropdown-menu">
   <!-- ko ifnot: $root.inTrash -->
-    <li data-bind="visible: (!isS3() && !isABFS() && !isOFS()) || (isS3() && !isS3Root()) || (isABFS() && !isABFSRoot()) || (isOFS() && !isOFSRoot() && !isOFSVol()), css: {'disabled': $root.selectedFiles().length != 1 || isCurrentDirSelected().length > 0}">
+    <li data-bind="visible: (!isS3() && !isABFS() && !isOFS()) || (isS3() && !isS3Root()) || (isABFS() && !isABFSRoot()) || (isOFS() && !isOFSServiceID() && !isOFSVol()), css: {'disabled': $root.selectedFiles().length != 1 || isCurrentDirSelected().length > 0}">
     <a href="javascript: void(0)" title="${_('Rename')}" data-bind="click: ($root.selectedFiles().length == 1 && isCurrentDirSelected().length == 0) ? $root.renameFile: void(0)"><i class="fa fa-fw fa-font"></i>
     ${_('Rename')}</a></li>
-    <li data-bind="visible: (!isS3() && !isABFS() && !isOFS()) || (isS3() && !isS3Root()) || (isABFS() && !isABFSRoot()) || (isOFS() && !isOFSRoot() && !isOFSVol()), css: {'disabled': $root.selectedFiles().length == 0 || isCurrentDirSelected().length > 0}">
+    <li data-bind="visible: (!isS3() && !isABFS() && !isOFS()) || (isS3() && !isS3Root()) || (isABFS() && !isABFSRoot()) || (isOFS() && !isOFSServiceID() && !isOFSVol()), css: {'disabled': $root.selectedFiles().length == 0 || isCurrentDirSelected().length > 0}">
     <a href="javascript: void(0)" title="${_('Move')}" data-bind="click: ( $root.selectedFiles().length > 0 && isCurrentDirSelected().length == 0) ? $root.move: void(0)"><i class="fa fa-fw fa-random"></i> ${_('Move')}</a></li>
-    <li data-bind="visible: (!isS3() && !isABFS() && !isOFS()) || (isS3() && !isS3Root()) || (isABFS() && !isABFSRoot()) || (isOFS() && !isOFSRoot() && !isOFSVol()), css: {'disabled': $root.selectedFiles().length == 0 || isCurrentDirSelected().length > 0}">
+    <li data-bind="visible: (!isS3() && !isABFS() && !isOFS()) || (isS3() && !isS3Root()) || (isABFS() && !isABFSRoot()) || (isOFS() && !isOFSServiceID() && !isOFSVol()), css: {'disabled': $root.selectedFiles().length == 0 || isCurrentDirSelected().length > 0}">
     <a href="javascript: void(0)" title="${_('Copy')}" data-bind="click: ($root.selectedFiles().length > 0 && isCurrentDirSelected().length == 0) ? $root.copy: void(0)"><i class="fa fa-fw fa-files-o"></i> ${_('Copy')}</a></li>
     % if show_download_button:
     <li data-bind="css: {'disabled': $root.inTrash() || $root.selectedFiles().length != 1 || selectedFile().type != 'file'}">
@@ -1156,8 +1156,12 @@ else:
         return self.isOFS() && self.currentPath().toLowerCase() === 'ofs://';
       });
 
-      self.isOFSVol = ko.pureComputed(function () {
+      self.isOFSServiceID = ko.pureComputed(function () {
         return self.isOFS() && self.currentPath().split("/").length === 3 && self.currentPath().split("/")[2] !== '';
+      });
+
+      self.isOFSVol = ko.pureComputed(function () {
+        return self.isOFS() && self.currentPath().split("/").length === 4 && self.currentPath().split("/")[3] !== '';
       });
 
       self.inTrash = ko.computed(function() {
@@ -1860,7 +1864,7 @@ else:
           resetPrimaryButtonsStatus(); //globally available
           return false;
         }
-        if (self.isOFSRoot() || self.isOFSVol()) {
+        if (self.isOFSServiceID() || self.isOFSVol()) {
           if ($("#newDirectoryNameInput").val().length < 3 || $("#newDirectoryNameInput").val().length > 63) {
             $("#volumeBucketNameAlert").show();
             $("#newDirectoryNameInput").addClass("fieldError");

--- a/desktop/core/src/desktop/lib/fs/ozone/ofs.py
+++ b/desktop/core/src/desktop/lib/fs/ozone/ofs.py
@@ -23,8 +23,10 @@ import logging
 import sys
 import threading
 
+from django.utils.encoding import smart_str
+
 from desktop.lib.rest import http_client, resource
-from desktop.lib.fs.ozone import OFS_ROOT, normpath, is_root, parent_path
+from desktop.lib.fs.ozone import OFS_ROOT, normpath, is_root, parent_path, _serviceid_join, join as ofs_join
 from desktop.lib.fs.ozone.ofsstat import OzoneFSStat
 from desktop.conf import PERMISSION_ACTION_OFS
 
@@ -85,10 +87,11 @@ class OzoneFS(WebHdfs):
     )
 
   def strip_normpath(self, path):
-    if path.startswith('ofs://'):
-      path = path[5:]
-    elif path.startswith('ofs:/'):
-      path = path[4:]
+    if path.startswith(OFS_ROOT + self._netloc):
+      path = path.split(OFS_ROOT + self._netloc)[1]
+    elif path.startswith('ofs:/' + self._netloc):
+      path = path.split('ofs:/' + self._netloc)[1]
+
     return path
 
   def normpath(self, path):
@@ -101,7 +104,7 @@ class OzoneFS(WebHdfs):
     return is_root(path)
 
   def parent_path(self, path):
-    return parent_path(path)
+    return parent_path(path, self._netloc)
 
   def listdir_stats(self, path, glob=None):
     """
@@ -109,31 +112,54 @@ class OzoneFS(WebHdfs):
 
     Get directory listing with stats.
     """
-    path = self.strip_normpath(path)
-    params = self._getparams()
-    if glob is not None:
-      params['filter'] = glob
-    params['op'] = 'LISTSTATUS'
-    headers = self._getheaders()
-    json = self._root.get(path, params, headers)
+    if path == OFS_ROOT:
+      json = self._handle_serviceid_path_status()
+    else:
+      path = self.strip_normpath(path)
+      params = self._getparams()
+
+      if glob is not None:
+        params['filter'] = glob
+      params['op'] = 'LISTSTATUS'
+      headers = self._getheaders()
+
+      json = self._root.get(path, params, headers)
+
     filestatus_list = json['FileStatuses']['FileStatus']
-    return [OzoneFSStat(st, path) for st in filestatus_list]
+    return [OzoneFSStat(st, path, self._netloc) for st in filestatus_list]
 
   def _stats(self, path):
     """
     This stats method returns None if the entry is not found.
     """
-    path = self.strip_normpath(path)
-    params = self._getparams()
-    params['op'] = 'GETFILESTATUS'
-    headers = self._getheaders()
-    try:
-      json = self._root.get(path, params, headers)
-      return OzoneFSStat(json['FileStatus'], path)
-    except WebHdfsException as ex:
-      if ex.server_exc == 'FileNotFoundException' or ex.code == 404:
-        return None
-      raise ex
+    if path == OFS_ROOT:
+      serviceid_path_status = self._handle_serviceid_path_status()['FileStatuses']['FileStatus'][0]
+      json = {'FileStatus': serviceid_path_status}
+    else:
+      path = self.strip_normpath(path)
+      params = self._getparams()
+      params['op'] = 'GETFILESTATUS'
+      headers = self._getheaders()
+
+      try:
+        json = self._root.get(path, params, headers)
+      except WebHdfsException as ex:
+        if ex.server_exc == 'FileNotFoundException' or ex.code == 404:
+          return None
+        raise ex
+    
+    return OzoneFSStat(json['FileStatus'], path, self._netloc)
+  
+  def _handle_serviceid_path_status(self):
+    json = {
+      'FileStatuses': {
+        'FileStatus': [{
+          'pathSuffix': self._netloc, 'type': 'DIRECTORY', 'length': 0, 'owner': '', 'group': '', 
+          'permission': '777', 'accessTime': 0, 'modificationTime': 0, 'blockSize': 0, 'replication': 0
+          }]
+        }
+      }
+    return json
   
   def stats(self, path):
     """
@@ -152,3 +178,35 @@ class OzoneFS(WebHdfs):
     Upload is done by the OFSFileUploadHandler
     """
     pass
+
+  def rename(self, old, new):
+    """rename(old, new)"""
+    old = self.strip_normpath(old)
+    if not self.is_absolute(new):
+      new = _serviceid_join(ofs_join(self.dirname(old), new), self._netloc)
+    new = self.strip_normpath(new)
+
+    params = self._getparams()
+    params['op'] = 'RENAME'
+    # Encode `new' because it's in the params
+    params['destination'] = smart_str(new)
+    headers = self._getheaders()
+
+    result = self._root.put(old, params, headers=headers)
+
+    if not result['boolean']:
+      raise IOError(_("Rename failed: %s -> %s") % (smart_str(old, errors='replace'), smart_str(new, errors='replace')))
+  
+  def rename_star(self, old_dir, new_dir):
+    """Equivalent to `mv old_dir/* new"""
+    if not self.isdir(old_dir):
+      raise IOError(errno.ENOTDIR, _("'%s' is not a directory") % old_dir)
+
+    if not self.exists(new_dir):
+      self.mkdir(new_dir)
+    elif not self.isdir(new_dir):
+      raise IOError(errno.ENOTDIR, _("'%s' is not a directory") % new_dir)
+  
+    ls = self.listdir(old_dir)
+    for dirent in ls:
+      self.rename(_serviceid_join(ofs_join(old_dir, dirent), self._netloc), _serviceid_join(ofs_join(new_dir, dirent), self._netloc))

--- a/desktop/core/src/desktop/lib/fs/ozone/ofs_test.py
+++ b/desktop/core/src/desktop/lib/fs/ozone/ofs_test.py
@@ -56,35 +56,38 @@ class TestOFSClient(object):
 
 
   def test_strip_normpath(self):
-    test_path = self.ofs_client.strip_normpath('ofs://vol1/buk1/key')
+    test_path = self.ofs_client.strip_normpath('ofs://ozone1/vol1/buk1/key')
     assert_equal(test_path, '/vol1/buk1/key')
 
-    test_path = self.ofs_client.strip_normpath('ofs:/vol1/buk1/key')
+    test_path = self.ofs_client.strip_normpath('ofs:/ozone1/vol1/buk1/key')
     assert_equal(test_path, '/vol1/buk1/key')
 
-    test_path = self.ofs_client.strip_normpath('/vol1/buk1/key')
-    assert_equal(test_path, '/vol1/buk1/key')
+    test_path = self.ofs_client.strip_normpath('/ozone1/vol1/buk1/key')
+    assert_equal(test_path, '/ozone1/vol1/buk1/key')
 
 
   def test_normpath(self):
     test_path = self.ofs_client.normpath('ofs://')
     assert_equal(test_path, 'ofs://')
 
-    test_path = self.ofs_client.normpath('ofs://vol1/buk1/key')
-    assert_equal(test_path, 'ofs://vol1/buk1/key')
+    test_path = self.ofs_client.normpath('ofs://ozone1/vol1/buk1/key')
+    assert_equal(test_path, 'ofs://ozone1/vol1/buk1/key')
 
-    test_path = self.ofs_client.normpath('ofs://vol1/buk1/key/')
-    assert_equal(test_path, 'ofs://vol1/buk1/key')
+    test_path = self.ofs_client.normpath('ofs://ozone1/vol1/buk1/key/')
+    assert_equal(test_path, 'ofs://ozone1/vol1/buk1/key')
 
-    test_path = self.ofs_client.normpath('ofs://vol1/buk1/key//')
-    assert_equal(test_path, 'ofs://vol1/buk1/key')
+    test_path = self.ofs_client.normpath('ofs://ozone1/vol1/buk1/key//')
+    assert_equal(test_path, 'ofs://ozone1/vol1/buk1/key')
 
-    test_path = self.ofs_client.normpath('ofs://vol1/buk1//key//')
-    assert_equal(test_path, 'ofs://vol1/buk1/key')
+    test_path = self.ofs_client.normpath('ofs://ozone1/vol1/buk1//key//')
+    assert_equal(test_path, 'ofs://ozone1/vol1/buk1/key')
 
 
   def test_isroot(self):
-    is_root = self.ofs_client.isroot('ofs://vol1/buk1/key')
+    is_root = self.ofs_client.isroot('ofs://ozone1/vol1/buk1/key')
+    assert_equal(is_root, False)
+
+    is_root = self.ofs_client.isroot('ofs://ozone1')
     assert_equal(is_root, False)
 
     is_root = self.ofs_client.isroot('ofs://')
@@ -95,17 +98,36 @@ class TestOFSClient(object):
     parent_path = self.ofs_client.parent_path('ofs://')
     assert_equal(parent_path, 'ofs://')
 
-    parent_path = self.ofs_client.parent_path('ofs://vol1/buk1/dir1/file1.csv')
-    assert_equal(parent_path, 'ofs://vol1/buk1/dir1')
+    parent_path = self.ofs_client.parent_path('ofs://ozone1/vol1/buk1/dir1/file1.csv')
+    assert_equal(parent_path, 'ofs://ozone1/vol1/buk1/dir1')
 
-    parent_path = self.ofs_client.parent_path('ofs://vol1/buk1/key')
-    assert_equal(parent_path, 'ofs://vol1/buk1')
+    parent_path = self.ofs_client.parent_path('ofs://ozone1/vol1/buk1/key')
+    assert_equal(parent_path, 'ofs://ozone1/vol1/buk1')
 
-    parent_path = self.ofs_client.parent_path('ofs://vol1/buk1')
-    assert_equal(parent_path, 'ofs://vol1/')
+    parent_path = self.ofs_client.parent_path('ofs://ozone1/vol1/buk1')
+    assert_equal(parent_path, 'ofs://ozone1/vol1')
 
-    parent_path = self.ofs_client.parent_path('ofs://vol1')
+    parent_path = self.ofs_client.parent_path('ofs://ozone1/vol1')
+    assert_equal(parent_path, 'ofs://ozone1/')
+
+    parent_path = self.ofs_client.parent_path('ofs://ozone1')
     assert_equal(parent_path, 'ofs://')
+
+
+  def test_listdir_stats_for_serviceid_path(self):
+    serviceid_stat = self.ofs_client.listdir_stats('ofs://')
+    assert_equal(
+      serviceid_stat[0].to_json_dict(),
+      {'path': 'ofs://ozone1', 'size': 0, 'atime': 0, 'mtime': 0, 'mode': 16895, 'user': '', 'group': '', 'blockSize': 0, 'replication': 0}
+    )
+
+
+  def test_stats_for_serviceid_path(self):
+    serviceid_stat = self.ofs_client.stats('ofs://')
+    assert_equal(
+      serviceid_stat.to_json_dict(),
+      {'path': 'ofs://ozone1', 'size': 0, 'atime': 0, 'mtime': 0, 'mode': 16895, 'user': '', 'group': '', 'blockSize': 0, 'replication': 0}
+    )
 
 
   @classmethod

--- a/desktop/core/src/desktop/lib/fs/ozone/ofsstat.py
+++ b/desktop/core/src/desktop/lib/fs/ozone/ofsstat.py
@@ -24,7 +24,7 @@ from django.utils.encoding import smart_str
 from hadoop.fs.hadoopfs import decode_fs_path
 from hadoop.fs.webhdfs_types import WebHdfsStat
 
-from desktop.lib.fs.ozone import join as ofs_join
+from desktop.lib.fs.ozone import _serviceid_join, join as ofs_join
 
 class OzoneFSStat(WebHdfsStat):
   """
@@ -33,9 +33,9 @@ class OzoneFSStat(WebHdfsStat):
   Modelled after org.apache.hadoop.fs.FileStatus
   """
 
-  def __init__(self, file_status, parent_path):
+  def __init__(self, file_status, parent_path, ofs_serviceid=''):
     super(OzoneFSStat, self).__init__(file_status, parent_path)
-    self.path = ofs_join(parent_path, self.name)
+    self.path = _serviceid_join(ofs_join(parent_path, self.name), ofs_serviceid)
 
   def __unicode__(self):
     return "[OzoneFSStat] %7s %8s %8s %12s %s%s" % (oct(self.mode), self.user, self.group, self.size, self.path, self.isDir and '/' or "")

--- a/desktop/core/src/desktop/lib/fs/ozone/ofsstat_test.py
+++ b/desktop/core/src/desktop/lib/fs/ozone/ofsstat_test.py
@@ -26,14 +26,14 @@ class TestOzoneFSStat(object):
       'pathSuffix': 'testfile.csv', 'type': 'FILE', 'length': 32, 'owner': 'hueadmin', 'group': 'huegroup',
       'permission': '666', 'accessTime': 1677914460588, 'modificationTime': 1677914460588, 'blockSize': 268435456, 'replication': 3}
 
-    test_parent_path = '/gethue/'
+    test_parent_path = '/ozone1/gethue/'
 
     self.stat = OzoneFSStat(test_file_status, test_parent_path)
 
 
   def test_stat_attributes(self):
     assert_equal(self.stat.name, 'testfile.csv')
-    assert_equal(self.stat.path, 'ofs://gethue/testfile.csv')
+    assert_equal(self.stat.path, 'ofs://ozone1/gethue/testfile.csv')
     assert_equal(self.stat.isDir, False)
     assert_equal(self.stat.type, 'FILE')
     assert_equal(self.stat.atime, 1677914460)
@@ -50,7 +50,7 @@ class TestOzoneFSStat(object):
 
   def test_to_json_dict(self):
     expected_json_dict = {
-      'path': 'ofs://gethue/testfile.csv', 'size': 32, 'atime': 1677914460, 'mtime': 1677914460, 'mode': 33206, 'user': 'hueadmin',
+      'path': 'ofs://ozone1/gethue/testfile.csv', 'size': 32, 'atime': 1677914460, 'mtime': 1677914460, 'mode': 33206, 'user': 'hueadmin',
       'group': 'huegroup', 'blockSize': 268435456, 'replication': 3}
 
     assert_equal(self.stat.to_json_dict(), expected_json_dict)

--- a/desktop/core/src/desktop/lib/fs/proxyfs.py
+++ b/desktop/core/src/desktop/lib/fs/proxyfs.py
@@ -223,7 +223,7 @@ class ProxyFS(object):
 
     # All users will have access to Ozone root.
     if is_ofs_enabled():
-      LOG.debug('Creation of user home path is not supported in Ozone. Redirect to %s' % OFS_ROOT)
+      LOG.debug('Creation of user home path is not supported in Ozone.')
 
     # Get the new home_path for S3/ABFS when RAZ is enabled.
     if is_raz_s3():

--- a/desktop/libs/indexer/src/indexer/indexers/sql.py
+++ b/desktop/libs/indexer/src/indexer/indexers/sql.py
@@ -33,7 +33,6 @@ from notebook.connectors.base import get_interpreter
 from notebook.models import make_notebook
 from useradmin.models import User
 
-from desktop.conf import OZONE
 from desktop.lib import django_mako
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.settings import BASE_DIR
@@ -183,18 +182,7 @@ class SQLIndexer(object):
 
     if external_path.lower().startswith("abfs"): #this is to check if its using an ABFS path
       external_path = abfspath(external_path)
-    elif external_path.lower().startswith("ofs") or source_path.lower().startswith("ofs"):  # This is to check if its using an OFS path
-      if OZONE['default'].FS_DEFAULTFS.get():
-        fs_defaultfs_schemeless = OZONE['default'].FS_DEFAULTFS.get()[6:]
 
-        # Add fs_defaultfs netloc in the OFS path for Hive/Impala.
-        # fs_defaultfs can be Ozone service ID if Ozone is in HA or Ozone Manager URI in non-HA mode.
-        # E.g: ofs:// + fs_defaultfs_schemeless + /vol1/buk1/key
-
-        external_path = external_path[:6] + fs_defaultfs_schemeless + external_path[5:]
-        source_path = source_path[:6] + fs_defaultfs_schemeless + source_path[5:]
-      else:
-        raise PopupException('Ozone fs_defaultFS is not configured.')
 
     tbl_properties = OrderedDict()
     if skip_header:


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Path now changes from ofs://vol1/buck1/... to ofs://serviceID/vol1/buck1/...

- We are actually mocking LISTSTATUS and GETFILESTATUS op calls for ofs:// now to only show serviceID as an element. This enables in correct breadcrumbs and ofs valid path structure.
- On the UI side, volume and bucket operations were shifted right to incorporate service_id as path and no operations should be allowed from UI on it.

## How was this patch tested?

- Manually E2E and via updated unit tests.

## Screenshots

<img width="1791" alt="Screenshot 2023-03-27 at 12 42 53 PM" src="https://user-images.githubusercontent.com/42064744/227867372-8d30001f-649a-440e-b9d3-e612950f04c7.png">

<img width="1790" alt="Screenshot 2023-03-27 at 12 43 10 PM" src="https://user-images.githubusercontent.com/42064744/227867447-efa3a6a4-78ea-4160-a343-d06a6bb219c2.png">



