### PR TITLE
[ci]Change node version from 14 to 18 in Frontend CI

### DIFF
--- a/.github/workflows/commitflow-frontend.yml
+++ b/.github/workflows/commitflow-frontend.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Caching npm with setup node
       uses: actions/setup-node@v3
       with:
-        node-version: 14
+        node-version: 18
         cache: 'npm'
 
     - name: Install npm dependencies


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Changed node version from 14 to 18 in Frontend CI

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
