### PR TITLE
[PIP] Upgrade cryptography python module from cryptography==36.0.1 to…

### DIFF
--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -1,4 +1,4 @@
-cryptography==36.0.1
+cryptography==41.0.1
 numpy==1.23.1
 pandas==1.4.2
 lxml==4.9.1


### PR DESCRIPTION
… cryptography==41.0.1 in requirements.txt

- Needs OpenSSL 1.1.1 or latest

## What changes were proposed in this pull request?

- Upgrading the cryptography library

## How was this patch tested?

- Tested on CDH  7.2.18-1
- Tested on Secure cluster on RedHat 8.4

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
