### PR TITLE
Hue [backend] Force env variable DESKTOP_LOG_DIR in docker creation

### DIFF
--- a/tools/container/hue/Dockerfile
+++ b/tools/container/hue/Dockerfile
@@ -15,6 +15,7 @@ ENV NAME="hue" \
     HUE_HOME="/opt/${HUEUSER}" \
     HUE_CONF_DIR="${HUE_CONF}/conf" \
     HUE_LOG_DIR="/var/log/${HUEUSER}" \
+    DESKTOP_LOG_DIR="/var/log/${HUEUSER}" \
     HUE_BUILDNO=${GBN} \
     HUE_SHAURL=${GSHA} \
     HUE_BRANCHURL=${GBRANCH} \

--- a/tools/container/hue/hue.sh
+++ b/tools/container/hue/hue.sh
@@ -6,7 +6,7 @@ set -x
 # Time marker for both stderr and stdout
 date; date 1>&2
 
-export DESKTOP_LOG_DIR="/opt/hive/logs"
+export DESKTOP_LOG_DIR="/var/log/hive"
 export PYTHON_EGG_CACHE=$HUE_CONF_DIR/.python-eggs
 export SERVER_SOFTWARE="apache"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Docker environment variable DESKTOP_LOG_DIR setting

## How was this patch tested?

- manually 
Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
