### PR TITLE
[fb] Fix render method call for new storage browser flag

### DIFF
--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -521,9 +521,6 @@ def listdir_paged(request, path):
     filter=?          - Specify a substring filter to search for in
                         the filename field.
   """
-  if ENABLE_NEW_STORAGE_BROWSER.get():
-    return render('storage_browser.mako', request, {})
-
   path = _normalize_path(path)
 
   if not request.fs.isdir(path):
@@ -630,7 +627,11 @@ def listdir_paged(request, path):
       'is_embeddable': request.GET.get('is_embeddable', False),
       's3_listing_not_allowed': s3_listing_not_allowed
   }
-  return render('listdir.mako', request, data)
+
+  if ENABLE_NEW_STORAGE_BROWSER.get():
+    return render('storage_browser.mako', request, data)
+  else:
+    return render('listdir.mako', request, data)
 
 
 def scheme_absolute_path(root, path):


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Checking for new storage browser flag at the top of the function was triggering the render method without any data. 
- This was causing the API to return empty data for both direct public API call and was visible in Hue UI also.
- Now correct placement of the check fixes this issue.


### How was this patch tested?
- Manually in local Hue (since this is WIP feature flag for now).