### PR TITLE
[release] Fix incorrect docker image url in 4.11 release notes

### DIFF
--- a/docs/docs-site/content/releases/release-notes-4.11.0.md
+++ b/docs/docs-site/content/releases/release-notes-4.11.0.md
@@ -72,7 +72,7 @@ Go grab it and give it a spin!
 
 * Docker
     ```
-    docker run -it -p 8888:8888 gethue/4.11.0
+    docker run -it -p 8888:8888 gethue/hue:4.11.0
     ```
 * Kubernetes :
     ```


### PR DESCRIPTION
the docker image gethue/4.11.0  missing hue name, should be gethue/hue:4.11.0

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
