### PR TITLE
[Filebrowser] Add get delegation token logic for secure hadoop (#3301)

### DIFF
--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -3,6 +3,7 @@ requests-gssapi==1.2.3
 asn1crypto==0.24.0
 avro-python3==1.8.2
 Babel==2.9.1
+cachetools==5.3.1
 celery[redis]==5.2.7
 cffi==1.15.0
 channels==3.0.3

--- a/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py
+++ b/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py
@@ -23,6 +23,8 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import oct
 from builtins import object
+from cachetools.func import ttl_cache
+from datetime import datetime, timedelta
 import errno
 import logging
 import posixpath
@@ -942,7 +944,7 @@ class WebHdfs(Hdfs):
         del params['user.name']
     return params
 
-
+  @ttl_cache(maxsize=128, ttl=timedelta(hours=8), timer=datetime.now, typed=False)
   def get_delegation_token(self, renewer):
     """get_delegation_token(user) -> Delegation token"""
     # Workaround for HDFS-3988

--- a/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py
+++ b/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py
@@ -236,11 +236,9 @@ class WebHdfs(Hdfs):
   @ttl_cache(maxsize=128, ttl=timedelta(hours=24), timer=datetime.now, typed=False)
   def get_delegation_token(self, renewer):
     """get_delegation_token(user) -> Delegation token"""
-    # Workaround for HDFS-3988
-    if self._security_enabled:
-      self.get_home_dir()
-
-    params = self._getparams()
+    params = {
+      "doas": self.user
+    }
     params['op'] = 'GETDELEGATIONTOKEN'
     params['renewer'] = renewer
     headers = self._getheaders()

--- a/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py
+++ b/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py
@@ -236,9 +236,7 @@ class WebHdfs(Hdfs):
   @ttl_cache(maxsize=128, ttl=timedelta(hours=24), timer=datetime.now, typed=False)
   def get_delegation_token(self, renewer):
     """get_delegation_token(user) -> Delegation token"""
-    params = {
-      "doas": self.user
-    }
+    params = self._getparams()
     params['op'] = 'GETDELEGATIONTOKEN'
     params['renewer'] = renewer
     headers = self._getheaders()
@@ -568,7 +566,6 @@ class WebHdfs(Hdfs):
     params['op'] = 'GETHOMEDIRECTORY'
     headers = self._getheaders()
     res = self._root.get(params=params, headers=headers)
-    print(res)
     for key, value in res.items():
       if key.lower() == "path":
         return self.normpath(value)
@@ -642,7 +639,8 @@ class WebHdfs(Hdfs):
     `permission' should be an octal integer or string.
     """
     path = self.strip_normpath(path)
-    params = self._getparams()
+    
+    
     params['op'] = 'CREATE'
     params['overwrite'] = overwrite and 'true' or 'false'
     if blocksize is not None:


### PR DESCRIPTION
## What changes were proposed in this pull request?

I am working on integrating Hue with SecureHadoop as a ProxyUser.
I found that the behavior of ProxyUser in WebHDFS FileBrowser needs to be enhanced.
When "security_enabled" is true, [only "read_url" method use delegation token](https://github.com/cloudera/hue/blob/master/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py#L565).

I want to modify the code
so that a user who has been impersonated from Hue(a proxy user) can issue a Delegation Token when using WebHDFS.
(https://github.com/cloudera/hue/discussions/3323)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
