### PR TITLE
Add vars 'work_group' and 'catalog_name' from python lib PyAthena for AWS Athena connector

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
+++ b/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
@@ -85,6 +85,7 @@ else:
   from urllib import quote_plus as urllib_quote_plus
   from cStringIO import StringIO
 
+import urllib
 
 ENGINES = {}
 CONNECTIONS = {}
@@ -169,8 +170,13 @@ class SqlAlchemyApi(Api):
     if url.startswith('awsathena+rest://'):
       url = url.replace(url[17:37], urllib_quote_plus(url[17:37]))
       url = url.replace(url[38:50], urllib_quote_plus(url[38:50]))
-      s3_staging_dir = url.rsplit('s3_staging_dir=', 1)[1]
+      parsed = urllib.parse.urlparse(url)
+      s3_staging_dir=urllib.parse.parse_qs(parsed.query)['s3_staging_dir'][0]
       url = url.replace(s3_staging_dir, urllib_quote_plus(s3_staging_dir))
+      work_group=urllib.parse.parse_qs(parsed.query)['work_group'][0]
+      url = url.replace(work_group, urllib_quote_plus(work_group))
+      catalog_name=urllib.parse.parse_qs(parsed.query)['catalog_name'][0]
+      url = url.replace(catalog_name, urllib_quote_plus(catalog_name))
 
     m = re.search(URL_PATTERN, url)
     driver_name = m.group('driver_name')

--- a/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
+++ b/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
@@ -171,11 +171,11 @@ class SqlAlchemyApi(Api):
       url = url.replace(url[17:37], urllib_quote_plus(url[17:37]))
       url = url.replace(url[38:50], urllib_quote_plus(url[38:50]))
       parsed = urllib.parse.urlparse(url)
-      s3_staging_dir=urllib.parse.parse_qs(parsed.query)['s3_staging_dir'][0]
+      s3_staging_dir = urllib.parse.parse_qs(parsed.query)['s3_staging_dir'][0]
       url = url.replace(s3_staging_dir, urllib_quote_plus(s3_staging_dir))
-      work_group=urllib.parse.parse_qs(parsed.query)['work_group'][0]
+      work_group = urllib.parse.parse_qs(parsed.query)['work_group'][0]
       url = url.replace(work_group, urllib_quote_plus(work_group))
-      catalog_name=urllib.parse.parse_qs(parsed.query)['catalog_name'][0]
+      catalog_name = urllib.parse.parse_qs(parsed.query)['catalog_name'][0]
       url = url.replace(catalog_name, urllib_quote_plus(catalog_name))
 
     m = re.search(URL_PATTERN, url)

--- a/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
+++ b/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
@@ -76,16 +76,14 @@ from notebook.connectors.base import Api, QueryError, QueryExpired, _get_snippet
 from notebook.models import escape_rows
 
 if sys.version_info[0] > 2:
-  from urllib.parse import quote_plus as urllib_quote_plus
+  from urllib.parse import quote_plus as urllib_quote_plus, urlparse as urllib_urlparse, parse_qs as urllib_parse_qs
   from past.builtins import long
   from io import StringIO
   from django.utils.translation import gettext as _
 else:
   from django.utils.translation import ugettext as _
-  from urllib import quote_plus as urllib_quote_plus
+  from urllib import quote_plus as urllib_quote_plus, urlparse as urllib_urlparse, parse_qs as urllib_parse_qs
   from cStringIO import StringIO
-
-import urllib
 
 ENGINES = {}
 CONNECTIONS = {}
@@ -170,12 +168,12 @@ class SqlAlchemyApi(Api):
     if url.startswith('awsathena+rest://'):
       url = url.replace(url[17:37], urllib_quote_plus(url[17:37]))
       url = url.replace(url[38:50], urllib_quote_plus(url[38:50]))
-      parsed = urllib.parse.urlparse(url)
-      s3_staging_dir = urllib.parse.parse_qs(parsed.query)['s3_staging_dir'][0]
+      parsed = urllib_urlparse(url)
+      s3_staging_dir = urllib_parse_qs(parsed.query)['s3_staging_dir'][0]
       url = url.replace(s3_staging_dir, urllib_quote_plus(s3_staging_dir))
-      work_group = urllib.parse.parse_qs(parsed.query)['work_group'][0]
+      work_group = urllib_parse_qs(parsed.query)['work_group'][0]
       url = url.replace(work_group, urllib_quote_plus(work_group))
-      catalog_name = urllib.parse.parse_qs(parsed.query)['catalog_name'][0]
+      catalog_name = urllib_parse_qs(parsed.query)['catalog_name'][0]
       url = url.replace(catalog_name, urllib_quote_plus(catalog_name))
 
     m = re.search(URL_PATTERN, url)

--- a/desktop/libs/notebook/src/notebook/connectors/sql_alchemy_tests.py
+++ b/desktop/libs/notebook/src/notebook/connectors/sql_alchemy_tests.py
@@ -78,7 +78,7 @@ class TestApi(object):
       'name': 'hive',
       'options': {
         'url': 'awsathena+rest://XXXXXXXXXXXXXXX:XXXXXXXXXXXXXXXXXXX@athena.us-west-2.amazonaws.com:443/default?'
-            's3_staging_dir=s3://gethue-athena/scratch'
+            's3_staging_dir=s3://gethue-athena/scratch&work_group=demo_group&catalog_name=AwsDataCatalog'
       }
     }
 

--- a/docs/docs-site/content/administrator/configuration/connectors/_index.md
+++ b/docs/docs-site/content/administrator/configuration/connectors/_index.md
@@ -261,11 +261,11 @@ Then give Hue the information about the database source:
     [[[athena]]]
     name = AWS Athena
     interface=sqlalchemy
-    options='{"url": "awsathena+rest://${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}@athena.${REGION}.amazonaws.com:443/${SCHEMA}?s3_staging_dir=${S3_BUCKET_DIRECTORY}&work_group=${WORK_GROUP}&catalog_name=${CATALOG_NAME}"}'
+    options='{"url": "awsathena+rest://${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}@athena.${REGION}.amazonaws.com:443/${SCHEMA}?s3_staging_dir=${S3_BUCKET_DIRECTORY}"}'
 
 e.g.
 
-    options='{"url": "awsathena+rest://XXXXXXXXXXXXXXXXXXXX:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX@athena.us-west-2.amazonaws.com:443/default?s3_staging_dir=s3://gethue-athena/scratch&work_group=demo_group&catalog_name=AwsDataCatalog"}'
+    options='{"url": "awsathena+rest://XXXXXXXXXXXXXXXXXXXX:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX@athena.us-west-2.amazonaws.com:443/default?s3_staging_dir=s3://gethue-athena/scratch"}'
 
 Note: Keys and S3 buckets need to be URL quoted but Hue does it automatically for you.
 

--- a/docs/docs-site/content/administrator/configuration/connectors/_index.md
+++ b/docs/docs-site/content/administrator/configuration/connectors/_index.md
@@ -261,11 +261,11 @@ Then give Hue the information about the database source:
     [[[athena]]]
     name = AWS Athena
     interface=sqlalchemy
-    options='{"url": "awsathena+rest://${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}@athena.${REGION}.amazonaws.com:443/${SCHEMA}?s3_staging_dir=${S3_BUCKET_DIRECTORY}"}'
+    options='{"url": "awsathena+rest://${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}@athena.${REGION}.amazonaws.com:443/${SCHEMA}?s3_staging_dir=${S3_BUCKET_DIRECTORY}&work_group=${WORK_GROUP}&catalog_name=${CATALOG_NAME}"}'
 
 e.g.
 
-    options='{"url": "awsathena+rest://XXXXXXXXXXXXXXXXXXXX:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX@athena.us-west-2.amazonaws.com:443/default?s3_staging_dir=s3://gethue-athena/scratch"}'
+    options='{"url": "awsathena+rest://XXXXXXXXXXXXXXXXXXXX:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX@athena.us-west-2.amazonaws.com:443/default?s3_staging_dir=s3://gethue-athena/scratch&work_group=demo_group&catalog_name=AwsDataCatalog"}'
 
 Note: Keys and S3 buckets need to be URL quoted but Hue does it automatically for you.
 

--- a/tools/docker/hue/Dockerfile
+++ b/tools/docker/hue/Dockerfile
@@ -85,7 +85,10 @@ RUN ./build/env/bin/pip install --no-cache-dir \
   # install after sqlalchemy-clickhouse and version == 1.0.4 \
   # otherwise Code: 516, Authentication failed will display \
   infi.clickhouse_orm==1.0.4 \
-  mysqlclient
+  mysqlclient \
+  PyAthena==2.25.2
+  # PyAthena == 3.x.x is latest, but not working with current configuration \
+  # otherwise, 'VisitableType' object is not subscriptable in Hue UI
 
 USER hue
 


### PR DESCRIPTION
## Hue: AWS Athena integration with PyAthena
https://github.com/laughingman7743/PyAthena
https://pyup.io/packages/pypi/pyathena/changelog

## What changes were proposed in this pull request?

- I would like to get variables '**work_group**' and '**catalog_name**' from python library **PyAthena**, otherwise can not use **Hue AWS Athena connector** without these variables.
- Not defined variable "workgroup" leads to the situation declined access:
```
An error occurred (AccessDeniedException) when calling the StartQueryExecution operation: You are not authorized to perform: athena:StartQueryExecution on the resource. After your AWS administrator or you have updated your permissions, please try again.
```
- And another variable '**catalog_name**' allow choose sources of data if you have a few sources in one AWS account instead of default data source.

## How was this patch tested?

Patch tested manually from Docker image gethue/hue:latest with additional layer python library PyAthena
**Dockerfile**
```
FROM gethue/hue:latest

WORKDIR /usr/share/hue

# Install DB connectors
# To move to requirements_connectors.txt
RUN ./build/env/bin/pip install --no-cache-dir \
  PyAthena==2.25.2

USER hue

EXPOSE 8888
```
Build new image from current:
```
docker build . -t hue-test:2
```
Run with overwrite changed file **sql_alchemy.py** and config **hue.ini**
_I used PostgreSQL database on localhost_
```
docker run -it -p 8888:8888 -v $PWD/hue.ini:/usr/share/hue/desktop/conf/hue.ini -v $PWD/sql_alchemy.py:/usr/share/hue/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py --network="host" hue-test:2 
```
**hue.ini**
```
---
[[database]]
engine=postgresql_psycopg2
host=localhost
port=5432
user=hue_user
password=hue_password
name=hue_database

[[[athena]]]
name = AWS Athena SomeAwsDataCatalog
interface=sqlalchemy
options='{"url": "awsathena+rest://AWS_USER_ID:AWS_USER_KEY@athena.example-region_name-1.amazonaws.com:443/default?s3_staging_dir=s3://some-staging-dir/&work_group=demo_group&catalog_name=SomeAwsDataCatalog"}'
---
```
**sql_alchemy.py**
You can see different in changes of pull request

And it works for me


Also tested and working with enabling hue 5
```
[desktop]
enable_connectors=true
enable_hue_5=true 
```

![image](https://github.com/gethue/hue/assets/66263951/76ddf555-cc2c-4538-83d2-1c0467610969)
![image](https://github.com/gethue/hue/assets/66263951/75dba43d-0f4a-4e89-8e66-511faaac31ed)


I guess it is not best quality code solution, but it works, of course if you would like you can change code on your choice, I just would like show up working tested solution.
Or maybe tell me please what to fix, for make this a some good pull request.


