### PR TITLE
[frontend] Bump the version and publish a new NPM package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gethue",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gethue",
-      "version": "5.0.0",
+      "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ant-design/icons": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gethue",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Hue is an Open source SQL Query Editor for Databases/Warehouses",
   "keywords": [
     "Query Editor",


### PR DESCRIPTION
For the public API we recently introduced versioning which is a breaking change so a new major version of the NPM package had to be published.