### PR TITLE
[log] Default log level to INFO in all handlers

### DIFF
--- a/desktop/conf/dev_log.conf
+++ b/desktop/conf/dev_log.conf
@@ -1,0 +1,97 @@
+########################################
+# Definition for the different objects
+# - FOR DEVELOPMENT ONLY -
+#
+# Directories where log files are kept must already exist.
+# That's why we pick /tmp.
+#
+# The loggers are configured to write to the log files ONLY.
+# Developers may set the DESKTOP_DEBUG environment variable to
+# enable stderr logging output.
+########################################
+
+[logger_root]
+handlers=logfile,errorlog
+
+[logger_access]
+handlers=accesslog
+qualname=access
+
+[logger_django_auth_ldap]
+handlers=accesslog
+qualname=django_auth_ldap
+
+[logger_kazoo_client]
+level=INFO
+handlers=errorlog
+qualname=kazoo.client
+
+[logger_djangosaml2]
+level=INFO
+handlers=errorlog
+qualname=djangosaml2
+
+[logger_requests_packages_urllib3_connectionpool]
+level=DEBUG
+handlers=errorlog
+qualname=requests.packages.urllib3.connectionpool
+
+[logger_django_db]
+level=DEBUG
+handlers=logfile
+propogate=False
+qualname=django.db.backends
+
+[logger_boto]
+level=ERROR
+handlers=errorlog
+qualname=boto
+
+[handler_stderr]
+class=StreamHandler
+formatter=default
+level=DEBUG
+args=(sys.stderr,)
+
+[handler_accesslog]
+class=handlers.RotatingFileHandler
+level=INFO
+propagate=True
+formatter=access
+args=('%LOG_DIR%/access.log', 'a', 1000000, 3)
+
+[handler_errorlog]
+class=handlers.RotatingFileHandler
+level=ERROR
+formatter=default
+args=('%LOG_DIR%/error.log', 'a', 1000000, 3)
+
+[handler_logfile]
+class=handlers.RotatingFileHandler
+# Choices are DEBUG, INFO, WARNING, ERROR, CRITICAL
+level=DEBUG
+formatter=default
+args=('%LOG_DIR%/%PROC_NAME%.log', 'a', 1000000, 3)
+
+[formatter_default]
+class=desktop.log.formatter.Formatter
+format=[%(asctime)s] %(module)-12s %(levelname)-8s %(message)s
+datefmt=%d/%b/%Y %H:%M:%S %z
+
+[formatter_access]
+class=desktop.log.formatter.Formatter
+format=[%(asctime)s] %(levelname)-8s %(message)s
+datefmt=%d/%b/%Y %H:%M:%S %z
+
+########################################
+# A summary of loggers, handlers and formatters
+########################################
+
+[loggers]
+keys=root,access,django_auth_ldap,kazoo_client,requests_packages_urllib3_connectionpool,djangosaml2,django_db,boto
+
+[handlers]
+keys=stderr,logfile,accesslog,errorlog
+
+[formatters]
+keys=default,access


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the Hue log level started with DEBUG. In Python 3, Logger.setLevel() calls to clear the cache. So, even the django_debug_mode=false, set the handler level to INFO.

```
class Logger(Filterer):
    ...
    def setLevel(self, level):
        """
        Set the logging level of this logger.  level must be an int or a str.
        """
        self.level = _checkLevel(level)
        self.manager._clear_cache()
```
Setting dev_log.conf in env variable DESKTOP_LOG_CONF_FILE is for local development with **runserver**.

## How was this patch tested?

CDW docker and data hub cluster.
