### PR TITLE
[python3.9] Upgrading greenlet and sasl as old versions are not compatible with py39

### DIFF
--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -27,7 +27,7 @@ djangomako==1.3.2
 djangorestframework-simplejwt==5.2.0
 djangorestframework==3.12.2
 future==0.18.3
-greenlet==0.4.15
+greenlet==2.0.2
 gunicorn==19.9.0
 ipython==8.1.1  # Python >= 3.8
 jaeger-client==4.3.0
@@ -58,7 +58,7 @@ PyJWT==2.4.0
 PyYAML==5.4.1
 requests-kerberos==0.12.0
 rsa==4.7
-sasl==0.2.1  # Move to https://pypi.org/project/sasl3/ ?
+sasl==0.3.1  # Move to https://pypi.org/project/sasl3/ ?
 slack-sdk==3.2.0
 SQLAlchemy==1.3.8
 sqlparse==0.4.2


### PR DESCRIPTION
## What changes were proposed in this pull request?

- greenlet==0.4.15 => greenlet==2.0.2
- sasl==0.2.1 => sasl==0.3.1

## How was this patch tested?

- Created a canary and build a jenkins cluster with that GBN (python3.8)
- Hue is running fine.
- All the basic functions are checked