### PR TITLE
[raz] Add JWT support for Hue-Raz Integration

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -963,7 +963,7 @@ tls=no
 ## Endpoint to contact
 # api_url=https://localhost:8080
 
-## How to authenticate against: KERBEROS or JWT (not supported yet)
+## How to authenticate against: KERBEROS or JWT
 # api_authentication=KERBEROS
 
 ## Autocreate the user home directory in the remote home storage path.

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -946,7 +946,7 @@
   ## Endpoint to contact
   # api_url=https://localhost:8080
 
-  ## How to authenticate against: KERBEROS or JWT (not supported yet)
+  ## How to authenticate against: KERBEROS or JWT
   # api_authentication=KERBEROS
 
   ## Autocreate the user home directory in the remote home storage path.

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -2189,7 +2189,7 @@ SDXAAS = ConfigSection(
 
 def is_sdxaas_jwt_enabled():
   """Check if SDXaaS token url is configured"""
-  return SDXAAS.TOKEN_URL.get() != ''
+  return bool(SDXAAS.TOKEN_URL.get())
 
 def handle_raz_api_auth():
   """Return RAZ authentication type from JWT (if SDXaaS token URL is set) or KERBEROS"""

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -2174,6 +2174,28 @@ def has_raz_url():
   return bool(_get_raz_url())
 
 
+SDXAAS = ConfigSection(
+  key='sdxaas',
+  help=_("""Configuration for SDXaaS JWT support."""),
+  members=dict(
+    TOKEN_URL=Config(
+      key='token_url',
+      help=_('Comma separated host URLs to fetch token from.'),
+      type=str,
+      default='',
+    )
+  )
+)
+
+def is_sdxaas_jwt_enabled():
+  """Check if SDXaaS token url is configured"""
+  return SDXAAS.TOKEN_URL.get() != ''
+
+def handle_raz_api_auth():
+  """Return RAZ authentication type from JWT (if SDXaaS token URL is set) or KERBEROS"""
+  return 'jwt' if is_sdxaas_jwt_enabled() else 'kerberos'
+
+
 RAZ = ConfigSection(
   key='raz',
   help=_("""Configuration for RAZ service integration"""),
@@ -2192,9 +2214,9 @@ RAZ = ConfigSection(
     ),
     API_AUTHENTICATION=Config(
         key='api_authentication',
-        help=_('How to authenticate against: KERBEROS or JWT (not supported yet)'),
+        help=_('How to authenticate against: KERBEROS or JWT'),
         type=coerce_str_lowercase,
-        default='kerberos',
+        dynamic_default=handle_raz_api_auth,
     ),
     AUTOCREATE_USER_DIR=Config(
       key='autocreate_user_dir',

--- a/desktop/core/src/desktop/lib/raz/raz_client.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client.py
@@ -32,7 +32,6 @@ from desktop.conf import AUTH_USERNAME
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.sdxaas.knox_jwt import fetch_jwt
 
-
 import desktop.lib.raz.signer_protos_pb2 as raz_signer
 
 if sys.version_info[0] > 2:
@@ -84,32 +83,6 @@ class RazToken:
     LOG.debug('Raz token: %s' % self.raz_token)
 
     return self.raz_token
-    # try:
-    #   response_from_knox = requests.get(knox_url, auth=self.auth_handler, verify=False)
-
-    #   LOG.debug('Response from Knox ---->>>>')
-    #   jwt_token = json.loads(response_from_knox.text)['access_token']
-    #   LOG.debug(jwt_token)
-
-    #   encoded_jwt_token = base64.b64encode(jwt_token.encode('utf-8')).decode('utf-8')
-    #   LOG.debug('encoded jwt token ----->>>')
-    #   LOG.debug(encoded_jwt_token)
-
-    #   headers = {
-    #     'Authorization': 'Bearer %s' % (jwt_token)
-    #   }
-    #   resp = requests.get(self.raz_url, GET_PARAMS, headers=headers, verify=False)
-    #   LOG.debug('new RAZ token --------->>>')
-    #   LOG.debug(str(resp))
-    #   LOG.debug(str(dict(resp)))
-    #   LOG.debug(resp.content)
-    #   LOG.debug(resp.body)
-    #   LOG.debug(str(json.loads(resp.text)))
-
-    #   # self.raz_token = json.loads(resp.text)['Token']['urlString']
-    # except Exception as e:
-    #   LOG.debug('Exception from Knox ---->>>>')
-    #   LOG.debug(str(e))
 
 
   def renew_delegation_token(self, user):

--- a/desktop/core/src/desktop/lib/raz/raz_client.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client.py
@@ -32,6 +32,7 @@ from desktop.conf import AUTH_USERNAME
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.sdxaas.knox_jwt import fetch_jwt
 
+
 import desktop.lib.raz.signer_protos_pb2 as raz_signer
 
 if sys.version_info[0] > 2:

--- a/desktop/core/src/desktop/lib/raz/raz_client.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client.py
@@ -74,11 +74,14 @@ class RazToken:
       r = requests.get(self.raz_url, GET_PARAMS, auth=self.auth_handler, verify=False)
     elif self.auth_type == 'jwt':
       jwt_token = fetch_jwt()
+      if jwt_token is None:
+        raise PopupException('Knox JWT is not available to send to RAZ.')
+
       _headers = {'Authorization': 'Bearer %s' % (jwt_token)}
       r = requests.get(self.raz_url, GET_PARAMS, headers=_headers, verify=False)
 
     self.raz_token = json.loads(r.text)['Token']['urlString']
-    LOG.debug('Raz Token: %s' % self.raz_token)
+    LOG.debug('Raz token: %s' % self.raz_token)
 
     return self.raz_token
     # try:

--- a/desktop/core/src/desktop/lib/raz/raz_client.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client.py
@@ -30,6 +30,8 @@ from datetime import datetime, timedelta
 
 from desktop.conf import AUTH_USERNAME
 from desktop.lib.exceptions_renderable import PopupException
+from desktop.lib.sdxaas.knox_jwt import fetch_jwt
+
 import desktop.lib.raz.signer_protos_pb2 as raz_signer
 
 if sys.version_info[0] > 2:
@@ -44,16 +46,19 @@ LOG = logging.getLogger(__name__)
 
 class RazToken:
 
-  def __init__(self, raz_url, auth_handler):
+  def __init__(self, raz_url, auth_type):
     self.raz_url = raz_url
-    self.auth_handler = auth_handler
+    self.auth_handler = requests_kerberos.HTTPKerberosAuth(mutual_authentication=requests_kerberos.OPTIONAL)
     self.init_time = datetime.now()
     self.raz_token = None
+    self.auth_type = auth_type
+
     o = lib_urlparse(self.raz_url)
     if not o.netloc:
       raise PopupException('Could not parse the host of the Raz server %s' % self.raz_url)
     self.raz_hostname, self.raz_port = o.netloc.split(':')
     self.scheme = o.scheme
+
 
   def get_delegation_token(self, user):
     ip_address = socket.gethostbyname(self.raz_hostname)
@@ -63,9 +68,45 @@ class RazToken:
       "renewer": AUTH_USERNAME.get(),
       "doAs": user
     }
-    r = requests.get(self.raz_url, GET_PARAMS, auth=self.auth_handler, verify=False)
+
+    if self.auth_type == 'kerberos':
+      r = requests.get(self.raz_url, GET_PARAMS, auth=self.auth_handler, verify=False)
+    elif self.auth_type == 'jwt':
+      jwt_token = fetch_jwt()
+      _headers = {'Authorization': 'Bearer %s' % (jwt_token)}
+      r = requests.get(self.raz_url, GET_PARAMS, headers=_headers, verify=False)
+
     self.raz_token = json.loads(r.text)['Token']['urlString']
+    LOG.debug('Raz Token: %s' % self.raz_token)
+
     return self.raz_token
+    # try:
+    #   response_from_knox = requests.get(knox_url, auth=self.auth_handler, verify=False)
+
+    #   LOG.debug('Response from Knox ---->>>>')
+    #   jwt_token = json.loads(response_from_knox.text)['access_token']
+    #   LOG.debug(jwt_token)
+
+    #   encoded_jwt_token = base64.b64encode(jwt_token.encode('utf-8')).decode('utf-8')
+    #   LOG.debug('encoded jwt token ----->>>')
+    #   LOG.debug(encoded_jwt_token)
+
+    #   headers = {
+    #     'Authorization': 'Bearer %s' % (jwt_token)
+    #   }
+    #   resp = requests.get(self.raz_url, GET_PARAMS, headers=headers, verify=False)
+    #   LOG.debug('new RAZ token --------->>>')
+    #   LOG.debug(str(resp))
+    #   LOG.debug(str(dict(resp)))
+    #   LOG.debug(resp.content)
+    #   LOG.debug(resp.body)
+    #   LOG.debug(str(json.loads(resp.text)))
+
+    #   # self.raz_token = json.loads(resp.text)['Token']['urlString']
+    # except Exception as e:
+    #   LOG.debug('Exception from Knox ---->>>>')
+    #   LOG.debug(str(e))
+
 
   def renew_delegation_token(self, user):
     if self.raz_token is None:
@@ -296,10 +337,7 @@ def get_raz_client(raz_url, username, auth='kerberos', service='s3', service_nam
   if not username:
     raise PopupException('No username set.')
 
-  if auth == 'kerberos' or True:  # True until JWT option
-    auth_handler = requests_kerberos.HTTPKerberosAuth(mutual_authentication=requests_kerberos.OPTIONAL)
-
-  raz = RazToken(raz_url, auth_handler)
+  raz = RazToken(raz_url, auth)
   raz_token = raz.get_delegation_token(user=username)
 
   return RazClient(raz_url, raz_token, username, service=service, service_name=service_name, cluster_name=cluster_name)

--- a/desktop/core/src/desktop/lib/raz/raz_client_test.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client_test.py
@@ -19,10 +19,11 @@ import sys
 import unittest
 
 from datetime import timedelta
-from nose.tools import assert_equal, assert_false, assert_true, assert_raises
+from nose.tools import assert_equal, assert_true, assert_raises
 
 from desktop.conf import RAZ
 from desktop.lib.raz.raz_client import RazToken, RazClient, get_raz_client
+from desktop.lib.exceptions_renderable import PopupException
 
 if sys.version_info[0] > 2:
   from unittest.mock import patch, Mock
@@ -36,55 +37,60 @@ class RazTokenTest(unittest.TestCase):
     self.username = 'gethue'
 
   def test_create(self):
-    kerb_auth = Mock()
+    with patch('desktop.lib.raz.raz_client.requests_kerberos.HTTPKerberosAuth') as HTTPKerberosAuth:
+      token = RazToken(raz_url='https://raz.gethue.com:8080', auth_type='kerberos')
 
-    token = RazToken(raz_url='https://raz.gethue.com:8080', auth_handler=kerb_auth)
+      assert_equal('raz.gethue.com', token.raz_hostname)
+      assert_equal('8080', token.raz_port)
+      assert_equal('https', token.scheme)
+      assert_equal('kerberos', token.auth_type)
 
-    assert_equal('raz.gethue.com', token.raz_hostname)
-    assert_equal('8080', token.raz_port)
-    assert_equal('https', token.scheme)
 
   def test_get_delegation_token(self):
-    kerb_auth = Mock()
+    with patch('desktop.lib.raz.raz_client.requests_kerberos.HTTPKerberosAuth') as HTTPKerberosAuth:
+      with patch('desktop.lib.raz.raz_client.requests.get') as requests_get:
+        with patch('desktop.lib.raz.raz_client.socket.gethostbyname') as gethostbyname:
+          with patch('desktop.lib.raz.raz_client.fetch_jwt') as fetch_jwt:
+            
+            gethostbyname.return_value = '128.0.0.1'
+            requests_get.return_value = Mock(
+              text='{"Token":{"urlString":"f3VLQVkuBCfGSyOLzI9PoxqHTjANUzMgZGVsZWdhdGlvbhExMC44MC4xNjQuMzc6NjA4Mg"}}'
+            )
 
-    with patch('desktop.lib.raz.raz_client.requests.get') as requests_get:
-      with patch('desktop.lib.raz.raz_client.socket.gethostbyname') as gethostbyname:
-        requests_get.return_value = Mock(
-          text='{"Token":{"urlString":"https://gethue-test.s3.amazonaws.com/gethue/data/customer.csv?' + \
-                'AWSAccessKeyId=AKIA23E77ZX2HVY76YGL' + \
-                '&Signature=3lhK%2BwtQ9Q2u5VDIqb4MEpoY3X4%3D&Expires=1617207304"}}'
-        )
-        gethostbyname.return_value = '128.0.0.1'
+            # When auth type is Kerberos
+            token = RazToken(raz_url='https://raz.gethue.com:8080', auth_type='kerberos')
+            t = token.get_delegation_token(user=self.username)
 
-        token = RazToken(raz_url='https://raz.gethue.com:8080', auth_handler=kerb_auth)
+            fetch_jwt.assert_not_called()
+            assert_equal('f3VLQVkuBCfGSyOLzI9PoxqHTjANUzMgZGVsZWdhdGlvbhExMC44MC4xNjQuMzc6NjA4Mg', t)
 
-        t = token.get_delegation_token(user=self.username)
+            # When auth type is JWT
+            fetch_jwt.return_value = 'test_jwt_token'
 
-        assert_equal(
-          'https://gethue-test.s3.amazonaws.com/gethue/data/customer.csv?AWSAccessKeyId=AKIA23E77ZX2HVY76YGL&'
-          'Signature=3lhK%2BwtQ9Q2u5VDIqb4MEpoY3X4%3D&Expires=1617207304',
-          t
-        )
+            token = RazToken(raz_url='https://raz.gethue.com:8080', auth_type='jwt')
+            t = token.get_delegation_token(user=self.username)
+
+            fetch_jwt.assert_called()
+            assert_equal('f3VLQVkuBCfGSyOLzI9PoxqHTjANUzMgZGVsZWdhdGlvbhExMC44MC4xNjQuMzc6NjA4Mg', t)
+
+            fetch_jwt.return_value = None # Should raise PopupException
+
+            token = RazToken(raz_url='https://raz.gethue.com:8080', auth_type='jwt')
+            assert_raises(PopupException, token.get_delegation_token, user=self.username)
+
 
   def test_renew_delegation_token(self):
-    kerb_auth = Mock()
-
     with patch('desktop.lib.raz.raz_client.requests.get') as requests_get:
       with patch('desktop.lib.raz.raz_client.socket.gethostbyname') as gethostbyname:
         requests_get.return_value = Mock(
-          text='{"Token":{"urlString":"https://gethue-test.s3.amazonaws.com/gethue/data/customer.csv?' + \
-                'AWSAccessKeyId=AKIA23E77ZX2HVY76YGL' + \
-                '&Signature=3lhK%2BwtQ9Q2u5VDIqb4MEpoY3X4%3D&Expires=1617207304"}}'
+          text='{"Token":{"urlString":"f3VLQVkuBCfGSyOLzI9PoxqHTjANUzMgZGVsZWdhdGlvbhExMC44MC4xNjQuMzc6NjA4Mg"}}'
         )
         gethostbyname.return_value = '128.0.0.1'
-        token = RazToken(raz_url='https://raz.gethue.com:8080', auth_handler=kerb_auth)
+        token = RazToken(raz_url='https://raz.gethue.com:8080', auth_type='kerberos')
 
         t = token.renew_delegation_token(user=self.username)
 
-        assert_equal(t,
-          'https://gethue-test.s3.amazonaws.com/gethue/data/customer.csv?AWSAccessKeyId=AKIA23E77ZX2HVY76YGL&'
-          'Signature=3lhK%2BwtQ9Q2u5VDIqb4MEpoY3X4%3D&Expires=1617207304'
-        )
+        assert_equal(t, 'f3VLQVkuBCfGSyOLzI9PoxqHTjANUzMgZGVsZWdhdGlvbhExMC44MC4xNjQuMzc6NjA4Mg')
 
         with patch('desktop.lib.raz.raz_client.requests.put') as requests_put:
           token.init_time += timedelta(hours=9)
@@ -107,22 +113,20 @@ class RazClientTest(unittest.TestCase):
 
   def test_get_raz_client_adls(self):
     with patch('desktop.lib.raz.raz_client.RazToken') as RazToken:
-      with patch('desktop.lib.raz.raz_client.requests_kerberos.HTTPKerberosAuth') as HTTPKerberosAuth:
-        client = get_raz_client(
-          raz_url=self.raz_url,
-          username=self.username,
-          auth='kerberos',
-          service='adls',
-          service_name='gethue_adls',
-          cluster_name='gethueCluster'
-        )
+      client = get_raz_client(
+        raz_url=self.raz_url,
+        username=self.username,
+        auth='kerberos',
+        service='adls',
+        service_name='gethue_adls',
+        cluster_name='gethueCluster'
+      )
 
-        assert_true(isinstance(client, RazClient))
+      assert_true(isinstance(client, RazClient))
 
-        HTTPKerberosAuth.assert_called()
-        assert_equal(client.raz_url, self.raz_url)
-        assert_equal(client.service_name, 'gethue_adls')
-        assert_equal(client.cluster_name, 'gethueCluster')
+      assert_equal(client.raz_url, self.raz_url)
+      assert_equal(client.service_name, 'gethue_adls')
+      assert_equal(client.cluster_name, 'gethueCluster')
 
 
   def test_check_access_adls(self):
@@ -307,22 +311,20 @@ class RazClientTest(unittest.TestCase):
 
   def test_get_raz_client_s3(self):
     with patch('desktop.lib.raz.raz_client.RazToken') as RazToken:
-      with patch('desktop.lib.raz.raz_client.requests_kerberos.HTTPKerberosAuth') as HTTPKerberosAuth:
-        client = get_raz_client(
-          raz_url=self.raz_url,
-          username=self.username,
-          auth='kerberos',
-          service='s3',
-          service_name='gethue_s3',
-          cluster_name='gethueCluster'
-        )
+      client = get_raz_client(
+        raz_url=self.raz_url,
+        username=self.username,
+        auth='kerberos',
+        service='s3',
+        service_name='gethue_s3',
+        cluster_name='gethueCluster'
+      )
 
-        assert_true(isinstance(client, RazClient))
+      assert_true(isinstance(client, RazClient))
 
-        HTTPKerberosAuth.assert_called()
-        assert_equal(client.raz_url, self.raz_url)
-        assert_equal(client.service_name, 'gethue_s3')
-        assert_equal(client.cluster_name, 'gethueCluster')
+      assert_equal(client.raz_url, self.raz_url)
+      assert_equal(client.service_name, 'gethue_s3')
+      assert_equal(client.cluster_name, 'gethueCluster')
 
 
   def test_check_access_s3(self):

--- a/desktop/core/src/desktop/lib/sdxaas/__init__.py
+++ b/desktop/core/src/desktop/lib/sdxaas/__init__.py
@@ -1,0 +1,15 @@
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/desktop/core/src/desktop/lib/sdxaas/knox_jwt.py
+++ b/desktop/core/src/desktop/lib/sdxaas/knox_jwt.py
@@ -34,7 +34,9 @@ def handle_knox_ha():
   res = None
 
   if knox_urls:
-    knox_urls_list = knox_urls.split(',')
+    # Config format is "['url1', 'url2']" for HA, so we need to clean up and split correctly in list.
+    # For non-HA, its normal url string.
+    knox_urls_list = knox_urls.replace("%20", "").replace("['", "").replace("']", "").replace("'", "").split(',')
 
     for k_url in knox_urls_list:
       try:
@@ -50,7 +52,7 @@ def handle_knox_ha():
 
 def fetch_jwt():
   '''
-  Return JWT fetched from healthy Knox host for SDXaaS.
+  Return JWT fetched from healthy Knox host.
   '''
   knox_url = handle_knox_ha()
   if not knox_url:
@@ -60,6 +62,7 @@ def fetch_jwt():
   knox_response = None
 
   try:
+    LOG.debug('Fetching Knox JWT from URL: %s' % knox_url)
     knox_response = requests.get(knox_url.rstrip('/') + _KNOX_TOKEN_API + _KNOX_TOKEN_GET_PARAM_STRING, auth=auth_handler, verify=False)
   except Exception as e:
     raise Exception('Error fetching JWT from Knox URL %s with exception: %s' % (knox_url, str(e)))

--- a/desktop/core/src/desktop/lib/sdxaas/knox_jwt.py
+++ b/desktop/core/src/desktop/lib/sdxaas/knox_jwt.py
@@ -25,6 +25,7 @@ from desktop.lib.exceptions_renderable import PopupException
 LOG = logging.getLogger(__name__)
 
 _KNOX_TOKEN_API = '/knoxtoken/api/v1/token'
+_KNOX_TOKEN_GET_PARAM_STRING = '?knox.token.include.groups=true'
 
 
 def handle_knox_ha():
@@ -59,7 +60,7 @@ def fetch_jwt():
   knox_response = None
 
   try:
-    knox_response = requests.get(knox_url.rstrip('/') + _KNOX_TOKEN_API + '?knox.token.include.groups=true', auth=auth_handler, verify=False)
+    knox_response = requests.get(knox_url.rstrip('/') + _KNOX_TOKEN_API + _KNOX_TOKEN_GET_PARAM_STRING, auth=auth_handler, verify=False)
   except Exception as e:
     raise Exception('Error fetching JWT from Knox URL %s with exception: %s' % (knox_url, str(e)))
 

--- a/desktop/core/src/desktop/lib/sdxaas/knox_jwt.py
+++ b/desktop/core/src/desktop/lib/sdxaas/knox_jwt.py
@@ -1,0 +1,65 @@
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import requests
+
+from requests_kerberos import HTTPKerberosAuth
+from desktop.conf import SDXAAS
+
+LOG = logging.getLogger(__name__)
+
+_KNOX_TOKEN_API = '/knoxtoken/api/v1/token'
+
+
+def handle_knox_ha():
+  knox_urls = SDXAAS.TOKEN_URL.get()
+  auth_handler = HTTPKerberosAuth(mutual_authentication=requests_kerberos.OPTIONAL)
+  res = None
+
+  if knox_urls:
+    knox_urls_list = knox_urls.split(',')
+
+    for k_url in knox_urls_list:
+      try:
+        res = requests.get(k_url.rstrip('/') + _KNOX_TOKEN_API, auth=auth_handler, verify=False)
+      except Exception as e:
+        if 'Name or service not known' in str(e):
+          LOG.warning('Knox URL %s is not available.' % k_url)
+
+      # Check response for None and if response code is successful (200) or authentication needed (401), use that host URL.
+      if (res is not None) and (res.status_code in (200, 401)):
+        return k_url
+
+
+def fetch_jwt():
+  '''
+  Return JWT fetched from healthy Knox host for SDXaaS.
+  '''
+  knox_url = handle_knox_ha()
+  auth_handler = HTTPKerberosAuth(mutual_authentication=requests_kerberos.OPTIONAL)
+  knox_response = None
+
+  try:
+    knox_response = requests.get(knox_url + _KNOX_TOKEN_API + '?knox.token.include.groups=true', auth=auth_handler, verify=False)
+  except Exception as e:
+    raise Exception('Error fetching JWT from Knox URL %s with exception: %s' % (knox_url, str(e)))
+  
+  if knox_response:
+    jwt_token = json.loads(knox_response.text)['access_token']
+    LOG.debug('Retrieved Knox JWT: %s' % jwt_token)
+    return jwt_token

--- a/desktop/core/src/desktop/lib/sdxaas/knox_jwt_test.py
+++ b/desktop/core/src/desktop/lib/sdxaas/knox_jwt_test.py
@@ -1,0 +1,88 @@
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+
+from nose.tools import assert_equal, assert_raises
+
+from desktop.conf import SDXAAS
+from desktop.lib.sdxaas.knox_jwt import handle_knox_ha, fetch_jwt
+from desktop.lib.exceptions_renderable import PopupException
+
+if sys.version_info[0] > 2:
+  from unittest.mock import patch, Mock
+else:
+  from mock import patch, Mock
+
+
+def test_handle_knox_ha():
+  with patch('desktop.lib.sdxaas.knox_jwt.requests_kerberos.HTTPKerberosAuth') as HTTPKerberosAuth:
+    with patch('desktop.lib.sdxaas.knox_jwt.requests.get') as requests_get:
+
+      requests_get.return_value = Mock(status_code=200)
+
+      # Non-HA mode
+      reset = SDXAAS.TOKEN_URL.set_for_testing('https://knox-gateway0.gethue.com:8443/dl-name/kt-kerberos/')
+
+      try:
+        knox_url = handle_knox_ha()
+        assert_equal(knox_url, 'https://knox-gateway0.gethue.com:8443/dl-name/kt-kerberos/')
+      finally:
+        reset()
+
+      # HA mode - where first URL sends 200 status code
+      reset = SDXAAS.TOKEN_URL.set_for_testing(
+        'https://knox-gateway0.gethue.com:8443/dl-name/kt-kerberos/, https://knox-gateway1.gethue.com:8443/dl-name/kt-kerberos/')
+
+      try:
+        knox_url = handle_knox_ha()
+        assert_equal(knox_url, 'https://knox-gateway0.gethue.com:8443/dl-name/kt-kerberos/')
+      finally:
+        reset()
+
+      # When no Knox URL is healthy
+      requests_get.return_value = Mock(status_code=404)
+      reset = SDXAAS.TOKEN_URL.set_for_testing(
+        'https://knox-gateway0.gethue.com:8443/dl-name/kt-kerberos/, https://knox-gateway1.gethue.com:8443/dl-name/kt-kerberos/')
+
+      try:
+        knox_url = handle_knox_ha()
+        assert_equal(knox_url, None)
+      finally:
+        reset()
+
+
+def test_fetch_jwt():
+  with patch('desktop.lib.sdxaas.knox_jwt.requests_kerberos.HTTPKerberosAuth') as HTTPKerberosAuth:
+    with patch('desktop.lib.sdxaas.knox_jwt.requests.get') as requests_get:
+      with patch('desktop.lib.sdxaas.knox_jwt.handle_knox_ha') as handle_knox_ha:
+
+        handle_knox_ha.return_value = 'https://knox-gateway.gethue.com:8443/dl-name/kt-kerberos/'
+        requests_get.return_value = Mock(text='{"access_token":"test_jwt_token"}')
+
+        jwt_token = fetch_jwt()
+
+        requests_get.assert_called_with(
+          'https://knox-gateway.gethue.com:8443/dl-name/kt-kerberos/knoxtoken/api/v1/token?knox.token.include.groups=true', 
+          auth=HTTPKerberosAuth(), 
+          verify=False
+        )
+        assert_equal(jwt_token, "test_jwt_token")
+
+        # Raises PopupException when knox_url is not available
+        handle_knox_ha.return_value = None
+        assert_raises(PopupException, fetch_jwt)


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Instead of directly asking RAZ for delegation token via Kerberos credentials, we are now fetching JWT from Knox host (this setup can be in HA mode) and then serve that JWT to RAZ to get back the delegation token.
- The later flow using the delegation token remains the same.

## How was this patch tested?

- Updated existing UTs and added new UTs.
- Tested in a live cluster - Hue is successfully able to fetch JWT from Knox and serve it to RAZ. This was tested for both HA and non-HA cluster.
- However, RAZ is not configured to return delegation token for JWT scenario. So we cannot fully test it E2E yet. This will be tested when RAZ changes are done from their side.