### PR TITLE
[raz] Add support for RAZ HA

### DIFF
--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -2235,7 +2235,7 @@ RAZ = ConfigSection(
     API_URL=Config(
         key='api_url',
         help=_('Endpoint to contact'),
-        type=str,
+        type=coerce_string,
         dynamic_default=_get_raz_url,
     ),
     API_AUTHENTICATION=Config(

--- a/desktop/core/src/desktop/lib/raz/raz_client.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client.py
@@ -151,9 +151,9 @@ class RazClient(object):
 
       request_headers['Authorization'] = 'Bearer %s' % (jwt_token)
       raz_response = self._handle_raz_ha(raz_url, headers=request_headers, data=request_data)
-    
+
     if not raz_response:
-      raise PopupException('Failed to receive response from RAZ server.')
+      raise PopupException('Failed to receive a valid response from RAZ.')
 
     return raz_response
 
@@ -183,23 +183,6 @@ class RazClient(object):
       # Check response for None and if response code is successful (200), return the raz response.
       if (raz_response is not None) and (raz_response.status_code == 200):
         return raz_response
-    
-    
-    # # Try to fetch signed header/token from RAZ URL serially.
-    # for r_url in raz_urls:
-    #   LOG.info('Attempting to connect to RAZ URL: %s' % r_url)
-    #   try:
-    #       raz_response = requests.post(r_url.strip('/'), **kwargs)
-    #       if raz_response.ok:
-    #           return raz_response
-    #       else:
-    #           raise Exception('RAZ URL %s is not available.' % r_url)
-
-    #   except Exception as e:
-    #     LOG.warning('Failed to connect to RAZ URL: %s' % r_url)
-
-    # # Raise exception when all URLs are not available.
-    # raise Exception('Failed to talk to RAZ: No healthy RAZ URL available.')
 
 
   def _make_adls_request(self, request_data, method, path, url_params, resource_path):

--- a/desktop/core/src/desktop/lib/raz/raz_client.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client.py
@@ -169,6 +169,7 @@ class RazClient(object):
     if auth_handler:
       params['auth'] = auth_handler
 
+    raz_response = None
     for r_url in raz_urls_list:
       r_url = "%s/api/authz/%s/access?doAs=%s" % (r_url.rstrip('/'), self.service, self.username)
       LOG.info('Attempting to connect to RAZ URL: %s' % r_url)

--- a/desktop/core/src/desktop/lib/raz/raz_client.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client.py
@@ -158,8 +158,8 @@ class RazClient(object):
     return raz_response
 
 
-  def _handle_raz_ha(self, raz_urls, headers, data, auth_handler=None, verify=False):
-    raz_urls_list = raz_urls.split(',')
+  def _handle_raz_ha(self, raz_url, headers, data, auth_handler=None, verify=False):
+    raz_urls_list = raz_url.split(',')
     params = {
       'headers': headers, 
       'json': data,

--- a/desktop/core/src/desktop/lib/raz/raz_client.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client.py
@@ -44,7 +44,7 @@ LOG = logging.getLogger()
 class RazClient(object):
 
   def __init__(self, raz_url, auth_type, username, service='s3', service_name='cm_s3', cluster_name='myCluster'):
-    self.raz_url = raz_url.strip('/')
+    self.raz_url = raz_url
     self.auth_type = auth_type
     self.username = username
     self.service = service
@@ -93,17 +93,15 @@ class RazClient(object):
       "context": {}
     }
     request_headers = {"Content-Type": "application/json"}
-    raz_url = "%s/api/authz/%s/access?doAs=%s" % (self.raz_url, self.service, self.username)
 
     if self.service == 'adls':
       self._make_adls_request(request_data, method, path, url_params, resource_path)
     elif self.service in ('s3', 'gs'):
       self._make_s3_request(request_data, request_headers, method, params, headers, url_params, endpoint, resource_path, data=data)
 
-    LOG.debug('Raz url: %s' % raz_url)
     LOG.debug("Sending access check headers: {%s} request_data: {%s}" % (request_headers, request_data))
 
-    raz_req = self._handle_raz_req(raz_url, request_headers, request_data)
+    raz_req = self._handle_raz_req(self.raz_url, request_headers, request_data)
 
     signed_response_result = None
     signed_response = None
@@ -144,17 +142,63 @@ class RazClient(object):
   def _handle_raz_req(self, raz_url, request_headers, request_data):
     if self.auth_type == 'kerberos':
       auth_handler = requests_kerberos.HTTPKerberosAuth(mutual_authentication=requests_kerberos.OPTIONAL)
-      raz_req = requests.post(raz_url, headers=request_headers, json=request_data, auth=auth_handler, verify=False)
+      raz_response = self._handle_raz_ha(raz_url, headers=request_headers, data=request_data, auth_handler=auth_handler)
+
     elif self.auth_type == 'jwt':
       jwt_token = fetch_jwt()
-
       if jwt_token is None:
         raise PopupException('Knox JWT is not available to send to RAZ.')
 
       request_headers['Authorization'] = 'Bearer %s' % (jwt_token)
-      raz_req = requests.post(raz_url, headers=request_headers, json=request_data, verify=False)
+      raz_response = self._handle_raz_ha(raz_url, headers=request_headers, data=request_data)
+    
+    if not raz_response:
+      raise PopupException('Failed to receive response from RAZ server.')
 
-    return raz_req
+    return raz_response
+
+
+  def _handle_raz_ha(self, raz_urls, headers, data, auth_handler=None, verify=False):
+    raz_urls_list = raz_urls.split(',')
+    params = {
+      'headers': headers, 
+      'json': data,
+      'verify': verify
+    }
+
+    if auth_handler:
+      params['auth'] = auth_handler
+
+    for r_url in raz_urls_list:
+      r_url = "%s/api/authz/%s/access?doAs=%s" % (r_url.rstrip('/'), self.service, self.username)
+      LOG.info('Attempting to connect to RAZ URL: %s' % r_url)
+
+      try:
+        raz_response = requests.post(r_url, **params)
+      except Exception as e:
+        if 'Failed to establish a new connection' in str(e):
+          LOG.warning('Raz URL %s is not available.' % r_url)
+
+      # Check response for None and if response code is successful (200), return the raz response.
+      if (raz_response is not None) and (raz_response.status_code == 200):
+        return raz_response
+    
+    
+    # # Try to fetch signed header/token from RAZ URL serially.
+    # for r_url in raz_urls:
+    #   LOG.info('Attempting to connect to RAZ URL: %s' % r_url)
+    #   try:
+    #       raz_response = requests.post(r_url.strip('/'), **kwargs)
+    #       if raz_response.ok:
+    #           return raz_response
+    #       else:
+    #           raise Exception('RAZ URL %s is not available.' % r_url)
+
+    #   except Exception as e:
+    #     LOG.warning('Failed to connect to RAZ URL: %s' % r_url)
+
+    # # Raise exception when all URLs are not available.
+    # raise Exception('Failed to talk to RAZ: No healthy RAZ URL available.')
 
 
   def _make_adls_request(self, request_data, method, path, url_params, resource_path):

--- a/desktop/core/src/desktop/lib/raz/raz_client_test.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client_test.py
@@ -380,12 +380,26 @@ class RazClientTest(unittest.TestCase):
         client = RazClient(self.raz_url, 'kerberos', username=self.username, service="s3", service_name="cm_s3", cluster_name="cl1")
         raz_response = client._handle_raz_ha(self.raz_url, auth_handler=HTTPKerberosAuth(), data=request_data, headers={})
 
+        requests_post.assert_called_with(
+          'https://raz.gethue.com:8080/api/authz/s3/access?doAs=gethue',
+          auth=HTTPKerberosAuth(), 
+          headers={}, 
+          json=request_data, 
+          verify=False
+        )
         assert_equal(raz_response.status_code, 200)
 
         # HA mode - where first URL sends 200 status code
         client = RazClient(self.raz_urls_ha, 'kerberos', username=self.username, service="s3", service_name="cm_s3", cluster_name="cl1")
         raz_response = client._handle_raz_ha(self.raz_urls_ha, auth_handler=HTTPKerberosAuth(), data=request_data, headers={})
 
+        requests_post.assert_called_with(
+          'https://raz_host_1.gethue.com:8080/api/authz/s3/access?doAs=gethue',
+          auth=HTTPKerberosAuth(), 
+          headers={}, 
+          json=request_data, 
+          verify=False
+        )
         assert_equal(raz_response.status_code, 200)
 
         # When no RAZ URL is healthy

--- a/desktop/core/src/desktop/lib/raz/raz_client_test.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client_test.py
@@ -129,7 +129,12 @@ class RazClientTest(unittest.TestCase):
 
           raz_req = client._handle_raz_req(self.raz_url, request_headers, request_data)
 
-          client._handle_raz_ha.assert_called_with('https://raz.gethue.com:8080', auth_handler=HTTPKerberosAuth(), data=request_data, headers={})
+          client._handle_raz_ha.assert_called_with(
+            'https://raz.gethue.com:8080',
+            auth_handler=HTTPKerberosAuth(),
+            data=request_data,
+            headers={}
+          )
           fetch_jwt.assert_not_called()
 
           # When auth type is JWT
@@ -140,7 +145,11 @@ class RazClientTest(unittest.TestCase):
 
           raz_req = client._handle_raz_req(self.raz_url, request_headers, request_data)
 
-          client._handle_raz_ha.assert_called_with('https://raz.gethue.com:8080', data=request_data, headers={'Authorization': 'Bearer test_jwt_token'})
+          client._handle_raz_ha.assert_called_with(
+            'https://raz.gethue.com:8080',
+            data=request_data,
+            headers={'Authorization': 'Bearer test_jwt_token'}
+          )
           fetch_jwt.assert_called()
 
           # Should raise PopupException when RAZ response is None


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add support for RAZ HA in Hue - multiple RAZ servers (min. 2)
- This changes is similar to the current approach for handling HA for services like Knox, Idbroker, Atlas etc. where we switch the host after error handling.

- There are long term improvements possible with caching healthy hosts with lazy switching -- but that requires some scoping for maintaining the cache state which is in the roadmap.

## How was this patch tested?

- Updated existing UTs and added new UTs.
- Tested in live cluster setup - both HA and non-HA.