### PR TITLE
[Python3.9] Thread.isAlive() has been removed in Python 3.9 in favour for is_alive()

### DIFF
--- a/apps/proxy/src/proxy/proxy_test.py
+++ b/apps/proxy/src/proxy/proxy_test.py
@@ -91,7 +91,7 @@ def run_test_server():
     # Make sure the server thread is done.
     print("Closing thread " + str(thread))
     thread.join(10.0) # Wait at most 10 seconds
-    assert_false(thread.isAlive())
+    assert_false(thread.is_alive())
 
   return httpd, finish
 run_test_server.__test__ = False

--- a/desktop/core/src/desktop/lib/wsgiserver.py
+++ b/desktop/core/src/desktop/lib/wsgiserver.py
@@ -1389,7 +1389,7 @@ class ThreadPool(object):
         # Grow/shrink the pool if necessary.
         # Remove any dead threads from our list
         for t in self._threads:
-            if not t.isAlive():
+            if not t.is_alive():
                 self._threads.remove(t)
                 amount -= 1
 
@@ -1411,13 +1411,13 @@ class ThreadPool(object):
         current = threading.currentThread()
         while self._threads:
             worker = self._threads.pop()
-            if worker is not current and worker.isAlive():
+            if worker is not current and worker.is_alive():
                 try:
                     if timeout is None or timeout < 0:
                         worker.join()
                     else:
                         worker.join(timeout)
-                        if worker.isAlive():
+                        if worker.is_alive():
                             # We exhausted the timeout.
                             # Forcibly shut down the socket.
                             c = worker.conn

--- a/desktop/core/src/desktop/supervisor.py
+++ b/desktop/core/src/desktop/supervisor.py
@@ -203,7 +203,7 @@ def shutdown(sups):
     still_alive = False
     for sup in sups:
       sup.join(0.2)
-      still_alive = still_alive or sup.isAlive()
+      still_alive = still_alive or sup.is_alive()
     if not still_alive:
       break
   if still_alive:
@@ -395,7 +395,7 @@ def wait_loop(sups, options):
     time.sleep(1)
     for sup in sups:
       sup.join(0.1)
-      if not sup.isAlive():
+      if not sup.is_alive():
         if sup.state == Supervisor.FINISHED:
           sups.remove(sup)
         else:


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Changed from isAlive() to is_alive()
- Related PR -> https://github.com/python/cpython/issues/81985
- The isAlive() method of [threading.Thread](https://docs.python.org/3/library/threading.html#threading.Thread) has been removed. It was deprecated since Python 3.8. Use [is_alive()](https://docs.python.org/3/library/threading.html#threading.Thread.is_alive) instead.

## How was this patch tested?

- In python3.8 and python2.7 importing thread and tried is_alive() operation. Working fine.
- is_alive() got added in python2.6 so no problem for python2.7 and python3.8 based Hue https://docs.python.org/2.7/library/threading.html#threading.Thread.is_alive.
