### PR TITLE
[notebook] fix notebook saving type

### DIFF
--- a/desktop/libs/notebook/src/notebook/api.py
+++ b/desktop/libs/notebook/src/notebook/api.py
@@ -475,11 +475,9 @@ def get_logs(request):
 
 def _save_notebook(notebook, user):
   if notebook['snippets'][0].get('connector') and notebook['snippets'][0]['connector'].get('dialect'):  # TODO Connector unification
-    notebook_type = 'query-%(dialect)s' % notebook['snippets'][0]['connector']
     if notebook['snippets'][0] and notebook['snippets'][0].get('executor'):
       notebook['snippets'][0]['executor']['executables'] = []
-  else:
-    notebook_type = notebook.get('type', 'notebook')
+  notebook_type = notebook.get('type', 'notebook')
 
   save_as = False
 

--- a/desktop/libs/notebook/src/notebook/api_tests.py
+++ b/desktop/libs/notebook/src/notebook/api_tests.py
@@ -176,7 +176,7 @@ class TestApi(object):
 
     assert_equal(0, data['status'], data)
     doc = Document2.objects.get(pk=data['id'])
-    assert_equal('query-mysql', doc.type)
+    assert_equal('query-hive', doc.type)
 
 
   def test_save_notebook_with_connector_on(self):
@@ -206,7 +206,7 @@ class TestApi(object):
 
     assert_equal(0, data['status'], data)
     doc = Document2.objects.get(pk=data['id'])
-    assert_equal('query-mysql', doc.type)
+    assert_equal('query-hive', doc.type)
 
 
   def test_historify(self):


### PR DESCRIPTION
…ppet's type

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)
As described in https://github.com/cloudera/hue/issues/3367 , I think it's wrong to save notebook type according the first snippet's type, because there are multi different types of snippets.
## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
manual tests

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
