### PR TITLE
[importer] Avoid creating scratchdir outside of encryption zone

### DIFF
--- a/desktop/libs/hadoop/src/hadoop/fs/webhdfs_types.py
+++ b/desktop/libs/hadoop/src/hadoop/fs/webhdfs_types.py
@@ -48,6 +48,7 @@ class WebHdfsStat(object):
     self.blockSize = file_status['blockSize']
     self.replication = file_status['replication']
     self.aclBit = file_status.get('aclBit')
+    self.encBit = file_status.get('encBit')
     self.fileId = file_status.get('fileId')
 
     self.mode = int(file_status['permission'], 8)

--- a/desktop/libs/indexer/src/indexer/indexers/sql.py
+++ b/desktop/libs/indexer/src/indexer/indexers/sql.py
@@ -173,7 +173,10 @@ class SQLIndexer(object):
       split = urlparse(source_path)
       # Only for HDFS, import data and non-external table
       if split.scheme in ('', 'hdfs') and oct(stats["mode"])[-1] != '7':
-        user_scratch_dir = self.fs.get_home_dir() + '/.scratchdir/%s' % str(uuid.uuid4()) # Make sure it's unique.
+        # check if the csv file is in encryption zone (encBit), then the scratch dir will be
+        # in the same directory
+        base_dir = parent_path if stats.encBit else self.fs.get_home_dir()
+        user_scratch_dir = base_dir + '/.scratchdir/%s' % str(uuid.uuid4()) # Make sure it's unique.
         self.fs.do_as_user(self.user, self.fs.mkdir, user_scratch_dir, 0o0777)
         self.fs.do_as_user(self.user, self.fs.rename, source['path'], user_scratch_dir)
         if editor_type == 'impala' and impala_conf and impala_conf.USER_SCRATCH_DIR_PERMISSION.get():


### PR DESCRIPTION
## What changes were proposed in this pull request?

Issue:
End user is using a csv file in an encryption zone in the importer, then an error pops up: 
```ValueError: Extra data: line 1 column 5```

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
  Added a unit test for checking the scratch path.
  Manual test in a cluster with csv inside/outside encryption zone

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
