### PR TITLE
[frontend] Only show unique error message that have contents

### DIFF
--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.test.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.test.tsx
@@ -1,0 +1,83 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// 'License'); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { act, getByRole, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import huePubSub from '../../utils/huePubSub';
+
+import AlertComponent from './AlertComponent';
+
+describe('AlertComponent', () => {
+  test('it should show a global error message', async () => {
+    render(<AlertComponent />);
+    expect(screen.queryAllByRole('alert')).toHaveLength(0);
+
+    act(() => huePubSub.publish('hue.global.error', { message: 'Some error' }));
+
+    const alerts = screen.queryAllByRole('alert');
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]).toHaveTextContent('Some error');
+  });
+
+  test('it should show multiple global error messages', async () => {
+    render(<AlertComponent />);
+    expect(screen.queryAllByRole('alert')).toHaveLength(0);
+
+    act(() => huePubSub.publish('hue.global.error', { message: 'Error 1' }));
+    act(() => huePubSub.publish('hue.global.error', { message: 'Error 2' }));
+
+    const alerts = screen.queryAllByRole('alert');
+    expect(alerts).toHaveLength(2);
+    expect(alerts[0]).toHaveTextContent('Error 1');
+    expect(alerts[1]).toHaveTextContent('Error 2');
+  });
+
+  test('it should show unique error messages', async () => {
+    render(<AlertComponent />);
+    expect(screen.queryAllByRole('alert')).toHaveLength(0);
+
+    act(() => huePubSub.publish('hue.global.error', { message: 'Error 1' }));
+    act(() => huePubSub.publish('hue.global.error', { message: 'Error 2' }));
+    act(() => huePubSub.publish('hue.global.error', { message: 'Error 1' }));
+
+    const alerts = screen.queryAllByRole('alert');
+    expect(alerts).toHaveLength(2);
+    expect(alerts[0]).toHaveTextContent('Error 1');
+    expect(alerts[1]).toHaveTextContent('Error 2');
+  });
+
+  test('alerts should be closable', async () => {
+    const user = userEvent.setup();
+    render(<AlertComponent />);
+    expect(screen.queryAllByRole('alert')).toHaveLength(0);
+    act(() => huePubSub.publish('hue.global.error', { message: 'Error 1' }));
+    act(() => huePubSub.publish('hue.global.error', { message: 'Error 2' }));
+    act(() => huePubSub.publish('hue.global.error', { message: 'Error 3' }));
+
+    // Closing "Error 2"
+    const initialAlerts = screen.queryAllByRole('alert');
+    expect(initialAlerts).toHaveLength(3);
+    const closeButton = getByRole(initialAlerts[1], 'button');
+    await user.click(closeButton);
+
+    const alertsAfterClosing = screen.queryAllByRole('alert');
+    expect(alertsAfterClosing).toHaveLength(2);
+    expect(alertsAfterClosing[0]).toHaveTextContent('Error 1');
+    expect(alertsAfterClosing[1]).toHaveTextContent('Error 3');
+  });
+});

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.test.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.test.tsx
@@ -47,6 +47,15 @@ describe('AlertComponent', () => {
     expect(alerts[1]).toHaveTextContent('Error 2');
   });
 
+  test("it shouldn't show empty error messages", async () => {
+    render(<AlertComponent />);
+    expect(screen.queryAllByRole('alert')).toHaveLength(0);
+
+    act(() => huePubSub.publish('hue.global.error', { message: '' }));
+
+    expect(screen.queryAllByRole('alert')).toHaveLength(0);
+  });
+
   test('it should show unique error messages', async () => {
     render(<AlertComponent />);
     expect(screen.queryAllByRole('alert')).toHaveLength(0);

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -28,8 +28,15 @@ const AlertComponent: React.FC = () => {
   const [errors, setErrors] = useState<ErrorAlert[]>([]);
 
   useEffect(() => {
-    const hueSub = huePubSub.subscribe('hue.global.error', (errorObj: ErrorAlert) => {
-      setErrors(prevData => [...prevData, errorObj]);
+    const hueSub = huePubSub.subscribe('hue.global.error', (newError: ErrorAlert) => {
+      setErrors(activeErrors => {
+        // Prevent showing the same message multiple times.
+        // TODO: Consider showing a count in the error notification when the same message is reported multiple times.
+        if (activeErrors.some(activeError => activeError.message === newError.message)) {
+          return activeErrors;
+        }
+        return [...activeErrors, newError];
+      });
     });
     return () => {
       hueSub.remove();
@@ -44,9 +51,9 @@ const AlertComponent: React.FC = () => {
   //TODO: add support for warnings and success messages
   return (
     <div className="hue-alert flash-messages cuix antd">
-      {errors.map((errorObj, index) => (
+      {errors.map(errorObj => (
         <Alert
-          key={index}
+          key={errorObj.message}
           type="error"
           message={errorObj.message}
           closable={true}

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -29,6 +29,10 @@ const AlertComponent: React.FC = () => {
 
   useEffect(() => {
     const hueSub = huePubSub.subscribe('hue.global.error', (newError: ErrorAlert) => {
+      if (!newError.message) {
+        return;
+      }
+
       setErrors(activeErrors => {
         // Prevent showing the same message multiple times.
         // TODO: Consider showing a count in the error notification when the same message is reported multiple times.


### PR DESCRIPTION
With this change we prevent showing multiple alerts with the same message and we also prevent showing alerts that are empty.

Unit tests added and tested manually