### PR TITLE
[core] Fixed the compute selection logic for query exec

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/base_tests.py
+++ b/desktop/libs/notebook/src/notebook/connectors/base_tests.py
@@ -44,7 +44,7 @@ class TestNotebook(object):
   def test_get_api(self):
     request = Mock()
     snippet = {
-      'connector': {'optimizer': 'api', 'interface': 'hiveserver2', 'type': 'hive-compute', 'dialect': 'hive'},
+      'connector': {'optimizer': 'api'},
       'type': 'hive'  # Backward compatibility
     }
 


### PR DESCRIPTION
There are multiple different ways that the various calls from UI pass
the compute information. Sometimes, it is a compute, other times it
is a connector etc. This change looks at config. So, if computes are
enabled then look up for compute in snippet, if connectors are
enabled then look for connector in snippet. If none of these are found,
then fallback to the default mechanism of picking up interpreter as
defined in the hue.ini

This bug got introduced in the earlier commit 283676c. Also, reverted
the unneeded change to connectors/base_test.py from that commit.

Change-Id: I8148f7dbf031c329f738ed94ba073161d8d8b4df