### PR TITLE
[Pyhton3.9] Allowing Hue to install virtualenv for >= python3.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ $(BLD_DIR_ENV)/stamp:
 	@echo "--- Creating virtual environment at $(BLD_DIR_ENV)"
 ifeq ($(PYTHON_VER),python2.7)
 	@$(SYS_PYTHON) $(VIRTUAL_BOOTSTRAP) $(VIRTUALENV_OPTS) --system-site-packages $(BLD_DIR_ENV)
-else ifeq ($(PYTHON_VER),python3.8)
+else if (${PYTHON_VER//[^0-9]/} -ge 38)
 	@$(SYS_PYTHON) -m pip install --upgrade pip==22.2.2
 	@$(SYS_PIP) install virtualenv==20.19.0 virtualenv-make-relocatable==0.0.1
 	@if [[ "ppc64le" == $(PPC64LE) ]]; then \
@@ -152,7 +152,7 @@ ifeq ($(PYTHON_VER),python2.7)
 	@$(ENV_PIP) install --upgrade pip
 	@$(ENV_PIP) install --upgrade --force-reinstall $(PIP_MODULES)
 	@echo "--- done installing PIP_MODULES in virtual-env"
-else ifeq ($(PYTHON_VER),python3.8)
+else if (${PYTHON_VER//[^0-9]/} -ge 38)
 	@if [[ "ppc64le" == $(PPC64LE) ]]; then \
 	  echo '--- Installing $(REQUIREMENT_PPC64LE_FILE) into virtual-env via $(ENV_PIP)'; \
 	  $(ENV_PIP) install -r $(REQUIREMENT_PPC64LE_FILE); \


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Allowing Hue to install virtualenv and all the python libs for >=python 3.8 

## How was this patch tested?
- Tested with creating creating cluster with a canary. 
- On centos7, Hue with python3.8 is working fine.
- On Redhat8, Hue with python3.8 is working fine.
- On ubuntu20, Hue with python3.8 is working fine.
- On sles12, Hue with python3.8 is working fine.


