### PR TITLE
[frontent] fixed incorrect namespaceId that caused assistpanel to swi…

### DIFF
--- a/desktop/core/src/desktop/js/apps/tableBrowser/metastoreSource.js
+++ b/desktop/core/src/desktop/js/apps/tableBrowser/metastoreSource.js
@@ -65,7 +65,7 @@ class MetastoreSource {
 
     huePubSub.subscribe(ASSIST_DB_PANEL_IS_READY_EVENT, () => {
       this.lastLoadNamespacesDeferred.done(() => {
-        const namespaceId = _this.namespace().namespace.id;
+        const namespaceId = this.namespace().namespace.id;
         const localStorageKey = `assist_${this.type}_${namespaceId}.lastSelectedDb`;
         let lastSelectedDb = getFromLocalStorage(localStorageKey);
         if (!lastSelectedDb && lastSelectedDb !== '') {

--- a/desktop/core/src/desktop/js/apps/tableBrowser/metastoreSource.js
+++ b/desktop/core/src/desktop/js/apps/tableBrowser/metastoreSource.js
@@ -65,9 +65,9 @@ class MetastoreSource {
 
     huePubSub.subscribe(ASSIST_DB_PANEL_IS_READY_EVENT, () => {
       this.lastLoadNamespacesDeferred.done(() => {
-        let lastSelectedDb = getFromLocalStorage(
-          'assist_' + this.type + '_' + this.namespace.id + '.lastSelectedDb'
-        );
+        const namespaceId = _this.namespace().namespace.id;
+        const localStorageKey = `assist_${this.type}_${namespaceId}.lastSelectedDb`;
+        let lastSelectedDb = getFromLocalStorage(localStorageKey);
         if (!lastSelectedDb && lastSelectedDb !== '') {
           lastSelectedDb = 'default';
         }


### PR DESCRIPTION
…tch to default DB

## What changes were proposed in this pull request?

- The namespace, used in the local storage path for the lastDBUsed, was incorrectly accessed as an object when it should be a function (observable). 

## How was this patch tested?

Manual testing done by selecting a DB other than the default and then creating a new table, verifying that the "assistpanel" stayed on the correct DB.


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
