### PR TITLE
[core][compute] fixed username for query execution

### DIFF
--- a/apps/beeswax/src/beeswax/server/dbms.py
+++ b/apps/beeswax/src/beeswax/server/dbms.py
@@ -101,6 +101,9 @@ def get(user, query_server=None, cluster=None):
   if query_server is None:
     query_server = get_query_server_config(connector=cluster)
 
+  if not query_server.get('auth_username'):
+    query_server['auth_username'] = user.username
+
   DBMS_CACHE_LOCK.acquire()
   try:
     DBMS_CACHE.setdefault(user.id, {})
@@ -331,8 +334,8 @@ def get_query_server_config_via_connector(connector):
       'server_host': server_host,
       'server_port': server_port,
       'principal': 'TODO',
-      'auth_username': AUTH_USERNAME.get(),
-      'auth_password': AUTH_PASSWORD.get(),
+      'auth_username': None,
+      'auth_password': '',
 
       'impersonation_enabled': impersonation_enabled,
       'use_sasl': str(compute['options'].get('use_sasl', True)).upper() == 'TRUE',

--- a/apps/beeswax/src/beeswax/server/dbms.py
+++ b/apps/beeswax/src/beeswax/server/dbms.py
@@ -101,7 +101,9 @@ def get(user, query_server=None, cluster=None):
   if query_server is None:
     query_server = get_query_server_config(connector=cluster)
 
-  if not query_server.get('auth_username'):
+  # if the auth_username is not set then we attempt to set using the current user
+  # this is likely to be the case when using connectors/computes
+  if not query_server.get('auth_username') and user and user.username:
     query_server['auth_username'] = user.username
 
   DBMS_CACHE_LOCK.acquire()
@@ -333,6 +335,8 @@ def get_query_server_config_via_connector(connector):
       'server_name': compute_name,
       'server_host': server_host,
       'server_port': server_port,
+      # For connectors/computes, the auth details are not available
+      # from configs and needs patching before submitting requests
       'principal': 'TODO',
       'auth_username': None,
       'auth_password': '',


### PR DESCRIPTION
The current logged in user's username was not being sent to Hive/Impala and instead `hive` was going out. This commit fixes it and sets the correct username.

Change-Id: I61bc4ac4545be397ca02c85c62daec74785667a6