### PR TITLE
Fix phoenix database and table names case sensitive

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
+++ b/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
@@ -441,11 +441,6 @@ class SqlAlchemyApi(Api):
 
   @query_error_handler
   def autocomplete(self, snippet, database=None, table=None, column=None, nested=None, operation=None):
-    if snippet['type'] == 'phoenix':
-      if database:
-        database = database.upper()
-      if table:
-        table = table.upper()
     engine = self._get_engine()
     inspector = inspect(engine)
 


### PR DESCRIPTION
In phoenix database and table names are case sensitive, but in the sql_achlemy code we do upper() which is causing the tables not to be listed out.

Internal Jira: CDPD-61651

## What changes were proposed in this pull request?
remove upper() for database and table

## How was this patch tested?
Performed manual test in a internal cluster and also via sqlalchemy.

>>> from sqlalchemy import create_engine, inspect
>>> engine = create_engine('phoenix://<phoenixserver>:8765')
>>> insp = inspect(engine)
>>> print(insp.get_schema_names())
['', 'SYSTEM', 'tcastestlower']
>>> print(insp.get_table_names("tcastestlower"))
['mahesh_test']
>>> print(insp.get_view_names("tcastestlower"))
['test_table']
>>> print(insp.get_table_names("TCASTESTLOWER"))
[]
>>> 
