### PR TITLE
hue_loglistener isn't starting.

### DIFF
--- a/tools/container/hue/supervisor-files/hue_loglistener_template
+++ b/tools/container/hue/supervisor-files/hue_loglistener_template
@@ -1,6 +1,6 @@
 [program:hue_loglistener]
 directory=${HUE_HOME}
-command="${HUE_HOME}/desktop/core/src/desktop/loglistener.py"
+command=python3.8 ${HUE_HOME}/desktop/core/src/desktop/loglistener.py
 autostart=true
 startretries=3
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
hue_loglistener isn't starting. thus logs are not generated. adding python before the log listener path

Change-Id: Ib8170176fcc8ce6deb9ec19aa75e4f1f51738705

## What changes were proposed in this pull request?

## How was this patch tested?

manual test, hue_loglistener comes up fine.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
