### PR TITLE
[core] Default to editor choice with default_app correctly

### DIFF
--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -2,6 +2,6 @@ cryptography==41.0.1
 numpy==1.23.1
 pandas==1.4.2
 lxml==4.9.1
-PyYAML==5.4.1
+PyYAML==6.0.1
 -r ${ROOT}/desktop/core/base_requirements.txt
 

--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -2,6 +2,6 @@ cryptography==41.0.1
 numpy==1.23.1
 pandas==1.4.2
 lxml==4.9.1
-PyYAML==6.0.1
+PyYAML==5.4.1
 -r ${ROOT}/desktop/core/base_requirements.txt
 

--- a/desktop/core/src/desktop/models.py
+++ b/desktop/core/src/desktop/models.py
@@ -1859,7 +1859,9 @@ class ClusterConfig(object):
         for di in default_interpreter:
           if di['name'] == DEFAULT_INTERPRETER.get():
             return di
-    return default_interpreter[0]
+      return default_interpreter[0]
+    else:
+      return default_app
 
 
   def _get_home(self):


### PR DESCRIPTION
## What changes were proposed in this pull request?
There was some error left in the PR (https://github.com/cloudera/hue/pull/3514/files), this is the update for the same.

Original PR (https://github.com/cloudera/hue/pull/3514/):
When a user visits Hue we open the editor by default after logging in. If Hue is configured to have multiple editors the first one is used by default.

Each user have the possibility to pick the default editor by clicking the star icon in the editor header. There are cases when an organization wants to control this for all users through configuration so we should add such a config setting in the .ini.

The order of deciding which editor to display would be:

If the user has "stared" an editor use that one
If there's a config for which editor to use use that one (new)
And lastly, pick the first editor in the list
For this task we'll need to implement step 2.


## How was this patch tested?
Manual testing, verifying the current editor in accordance with what was expected out from code.

Demo video:
https://drive.google.com/file/d/1M2XrrlrhSgffV9fliSamPKv_lML3PfHq/view?usp=sharing

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
