### PR TITLE
[beeswax][compute] set username for computes/hive connection

### DIFF
--- a/apps/beeswax/src/beeswax/server/dbms.py
+++ b/apps/beeswax/src/beeswax/server/dbms.py
@@ -331,6 +331,7 @@ def get_query_server_config_via_connector(connector):
     impersonation_enabled = hiveserver2_impersonation_enabled()
 
   return {
+      'is_compute': True,
       'dialect': compute['dialect'],
       'server_name': compute_name,
       'server_host': server_host,

--- a/apps/beeswax/src/beeswax/server/hive_server2_lib.py
+++ b/apps/beeswax/src/beeswax/server/hive_server2_lib.py
@@ -678,7 +678,8 @@ class HiveServerClient(object):
       if self.query_server.get('dialect') == 'impala':  # Only when Impala accepts it
         kwargs['configuration'].update({'impala.doas.user': user.username})
 
-    if self.query_server['server_name'] == 'beeswax': # All the time
+    if self.query_server['server_name'] == 'beeswax' or \
+        (self.query_server.get('is_compute') and self.query_server.get('dialect') == 'hive'):
       kwargs['configuration'].update({'hive.server2.proxy.user': user.username})
       xff_header = json.loads(user.userprofile.json_data).get('X-Forwarded-For', None)
       if xff_header and ENABLE_XFF_FOR_HIVE_IMPALA.get():


### PR DESCRIPTION
The regular beeswax/hive connections set `hive.server2.proxy.user` to the current username but it was missing for the compute based connections. This commit adds a flag `is_compute` to query_server_config for compute/connector based configs.

Impala based connections were already setting the correct usernames on the connection.

Change-Id: I23521a5c1cf3d650da551b343d18820862feb7c5