### PR TITLE
Add cache-control headers to restrict webpage caching

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -99,6 +99,10 @@ http_500_debug_mode=false
 ## limit_request_fields=100
 ## limit_request_line=4094
 
+# Flag to disable webpage caching. Enabling this flag will reduce the performance of the application but it ensures that
+# the client is always receiving the latest version of the resource.
+## custom_cache_control=true
+
 # Filename of SSL Certificate
 ## ssl_certificate=
 

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -104,6 +104,10 @@
   ## limit_request_fields=100
   ## limit_request_line=4094
 
+  # Flag to disable webpage caching. Enabling this flag will reduce the performance of the application but it ensures
+  # that the client is always receiving the latest version of the resource.
+  ## custom_cache_control=true
+
   # Filename of SSL Certificate
   ## ssl_certificate=
 

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -1671,6 +1671,13 @@ SEND_DBUG_MESSAGES = Config(
   default=False
 )
 
+CUSTOM_CACHE_CONTROL = Config(
+  key="custom_cache_control",
+  help=_("Flag to disable webpage caching."),
+  type=coerce_bool,
+  default=False
+)
+
 DATABASE_LOGGING = Config(
   key="database_logging",
   help=_("Enable or disable database debug mode."),

--- a/desktop/core/src/desktop/middleware.py
+++ b/desktop/core/src/desktop/middleware.py
@@ -53,7 +53,8 @@ import desktop.views
 from desktop import appmanager, metrics
 from desktop.auth.backend import is_admin, find_or_create_user, ensure_has_a_group, rewrite_user
 from desktop.conf import AUTH, HTTP_ALLOWED_METHODS, ENABLE_PROMETHEUS, KNOX, DJANGO_DEBUG_MODE, AUDIT_EVENT_LOG_DIR, \
-    METRICS, SERVER_USER, REDIRECT_WHITELIST, SECURE_CONTENT_SECURITY_POLICY, has_connectors, is_gunicorn_report_enabled
+    METRICS, SERVER_USER, REDIRECT_WHITELIST, SECURE_CONTENT_SECURITY_POLICY, has_connectors, is_gunicorn_report_enabled, \
+    CUSTOM_CACHE_CONTROL
 from desktop.context_processors import get_app_name
 from desktop.lib import apputil, i18n, fsmanager
 from desktop.lib.django_util import JsonResponse, render, render_json
@@ -953,3 +954,19 @@ class MultipleProxyMiddleware:
       request.META['HTTP_X_FORWARDED_FOR'] = request.META['REMOTE_ADDR']
 
     return self.get_response(request)
+
+
+class CacheControlMiddleware(MiddlewareMixin):
+  def __init__(self, get_response):
+    self.get_response = get_response
+    self.custom_cache_control = CUSTOM_CACHE_CONTROL.get()
+    if not self.custom_cache_control:
+      LOG.info('Unloading CacheControlMiddleware')
+      raise exceptions.MiddlewareNotUsed
+
+  def process_response(self, request, response):
+    if self.custom_cache_control:
+      response['Cache-Control'] = 'no-cache, no-store, must-revalidate'
+      response['Pragma'] = 'no-cache'
+      response['Expires'] = '0'
+    return response

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -164,7 +164,7 @@ MIDDLEWARE = [
     'desktop.middleware.ExceptionMiddleware',
     'desktop.middleware.ClusterMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
-
+    'desktop.middleware.CacheControlMiddleware',
     'django.middleware.http.ConditionalGetMiddleware',
     #'axes.middleware.FailedLoginMiddleware',
     'desktop.middleware.MimeTypeJSFileFixStreamingMiddleware',


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add headers which restrict caching of the webpage (headers : Cache-Control, Pragma, Expires). This can be turned on/off by the config 'custom_cache_control'. By default caching is turned on and the config 'custom_cache_control' is set to false.

## How was this patch tested?
Manual tests - on a local Hue and CDH cluster Hue. The caching headers are visible in response headers. 
Attaching screenshot.

<img width="614" alt="Screenshot 2023-05-03 at 11 51 41 AM" src="https://user-images.githubusercontent.com/33496652/236015572-9b76db85-e6c4-4e84-8918-759a1f28180b.png">


