### PR TITLE
Latest virtual-env crash with Rhel9, falling back to older version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ $(BLD_DIR_ENV)/stamp:
 ifeq ($(PYTHON_VER),python3.9)
 	@echo "--- Creating virtual environment at $(BLD_DIR_ENV) using $(PYTHON_VER)"
 	@$(SYS_PYTHON) -m pip install --upgrade pip==22.2.2
-	@$(SYS_PIP) install virtualenv==$(VIRTUAL_ENV_VERSION) virtualenv-make-relocatable==$(VIRTUAL_ENV_RELOCATABLE_VERSION)
+	@$(SYS_PIP) install virtualenv==20.19.0 virtualenv-make-relocatable==0.0.1
 	@if [[ "ppc64le" == $(PPC64LE) ]]; then \
 	  $(SYS_PYTHON) -m venv $(BLD_DIR_ENV); \
 	 fi


### PR DESCRIPTION
Change-Id: I7043802405ba0c5d7371deeddaf5aa637c15fe69

## What changes were proposed in this pull request?
New version of virtual-env 20.24.4 crashes for rhel9 when running setup.py for pysaml2 with the following error
" ModuleNotFoundError: No module named 'setuptools'. "
Pinning the virtual-env version to 20.19.0 for Rhel9 fixes this issue. 


## How was this patch tested?
Created a build on Rhel9 and tested it.
- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
