### PR TITLE
Adding kubectl in docker image creation to support cronjob dependencies

### DIFF
--- a/tools/container/hue/Dockerfile
+++ b/tools/container/hue/Dockerfile
@@ -27,6 +27,10 @@ ENV NAME="hue" \
 # Switch to non-root default user
 RUN yum install -y microdnf && \
     microdnf install -y shadow-utils findutils && \
+    microdnf install -y curl jq && \
+    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    chmod +x kubectl && \
+    mv kubectl /usr/local/bin/ &&\
     groupadd -g 1000 ${HUEUSER} && \
     useradd -g 1000 -d ${HUE_HOME} -s /bin/bash -u 1000 ${HUEUSER}
 


### PR DESCRIPTION
Change-Id: Ifd52e5ef0fdb2b52e2550eec40302b20e04cab05

## What changes were proposed in this pull request?
Cronjob in K8s require kubectl to perform cleanup jobs. So installing kubectl in hue docker image. 

## How was this patch tested?
manual tests on K8s cluster. 

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
