### PR TITLE
[jb] Clear the widget status on workflow rerun

### DIFF
--- a/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflow_graph.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/list_oozie_workflow_graph.mako
@@ -140,6 +140,12 @@ ${ dashboard.import_layout() }
         }
       }
 
+      huePubSub.subscribe('graph.clear.widget.status', function() {
+        viewModel.getAllWidgets().forEach(function(widget) {
+          widget.status('');
+        });
+      });
+
       huePubSub.subscribe('graph.refresh.view', refreshView);
 
       huePubSub.subscribe('graph.stop.refresh.view', function(){

--- a/apps/oozie/src/oozie/templates/dashboard/rerun_workflow_popup.mako
+++ b/apps/oozie/src/oozie/templates/dashboard/rerun_workflow_popup.mako
@@ -107,6 +107,7 @@
 
       % if return_json:
         $('#submit-rerun-form${ SUFFIX }').submit(function (e) {
+          huePubSub.publish('graph.clear.widget.status');
           $.ajax({
             type: "POST",
             url: window.HUE_BASE_URL + '${ action }', // window.HUE_BASE_URL is empty string when Knox is not enabled


### PR DESCRIPTION
In the job browser view of Oozie workflow graphs we show the status of each widget as a progress bar attached to the individual widgets. When a user initiated a re-run of the entire workflow the status bars were updated one by one as they were executed and any following widgets were left with their previous status making it impossible for the user to get an indication of the current progress of the rerun.

To fix this it will now clear the status of all widgets in the graph once a re-run is submitted.