### PR TITLE
resolve:"no app for view func : submit_schedule"

### DIFF
--- a/desktop/core/src/desktop/lib/apputil.py
+++ b/desktop/core/src/desktop/lib/apputil.py
@@ -55,6 +55,8 @@ def get_app_for_module(module):
       return app
     elif module.__name__.startswith('desktop.lib.connectors'):
       return app
+    elif module.__name__.startswith('desktop.lib.scheduler'):
+      return app
     elif module.__name__.startswith(app) and not module.__name__.startswith("desktop.lib"):
       return app
   return None


### PR DESCRIPTION
## What changes were proposed in this pull request?

I modify the method of \desktop\core\src\desktop\lib\apputil.py to :

def get_app_for_module(module):
for app in settings.INSTALLED_APPS:
if module.name.startswith('desktop.lib.metrics.views'):
return app
elif module.name.startswith('desktop.lib.analytics.views'):
return app
elif module.name.startswith('desktop.lib.connectors'):
return app
elif module.name.startswith('desktop.lib.scheduler'):
return app
elif module.name.startswith(app) and not module.name.startswith("desktop.lib"):
return app
return None

## How was this patch tested?

I test it in my local env.


