### PR TITLE
[jwt] Support JKU HA for public APIs JWT auth

### DIFF
--- a/desktop/core/src/desktop/auth/api_authentications.py
+++ b/desktop/core/src/desktop/auth/api_authentications.py
@@ -135,21 +135,20 @@ class JwtAuthentication(authentication.BaseAuthentication):
       return None
 
     if "," in key_server_urls:
-      # Config format is "['url1', 'url2']" for HA, so we need to clean up and split correctly in list.
-      key_server_urls_list = key_server_urls.replace("%20", "").replace("['", "").replace("']", "").replace("'", "").split(',')
+      key_server_urls_list = key_server_urls.split(',')
 
       for jku in key_server_urls_list:
         try:
           res = requests.get(jku.rstrip('/'), verify=False)
         except Exception as e:
-          if 'Name or service not known' in str(e):
+          if 'Failed to establish a new connection' in str(e):
             LOG.warning('JKU %s is not available.' % jku)
 
         # Check response for None and if response code is successful (200) or authentication needed (401), use that host URL.
         if (res is not None) and (res.status_code in (200, 401)):
           return jku
     else:
-      # For non-HA, its normal url string.
+      # For non-HA, it's normal url string.
       return key_server_urls
 
 class DummyCustomAuthentication(authentication.BaseAuthentication):

--- a/desktop/core/src/desktop/auth/api_authentications.py
+++ b/desktop/core/src/desktop/auth/api_authentications.py
@@ -136,7 +136,6 @@ class JwtAuthentication(authentication.BaseAuthentication):
 
     if "," in key_server_urls:
       # Config format is "['url1', 'url2']" for HA, so we need to clean up and split correctly in list.
-      # For non-HA, its normal url string.
       key_server_urls_list = key_server_urls.replace("%20", "").replace("['", "").replace("']", "").replace("'", "").split(',')
 
       for jku in key_server_urls_list:
@@ -150,6 +149,7 @@ class JwtAuthentication(authentication.BaseAuthentication):
         if (res is not None) and (res.status_code in (200, 401)):
           return jku
     else:
+      # For non-HA, its normal url string.
       return key_server_urls
 
 class DummyCustomAuthentication(authentication.BaseAuthentication):

--- a/desktop/core/src/desktop/auth/api_authentications.py
+++ b/desktop/core/src/desktop/auth/api_authentications.py
@@ -111,9 +111,11 @@ class JwtAuthentication(authentication.BaseAuthentication):
   def _handle_public_key(self, access_token):
     token_metadata = jwt.get_unverified_header(access_token)
     kid = token_metadata.get('kid')
+    key_server_url = self._handle_jku_ha()
 
-    if AUTH.JWT.KEY_SERVER_URL.get():
-      response = requests.get(AUTH.JWT.KEY_SERVER_URL.get(), verify=False)
+    if key_server_url:
+      LOG.debug('Fetching JWKS from URL: %s' % key_server_url)
+      response = requests.get(key_server_url, verify=False)
       jwk = json.loads(response.content)
 
       if jwk.get('keys'):
@@ -125,6 +127,30 @@ class JwtAuthentication(authentication.BaseAuthentication):
 
             return public_key_pem
 
+  def _handle_jku_ha(self):
+    res = None
+
+    key_server_urls = AUTH.JWT.KEY_SERVER_URL.get()
+    if not key_server_urls:
+      return None
+
+    if "," in key_server_urls:
+      # Config format is "['url1', 'url2']" for HA, so we need to clean up and split correctly in list.
+      # For non-HA, its normal url string.
+      key_server_urls_list = key_server_urls.replace("%20", "").replace("['", "").replace("']", "").replace("'", "").split(',')
+
+      for jku in key_server_urls_list:
+        try:
+          res = requests.get(jku.rstrip('/'), verify=False)
+        except Exception as e:
+          if 'Name or service not known' in str(e):
+            LOG.warning('JKU %s is not available.' % jku)
+
+        # Check response for None and if response code is successful (200) or authentication needed (401), use that host URL.
+        if (res is not None) and (res.status_code in (200, 401)):
+          return jku
+    else:
+      return key_server_urls
 
 class DummyCustomAuthentication(authentication.BaseAuthentication):
   """

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -1231,7 +1231,7 @@ AUTH = ConfigSection(
         KEY_SERVER_URL=Config(
             key="key_server_url",
             default=None,
-            type=str,
+            type=coerce_string,
             help=_("Endpoint to fetch the public key from verification server.")
         ),
         ISSUER=Config(


### PR DESCRIPTION
## What changes were proposed in this pull request?

- When in HA mode, take healthy JKU to fetch the public key-set.
- Key server urls are comma separated configs in Hue in HA mode.

## How was this patch tested?

- Adding new unit tests.
- Tested in HA setup.