### PR TITLE
[ozone] Skip copying files with size greater than chunk size

### DIFF
--- a/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
+++ b/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
@@ -1540,8 +1540,14 @@ else:
             self.retrieveData(true);
           },
           error: function(xhr){
-            $.jHueNotify.error(xhr.responseText);
-            resetPrimaryButtonsStatus();
+            if (xhr.status === 413) {
+              $.jHueNotify.error(JSON.parse(xhr.responseText).message);
+              resetPrimaryButtonsStatus();
+            }
+            else {
+              $.jHueNotify.error(xhr.responseText);
+              resetPrimaryButtonsStatus();
+            }
           }
         });
 

--- a/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
+++ b/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
@@ -1540,14 +1540,8 @@ else:
             self.retrieveData(true);
           },
           error: function(xhr){
-            if (xhr.status === 413) {
-              $.jHueNotify.error(JSON.parse(xhr.responseText).message);
-              resetPrimaryButtonsStatus();
-            }
-            else {
-              $.jHueNotify.error(xhr.responseText);
-              resetPrimaryButtonsStatus();
-            }
+            $.jHueNotify.error(xhr.responseText);
+            resetPrimaryButtonsStatus();
           }
         });
 

--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -1318,17 +1318,22 @@ def move(request):
 def copy(request):
   recurring = ['dest_path']
   params = ['src_path']
-  ozone_skip_files = []
   def bulk_copy(*args, **kwargs):
+    ofs_skip_files = ''
     for arg in args:
       if arg['src_path'] == arg['dest_path']:
         raise PopupException(_('Source path and destination path cannot be same'))
-      if arg['src_path'].startswith("ofs://"):
-        ozone_skip_files.append(request.fs.copy(arg['src_path'], arg['dest_path'], recursive=True, owner=request.user))
+
+      # Copy method for OFS returns a string of skipped files if their size is greater than chunk size.
+      if arg['src_path'].startswith('ofs://'):
+        ofs_skip_files += request.fs.copy(arg['src_path'], arg['dest_path'], recursive=True, owner=request.user)
       else:
         request.fs.copy(arg['src_path'], arg['dest_path'], recursive=True, owner=request.user)
-    if ozone_skip_files:
-      raise PopupException(_(str(ozone_skip_files)), error_code=413)
+    
+    # Send skipped filenames via raising exception to let users know.
+    if ofs_skip_files:
+      raise PopupException("Following files were skipped due to file size limitations:" + ofs_skip_files)
+
   return generic_op(CopyFormSet, request, bulk_copy, ["src_path", "dest_path"], None,
                     data_extractor=formset_data_extractor(recurring, params),
                     arg_extractor=formset_arg_extractor,

--- a/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py
+++ b/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py
@@ -798,7 +798,7 @@ class WebHdfs(Hdfs):
     if owner is None:
       owner = self.user
 
-    # Hue was defauling permissions on copying files to the permissions
+    # Hue was defaulting permissions on copying files to the permissions
     # of the original file, but was not doing the same for directories
     # changed below for directories to remain consistent
     if dir_mode is None:


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Copy operation uses /append API for files with size greater than the chunk size. But Ozone HttpFS APIs does not support /append API yet, so we are skipping all file sizes greater than the chunk size.
- Since the copy operation can be recursive, we are skipping file recursively from directories and showing on the UI for users to know about it.

## Workaround
- Increasing the chunk size value in the Hue config can allow large files to be copied without skipping.

## How was this patch tested?

- Tested manually.