### PR TITLE
notebook multisession errror: Session matching query does not exist

### DIFF
--- a/desktop/core/src/desktop/js/apps/notebook/snippet.js
+++ b/desktop/core/src/desktop/js/apps/notebook/snippet.js
@@ -1887,6 +1887,7 @@ class Snippet {
               } else {
                 notebook.sessions()[0].session_id(data.handle.session_guid);
                 notebook.sessions()[0].id(data.handle.session_id);
+                notebook.sessions()[0].type(self.type());
               }
             }
             if (vm.editorMode()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Issue:** notebook multisession errror: Session matching query does not exist

**Fix:** Type is not added on execute hence throws session matching query does not exist, adding the current type fixes the issue.

## How was this patch tested?
Local Testing:
  * Reproduce the issue without the code change.
  * Performed the same steps back to verify the fix.
