### PR TITLE
[commands] Check if Oozie is enabled in desktop document cleanup

### DIFF
--- a/desktop/core/src/desktop/management/commands/desktop_document_cleanup.py
+++ b/desktop/core/src/desktop/management/commands/desktop_document_cleanup.py
@@ -25,11 +25,14 @@ from beeswax.models import SavedQuery
 from beeswax.models import Session
 from datetime import date, timedelta
 from desktop.models import Document2
+from desktop.settings import INSTALLED_APPS
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db.utils import DatabaseError
 from importlib import import_module
-from oozie.models import Workflow
+
+if 'oozie' in INSTALLED_APPS:
+  from oozie.models import Workflow
 
 if sys.version_info[0] > 2:
   from django.utils.translation import gettext_lazy as _t, gettext as _
@@ -129,17 +132,18 @@ class Command(BaseCommand):
     # Clear out old Hive/Impala sessions
     self.objectCleanup(Session, 'status_code__gte', -10000, 'last_used')
 
-    # Clean out Trashed Workflows
-    try:
-      self.objectCleanup(Workflow, 'is_trashed', True, 'last_modified')
-    except NameError as NE:
-      LOG.info('Oozie app is not configured to clean out trashed workflows')
+    if 'oozie' in INSTALLED_APPS:  # check if oozie is enabled
+      # Clean out Trashed Workflows
+      try:
+        self.objectCleanup(Workflow, 'is_trashed', True, 'last_modified')
+      except NameError as NE:
+        LOG.info('Oozie app is not configured to clean out trashed workflows')
 
-    # Clean out Workflows without a name
-    try:
-      self.objectCleanup(Workflow, 'name', '', 'last_modified')
-    except NameError as NE:
-      LOG.info('Oozie app is not configured to clean out workflows without a name')
+      # Clean out Workflows without a name
+      try:
+        self.objectCleanup(Workflow, 'name', '', 'last_modified')
+      except NameError as NE:
+        LOG.info('Oozie app is not configured to clean out workflows without a name')
 
     # Clean out history Doc2 objects
     self.objectCleanup(Document2, 'is_history', True, 'last_modified')


### PR DESCRIPTION
## What changes were proposed in this pull request?

In some cluster, the Oozie is not enabled, so it is blacklisted app. document cleanup will failed with error:

`RuntimeError: Model class oozie.models.Job doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.`

## How was this patch tested?

Manually tested with oozie  enabled or disabled

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
