### PR TITLE
[Dockerfile] Add /var/log/hue folder for loading log data

### DIFF
--- a/tools/docker/hue/Dockerfile
+++ b/tools/docker/hue/Dockerfile
@@ -41,7 +41,7 @@ RUN pip3 install --upgrade --no-cache-dir setuptools virtualenv pip && \
   chown -R hue /usr/share/hue && \
   rm -rf /hue/desktop/conf && \
   cp -r /hue/desktop/conf.dist /hue/desktop/conf && \
-  mkdir -m 777 /var/log/hue && \
+  mkdir -m 755 /var/log/hue && \
   cd /hue && \
   ln -fs /usr/local/bin/pip3.8 /usr/bin/pip3.8 && \
   ln -fs /usr/local/bin/pip3.8 /usr/bin/pip3 && \

--- a/tools/docker/hue/Dockerfile
+++ b/tools/docker/hue/Dockerfile
@@ -41,6 +41,7 @@ RUN pip3 install --upgrade --no-cache-dir setuptools virtualenv pip && \
   chown -R hue /usr/share/hue && \
   rm -rf /hue/desktop/conf && \
   cp -r /hue/desktop/conf.dist /hue/desktop/conf && \
+  mkdir -m 777 /var/log/hue && \
   cd /hue && \
   ln -fs /usr/local/bin/pip3.8 /usr/bin/pip3.8 && \
   ln -fs /usr/local/bin/pip3.8 /usr/bin/pip3 && \


### PR DESCRIPTION
## What changes were proposed in this pull request?

When I build a hue dockerfile and run that image on the container, I found the Error Log that "Folder Not found /var/log/hue". So I add the code to make a /var/log/hue folder in the Dockerfile.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
