### PR TITLE
[log] Fix missing gunicorn_log.conf file in /etc/hue/conf folder.

### DIFF
--- a/desktop/conf.dist/gunicorn_log.conf
+++ b/desktop/conf.dist/gunicorn_log.conf
@@ -1,0 +1,115 @@
+########################################
+# Definition for the different objects
+# - FOR DEVELOPMENT ONLY -
+#
+# Directories where log files are kept must already exist.
+# That's why we pick /tmp.
+#
+# The loggers are configured to write to the log files ONLY.
+# Developers may set the DESKTOP_DEBUG environment variable to
+# enable stderr logging output.
+########################################
+
+[logger_root]
+handlers=logfile,errorlog
+
+[logger_access]
+handlers=accesslog
+qualname=access
+
+[logger_django_auth_ldap]
+handlers=accesslog
+qualname=django_auth_ldap
+
+[logger_kazoo_client]
+level=INFO
+handlers=errorlog
+qualname=kazoo.client
+
+[logger_djangosaml2]
+level=INFO
+handlers=errorlog
+qualname=djangosaml2
+
+[logger_requests_packages_urllib3_connectionpool]
+level=DEBUG
+handlers=errorlog
+qualname=requests.packages.urllib3.connectionpool
+
+[logger_django_db]
+level=DEBUG
+handlers=errorlog
+qualname=django.db.backends
+
+[logger_boto]
+level=ERROR
+handlers=errorlog
+qualname=boto
+
+[logger_gunicorn.error]
+level=INFO
+handlers=errorlog
+propagate=1
+qualname=gunicorn.error
+
+[logger_gunicorn.access]
+level=INFO
+handlers=accesslog
+propagate=0
+qualname=gunicorn.access
+
+[handler_stderr]
+class=StreamHandler
+formatter=default
+level=DEBUG
+args=(sys.stderr,)
+
+[handler_stdout]
+class=StreamHandler
+formatter=default
+level=DEBUG
+args=(sys.stdout,)
+
+[handler_accesslog]
+class=handlers.RotatingFileHandler
+level=INFO
+propagate=True
+formatter=access
+args=('%LOG_DIR%/access.log', 'a', 5000000, 5)
+
+[handler_errorlog]
+class=handlers.RotatingFileHandler
+level=ERROR
+formatter=default
+args=('%LOG_DIR%/error.log', 'a', 5000000, 5)
+
+[handler_logfile]
+class=handlers.RotatingFileHandler
+# Choices are DEBUG, INFO, WARNING, ERROR, CRITICAL
+level=DEBUG
+formatter=default
+args=('%LOG_DIR%/rungunicornserver.log', 'a', 5000000, 5)
+
+[formatter_default]
+class=logging.Formatter
+format=[%(asctime)s] %(module)-12s %(levelname)-8s %(message)s
+datefmt=%d/%b/%Y %H:%M:%S %z
+
+[formatter_access]
+class=logging.Formatter
+format=[%(asctime)s] %(levelname)-8s %(message)s
+datefmt=%d/%b/%Y %H:%M:%S %z
+
+
+########################################
+# A summary of loggers, handlers and formatters
+########################################
+
+[loggers]
+keys=root,access,django_auth_ldap,kazoo_client,requests_packages_urllib3_connectionpool,djangosaml2,django_db,boto,gunicorn.error,gunicorn.access
+
+[handlers]
+keys=stderr,logfile,accesslog,errorlog,stdout
+
+[formatters]
+keys=default,access

--- a/desktop/conf.dist/log.conf
+++ b/desktop/conf.dist/log.conf
@@ -1,82 +1,36 @@
-##########################################
-# To change the log leve, edit the `level' field.
-# Choices are: DEBUG, INFO, WARNING, ERROR, CRITICAL
+########################################
+# Definition for the different objects
+# - FOR DEVELOPMENT ONLY -
 #
-# The logrotation limit is set at 5MB per file for a total of 5 copies.
-# I.e. 25MB for each set of logs.
-##########################################
-[handler_logfile]
-level=INFO
-class=handlers.RotatingFileHandler
-formatter=default
-args=('%LOG_DIR%/%PROC_NAME%.log', 'a', 5000000, 5)
-
-##########################################
-# Please do not change the settings below
-##########################################
-
+# Directories where log files are kept must already exist.
+# That's why we pick /tmp.
+#
+# The loggers are configured to write to the log files ONLY.
+# Developers may set the DESKTOP_DEBUG environment variable to
+# enable stderr logging output.
+########################################
 [logger_root]
-handlers=logfile,errorlog
+handlers=logfile
 
-[logger_access]
-handlers=accesslog
-qualname=access
-
-[logger_django_auth_ldap]
-handlers=accesslog
-qualname=django_auth_ldap
-
-[logger_kazoo_client]
-level=INFO
-handlers=errorlog
-qualname=kazoo.client
-
-[logger_djangosaml2]
-level=INFO
-handlers=errorlog
-qualname=djangosaml2
-
-[logger_django_db]
+[handler_logfile]
 level=DEBUG
-handlers=errorlog
-qualname=django.db.backends
-
-[logger_boto]
-level=ERROR
-handlers=errorlog
-qualname=boto
-
-# The logrotation limit is set at 5MB per file for a total of 5 copies.
-# I.e. 25MB for each set of logs.
-[handler_accesslog]
-class=handlers.RotatingFileHandler
-level=DEBUG
-propagate=True
-formatter=access
-args=('%LOG_DIR%/access.log', 'a', 5000000, 5)
-
-# All errors go into error.log
-[handler_errorlog]
-class=handlers.RotatingFileHandler
-level=ERROR
+class=handlers.SocketHandler
 formatter=default
-args=('%LOG_DIR%/error.log', 'a', 5000000, 5)
+args=('%LOG_DIR%/hue.uds',None,)
 
 [formatter_default]
 class=desktop.log.formatter.Formatter
 format=[%(asctime)s] %(module)-12s %(levelname)-8s %(message)s
 datefmt=%d/%b/%Y %H:%M:%S %z
 
-[formatter_access]
-class=desktop.log.formatter.Formatter
-format=[%(asctime)s] %(levelname)-8s %(message)s
-datefmt=%d/%b/%Y %H:%M:%S %z
-
+########################################
+# A summary of loggers, handlers and formatters
+########################################
 [loggers]
-keys=root,access,django_auth_ldap,kazoo_client,djangosaml2,django_db,boto
+keys=root
 
 [handlers]
-keys=logfile,accesslog,errorlog
+keys=logfile
 
 [formatters]
-keys=default,access
+keys=default


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Fix missing gunicorn_log.conf file in /etc/hue/conf folder.

## How was this patch tested?

- Checked CDH parcel containing gunicorn_log.conf file.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
