### PR TITLE
[core] Adde Hue LB's to the CSRF_TRUSTED_ORIGINS list

### DIFF
--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -38,6 +38,7 @@ from desktop.lib.python_util import force_dict_to_strings
 from aws.conf import is_enabled as is_s3_enabled
 from azure.conf import is_abfs_enabled
 from desktop.conf import is_ofs_enabled
+from urllib.parse import urlparse
 
 if sys.version_info[0] > 2:
   from django.utils.translation import gettext_lazy as _
@@ -478,6 +479,13 @@ CSRF_COOKIE_NAME = 'csrftoken'
 TRUSTED_ORIGINS = []
 if desktop.conf.SESSION.TRUSTED_ORIGINS.get():
   TRUSTED_ORIGINS += desktop.conf.SESSION.TRUSTED_ORIGINS.get()
+
+# All Hue LB's must be in the TRUSTED_ORIGINS
+if desktop.conf.HUE_LOAD_BALANCER.get():
+  for hue_lb in desktop.conf.HUE_LOAD_BALANCER.get():
+    # We only want the host:port and strip out the scheme
+    lb_host = urlparse(hue_lb).netloc
+    TRUSTED_ORIGINS.append(lb_host)
 
 # This is required for knox
 if desktop.conf.KNOX.KNOX_PROXYHOSTS.get(): # The hosts provided here don't have port. Add default knox port


### PR DESCRIPTION
All Hue LB's or any other intermediate hosts, such as reverse proxies or Knox gateway that forwards requests to Hue server, has to be present in `desktop.settings.CSRF_TRUSTED_ORIGINS`. If any of these hosts are missing in `CSRF_TRUSTED_ORIGINS`, then it can lead to auth failure due to CSRF.

We have two configs that currently push hosts into `CSRF_TRUSTED_ORIGINS`

a. `KNOX_PROXYHOSTS`: To get the list of knox gateways and append it to the `CSRF_TRUSTED_ORIGINS`.
b. `TRUSTED_ORIGINS`: To allow additional intermediate hosts to be added to `CSRF_TRUSTED_ORIGINS`.

Without this change, Hue LB needs to be added to two configs, `TRUSTED_ORIGINS` and `desktop.conf.HUE_LOAD_BALANCER`. This commit eases this requirement and copies over the list from `HUE_LOAD_BALANCER` into `TRUSTED_ORIGINS`.
