### PR TITLE
[Backend] Removing future library dependancy as it is not required in…

### DIFF
--- a/apps/beeswax/src/beeswax/design.py
+++ b/apps/beeswax/src/beeswax/design.py
@@ -19,8 +19,6 @@
 The HQLdesign class can (de)serialize a design to/from a QueryDict.
 """
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import json
 import logging

--- a/apps/beeswax/src/beeswax/tests.py
+++ b/apps/beeswax/src/beeswax/tests.py
@@ -16,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import next, map, str, chr, range, object
 import gzip
 import json

--- a/apps/filebrowser/src/filebrowser/forms.py
+++ b/apps/filebrowser/src/filebrowser/forms.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import zip
 from builtins import range
 import logging

--- a/apps/filebrowser/src/filebrowser/lib/xxd_test.py
+++ b/apps/filebrowser/src/filebrowser/lib/xxd_test.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 import unittest
 import logging

--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import errno
 import logging

--- a/apps/filebrowser/src/filebrowser/views_test.py
+++ b/apps/filebrowser/src/filebrowser/views_test.py
@@ -17,8 +17,6 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import zip
 from builtins import range
 from builtins import object

--- a/apps/hbase/src/hbase/views.py
+++ b/apps/hbase/src/hbase/views.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 import base64
 import json
 import logging

--- a/apps/help/src/help/views.py
+++ b/apps/help/src/help/views.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from desktop.lib.django_util import render
 from desktop.lib.exceptions_renderable import PopupException

--- a/apps/jobbrowser/src/jobbrowser/views.py
+++ b/apps/jobbrowser/src/jobbrowser/views.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 
 from past.builtins import cmp
-from future import standard_library
-standard_library.install_aliases()
 from builtins import filter
 from builtins import str
 import functools

--- a/apps/jobbrowser/src/jobbrowser/yarn_models.py
+++ b/apps/jobbrowser/src/jobbrowser/yarn_models.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import object
 import logging

--- a/apps/metastore/src/metastore/tests.py
+++ b/apps/metastore/src/metastore/tests.py
@@ -16,9 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
 
-standard_library.install_aliases()
 from builtins import object
 import json
 import logging

--- a/apps/metastore/src/metastore/views.py
+++ b/apps/metastore/src/metastore/views.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 import json
 import logging

--- a/apps/oozie/src/oozie/models.py
+++ b/apps/oozie/src/oozie/models.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from past.builtins import basestring
 from builtins import object

--- a/apps/oozie/src/oozie/tests.py
+++ b/apps/oozie/src/oozie/tests.py
@@ -16,9 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
 from functools import reduce
-standard_library.install_aliases()
 from builtins import str
 from past.builtins import basestring
 from builtins import object

--- a/apps/oozie/src/oozie/utils.py
+++ b/apps/oozie/src/oozie/utils.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from past.builtins import basestring
 import json

--- a/apps/oozie/src/oozie/views/dashboard.py
+++ b/apps/oozie/src/oozie/views/dashboard.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 import json
 import logging

--- a/apps/pig/src/pig/views.py
+++ b/apps/pig/src/pig/views.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 import json
 import logging

--- a/apps/proxy/src/proxy/proxy_test.py
+++ b/apps/proxy/src/proxy/proxy_test.py
@@ -18,8 +18,6 @@
 # Tests for proxy app.
 
 from __future__ import print_function
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 import threading
 import logging

--- a/apps/proxy/src/proxy/views.py
+++ b/apps/proxy/src/proxy/views.py
@@ -23,8 +23,6 @@
 # to create links (within the application) to trusted
 # URLs, by appending an HMAC to the parameters.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 import logging
 import re

--- a/apps/useradmin/src/useradmin/tests.py
+++ b/apps/useradmin/src/useradmin/tests.py
@@ -16,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import json
 import ldap

--- a/apps/zookeeper/src/zookeeper/rest.py
+++ b/apps/zookeeper/src/zookeeper/rest.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import map
 from builtins import object
 import json

--- a/apps/zookeeper/src/zookeeper/stats.py
+++ b/apps/zookeeper/src/zookeeper/stats.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import map
 from builtins import object
 import logging

--- a/desktop/core/src/desktop/api2.py
+++ b/desktop/core/src/desktop/api2.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import map
 import logging
 import os

--- a/desktop/core/src/desktop/auth/views.py
+++ b/desktop/core/src/desktop/auth/views.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 import json
 
-from future import standard_library
-standard_library.install_aliases()
 try:
   import oauth2 as oauth
 except:

--- a/desktop/core/src/desktop/lib/conf_test.py
+++ b/desktop/core/src/desktop/lib/conf_test.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import configobj
 import logging

--- a/desktop/core/src/desktop/lib/django_forms.py
+++ b/desktop/core/src/desktop/lib/django_forms.py
@@ -17,8 +17,6 @@
 #
 # Extra form fields and widgets.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import filter
 from builtins import range
 from builtins import object

--- a/desktop/core/src/desktop/lib/export_csvxls.py
+++ b/desktop/core/src/desktop/lib/export_csvxls.py
@@ -18,8 +18,6 @@
 """
 Common library to export either CSV or XLS.
 """
-from future import standard_library
-standard_library.install_aliases()
 from builtins import next, object
 import gc
 import logging

--- a/desktop/core/src/desktop/lib/export_csvxls_tests.py
+++ b/desktop/core/src/desktop/lib/export_csvxls_tests.py
@@ -16,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 import sys
 
 from nose.tools import assert_equal

--- a/desktop/core/src/desktop/lib/fs/__init__.py
+++ b/desktop/core/src/desktop/lib/fs/__init__.py
@@ -16,8 +16,6 @@
 
 from __future__ import absolute_import
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import filter
 import posixpath
 import sys

--- a/desktop/core/src/desktop/lib/fs/proxyfs.py
+++ b/desktop/core/src/desktop/lib/fs/proxyfs.py
@@ -16,8 +16,6 @@
 
 from __future__ import absolute_import
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import logging
 import sys

--- a/desktop/core/src/desktop/lib/raz/__init__.py
+++ b/desktop/core/src/desktop/lib/raz/__init__.py
@@ -16,7 +16,7 @@
 from __future__ import absolute_import
 
 from builtins import map
-from future.utils import raise_
+from six import reraise as raise_
 import calendar
 import errno
 import logging

--- a/desktop/core/src/desktop/lib/raz/ranger/__init__.py
+++ b/desktop/core/src/desktop/lib/raz/ranger/__init__.py
@@ -16,7 +16,7 @@
 from __future__ import absolute_import
 
 from builtins import map
-from future.utils import raise_
+from six import reraise as raise_
 import calendar
 import errno
 import logging

--- a/desktop/core/src/desktop/lib/rest/http_client.py
+++ b/desktop/core/src/desktop/lib/rest/http_client.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import logging
 import posixpath

--- a/desktop/core/src/desktop/lib/tasks/compress_files/compress_utils.py
+++ b/desktop/core/src/desktop/lib/tasks/compress_files/compress_utils.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 import json
 import sys
 

--- a/desktop/core/src/desktop/lib/tasks/extract_archive/extract_utils.py
+++ b/desktop/core/src/desktop/lib/tasks/extract_archive/extract_utils.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 import json
 import sys
 import urllib.request, urllib.parse, urllib.error

--- a/desktop/core/src/desktop/lib/thread_util.py
+++ b/desktop/core/src/desktop/lib/thread_util.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 
 from __future__ import print_function
-from future import standard_library
-standard_library.install_aliases()
 import logging
 import socket
 import sys

--- a/desktop/core/src/desktop/lib/thread_util_test.py
+++ b/desktop/core/src/desktop/lib/thread_util_test.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 import sys
 import threading
 import time

--- a/desktop/core/src/desktop/lib/thrift_/http_client.py
+++ b/desktop/core/src/desktop/lib/thrift_/http_client.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 #
 
-from future import standard_library
-standard_library.install_aliases()
 import logging
 import sys
 

--- a/desktop/core/src/desktop/lib/thrift_sasl.py
+++ b/desktop/core/src/desktop/lib/thrift_sasl.py
@@ -19,8 +19,6 @@
 """ SASL transports for Thrift. """
 from __future__ import absolute_import
 
-from future import standard_library
-standard_library.install_aliases()
 from thrift.transport import TTransport
 from thrift.transport.TTransport import *
 from thrift.protocol import TBinaryProtocol

--- a/desktop/core/src/desktop/lib/thrift_util.py
+++ b/desktop/core/src/desktop/lib/thrift_util.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 #
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
 from builtins import map
 from builtins import range
 from past.builtins import basestring

--- a/desktop/core/src/desktop/lib/vcs/apis/github_readonly_api.py
+++ b/desktop/core/src/desktop/lib/vcs/apis/github_readonly_api.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 
 
-from future import standard_library
-standard_library.install_aliases()
 import binascii
 import logging
 import re

--- a/desktop/core/src/desktop/lib/vcs/github_client.py
+++ b/desktop/core/src/desktop/lib/vcs/github_client.py
@@ -16,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import binascii
 import json

--- a/desktop/core/src/desktop/lib/wsgiserver.py
+++ b/desktop/core/src/desktop/lib/wsgiserver.py
@@ -100,9 +100,7 @@ number of requests and their responses, so we run a nested loop:
 """
 
 
-from future import standard_library
-from future.utils import raise_
-standard_library.install_aliases()
+from six import reraise as raise_
 from builtins import hex
 from builtins import range
 from past.builtins import basestring

--- a/desktop/core/src/desktop/log/__init__.py
+++ b/desktop/core/src/desktop/log/__init__.py
@@ -17,8 +17,6 @@
 
 from __future__ import print_function
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import logging
 import logging.config
 import os

--- a/desktop/core/src/desktop/manage_entry.py
+++ b/desktop/core/src/desktop/manage_entry.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 
 from __future__ import print_function
-from future import standard_library
-standard_library.install_aliases()
 import logging
 import os
 import os.path

--- a/desktop/core/src/desktop/metrics.py
+++ b/desktop/core/src/desktop/metrics.py
@@ -16,8 +16,6 @@
 
 from __future__ import absolute_import
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 import gc
 import logging

--- a/desktop/core/src/desktop/models.py
+++ b/desktop/core/src/desktop/models.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import next
 from builtins import object
 import calendar

--- a/desktop/core/src/desktop/redaction/tests.py
+++ b/desktop/core/src/desktop/redaction/tests.py
@@ -16,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import zip, range, object
 
 from django.utils.encoding import smart_str

--- a/desktop/core/src/desktop/tests.py
+++ b/desktop/core/src/desktop/tests.py
@@ -17,8 +17,6 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range, object
 import json
 import logging

--- a/desktop/core/src/desktop/views.py
+++ b/desktop/core/src/desktop/views.py
@@ -15,9 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
 
-standard_library.install_aliases()
 import json
 import logging
 import os

--- a/desktop/libs/aws/src/aws/s3/__init__.py
+++ b/desktop/libs/aws/src/aws/s3/__init__.py
@@ -16,7 +16,7 @@
 from __future__ import absolute_import
 
 from builtins import map
-from future.utils import raise_
+from six import reraise as raise_
 import calendar
 import errno
 import logging

--- a/desktop/libs/aws/src/aws/s3/upload.py
+++ b/desktop/libs/aws/src/aws/s3/upload.py
@@ -21,8 +21,6 @@ Classes for a custom upload handler to stream into S3.
 See http://docs.djangoproject.com/en/1.9/topics/http/file-uploads/
 """
 
-from future import standard_library
-standard_library.install_aliases()
 import logging
 import sys
 

--- a/desktop/libs/azure/src/azure/abfs/abfs.py
+++ b/desktop/libs/azure/src/azure/abfs/abfs.py
@@ -18,8 +18,6 @@
 """
 Interfaces for ABFS
 """
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import logging
 import os

--- a/desktop/libs/azure/src/azure/abfs/upload.py
+++ b/desktop/libs/azure/src/azure/abfs/upload.py
@@ -13,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from future import standard_library
-standard_library.install_aliases()
 import logging
 import sys
 

--- a/desktop/libs/azure/src/azure/adls/webhdfs.py
+++ b/desktop/libs/azure/src/azure/adls/webhdfs.py
@@ -18,8 +18,6 @@
 """
 Interfaces for ADLS via HttpFs/WebHDFS
 """
-from future import standard_library
-standard_library.install_aliases()
 import logging
 import threading
 

--- a/desktop/libs/dashboard/src/dashboard/facet_builder.py
+++ b/desktop/libs/dashboard/src/dashboard/facet_builder.py
@@ -17,8 +17,6 @@
 # limitations under the License.
 
 from __future__ import division, print_function
-from future import standard_library
-standard_library.install_aliases()
 
 from builtins import str, range
 

--- a/desktop/libs/hadoop/src/hadoop/fs/__init__.py
+++ b/desktop/libs/hadoop/src/hadoop/fs/__init__.py
@@ -30,9 +30,7 @@ When possible, the interfaces here have fidelity to the
 native python interfaces.
 """
 from __future__ import division
-from future import standard_library
 from functools import reduce
-standard_library.install_aliases()
 from builtins import map
 from builtins import range
 from builtins import object

--- a/desktop/libs/hadoop/src/hadoop/fs/hadoopfs.py
+++ b/desktop/libs/hadoop/src/hadoop/fs/hadoopfs.py
@@ -24,8 +24,6 @@ Interfaces for Hadoop filesystem access via the HADOOP-4707 Thrift APIs.
 """
 from __future__ import division
 from past.builtins import cmp
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import codecs
 import errno

--- a/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py
+++ b/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py
@@ -19,8 +19,6 @@
 Interfaces for Hadoop filesystem access via HttpFs/WebHDFS
 """
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import oct
 from builtins import object
 import errno

--- a/desktop/libs/hadoop/src/hadoop/mini_cluster.py
+++ b/desktop/libs/hadoop/src/hadoop/mini_cluster.py
@@ -38,8 +38,6 @@
 # done
 
 from __future__ import print_function
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import atexit
 import subprocess

--- a/desktop/libs/hadoop/src/hadoop/tests.py
+++ b/desktop/libs/hadoop/src/hadoop/tests.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 import os
 import sys
 

--- a/desktop/libs/hadoop/src/hadoop/yarn/clients.py
+++ b/desktop/libs/hadoop/src/hadoop/yarn/clients.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import next
 import logging
 import sys

--- a/desktop/libs/hadoop/src/hadoop/yarn/spark_history_server_api.py
+++ b/desktop/libs/hadoop/src/hadoop/yarn/spark_history_server_api.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import json
 import logging

--- a/desktop/libs/indexer/src/indexer/api3.py
+++ b/desktop/libs/indexer/src/indexer/api3.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 
 from builtins import zip
 from past.builtins import basestring

--- a/desktop/libs/indexer/src/indexer/conf.py
+++ b/desktop/libs/indexer/src/indexer/conf.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 import logging
 import os
 import sys

--- a/desktop/libs/indexer/src/indexer/file_format.py
+++ b/desktop/libs/indexer/src/indexer/file_format.py
@@ -13,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.import logging
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from past.builtins import basestring
 from builtins import object

--- a/desktop/libs/indexer/src/indexer/indexers/morphline_tests.py
+++ b/desktop/libs/indexer/src/indexer/indexers/morphline_tests.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.from nose.tools import assert_equal
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import zip
 from past.builtins import basestring
 from builtins import object

--- a/desktop/libs/indexer/src/indexer/indexers/sql.py
+++ b/desktop/libs/indexer/src/indexer/indexers/sql.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.import logging
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import csv
 import logging

--- a/desktop/libs/indexer/src/indexer/test_utils.py
+++ b/desktop/libs/indexer/src/indexer/test_utils.py
@@ -16,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 import sys
 
 from desktop.lib.i18n import force_unicode

--- a/desktop/libs/indexer/src/indexer/utils.py
+++ b/desktop/libs/indexer/src/indexer/utils.py
@@ -16,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import next
 from builtins import range
 from builtins import object

--- a/desktop/libs/libanalyze/src/libanalyze/analyze_test.py
+++ b/desktop/libs/libanalyze/src/libanalyze/analyze_test.py
@@ -14,8 +14,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import cProfile, logging, os, pstats, sys, time
 from libanalyze import analyze as a

--- a/desktop/libs/liboauth/src/liboauth/backend.py
+++ b/desktop/libs/liboauth/src/liboauth/backend.py
@@ -18,8 +18,6 @@
 See desktop/auth/backend.py
 """
 
-from future import standard_library
-standard_library.install_aliases()
 import json
 import cgi
 import logging

--- a/desktop/libs/liboauth/src/liboauth/views.py
+++ b/desktop/libs/liboauth/src/liboauth/views.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 
 import logging
 import sys

--- a/desktop/libs/liboozie/src/liboozie/types.py
+++ b/desktop/libs/liboozie/src/liboozie/types.py
@@ -23,8 +23,6 @@ http://incubator.apache.org/oozie/docs/3.2.0-incubating/docs/WebServicesAPI.html
 """
 from __future__ import division
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import logging
 import math

--- a/desktop/libs/liboozie/src/liboozie/utils.py
+++ b/desktop/libs/liboozie/src/liboozie/utils.py
@@ -20,8 +20,6 @@ Misc helper functions
 """
 from __future__ import print_function
 
-from future import standard_library
-standard_library.install_aliases()
 from past.builtins import basestring
 
 import logging

--- a/desktop/libs/libsolr/src/libsolr/api.py
+++ b/desktop/libs/libsolr/src/libsolr/api.py
@@ -16,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import next
 from builtins import str
 from builtins import zip

--- a/desktop/libs/libsolr/src/libsolr/conf.py
+++ b/desktop/libs/libsolr/src/libsolr/conf.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 import logging
 import sys
 

--- a/desktop/libs/libzookeeper/src/libzookeeper/conf.py
+++ b/desktop/libs/libzookeeper/src/libzookeeper/conf.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 import logging
 import sys
 

--- a/desktop/libs/metadata/src/metadata/manager_client.py
+++ b/desktop/libs/metadata/src/metadata/manager_client.py
@@ -16,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import base64
 import json

--- a/desktop/libs/notebook/src/notebook/api.py
+++ b/desktop/libs/notebook/src/notebook/api.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 import json
 import logging
 

--- a/desktop/libs/notebook/src/notebook/connectors/altus_adb.py
+++ b/desktop/libs/notebook/src/notebook/connectors/altus_adb.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import logging
 import json

--- a/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py
+++ b/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
 from builtins import next, object
 import binascii
 import copy

--- a/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
+++ b/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
@@ -49,8 +49,6 @@ Each URL is mapped to one engine and should be created once per process.
 Each query statement grabs a connection from the engine and will return it after its close().
 Disposing the engine closes all its connections.
 '''
-from future import standard_library
-standard_library.install_aliases()
 
 from builtins import next, object
 import datetime

--- a/desktop/libs/notebook/src/notebook/models.py
+++ b/desktop/libs/notebook/src/notebook/models.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str, object
 import datetime
 import json

--- a/desktop/libs/notebook/src/notebook/sql_utils.py
+++ b/desktop/libs/notebook/src/notebook/sql_utils.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 import hashlib
 import os
 import re

--- a/desktop/libs/notebook/src/notebook/tasks.py
+++ b/desktop/libs/notebook/src/notebook/tasks.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 
 from __future__ import absolute_import, unicode_literals
-from future import standard_library
-standard_library.install_aliases()
 
 from builtins import next, object
 


### PR DESCRIPTION
… Python 3.8 and later.

- The future library imports have no effect on Python 3.

## What changes were proposed in this pull request?

- Removing future library dependancy

## How was this patch tested?

- Tested it by running Hue using python3.8 on MacBook and RHEL 8.4 system

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
