### PR TITLE
[raz] Skip using RAZ DTs for FS operation authorisation

### DIFF
--- a/desktop/core/src/desktop/lib/raz/clients_test.py
+++ b/desktop/core/src/desktop/lib/raz/clients_test.py
@@ -71,29 +71,28 @@ class AdlsRazClientTest(unittest.TestCase):
     self.username = 'csso_hueuser'
   
   def test_check_rename_operation(self):
-    with patch('desktop.lib.raz.raz_client.RazToken.get_delegation_token') as raz_token:
-      with patch('desktop.lib.raz.raz_client.requests.post') as requests_post:
-        with patch('desktop.lib.raz.raz_client.uuid.uuid4') as uuid:
-          with patch('desktop.lib.raz.raz_client.RazClient.check_access') as check_access:
+    with patch('desktop.lib.raz.raz_client.requests.post') as requests_post:
+      with patch('desktop.lib.raz.raz_client.uuid.uuid4') as uuid:
+        with patch('desktop.lib.raz.raz_client.RazClient.check_access') as check_access:
 
-            reset = RAZ.API_URL.set_for_testing('https://raz_url:8000')
-            check_access.return_value = {'token': 'some_random_sas_token'}
+          reset = RAZ.API_URL.set_for_testing('https://raz_url:8000')
+          check_access.return_value = {'token': 'some_random_sas_token'}
 
-            try:
-              sas_token = AdlsRazClient(
-                username=self.username
-              ).get_url(
-                action='PUT',
-                path='https://gethuestorage.dfs.core.windows.net/data/user/csso_hueuser/rename_destination_dir',
-                headers={'x-ms-version': '2019-12-12', 'x-ms-rename-source': '/data/user/csso_hueuser/rename_source_dir'})
+          try:
+            sas_token = AdlsRazClient(
+              username=self.username
+            ).get_url(
+              action='PUT',
+              path='https://gethuestorage.dfs.core.windows.net/data/user/csso_hueuser/rename_destination_dir',
+              headers={'x-ms-version': '2019-12-12', 'x-ms-rename-source': '/data/user/csso_hueuser/rename_source_dir'})
 
-              check_access.assert_called_with(
-                headers={
-                  'x-ms-version': '2019-12-12', 
-                  'x-ms-rename-source': '/data/user/csso_hueuser/rename_source_dir?some_random_sas_token'
-                },
-                method='PUT',
-                url='https://gethuestorage.dfs.core.windows.net/data/user/csso_hueuser/rename_destination_dir'
-              )
-            finally:
-              reset()
+            check_access.assert_called_with(
+              headers={
+                'x-ms-version': '2019-12-12', 
+                'x-ms-rename-source': '/data/user/csso_hueuser/rename_source_dir?some_random_sas_token'
+              },
+              method='PUT',
+              url='https://gethuestorage.dfs.core.windows.net/data/user/csso_hueuser/rename_destination_dir'
+            )
+          finally:
+            reset()

--- a/desktop/core/src/desktop/lib/raz/raz_client.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client.py
@@ -149,7 +149,6 @@ class RazClient(object):
 
       if jwt_token is None:
         raise PopupException('Knox JWT is not available to send to RAZ.')
-      LOG.debug('JWT: %s' % jwt_token)
 
       request_headers['Authorization'] = 'Bearer %s' % (jwt_token)
       raz_req = requests.post(raz_url, headers=request_headers, json=request_data, verify=False)

--- a/desktop/core/src/desktop/lib/raz/raz_client.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client.py
@@ -103,7 +103,7 @@ class RazClient(object):
     LOG.debug('Raz url: %s' % raz_url)
     LOG.debug("Sending access check headers: {%s} request_data: {%s}" % (request_headers, request_data))
 
-    raz_req = self._handle_raz_req(raz_url, auth_type, request_headers, request_data)
+    raz_req = self._handle_raz_req(raz_url, request_headers, request_data)
 
     signed_response_result = None
     signed_response = None
@@ -140,7 +140,7 @@ class RazClient(object):
             return dict([(i.key, i.value) for i in signed_response.signer_generated_headers])
 
 
-  def _handle_raz_req(self, raz_url, auth_type, request_headers, request_data):
+  def _handle_raz_req(self, raz_url, request_headers, request_data):
     if self.auth_type == 'kerberos':
       auth_handler = requests_kerberos.HTTPKerberosAuth(mutual_authentication=requests_kerberos.OPTIONAL)
       raz_req = requests.post(raz_url, headers=request_headers, json=request_data, auth=auth_handler, verify=False)

--- a/desktop/core/src/desktop/lib/raz/raz_client.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client.py
@@ -19,14 +19,11 @@
 import base64
 import json
 import logging
-import socket
 import sys
 import uuid
 
 import requests
 import requests_kerberos
-
-from datetime import datetime, timedelta
 
 from desktop.conf import AUTH_USERNAME
 from desktop.lib.exceptions_renderable import PopupException
@@ -44,60 +41,11 @@ else:
 LOG = logging.getLogger(__name__)
 
 
-class RazToken:
-
-  def __init__(self, raz_url, auth_type):
-    self.raz_url = raz_url
-    self.auth_handler = requests_kerberos.HTTPKerberosAuth(mutual_authentication=requests_kerberos.OPTIONAL)
-    self.init_time = datetime.now()
-    self.raz_token = None
-    self.auth_type = auth_type
-
-    o = lib_urlparse(self.raz_url)
-    if not o.netloc:
-      raise PopupException('Could not parse the host of the Raz server %s' % self.raz_url)
-    self.raz_hostname, self.raz_port = o.netloc.split(':')
-    self.scheme = o.scheme
-
-
-  def get_delegation_token(self, user):
-    ip_address = socket.gethostbyname(self.raz_hostname)
-    GET_PARAMS = {
-      "op": "GETDELEGATIONTOKEN",
-      "service": "%s:%s" % (ip_address, self.raz_port),
-      "renewer": AUTH_USERNAME.get(),
-      "doAs": user
-    }
-
-    if self.auth_type == 'kerberos':
-      r = requests.get(self.raz_url, GET_PARAMS, auth=self.auth_handler, verify=False)
-    elif self.auth_type == 'jwt':
-      jwt_token = fetch_jwt()
-      if jwt_token is None:
-        raise PopupException('Knox JWT is not available to send to RAZ.')
-
-      _headers = {'Authorization': 'Bearer %s' % (jwt_token)}
-      r = requests.get(self.raz_url, GET_PARAMS, headers=_headers, verify=False)
-
-    self.raz_token = json.loads(r.text)['Token']['urlString']
-    LOG.debug('Raz token: %s' % self.raz_token)
-
-    return self.raz_token
-
-
-  def renew_delegation_token(self, user):
-    if self.raz_token is None:
-      self.raz_token = self.get_delegation_token(user=user)
-    if (self.init_time - timedelta(hours=8)) > datetime.now():
-      r = requests.put("%s?op=RENEWDELEGATIONTOKEN&token=%s"%(self.raz_url, self.raz_token), auth=self.auth_handler, verify=False)
-    return self.raz_token
-
-
 class RazClient(object):
 
-  def __init__(self, raz_url, raz_token, username, service='s3', service_name='cm_s3', cluster_name='myCluster'):
+  def __init__(self, raz_url, auth_type, username, service='s3', service_name='cm_s3', cluster_name='myCluster'):
     self.raz_url = raz_url.strip('/')
-    self.raz_token = raz_token
+    self.auth_type = auth_type
     self.username = username
     self.service = service
 
@@ -117,7 +65,6 @@ class RazClient(object):
     self.service_name = service_name
     self.cluster_name = cluster_name
     self.requestid = str(uuid.uuid4())
-    self.auth_type = 'kerberos'
 
 
   def check_access(self, method, url, params=None, headers=None, data=None):
@@ -146,7 +93,7 @@ class RazClient(object):
       "context": {}
     }
     request_headers = {"Content-Type": "application/json"}
-    raz_url = "%s/api/authz/%s/access" % (self.raz_url, self.service)
+    raz_url = "%s/api/authz/%s/access?doAs=%s" % (self.raz_url, self.service, self.username)
 
     if self.service == 'adls':
       self._make_adls_request(request_data, method, path, url_params, resource_path)
@@ -154,23 +101,9 @@ class RazClient(object):
       self._make_s3_request(request_data, request_headers, method, params, headers, url_params, endpoint, resource_path, data=data)
 
     LOG.debug('Raz url: %s' % raz_url)
-
-    if self.auth_type == 'kerberos':
-      auth_handler = requests_kerberos.HTTPKerberosAuth(mutual_authentication=requests_kerberos.OPTIONAL)
-
-      LOG.debug("Sending access check headers: {%s} request_data: {%s}" % (request_headers, request_data))
-      raz_req = requests.post(raz_url, headers=request_headers, json=request_data, auth=auth_handler, verify=False)
-    elif self.auth_type == 'jwt':
-      jwt_token = fetch_jwt()
-      if jwt_token is None:
-        raise PopupException('Knox JWT is not available to send to RAZ.')
-      
-      request_headers['Authorization'] = 'Bearer %s' % (jwt_token)
-      LOG.debug("Sending access check headers: {%s} request_data: {%s}" % (request_headers, request_data))
-      raz_req = requests.post(raz_url, headers=request_headers, json=request_data, verify=False)
-
     LOG.debug("Sending access check headers: {%s} request_data: {%s}" % (request_headers, request_data))
-    raz_req = requests.post(raz_url, headers=request_headers, json=request_data, verify=False)
+
+    raz_req = self._handle_raz_req(raz_url, auth_type, request_headers, request_data)
 
     signed_response_result = None
     signed_response = None
@@ -205,6 +138,23 @@ class RazClient(object):
           # Signed headers "only"
           if signed_response is not None:
             return dict([(i.key, i.value) for i in signed_response.signer_generated_headers])
+
+
+  def _handle_raz_req(self, raz_url, auth_type, request_headers, request_data):
+    if self.auth_type == 'kerberos':
+      auth_handler = requests_kerberos.HTTPKerberosAuth(mutual_authentication=requests_kerberos.OPTIONAL)
+      raz_req = requests.post(raz_url, headers=request_headers, json=request_data, auth=auth_handler, verify=False)
+    elif self.auth_type == 'jwt':
+      jwt_token = fetch_jwt()
+
+      if jwt_token is None:
+        raise PopupException('Knox JWT is not available to send to RAZ.')
+      LOG.debug('JWT: %s' % jwt_token)
+
+      request_headers['Authorization'] = 'Bearer %s' % (jwt_token)
+      raz_req = requests.post(raz_url, headers=request_headers, json=request_data, verify=False)
+
+    return raz_req
 
 
   def _make_adls_request(self, request_data, method, path, url_params, resource_path):
@@ -330,7 +280,4 @@ def get_raz_client(raz_url, username, auth='kerberos', service='s3', service_nam
   if not username:
     raise PopupException('No username set.')
 
-  raz = RazToken(raz_url, auth)
-  raz_token = raz.get_delegation_token(user=username)
-
-  return RazClient(raz_url, raz_token, username, service=service, service_name=service_name, cluster_name=cluster_name)
+  return RazClient(raz_url, auth, username, service=service, service_name=service_name, cluster_name=cluster_name)


### PR DESCRIPTION
## What changes were proposed in this pull request?

- With these changes, we are now directly talking to RAZ endpoint for FS operation authorisation checks either via Kerberos or JWT.
- This completely removes using RAZ delegation tokens from the flow now. Earlier we use to get RAZ DTs via Kerberos (and future JWT) and pass that DT to RAZ again along with FS operation authorisation call, but its direct now and removing this hop.

 
## How was this patch tested?

- Tested in a live cluster - Hue is working fine using Kerberos to call RAZ. All existing FS operations looks good.
- Tested fetching JWT from Knox also in the live cluster and Hue is successful in getting it and passing to RAZ.
- However, RAZ is not configured to validate the incoming JWT and then authorise the FS operations. So we cannot fully test the existing FS operations E2E yet for JWT scenario. This will be tested when RAZ changes are done from their side.
