### PR TITLE
Add support for XFF header in Knox and SAML logins

### DIFF
--- a/apps/beeswax/gen-py/TCLIService/TCLIService.py
+++ b/apps/beeswax/gen-py/TCLIService/TCLIService.py
@@ -222,15 +222,15 @@ def add_xff_header(func):
     configuration = None
     if args[1].__dict__ is not None and 'configuration' in args[1].__dict__:
       configuration = args[1].__dict__['configuration']
-    if configuration is not None and 'HTTP-X-FORWARDED-FOR' in configuration:
-        xff = configuration.get('HTTP-X-FORWARDED-FOR')
+    if configuration is not None and 'X-Forwarded-For' in configuration:
+        xff = configuration.get('X-Forwarded-For')
     try:
         if hasattr(self._oprot.trans, 'TFramedTransport'):
           trans_client = self._oprot.trans._TFramedTransport__trans
         else:
           trans_client = self._oprot.trans._TBufferedTransport__trans
 
-        trans_client.setCustomHeaders({'HTTP-X-FORWARDED-FOR': xff})
+        trans_client.setCustomHeaders({'X-Forwarded-For': xff})
     except AttributeError as e:
         LOG.error('Could not set HTTP-X-FORWARDED-FOR header: %s' % smart_str(e))
 

--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -186,6 +186,9 @@ http_500_debug_mode=false
 # Enable X-Forwarded-Host header if the load balancer requires it.
 ## use_x_forwarded_host=true
 
+# Enable X-Forwarded-For header if hive/impala requires it.
+## enable_xff_for_hive_impala=true
+
 # Support for HTTPS termination at the load-balancer level with SECURE_PROXY_SSL_HEADER.
 ## secure_proxy_ssl_header=false
 

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -191,6 +191,9 @@
   # Enable X-Forwarded-Host header if the load balancer requires it.
   ## use_x_forwarded_host=true
 
+  # Enable X-Forwarded-For header if hive/impala requires it.
+  ## enable_xff_for_hive_impala=true
+
   # Support for HTTPS termination at the load-balancer level with SECURE_PROXY_SSL_HEADER.
   ## secure_proxy_ssl_header=false
 

--- a/desktop/core/src/desktop/auth/backend.py
+++ b/desktop/core/src/desktop/auth/backend.py
@@ -238,6 +238,13 @@ def force_username_case(username):
     username = username.upper()
   return username
 
+def knox_login_headers(request):
+  userprofile = get_profile(request.user)
+  try:
+    userprofile.update_data({'X-Forwarded-For': request.META['HTTP_X_FORWARDED_FOR']})
+    userprofile.save()
+  except Exception:
+    LOG.error("X-FORWARDED-FOR header not found")
 
 class DesktopBackendBase(object):
   """

--- a/desktop/core/src/desktop/auth/views.py
+++ b/desktop/core/src/desktop/auth/views.py
@@ -49,7 +49,7 @@ from desktop.lib import fsmanager
 from desktop.lib.django_util import render, login_notrequired, JsonResponse
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.log.access import access_log, access_warn, last_access_map
-from desktop.views import samlgroup_check
+from desktop.views import samlgroup_check, saml_login_headers
 from desktop.settings import LOAD_BALANCER_COOKIE
 from django.utils.encoding import smart_str
 
@@ -165,7 +165,7 @@ def dt_login(request, from_modal=False):
           userprofile.creation_method = UserProfile.CreationMethod.EXTERNAL.name
         userprofile.update_data({'auth_backend': user.backend})
         try:
-          userprofile.update_data({'HTTP-X-FORWARDED-FOR': request.META['HTTP_X_FORWARDED_FOR']})
+          userprofile.update_data({'X-Forwarded-For': request.META['HTTP_X_FORWARDED_FOR']})
         except KeyError as e:
           LOG.error('HTTP-X-FORWARDED-FOR header not found: %s' %smart_str(e))
         userprofile.save()
@@ -211,6 +211,7 @@ def dt_login(request, from_modal=False):
 
   if 'SAML2Backend' in backend_names:
     request.session['samlgroup_permitted_flag'] = samlgroup_check(request)
+    saml_login_headers(request)
 
   renderable_path = 'login.mako'
   if from_modal:

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -544,6 +544,12 @@ USE_X_FORWARDED_HOST = Config(
   type=coerce_bool,
   dynamic_default=is_lb_enabled)
 
+ENABLE_XFF_FOR_HIVE_IMPALA = Config(
+  key="enable_xff_for_hive_impala",
+  help=_("Enable X-Forwarded-For header if the hive/impala requires it."),
+  type=coerce_bool,
+  default=False)
+
 SECURE_PROXY_SSL_HEADER = Config(
   key="secure_proxy_ssl_header",
   help=_("Support for HTTPS termination at the load-balancer level with SECURE_PROXY_SSL_HEADER."),

--- a/desktop/core/src/desktop/views.py
+++ b/desktop/core/src/desktop/views.py
@@ -114,6 +114,14 @@ def samlgroup_check(request):
       LOG.info("User %s found in the required SAML groups %s" % (request.user.username, ",".join(saml_group_found)))
   return True
 
+def saml_login_headers(request):
+  userprofile = get_profile(request.user)
+  try:
+    userprofile.update_data({'X-Forwarded-For': request.META['HTTP_X_FORWARDED_FOR']})
+    userprofile.save()
+  except KeyError as e:
+    LOG.error('X-FORWARDED-FOR header not found: %s' % smart_str(e))
+
 def hue(request):
   current_app, other_apps, apps_list = _get_apps(request.user, '')
   clusters = list(get_clusters(request.user).values())


### PR DESCRIPTION
## What changes were proposed in this pull request?
Passing X-Forwarded-For header via thrift calls made to hive/impala when using knox and saml logins. 

## How was this patch tested?
Tested on Clusters with Knox and SAML logins. Hive debug logs shows the X-Forwarded-For header received from Hue. 

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
