### PR TITLE
[frontend] Introduced a new warning message popup

### DIFF
--- a/desktop/core/src/desktop/templates/common_footer_m.mako
+++ b/desktop/core/src/desktop/templates/common_footer_m.mako
@@ -44,7 +44,7 @@ else:
         %if message.tags == 'error':
           $(document).trigger('error', '${ escapejs(escape(message)) }');
         %elif message.tags == 'warning':
-          $(document).trigger('warn', '${ escapejs(escape(message)) }');
+          huePubSub.publish('hue.global.warn', {message: '${ escapejs(escape(message)) }'});
         %else:
           $(document).trigger('info', '${ escapejs(escape(message)) }');
         %endif

--- a/desktop/core/src/desktop/templates/common_header_footer_components.mako
+++ b/desktop/core/src/desktop/templates/common_header_footer_components.mako
@@ -398,7 +398,7 @@ else:
         %if message.tags == 'error':
           $(document).trigger('error', '${ escapejs(escape(message)) }');
         %elif message.tags == 'warning':
-          $(document).trigger('warn', '${ escapejs(escape(message)) }');
+          huePubSub.publish('hue.global.warn', {message: '${ escapejs(escape(message)) }'});
         %else:
           $(document).trigger('info', '${ escapejs(escape(message)) }');
         %endif


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changes at all places to make the alert component (warn / warning messages) work according to the new CUIX component because of which the warn message popup will now the follow the Cloudera design and the warn message is better for the users to understand (though the actual error message from the backend side still needs to be updated instead of declaring the warn as global warn message).
Also, this is PR is an extension of the PR (https://github.com/cloudera/hue/pull/3488) where the changes in the hue error message popups was made.

## How was this patch tested?
Manual testing

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
