### PR TITLE
[build] Pin virtualenv==20.24.4 and virtualenv-make-relocatable==0.0.1 versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,8 @@
 ###################################
 ROOT := $(realpath .)
 PPC64LE := $(shell uname -m)
+VIRTUAL_ENV_VERSION := 20.24.4
+VIRTUAL_ENV_RELOCATABLE_VERSION := 0.0.1
 
 include $(ROOT)/Makefile.vars.priv
 
@@ -154,7 +156,7 @@ $(BLD_DIR_ENV)/stamp:
 ifeq ($(PYTHON_VER),python3.8)
 	@echo "--- Creating virtual environment at $(BLD_DIR_ENV) using $(PYTHON_VER)"
 	@$(SYS_PYTHON) -m pip install --upgrade pip==22.2.2
-	@$(SYS_PIP) install virtualenv==20.19.0 virtualenv-make-relocatable==0.0.1
+	@$(SYS_PIP) install virtualenv==$(VIRTUAL_ENV_VERSION) virtualenv-make-relocatable==$(VIRTUAL_ENV_RELOCATABLE_VERSION)
 	@if [[ "ppc64le" == $(PPC64LE) ]]; then \
 	  $(SYS_PYTHON) -m venv $(BLD_DIR_ENV); \
 	 fi
@@ -182,7 +184,7 @@ $(BLD_DIR_ENV)/stamp:
 ifeq ($(PYTHON_VER),python3.9)
 	@echo "--- Creating virtual environment at $(BLD_DIR_ENV) using $(PYTHON_VER)"
 	@$(SYS_PYTHON) -m pip install --upgrade pip==22.2.2
-	@$(SYS_PIP) install virtualenv==20.19.0 virtualenv-make-relocatable==0.0.1
+	@$(SYS_PIP) install virtualenv==$(VIRTUAL_ENV_VERSION) virtualenv-make-relocatable==$(VIRTUAL_ENV_RELOCATABLE_VERSION)
 	@if [[ "ppc64le" == $(PPC64LE) ]]; then \
 	  $(SYS_PYTHON) -m venv $(BLD_DIR_ENV); \
 	 fi

--- a/tools/cloudera/build_hue_cloudera.sh
+++ b/tools/cloudera/build_hue_cloudera.sh
@@ -90,6 +90,8 @@ big_console_header "Hue PreRequisite Start" "$@"
 install_prerequisite $DOCKEROS
 big_console_header "Hue PreRequisite End" "$@"
 
+export VIRTUAL_ENV_VERSION="20.24.4"
+export VIRTUAL_ENV_RELOCATABLE_VERSION="0.0.1"
 export DESKTOP_VERSION=$2
 export HUE_WEBPACK_CONFIG='webpack.config.internal.js'
 export PYTHON_H=$PYTHON38_PATH/include/python3.8/Python.h

--- a/tools/cloudera/build_hue_common.sh
+++ b/tools/cloudera/build_hue_common.sh
@@ -76,7 +76,7 @@ function redhat7_ppc_install() {
       ./configure --enable-shared --prefix=/opt/cloudera/cm-agent && \
       make install'
     # Pip modules install
-    sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv virtualenv-make-relocatable'
+    sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv==${VIRTUAL_ENV_VERSION} virtualenv-make-relocatable==${VIRTUAL_ENV_RELOCATABLE_VERSION}'
     sudo pip38_bin=${pip38_bin} -- sh -c 'ln -fs ${pip38_bin} $(dirname ${pip38_bin})/pip'
   fi
 }
@@ -108,7 +108,7 @@ function redhat8_ppc_install() {
     # NODEJS 14 install
     sudo -- sh -c 'yum install -y nodejs npm'
     # Pip modules install
-    sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv virtualenv-make-relocatable mysqlclient==2.1.1'
+    sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv==${VIRTUAL_ENV_VERSION} virtualenv-make-relocatable==${VIRTUAL_ENV_RELOCATABLE_VERSION} mysqlclient==2.1.1'
     sudo pip38_bin=${pip38_bin} -- sh -c 'ln -fs ${pip38_bin} $(dirname ${pip38_bin})/pip'
     # sqlite3 install
     sudo TOOLS_HOME=${TOOLS_HOME} -- sh -c 'mkdir -p ${TOOLS_HOME} && \
@@ -138,7 +138,7 @@ function redhat9_ppc_install() {
     # NODEJS 14 install
     sudo -- sh -c 'yum install -y nodejs npm'
     # Pip modules install
-    sudo pip39_bin=${pip39_bin} -- sh -c '${pip39_bin} install virtualenv virtualenv-make-relocatable mysqlclient==2.1.1'
+    sudo pip39_bin=${pip39_bin} -- sh -c '${pip39_bin} install virtualenv==${VIRTUAL_ENV_VERSION} virtualenv-make-relocatable==${VIRTUAL_ENV_RELOCATABLE_VERSION} mysqlclient==2.1.1'
     sudo pip39_bin=${pip39_bin} -- sh -c 'ln -fs ${pip39_bin} $(dirname ${pip39_bin})/pip'
     # sqlite3 install
     sudo TOOLS_HOME=${TOOLS_HOME} -- sh -c 'mkdir -p ${TOOLS_HOME} && \
@@ -169,7 +169,7 @@ function sles12_install() {
     # NODEJS 14 install
     sudo -- sh -c 'zypper install -y npm14 nodejs14'
     # Pip modules install
-    sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv virtualenv-make-relocatable mysqlclient==2.1.1'
+    sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv==${VIRTUAL_ENV_VERSION} virtualenv-make-relocatable==${VIRTUAL_ENV_RELOCATABLE_VERSION} mysqlclient==2.1.1'
     sudo pip38_bin=${pip38_bin} -- sh -c 'ln -fs ${pip38_bin} $(dirname ${pip38_bin})/pip'
     # sqlite3 install
     sudo -- sh -c 'curl --insecure -o sqlite-autoconf-3350500.tar.gz https://www.sqlite.org/2021/sqlite-autoconf-3350500.tar.gz && \
@@ -198,7 +198,7 @@ function sles15_install() {
     # NODEJS 14 install
     sudo -- sh -c 'zypper install -y nodejs18 npm16'
     # Pip modules install
-    sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv virtualenv-make-relocatable mysqlclient==2.1.1'
+    sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv==${VIRTUAL_ENV_VERSION} virtualenv-make-relocatable==${VIRTUAL_ENV_RELOCATABLE_VERSION} mysqlclient==2.1.1'
     sudo pip38_bin=${pip38_bin} -- sh -c 'ln -fs ${pip38_bin} $(dirname ${pip38_bin})/pip'
     # sqlite3 install
     sudo -- sh -c 'curl --insecure -o sqlite-autoconf-3350500.tar.gz https://www.sqlite.org/2021/sqlite-autoconf-3350500.tar.gz && \
@@ -244,7 +244,7 @@ function centos7_install() {
       ./configure --enable-shared --prefix=/opt/cloudera/cm-agent && \
       make install'
     # Pip modules install
-    sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv virtualenv-make-relocatable mysqlclient==2.1.1'
+    sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv==${VIRTUAL_ENV_VERSION} virtualenv-make-relocatable==${VIRTUAL_ENV_RELOCATABLE_VERSION} mysqlclient==2.1.1'
     sudo pip38_bin=${pip38_bin} -- sh -c 'ln -fs ${pip38_bin} $(dirname ${pip38_bin})/pip'
   fi
 }
@@ -268,7 +268,7 @@ function redhat8_install() {
     # NODEJS 14 install
     sudo -- sh -c 'curl -sL https://rpm.nodesource.com/setup_14.x | bash - && yum install -y nodejs'
     # Pip modules install
-    sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv virtualenv-make-relocatable mysqlclient==2.1.1'
+    sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv==${VIRTUAL_ENV_VERSION} virtualenv-make-relocatable==${VIRTUAL_ENV_RELOCATABLE_VERSION} mysqlclient==2.1.1'
     sudo pip38_bin=${pip38_bin} -- sh -c 'ln -fs ${pip38_bin} $(dirname ${pip38_bin})/pip'
     # sqlite3 install
     sudo -- sh -c 'curl -o sqlite-autoconf-3350500.tar.gz https://www.sqlite.org/2021/sqlite-autoconf-3350500.tar.gz && \
@@ -312,7 +312,7 @@ function ubuntu18_install() {
     sudo -- sh -c 'curl -sL https://deb.nodesource.com/setup_14.x | sudo bash - && \
       apt -y install nodejs'
     # Pip modules install
-    sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv virtualenv-make-relocatable mysqlclient==2.1.1'
+    sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv==${VIRTUAL_ENV_VERSION} virtualenv-make-relocatable==${VIRTUAL_ENV_RELOCATABLE_VERSION} mysqlclient==2.1.1'
     sudo pip38_bin=${pip38_bin} -- sh -c 'ln -fs ${pip38_bin} $(dirname ${pip38_bin})/pip'
     # sqlite3 install
     sudo -- sh -c 'curl -o sqlite-autoconf-3350500.tar.gz https://www.sqlite.org/2021/sqlite-autoconf-3350500.tar.gz && \
@@ -359,7 +359,7 @@ function ubuntu20_install() {
     sudo -- sh -c 'curl -sL https://deb.nodesource.com/setup_14.x | sudo bash - && \
       apt -y install nodejs'
     # Pip modules install
-    sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv virtualenv-make-relocatable mysqlclient==2.1.1'
+    sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv==${VIRTUAL_ENV_VERSION} virtualenv-make-relocatable==${VIRTUAL_ENV_RELOCATABLE_VERSION} mysqlclient==2.1.1'
     sudo pip38_bin=${pip38_bin} -- sh -c 'ln -fs ${pip38_bin} $(dirname ${pip38_bin})/pip'
     # sqlite3 install
     sudo -- sh -c 'curl -o sqlite-autoconf-3350500.tar.gz https://www.sqlite.org/2021/sqlite-autoconf-3350500.tar.gz && \
@@ -389,7 +389,7 @@ function redhat9_install() {
     # NODEJS 14 install
     sudo -- sh -c 'curl -sL https://rpm.nodesource.com/setup_14.x | bash - && yum install -y nodejs'
     # Pip modules install
-    sudo pip39_bin=${pip39_bin} -- sh -c '${pip39_bin} install virtualenv virtualenv-make-relocatable mysqlclient==2.1.1'
+    sudo pip39_bin=${pip39_bin} -- sh -c '${pip39_bin} install virtualenv==${VIRTUAL_ENV_VERSION} virtualenv-make-relocatable==${VIRTUAL_ENV_RELOCATABLE_VERSION} mysqlclient==2.1.1'
     sudo pip39_bin=${pip39_bin} -- sh -c 'ln -fs ${pip39_bin} $(dirname ${pip39_bin})/pip'
     # sqlite3 install
     sudo -- sh -c 'curl -o sqlite-autoconf-3350500.tar.gz https://www.sqlite.org/2021/sqlite-autoconf-3350500.tar.gz && \


### PR DESCRIPTION
Change-Id: I487830795482f9387a1fd41c9df51043d2b63c3d

## What changes were proposed in this pull request?
The latest version of virtualenv==20.24.5 has changes related to brew and it crashes when building hue, as hue pulls the latest version of virtualenv. 
Error: " AttributeError: module 'virtualenv.create.via_global_ref.builtin.cpython.mac_os' has no attribute 'CPython3macOsBrew'"
So pinning the version of virtualenv==20.24.4 and virtualenv-make-relocatable==0.0.1 to avoid build failures. 

## How was this patch tested?
created a build and tested

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
