### PR TITLE
[compute] don't use session_pool by default

### DIFF
--- a/apps/beeswax/src/beeswax/server/dbms.py
+++ b/apps/beeswax/src/beeswax/server/dbms.py
@@ -351,7 +351,7 @@ def get_query_server_config_via_connector(connector):
       'http_url': compute['options'].get('http_url', 'http://%s:%s/cliservice' % (server_host, server_port)),
 
       'close_sessions': str(compute['options'].get('close_sessions', True)).upper() == 'TRUE',
-      'has_session_pool': str(compute['options'].get('has_session_pool', True)).upper() == 'TRUE',
+      'has_session_pool': str(compute['options'].get('has_session_pool', False)).upper() == 'TRUE',
       'max_number_of_sessions': compute['options'].get('has_session_pool', -1)
   }
 


### PR DESCRIPTION
The regular connections are not using session_pools. Our compute based connections are using session pools. This is leading to occasional expired queries.

This commit changes the default for compute/connector configs to not use session pools by default.

Change-Id: I1472a32146a14a159190226caa11fa6d6852a5bf