### PR TITLE
[jwt] Remove redundant IS_ENABLED config

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -447,10 +447,8 @@ idle_session_timeout=-1
 ## reverse_proxy_header=HTTP_X_FORWARDED_FOR
 
 [[[jwt]]]
-# Adds custom JWT Authentication backend for REST APIs in top priority.
-## is_enabled=false
-
 # Endpoint to fetch the public key from verification server.
+# Also adds custom JWT Authentication backend for REST APIs in top priority if set.
 ## key_server_url=https://ext_authz:8000
 
 # The JWT payload header containing the username.

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -452,10 +452,8 @@
     ## reverse_proxy_header=HTTP_X_FORWARDED_FOR
 
     [[[jwt]]]
-      # Adds custom JWT Authentication backend for REST APIs in top priority.
-      ## is_enabled=false
-
       # Endpoint to fetch the public key from verification server.
+      # Also adds custom JWT Authentication backend for REST APIs in top priority if set.
       ## key_server_url=https://ext_authz:8000
 
       # The JWT payload header containing the username.

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -151,9 +151,9 @@ def is_python2():
   """Hue is running on Python 2."""
   return sys.version_info[0] == 2
 
-def is_jwt_authentication_enabled():
-  """JWT backend flag enabled or backend set in api auth explicitly"""
-  return AUTH.JWT.IS_ENABLED.get() or 'desktop.auth.api_authentications.JwtAuthentication' in AUTH.API_AUTH.get()
+def is_custom_jwt_auth_enabled():
+  """Returns True if key server url is set else returns False"""
+  return bool(AUTH.JWT.KEY_SERVER_URL.get())
 
 USE_CHERRYPY_SERVER = Config(
   key="use_cherrypy_server",
@@ -1228,12 +1228,6 @@ AUTH = ConfigSection(
       key="jwt",
       help=_("Configuration for Custom JWT Authentication."),
       members=dict(
-        IS_ENABLED=Config(
-            key='is_enabled',
-            help=_('Adds custom JWT Authentication backend for REST APIs in top priority.'),
-            type=coerce_bool,
-            default=False,
-        ),
         KEY_SERVER_URL=Config(
             key="key_server_url",
             default=None,

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -332,7 +332,7 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_AUTHENTICATION_CLASSES': desktop.conf.AUTH.API_AUTH.get()
 }
-if desktop.conf.AUTH.JWT.IS_ENABLED.get() and \
+if desktop.conf.is_custom_jwt_auth_enabled() and \
   'desktop.auth.api_authentications.JwtAuthentication' not in REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES']:
   REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'].insert(0, 'desktop.auth.api_authentications.JwtAuthentication')
 


### PR DESCRIPTION

## What changes were proposed in this pull request?

- Use the key server url to determine if custom jwt auth is set or not.

## How was this patch tested?

- Manually