### PR TITLE
[circleci] Update ARM64 machine image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
 
   build-py-38-arm64:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:2023.07.1
     resource_class: arm.medium
 
     working_directory: ~/repo


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix ARM64 build failed.
For detail of arm64 circle ci vm: https://circleci.com/docs/using-arm/

## How was this patch tested?

- tested by the circle ci test
