### PR TITLE
Enable threaddump via curl and without login when HUE UI not accessible

### DIFF
--- a/desktop/core/src/desktop/views.py
+++ b/desktop/core/src/desktop/views.py
@@ -390,14 +390,14 @@ def dump_config(request):
   return render("dump_config.mako", request, {})
 
 
-@hue_admin_required
+@login_notrequired
 @access_log_level(logging.WARN)
 def threads(request):
   """Dumps out server threads. Useful for debugging."""
   out = string_io()
   dump_traceback(file=out)
 
-  if is_ajax(request):
+  if is_ajax(request) or request.GET.get("format") == "json":
     return HttpResponse(out.getvalue(), content_type="text/plain")
   else:
     return render("threads.mako", request, {'text': out.getvalue(), 'is_embeddable': request.GET.get('is_embeddable', False)})


### PR DESCRIPTION
Internal Jira: CDPD-54522

## What changes were proposed in this pull request?
setting no login needed for threaddump and to include the request to be json as well when using curl command

## How was this patch tested?
Manually, output from nightly env

```
[root@nightly-71x-ky-1 ~]# curl -k --negotiate -L -v -H "Content-Type: text/plain" -u 'admin:admin' "https://nightly-71x-ky-1.nightly-71x-ky.root.hwx.site:8888/desktop/debug/threads?format=json"  -o nightly-71x-ky-1.nightly-71x-ky.root.hwx.site_1.thread
* Uses proxy env variable no_proxy == '0.0.0.0,localhost,127.0.0.1,.openstacklocal,.novalocal,169.254.169.254,openstack.eng.hortonworks.com,dashboard.qe.hortonworks.com,172.22.192.250,192.175.27.100,ad-ec2.qe.hortonworks.com,ad-nano.qe.hortonworks.com,.site,.hwx.site,.hwx.site.com,172.27.0.101,kts-cdep-server-1.vpc.cloudera.com,kts-cdep-server-2.vpc.cloudera.com'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 172.27.73.64...
* TCP_NODELAY set
* Connected to nightly-71x-ky-1.nightly-71x-ky.root.hwx.site (172.27.73.64) port 8888 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/pki/tls/certs/ca-bundle.crt
  CApath: none
} [5 bytes data]
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
} [512 bytes data]
* TLSv1.3 (IN), TLS handshake, Server hello (2):
{ [93 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2483 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [428 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: C=US; ST=CA; CN=nightly-71x-ky-1.nightly-71x-ky.root.hwx.site
*  start date: May  1 05:59:43 2023 GMT
*  expire date: Apr 30 23:59:59 2024 GMT
*  issuer: C=US; ST=CA; CN=SCM Local CA on nightly-71x-ky-1.nightly-71x-ky.root.hwx.site
*  SSL certificate verify result: self signed certificate in certificate chain (19), continuing anyway.
} [5 bytes data]
> GET /desktop/debug/threads?format=json HTTP/1.1
> Host: nightly-71x-ky-1.nightly-71x-ky.root.hwx.site:8888
> User-Agent: curl/7.61.1
> Accept: */*
> Content-Type: text/plain
> 
{ [5 bytes data]
< HTTP/1.1 200 OK
< Server: gunicorn/19.9.0
< Date: Tue, 02 May 2023 18:16:27 GMT
< Connection: keep-alive
< Content-Type: text/plain
< ETag: "ef80cc11f7752648edf5850b33e9325f"
< Content-Security-Policy: script-src 'self' 'unsafe-inline' 'unsafe-eval' *.google-analytics.com *.doubleclick.net data:;img-src 'self' *.google-analytics.com *.doubleclick.net http://*.tile.osm.org *.tile.osm.org *.gstatic.com data:;style-src 'self' 'unsafe-inline' fonts.googleapis.com;connect-src 'self';frame-src *;child-src 'self' data: *.vimeo.com;object-src 'none'
< X-Frame-Options: SAMEORIGIN
< Strict-Transport-Security: max-age=31536000; includeSubDomains
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< Vary: Accept-Language, Cookie
< Content-Language: en-us
< Content-Length: 12594
< audited: False
< 
  0 12594    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0{ [5 bytes data]
100 12594  100 12594    0     0   227k      0 --:--:-- --:--:-- --:--:--  227k
* Connection #0 to host nightly-71x-ky-1.nightly-71x-ky.root.hwx.site left intact
```


[root@nightly-71x-ky-1 ~]# less nightly-71x-ky-1.nightly-71x-ky.root.hwx.site_1.thread

```
nightly-71x-ky-1.nightly-71x-ky.root.hwx.site: Current thread MainThread 139812918739200 (most recent call last):
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p0.40454090/lib/hue/build/env/lib/python3.8/site-packages/eventlet/greenthread.py", line 221, in main
    result = function(*args, **kwargs)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p0.40454090/lib/hue/build/env/lib/python3.8/site-packages/gunicorn/workers/geventlet.py", line 119, in handle
    super(EventletWorker, self).handle(listener, client, addr)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p0.40454090/lib/hue/build/env/lib/python3.8/site-packages/gunicorn/workers/base_async.py", line 56, in handle
    self.handle_request(listener_name, req, client, addr)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p0.40454090/lib/hue/build/env/lib/python3.8/site-packages/gunicorn/workers/base_async.py", line 107, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p0.40454090/lib/hue/build/env/lib/python3.8/site-packages/django/core/handlers/wsgi.py", line 133, in __call__
    response = self.get_response(request)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p0.40454090/lib/hue/build/env/lib/python3.8/site-packages/django/core/handlers/base.py", line 130, in get_response
    response = self._middleware_chain(request)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p0.40454090/lib/hue/build/env/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p0.40454090/lib/hue/build/env/lib/python3.8/site-packages/django/utils/deprecation.py", line 117, in __call__
    response = response or self.get_response(request)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p0.40454090/lib/hue/build/env/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p0.40454090/lib/hue/build/env/lib/python3.8/site-packages/django/utils/deprecation.py", line 117, in __call__
    response = response or self.get_response(request)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p0.40454090/lib/hue/build/env/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p0.40454090/lib/hue/build/env/lib/python3.8/site-packages/django/utils/deprecation.py", line 117, in __call__
    response = response or self.get_response(request)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p0.40454090/lib/hue/build/env/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, 
```