### PR TITLE
[build] remove cuix dependencies from published npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gethue",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Hue is an Open source SQL Query Editor for Databases/Warehouses",
   "keywords": [
     "Query Editor",

--- a/webpack.config.npm.js
+++ b/webpack.config.npm.js
@@ -65,7 +65,26 @@ const copySourceConfig = {
     new CopyWebpackPlugin({
       patterns: [
         { from: './NPM-README.md', to: `${DIST_DIR}/README.md` },
-        { from: './package.json', to: `${DIST_DIR}/package.json` },
+        {
+          from: './package.json',
+          to: `${DIST_DIR}/package.json`,
+          transform: (content) => {
+            // Remove local dependencies (currently only cuix) since it is not needed
+            // and cannot be accessed by the npm registry.
+            const contentStr = content.toString();      
+            const contentObj = JSON.parse(contentStr);
+
+            // Iterate over the dependencies and remove local references
+            Object.keys(contentObj.dependencies || {}).forEach((key) => {
+              const value = contentObj.dependencies[key];
+              if (value.startsWith("file:")) {
+                delete contentObj.dependencies[key];
+              }
+            });
+            
+            return JSON.stringify(contentObj, null, 2);
+          }
+        },
         {
           from: JS_ROOT,
           to: `${DIST_DIR}`,


### PR DESCRIPTION
## What changes were proposed in this pull request?

- added fix to remove npm dependencies starting with "file:"

## How was this patch tested?

- built using `npm run webpack-npm`
- ran `npm install` in npm_dist folder to verify that there was no error 

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
