### PR TITLE
[Importer] Add a regex for column name validation in table creation

### DIFF
--- a/desktop/libs/indexer/src/indexer/templates/importer.mako
+++ b/desktop/libs/indexer/src/indexer/templates/importer.mako
@@ -1163,7 +1163,7 @@ ${ commonheader(_("Importer"), "indexer", user, request, "60px") | n,unicode }
 <script type="text/html" id="table-field-template">
   <div>
     <label data-bind="visible: level() == 0 || ($parent.type() != 'array' && $parent.type() != 'map')">${ _('Name') }&nbsp;
-      <input data-hue-analytics="importer:field-name-click" type="text" class="input-large" placeholder="${ _('Field name') }" required data-bind="textInput: name" pattern="[a-zA-Z0-9_]+$" title="${ _('Only alphanumeric and underscore characters') }">
+      <input data-hue-analytics="importer:field-name-click" type="text" class="input-large" placeholder="${ _('Field name') }" required data-bind="textInput: name, attr: { pattern: $root.createWizard.source.columnNamePattern, title: $root.createWizard.source.columnNameAllowedCharacters() }">
     </label>
 
     <label class="margin-left-5">${ _('Type') }&nbsp;
@@ -1532,6 +1532,14 @@ ${ commonheader(_("Importer"), "indexer", user, request, "60px") | n,unicode }
       return "new_field_" + fieldNum
     };
 
+    var getColumnNameValidationRegex = function (sourceType) {
+        if (sourceType === 'hive') {
+          return "^[a-zA-Z0-9_ ]+$";
+        } else {
+          return "^[a-zA-Z0-9_]+$";
+        }
+    };
+
     var createDefaultField = function () {
       var defaultField = ko.mapping.fromJS(${default_field_type | n});
 
@@ -1843,6 +1851,8 @@ ${ commonheader(_("Importer"), "indexer", user, request, "60px") | n,unicode }
         }
         return self.inputFormatsAll();
       });
+      self.columnNamePattern = getColumnNameValidationRegex(vm.sourceType);
+      self.columnNameAllowedCharacters = ko.observable(vm.sourceType === 'hive' ? _('Only alphanumeric, underscore and space characters') : _('Only alphanumeric and underscore characters') );
 
       self.interpreters = ko.pureComputed(function() {
         return window.getLastKnownConfig().app_config.editor.interpreters.filter(function (interpreter) { return interpreter.is_sql && interpreter.dialect != 'phoenix' });
@@ -2827,6 +2837,10 @@ ${ commonheader(_("Importer"), "indexer", user, request, "60px") | n,unicode }
       });
       self.readyToIndex = ko.pureComputed(function () {
         var validFields = self.destination.columns().length || self.destination.outputFormat() === 'database';
+        var isValidColumnNames = self.destination.columns().every(function (column) {
+          return RegExp(getColumnNameValidationRegex(vm.sourceType)).test(column.name());
+        });
+  
         var validTableColumns = self.destination.outputFormat() !== 'table' || ($.grep(self.destination.columns(), function(column) {
             return column.name().length === 0;
           }).length === 0
@@ -2859,7 +2873,7 @@ ${ commonheader(_("Importer"), "indexer", user, request, "60px") | n,unicode }
           }).length === 0
         ) || self.destination.indexerConfigSet();
 
-        return self.isValidDestination() && validFields && validTableColumns && validIndexFields && isTargetAlreadyExisting && isValidTable;
+        return self.isValidDestination() && validFields && validTableColumns && validIndexFields && isTargetAlreadyExisting && isValidTable && isValidColumnNames;
       });
 
       self.formatTypeSubscribed = false;


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Implement a regular expression for validating column names in tables for the importer.
- Hive tables allow spaces in column names
- https://issues.apache.org/jira/browse/IMPALA-4443

## How was this patch tested?

- Locally 

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
