### PR TITLE
[jb] Uncheck jobs that transition between completed and running

### DIFF
--- a/apps/jobbrowser/src/jobbrowser/templates/job_browser.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/job_browser.mako
@@ -2890,6 +2890,12 @@ ${ commonheader("Job Browser", "jobbrowser", user, request) | n,unicode }
         return ['RUNNING', 'PAUSED'].indexOf(self.apiStatus()) != -1 || job.isRunning;
       });
 
+      self.isRunning.subscribe(function () {
+        // The JB page for jobs is split in two tables, "Running" and "Completed", this esentially unchecks any job
+        // that moves from one table to the other.
+        ko.utils.arrayRemoveItem(vm.jobs.selectedJobs(), self)
+      });
+
       self.user = ko.observableDefault(job.user);
       self.queue = ko.observableDefault(job.queue);
       self.cluster = ko.observableDefault(job.cluster);


### PR DESCRIPTION
The Job Browser page is split in two tables, one for running and one for completed jobs. When a user checks an item in the running table and performs some action, that moves the item to the completed table, the selected item might not be visible anymore. This can cause confusion when there are many jobs as some actions are only allowed when a single item is checked.

Manually tested