### PR TITLE
[ABFS] Fix reading file operation by 1 bytes

### DIFF
--- a/desktop/libs/azure/src/azure/abfs/abfs.py
+++ b/desktop/libs/azure/src/azure/abfs/abfs.py
@@ -408,8 +408,8 @@ class ABFS(object):
     """
     path = Init_ABFS.strip_scheme(path)
     headers = self._getheaders()
-    if length != 0 and length != '0':
-      headers['range'] = 'bytes=%s-%s' % (str(offset), str(int(offset) + int(length)))
+    if length > 0 and length > '0':
+      headers['range'] = 'bytes=%s-%s' % (str(offset), str(int(offset) + int(length) - 1))
 
     return self._root.get(path, headers=headers)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- We were reading extra 1 byte from the abfs file
- Header['range'] = headers['range'] = 'bytes=x-y' in this x is starting point and y is end point and both are included hence we removed the 1 byte from y to make sure we are not duplicating the bytes.

## How was this patch tested?

- Locally
