### PR TITLE
[download] Fix zero size file downloading for ABFS

### DIFF
--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -197,8 +197,10 @@ def download(request, path):
     request.fs.read(path, offset=0, length=1)
   except WebHdfsException as e:
     if e.code == 403:
-      raise PopupException(_('User %s is not authorized to download file at path "%s"') %
-                           (request.user.username, path))
+      raise PopupException(_('User %s is not authorized to download file at path "%s"') % (request.user.username, path))
+    elif request.fs._get_scheme(path).lower() == 'abfs' and e.code == 416:
+      # Safe to skip ABFS exception of code 416 for zero length objects, file will get downloaded anyway.
+      logger.exception('Skipping exception from ABFS: ' + str(e))
     else:
       raise PopupException(_('Failed to download file at path "%s": %s') % (path, e))
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is related to ABFS in general and is reproducible in the local setup. 
From the logs, we are getting the following error from ABFS:

```
{"error":{"code":"InvalidRange","message":"The range specified is invalid for the current size of the resource.\nRequestId:87e0fcb0-201f-0042-6b7b-6cfc87000000\nTime:2023-04-11T13:41:21.7375625Z"}} (error 416)
```

Searching more, this is the expected behaviour from ABFS: https://stackoverflow.com/questions/55689719/unable-to-download-blobs-from-azure-blob-storage

So, tried catching this particular exception and simply pass to see if zero size file download actually happens after that (indicated in one of the stackoverflow answers above) and it works.

## How was this patch tested?

- Tested manually in the local setup.