### PR TITLE
Updated Hue documentation with ROOT's path

### DIFF
--- a/docs/docs-site/content/administrator/installation/dependencies/_index.md
+++ b/docs/docs-site/content/administrator/installation/dependencies/_index.md
@@ -17,6 +17,9 @@ Versions supported:
 ```
 # If you are using Python 3.8, set PYTHON_VER before the build, like
 export PYTHON_VER=python3.8
+
+# Export ROOT which should point to your Hue directory
+export ROOT=<path_to_hue_directory>
 ```
 
 ## Database

--- a/docs/docs-site/content/developer/development/_index.md
+++ b/docs/docs-site/content/developer/development/_index.md
@@ -27,6 +27,9 @@ Build once:
     # Mac user might need to set
     export SKIP_PYTHONDEV_CHECK=true
 
+    # Export ROOT which should point to your Hue directory
+    export ROOT=<path_to_hue_directory>
+
     make apps
 
 The [dependencies documentation](/administrator/installation/dependencies/) is here to help for troubleshooting build issues.


### PR DESCRIPTION
## What changes were proposed in this pull request?
Updated the documents under content section. The following 2 lines of coded have been added: 
#export ROOT which should point to your Hue directory 
export ROOT=<path_to_hue_directory>

## How was it tested?
The added lines have been reviewed on GitHub before committing and merging them.
