### PR TITLE
[Dockerfile] Add pkg-config for mysqlclient package 2.2.0

### DIFF
--- a/tools/docker/hue/Dockerfile
+++ b/tools/docker/hue/Dockerfile
@@ -6,6 +6,7 @@ LABEL description="Hue SQL Assistant - gethue.com"
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get install -y \
+  pkg-config \
   python3-pip \
   libkrb5-dev  \
   libsasl2-modules-gssapi-mit \

--- a/tools/docker/hue/Dockerfile
+++ b/tools/docker/hue/Dockerfile
@@ -6,6 +6,7 @@ LABEL description="Hue SQL Assistant - gethue.com"
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get install -y \
+  python3-future \
   pkg-config \
   python3-pip \
   libkrb5-dev  \


### PR DESCRIPTION
## What changes were proposed in this pull request?

- [As mysqlclient is updated to version 2.2.0 (2023-06-22)](https://github.com/PyMySQL/mysqlclient/blob/main/HISTORY.rst#whats-new-in-220), pkg-config is required instead of mysql_config.
Without pkg-config, building Dockerfile is failed.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.