### PR TITLE
mpm_event module to improve apache scalability

### DIFF
--- a/tools/container/huelb/hue_httpd_template
+++ b/tools/container/huelb/hue_httpd_template
@@ -7,6 +7,7 @@ LoadModule lbmethod_byrequests_module /etc/httpd/modules/mod_lbmethod_byrequests
 LoadModule authz_core_module /etc/httpd/modules/mod_authz_core.so
 LoadModule log_config_module /etc/httpd/modules/mod_log_config.so
 LoadModule mime_module /etc/httpd/modules/mod_mime.so
+LoadModule mpm_event_module /etc/httpd/modules/mpm_event_module.so
 
 ErrorLog "${HUE_LOG_DIR}/httpd_error_log"
 LogLevel warn
@@ -15,6 +16,16 @@ LogLevel warn
   LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
   LogFormat "%h %l %u %t \"%r\" %>s %b" common
   CustomLog "${HUE_LOG_DIR}/httpd_access_log" common
+</IfModule>
+
+<IfModule mpm_event_module>
+  ServerLimit             5000
+  StartServers            1000
+  MaxClients              10000
+  MinSpareThreads         750
+  MaxSpareThreads         2500
+  ThreadsPerChild         500
+  MaxRequestsPerChild     10000
 </IfModule>
 
 <IfModule mime_module>
@@ -43,6 +54,10 @@ ProxyPass / balancer://hue/ stickysession=ROUTEID
 
 SetEnv proxy-initial-not-pooled 1
 ProxyTimeout 900
+
+KeepAlive On
+KeepAliveTimeout 120
+MaxKeepAliveRequests 500
 
 AllowEncodedSlashes NoDecode
 User ${HUEUSER}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request addresses the throttling of concurrent connections (approximately at 200 simultaneous threads) by the Apache load balancer when directing traffic to the Hue server. The scalability of the Apache load balancer is enhanced by implementing the mpm_event module.

## How was this patch tested?

- The patch underwent stress testing using Jmeter.
- Tests were conducted on both Redhat8 and Centos7 systems with varying computational capacities and node configurations.
- Below is a sample result from a Redhat 8 machine:

  **Default Apache Configurations:**
```
  "Summary: + 1591 in 00:00:30 = 53.1/s Avg: 20938 Min: 0 Max: 172930 Err: 510 (32.06%) Active: 989 Started: 1000 Finished: 11
  Summary Total: 14118 in 00:09:17 = 25.4/s Avg: 20088 Min: 0 Max: 174866 Err: 2668 (18.90%)"
```
- The test concluded in roughly 10 minutes, although it was anticipated to run for over 3 hours. This early completion was due to the Apache Load Balancer throttling connections, preventing responses from the Hue server.

  **With mpm_event Configuration Changes and an Extended KeepAliveTimeout:**
```
  "Summary: + 395 in 00:00:30 = 13.0/s Avg: 74657 Min: 101 Max: 249963 Err: 4 (1.01%) Active: 1000 Started: 1000 Finished: 0
  Summary Total: 81274 in 01:41:19 = 13.4/s Avg: 70975 Min: 0 Max: 690747 Err: 1863 (2.29%)"
```
- The test had a duration of approximately 1 hour and 40 minutes (was manually killed). Remarkably, none of the 1000 concurrent threads were terminated, and all received responses from the Hue server.

- The error rate with the default Apache load balancer configuration stood at 18%. However, after implementing the mpm_event module configurations, the error rate significantly dropped to around 2%.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
