### PR TITLE
[compute] Ignore cluster obj when type is direct

### DIFF
--- a/desktop/libs/notebook/src/notebook/api.py
+++ b/desktop/libs/notebook/src/notebook/api.py
@@ -1037,8 +1037,11 @@ def describe(request, database, table=None, column=None):
   response = {'status': -1, 'message': ''}
   notebook = json.loads(request.POST.get('notebook', '{}'))
   source_type = request.POST.get('source_type', '')
+  connector = json.loads(request.POST.get('connector', '{}'))
   cluster = json.loads(request.POST.get('cluster', '{}'))
-  connector = cluster if cluster else json.loads(request.POST.get('connector', '{}'))
+  if cluster and cluster.get('type') != 'direct':
+    connector = cluster
+
   compute = json.loads(request.POST.get('compute', '{}'))
 
   snippet = {'type': source_type, 'connector': connector, 'compute': compute}


### PR DESCRIPTION
Cluster type is direct when there is no separate cluster/compute configured and the queries are supposed to go through the hive/impala specified in the connector request object.

Change-Id: I52c0ad97774c569cc41109c95f5334506c6b1386