### PR TITLE
[query] Stop fetching sample data of a view

### DIFF
--- a/apps/beeswax/src/beeswax/api.py
+++ b/apps/beeswax/src/beeswax/api.py
@@ -733,6 +733,11 @@ def _get_sample_data(db, database, table, column, is_async=False, cluster=None, 
       query_server = get_query_server_config('impala', connector=cluster)
       db = dbms.get(db.client.user, query_server, cluster=cluster)
 
+  if table_obj and table_obj.is_view:
+    response = {'status': -1}
+    response['message'] = _('Not getting sample data as this is a view which can be expensive when run.')
+    return response
+
   sample_data = db.get_sample(database, table_obj, column, generate_sql_only=is_async, operation=operation)
   response = {'status': -1}
 

--- a/desktop/core/src/desktop/js/catalog/DataCatalogEntry.ts
+++ b/desktop/core/src/desktop/js/catalog/DataCatalogEntry.ts
@@ -1660,6 +1660,10 @@ export default class DataCatalogEntry {
       operation?: string;
     }
   ): CancellablePromise<Sample> {
+    if (this.isView()) {
+      return CancellablePromise.reject();
+    }
+
     if (this.samplePromise && this.samplePromise.cancelled) {
       this.samplePromise = undefined;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

fetching sample data from a view might be an expensive operation which causing query engineer resource issue

## How was this patch tested?

Manually tested

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
