### PR TITLE
[download] Check for binary empty chunk string correctly

### DIFF
--- a/desktop/core/src/desktop/lib/export_csvxls.py
+++ b/desktop/core/src/desktop/lib/export_csvxls.py
@@ -60,7 +60,7 @@ def file_reader(fh):
   """Generator that reads a file, chunk-by-chunk."""
   while True:
     chunk = fh.read(DOWNLOAD_CHUNK_SIZE)
-    if chunk == '':
+    if not chunk:
       fh.close()
       break
     yield chunk


### PR DESCRIPTION
## What changes were proposed in this pull request?

- In py3, the last file chunk is b'' and the file_reader loop never breaks!
- This is causing a wild infinite for loop and making infinite request to the connected FS for the empty chunk string.

- With the fix, it will break correctly after receiving the first empty binary string of file chunk.

## How was this patch tested?

- Tested in local Hue setup