### PR TITLE
[docs] Fix few dead links

### DIFF
--- a/docs/docs-site/content/administrator/installation/_index.md
+++ b/docs/docs-site/content/administrator/installation/_index.md
@@ -21,6 +21,6 @@ You can also find distributions of Hue via these companies:
 
 * [Cloudera Data Platform - Hue](https://www.cloudera.com/products/cloudera-data-platform.html)
 * [Amazon AWS EMR - Hue](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-hue.html)
-* [Open Data Hub - Data Catalog](https://opendatahub.io/docs/advanced-tutorials/data-exploration.html)
 * [Google Cloud Dataproc - Hue](https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/tree/master/hue)
 * [Azure HDInsight - Hue](https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-hadoop-hue-linux)
+* Open Data Hub - Data Catalog

--- a/docs/docs-site/content/releases/release-notes-4.4.0.md
+++ b/docs/docs-site/content/releases/release-notes-4.4.0.md
@@ -46,7 +46,7 @@ Notable Changes
   * [HUE-8140](https://issues.cloudera.org/browse/HUE-8140) [editor] Improve multi-statement execution
   * [HUE-8662](https://issues.cloudera.org/browse/HUE-8662) [core] Fix missing static URLs
 * The [Hue Docker image](https://github.com/cloudera/hue/tree/master/tools/docker) was simplified
-* [Upstream](http://cloudera.github.io/hue/latest/) documentations has a better table of contents, restyling, update of old instructions... Reporting issues or sending a suggestion is one click away via GitHub, so feel free to send some pull requests!
+* [Upstream](https://docs.gethue.com/) documentations has a better table of contents, restyling, update of old instructions... Reporting issues or sending a suggestion is one click away via GitHub, so feel free to send some pull requests!
 
 
 Compatibility

--- a/docs/gethue/content/en/posts/2018-04-04-hue-4-2-and-its-self-service-bi-improvements-are-out.md
+++ b/docs/gethue/content/en/posts/2018-04-04-hue-4-2-and-its-self-service-bi-improvements-are-out.md
@@ -190,7 +190,7 @@ Here is a list of the main improvements. For all the changes, check out the�
   <span style="font-weight: 300;">SAML update (with idle session fix)</span>
 </li>
 <li style="font-weight: 400;">
-  <span style="font-weight: 300;"><a href="http://cloudera.github.io/hue/latest/">Documentation revamp</a></span>
+  <span style="font-weight: 300;"><a href="https://docs.gethue.com/">Documentation revamp</a></span>
 </li>
 <li style="font-weight: 400;">
   <span style="font-weight: 300;">Thread page</span>

--- a/docs/gethue/content/en/posts/2018-10-17-hue-4-3-and-its-app-building-improvements-are-out.md
+++ b/docs/gethue/content/en/posts/2018-10-17-hue-4-3-and-its-app-building-improvements-are-out.md
@@ -106,7 +106,7 @@ As usual thank you to all the project contributors and for sending feedback a
  [6]: https://github.com/cloudera/hue/commits/release-4.3.0
  [7]: http://cloudera.github.io/hue/docs-4.3.0/release-notes/release-notes-4.3.0.html
  [8]: http://demo.gethue.com/
- [9]: http://cloudera.github.io/hue/latest/admin-manual/manual.html#centosoracleredhat-6x
+ [9]: https://docs.gethue.com/administrator/installation/dependencies/#redhat-68--69-os
  [10]: https://gethue.com/additional-sql-improvements-in-hue-4-3/
  [11]: https://cdn.gethue.com/uploads/2018/10/sample_context_operations.gif
  [12]: https://gethue.com/simplifying-the-end-user-data-catalog-search/

--- a/docs/gethue/content/en/posts/2019-03-02-configure-ambari-hdp-with-hue.md
+++ b/docs/gethue/content/en/posts/2019-03-02-configure-ambari-hdp-with-hue.md
@@ -150,7 +150,7 @@ build/env/bin/hue runcpserver
 
 <span style="font-weight: 400;">As always please feel free to comment and send feedback on the </span>[<span style="font-weight: 400;">hue-user</span>][8] <span style="font-weight: 400;">list or </span>[<span style="font-weight: 400;">@gethue</span>][9]<span style="font-weight: 400;">!</span>
 
- [1]: http://cloudera.github.io/hue/latest/admin-manual/manual.html
+ [1]: https://docs.gethue.com/administrator/
  [2]: https://cdn.gethue.com/uploads/2019/02/Screen-Shot-2019-02-27-at-3.05.28-PM.png
  [3]: https://cdn.gethue.com/uploads/2019/02/Screen-Shot-2019-02-27-at-3.10.39-PM.png
  [4]: http://hue-2.example.com:8888

--- a/docs/gethue/content/en/posts/2019-03-12-hue-in-docker.md
+++ b/docs/gethue/content/en/posts/2019-03-12-hue-in-docker.md
@@ -133,7 +133,7 @@ As usual feel free to send feedback to the [hue-user][10] list or [@gethue][1
  [5]: https://hub.docker.com/r/gethue/hue/
  [6]: https://cdn.gethue.com/uploads/2017/12/Screen-Shot-2017-11-15-at-3.34.20-PM.png
  [7]: https://github.com/cloudera/hue/blob/master/desktop/conf.dist/hue.ini
- [8]: http://cloudera.github.io/hue/latest/admin-manual/manual.html
+ [8]: https://docs.gethue.com/administrator/
  [9]: https://kubernetes.io/
  [10]: http://groups.google.com/a/cloudera.org/group/hue-user
  [11]: https://twitter.com/gethue

--- a/docs/gethue/content/en/posts/2019-03-22-quick-task-how-to-query-apache-druid-analytic-database.md
+++ b/docs/gethue/content/en/posts/2019-03-22-quick-task-how-to-query-apache-druid-analytic-database.md
@@ -91,7 +91,7 @@ As usual feel free to comment here or to send feedback to the [hue-user][9] li
 
  [1]: https://impala.apache.org/
  [2]: https://hive.apache.org/
- [3]: http://cloudera.github.io/hue/latest/user/editor/
+ [3]: https://docs.gethue.com/user/querying/#editor
  [4]: http://druid.io/
  [5]: http://druid.io/docs/latest/design/index.html#what-is-druid
  [6]: http://druid.io/downloads.html

--- a/docs/gethue/content/en/posts/2019-03-26-quick-task-fixing-importerror-no-module-named-google_compute_engine-when-building-hue.md
+++ b/docs/gethue/content/en/posts/2019-03-26-quick-task-fixing-importerror-no-module-named-google_compute_engine-when-building-hue.md
@@ -150,4 +150,4 @@ make: \*** [desktop] Error 2
   </code></pre>
 </p>
 
- [1]: http://cloudera.github.io/hue/latest/administrator/installation/
+ [1]: https://docs.gethue.com/administrator/installation/

--- a/docs/gethue/content/en/posts/2019-03-28-hue-4-4-and-its-improvements-are-out.md
+++ b/docs/gethue/content/en/posts/2019-03-28-hue-4-4-and-its-improvements-are-out.md
@@ -163,7 +163,7 @@ Onwards!
 &nbsp;
 
  [1]: https://cdn.gethue.com/uploads/2015/08/hue-logo-copy.png
- [2]: http://cloudera.github.io/hue/latest/releases/release-notes-4.4.0/index.html
+ [2]: https://docs.gethue.com/releases/release-notes-4.4.0/
  [3]: https://github.com/cloudera/hue/archive/release-4.4.0.zip
  [4]: http://demo.gethue.com/
  [5]: https://blog.cloudera.com/blog/2018/06/new-in-cloudera-5-15-simplifying-the-end-user-data-catalog-for-the-self-service-analytic-database/

--- a/docs/gethue/content/en/posts/2019-04-01-hive-on-tez-integrations-improvements.md
+++ b/docs/gethue/content/en/posts/2019-04-01-hive-on-tez-integrations-improvements.md
@@ -80,5 +80,5 @@ categories:
  [2]: https://gethue.com/sql-editor/
  [3]: https://cdn.gethue.com/uploads/2019/04/Screen-Shot-2019-03-29-at-3.53.54-PM.png
  [4]: https://cdn.gethue.com/uploads/2019/04/Screen-Shot-2019-03-29-at-3.50.35-PM.png
- [5]: http://cloudera.github.io/hue/latest/administrator/configuration/editor/#hive
+ [5]: https://docs.gethue.com/administrator/configuration/connectors/#apache-hive
  [6]: https://gethue.com/restrict-number-of-concurrent-sessions-per-user/

--- a/docs/gethue/content/en/posts/2019-04-12-documentation-revamp-making-hue-easier-to-install-use-and-develop.md
+++ b/docs/gethue/content/en/posts/2019-04-12-documentation-revamp-making-hue-easier-to-install-use-and-develop.md
@@ -56,7 +56,7 @@ Can be seen in older version: <http://cloudera.github.io/hue/docs-4.3.0/>
 
 ### After
 
-Can be seen in latest: <http://cloudera.github.io/hue/latest/>
+Can be seen in latest: <https://docs.gethue.com/>
 
 [<img src="https://cdn.gethue.com/uploads/2019/04/new_hue_doc_4.5.png"/>][4]
 
@@ -118,17 +118,17 @@ Thank you to everybody using the product and who contributed. One popular ask is
 </div>
 
  [1]: https://gethue.com/additional-sql-improvements-in-hue-4-3/
- [2]: http://cloudera.github.io/hue/latest/
+ [2]: https://docs.gethue.com/
  [3]: https://cdn.gethue.com/uploads/2019/03/hue_4.3_documentation.png.png
  [4]: https://cdn.gethue.com/uploads/2019/04/new_hue_doc_4.5.png
- [5]: http://cloudera.github.io/hue/latest/administrator/
- [6]: http://cloudera.github.io/hue/latest/user/
- [7]: http://cloudera.github.io/hue/latest/developer/
- [8]: http://cloudera.github.io/hue/latest/releases/
+ [5]: https://docs.gethue.com/administrator/
+ [6]: https://docs.gethue.com/user/
+ [7]: hhttps://docs.gethue.com/developer/
+ [8]: https://docs.gethue.com/releases/
  [9]: https://cdn.gethue.com/uploads/2019/03/doc_right_side.png
  [10]: https://cdn.gethue.com/uploads/2019/04/doc_right_toc.png
  [11]: https://cdn.gethue.com/uploads/2019/03/breadcrumbs_docs.png
  [12]: https://cdn.gethue.com/uploads/2019/03/docs_copy_clipboard.png
  [13]: https://cdn.gethue.com/uploads/2019/03/docs_search_bar.png
  [14]: https://cdn.gethue.com/uploads/2019/03/docs_git_edit.png
- [15]: http://cloudera.github.io/hue/latest/user/editor/
+ [15]: https://docs.gethue.com/administrator/configuration/connectors/#databases

--- a/docs/gethue/content/jp/posts/2018-10-31-hue-4-3-and-its-app-building-improvements-are-out.md
+++ b/docs/gethue/content/jp/posts/2018-10-31-hue-4-3-and-its-app-building-improvements-are-out.md
@@ -112,7 +112,7 @@ Hueチームは全てのコントリビューターに感謝し、Hue 4.3 のリ
  [6]: https://github.com/cloudera/hue/commits/release-4.3.0
  [7]: http://cloudera.github.io/hue/docs-4.3.0/release-notes/release-notes-4.3.0.html
  [8]: http://demo.gethue.com/
- [9]: http://cloudera.github.io/hue/latest/admin-manual/manual.html#centosoracleredhat-6x
+ [9]: https://docs.gethue.com/administrator/installation/dependencies/#redhat-68--69-os
  [10]: http://jp.gethue.com/additional-sql-improvements-in-hue-4-3/
  [11]: https://cdn.gethue.com/uploads/2018/10/sample_context_operations.gif
  [12]: https://gethue.com/simplifying-the-end-user-data-catalog-search/

--- a/docs/gethue/content/jp/posts/2019-03-08-configure-ambari-hdp-with-hue.md
+++ b/docs/gethue/content/jp/posts/2019-03-08-configure-ambari-hdp-with-hue.md
@@ -113,7 +113,7 @@ build/env/bin/hue runcpserver
 
 いつものように、コメントやフィードバックは [hue-user][8] リストは [@gethue ][9]までお送りください！
 
- [1]: http://cloudera.github.io/hue/latest/admin-manual/manual.html
+ [1]: https://docs.gethue.com/administrator/
  [2]: https://cdn.gethue.com/uploads/2019/02/Screen-Shot-2019-02-27-at-3.05.28-PM.png
  [3]: https://cdn.gethue.com/uploads/2019/02/Screen-Shot-2019-02-27-at-3.10.39-PM.png
  [4]: http://hue-2.example.com:8888


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Update old docs dead links with new docs.gethue.com links.
- Remove open datahub dead link.

## How was this patch tested?

- Docs and blog built locally via hugo