### PR TITLE
[docker] Add dependencies for mysqlclient in docker build

### DIFF
--- a/tools/container/compile/hue/Dockerfile
+++ b/tools/container/compile/hue/Dockerfile
@@ -48,6 +48,9 @@ RUN set -eux; \
 RUN set -eux; \
       curl -sL https://rpm.nodesource.com/setup_14.x | bash - \
         && yum install -y nodejs \
+        && curl -sSLO https://repo.mysql.com/mysql80-community-release-el8-5.noarch.rpm \
+        && rpm -ivh mysql80-community-release-el8-5.noarch.rpm \
+        && yum install -y mysql-community-libs mysql-community-client-plugins mysql-community-common mysql-community-devel gcc \
         && yum clean all -y
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
## What changes were proposed in this pull request?

docker build Hue container failed when installing mysqlclient

## How was this patch tested?

test: `$ sudo REGISTRY=docker.io/wing2fly GBN=build-yc ./tools/container/build.sh`

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
