### PR TITLE
[filebrowser] Fix of changePermissionModal

### DIFF
--- a/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
+++ b/apps/filebrowser/src/filebrowser/templates/listdir_components.mako
@@ -354,23 +354,23 @@ else:
           <tbody>
             <tr>
               <td><strong>${_('Read')}</strong></td>
-              <td class="center"><input type="checkbox" data-bind="attr: {checked: selectedFile.mode }" checked="" name="user_read"></td>
-              <td class="center"><input type="checkbox" data-bind="attr: {checked: selectedFile.mode }" checked="" name="group_read"></td>
-              <td class="center"><input type="checkbox" data-bind="attr: {checked: selectedFile.mode }" checked="" name="other_read"></td>
+              <td class="center"><input type="checkbox" name="user_read"></td>
+              <td class="center"><input type="checkbox" name="group_read"></td>
+              <td class="center"><input type="checkbox" name="other_read"></td>
               <td colspan="2">&nbsp;</td>
             </tr>
             <tr>
               <td><strong>${_('Write')}</strong></td>
-              <td class="center"><input type="checkbox" data-bind="attr: {checked: selectedFile.mode }" checked="" name="user_write"></td>
-              <td class="center"><input type="checkbox" data-bind="attr: {checked: selectedFile.mode }" checked="" name="group_write"></td>
-              <td class="center"><input type="checkbox" data-bind="attr: {checked: selectedFile.mode }" checked="" name="other_write"></td>
+              <td class="center"><input type="checkbox" name="user_write"></td>
+              <td class="center"><input type="checkbox" name="group_write"></td>
+              <td class="center"><input type="checkbox" name="other_write"></td>
               <td colspan="2">&nbsp;</td>
             </tr>
             <tr>
               <td><strong>${_('Execute')}</strong></td>
-              <td class="center"><input type="checkbox" checked="" name="user_execute"></td>
-              <td class="center"><input type="checkbox" checked="" name="group_execute"></td>
-              <td class="center"><input type="checkbox" checked="" name="other_execute"></td>
+              <td class="center"><input type="checkbox" name="user_execute"></td>
+              <td class="center"><input type="checkbox" name="group_execute"></td>
+              <td class="center"><input type="checkbox" name="other_execute"></td>
               <td colspan="2">&nbsp;</td>
             </tr>
             <tr>


### PR DESCRIPTION
## The issue

Currently, the state of checkboxes in changePermissionModal sometimes does not correspond to the real file/directory permissions.
I observe this in different cases, but I was not able to find exact pattern.

However, the following steps leads to a stable reproduce:
- create some directory A
- change it's permissions to something non-default
- create another directory B
- try to change directory B permissions

And here is what I get:

![Screenshot from 2023-06-14 16-02-24](https://github.com/cloudera/hue/assets/23353239/ce05b747-fc45-4894-9804-5b5678e0990b)

# Root cause
The root seems to be a usage of `attr` function to pragmatically check those checkboxes during initialization of the modal window:
https://github.com/cloudera/hue/blob/4d303a0/apps/filebrowser/src/filebrowser/templates/listdir_components.mako#L1661-L1663

However, according to jQuery documentation, [since jQuery 1.6](https://blog.jquery.com/2011/05/03/jquery-16-released/) `prop` function should be used for those cases instead of `attr` (see the "Breaking Changes" section).

### What else changed in this PR?

Seems like `data-bind` and `checked` attributes don't do anything here:
https://github.com/cloudera/hue/blob/4d303a0/apps/filebrowser/src/filebrowser/templates/listdir_components.mako#L357-L373

`checked` attribute should be overwritten on modal initialization, as long as `data-bind="attr: {checked: ...} '`.

Furthermore, the expression `data-bind="attr: {checked: selectedFile.mode}"` does not have any sense, as `selectedFile.mode` [is an octal representation](https://github.com/cloudera/hue/blob/4d303a0/apps/filebrowser/src/filebrowser/templates/listdir_components.mako#L849) of file access mode, so there is no way how it can be used to set `checked` attribute for different inputs without any additional arguments and logic there.

And finally, those two attributes are not used for "sticky" checkbox, and it still works.

So in this PR I also remove those two attributes.

## How was this patch tested?

Manual.