### PR TITLE
Added filter and fixed pagination for the tasks list in the schedules Job Browser

### DIFF
--- a/apps/jobbrowser/src/jobbrowser/api2.py
+++ b/apps/jobbrowser/src/jobbrowser/api2.py
@@ -94,8 +94,11 @@ def job(request, interface=None):
     app_id = json.loads(request.POST.get('app_id'))
 
   if interface == 'schedules':
+    filters = dict([(key, value) for _filter in json.loads(
+        request.POST.get('filters', '[]')) for key, value in list(_filter.items()) if value
+    ])
     offset = json.loads(request.POST.get('pagination', '{"offset": 1}')).get('offset')
-    response_app = get_api(request.user, interface, cluster=cluster).app(app_id, offset=offset)
+    response_app = get_api(request.user, interface, cluster=cluster).app(app_id, offset=offset, filters=filters)
   else:
     response_app = get_api(request.user, interface, cluster=cluster).app(app_id)
 


### PR DESCRIPTION
With this PR the status filter has been implemented for the tasks table, this was left todo many years ago, back when we made the switch from the dedicated Oozie status pages to the Job Browser in Hue 4, and for some reason we never got around to fixing this.

Given that the Job Browser pages are generic in the sense that the same code is used to display many types of "jobs" I've deliberately kept this change as non-intrusive as possible. Existing patterns, variables and values have been re-used even if there's quite some room for improvement and the filter will only appear for the tasks listing in the schedules tab.

While working on this I noticed that the pagination for the tasks listing was completely broken so I also fixed that.