### PR TITLE
[build] Pin mysqlclient 2.1.1 in Hue build time

### DIFF
--- a/tools/docker/hue/Dockerfile
+++ b/tools/docker/hue/Dockerfile
@@ -86,7 +86,7 @@ RUN ./build/env/bin/pip install --no-cache-dir \
   # install after sqlalchemy-clickhouse and version == 1.0.4 \
   # otherwise Code: 516, Authentication failed will display \
   infi.clickhouse_orm==1.0.4 \
-  mysqlclient \
+  mysqlclient==2.1.1 \
   PyAthena==2.25.2
   # PyAthena == 3.x.x is latest, but not working with current configuration \
   # otherwise, 'VisitableType' object is not subscriptable in Hue UI


### PR DESCRIPTION
## What changes were proposed in this pull request?

-  Pin the mysqlclient to 2.1.1 to avoid build time error with 2.2.0.

## How was this patch tested?

- https://github.com/cloudera/hue/pull/3370
