### PR TITLE
Enable temporarily disabled lint check

### DIFF
--- a/tools/ci/check_for_python_lint.sh
+++ b/tools/ci/check_for_python_lint.sh
@@ -17,8 +17,6 @@
 
 # Checking all python changes in the new commits
 
-exit 0
-
 HOME=${1:-"."}
 FOUND_ISSUE=-1
 


### PR DESCRIPTION
This reverts commit d2ffc44e8b143d57015dc8f4fd0e594f2d5305ab.

## What changes were proposed in this pull request?

re-enable the lint check
