### PR TITLE
[frontend][Duplicate] Updating the hue error message alert so that it follows Cloudera's Design

### DIFF
--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.scss
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.scss
@@ -27,6 +27,10 @@
   flex-flow: column;
   row-gap: 10px;
 
+  .ant-alert {
+    padding-right: 12px;
+  }
+
   button:hover,
   button:focus {
     background-color: unset;
@@ -34,7 +38,6 @@
 
   button span {
     font-size: $font-size-sm;
-    padding-top: 5px;
   }
 
   button svg.cdp-icon-close {

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.scss
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.scss
@@ -29,7 +29,7 @@
 
   .ant-alert {
     padding-right: 12px;
-  
+
     .ant-alert-description {
       display: inline;
     }

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.scss
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.scss
@@ -29,6 +29,10 @@
 
   .ant-alert {
     padding-right: 12px;
+  
+    .ant-alert-description {
+      display: inline;
+    }
   }
 
   button:hover,

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -59,7 +59,8 @@ const AlertComponent: React.FC = () => {
         <Alert
           key={errorObj.message}
           type="error"
-          message={errorObj.message}
+          message="Error"
+          description={errorObj.message}
           showIcon={true}
           closable={true}
           onClose={() => handleClose(errorObj)}

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -60,6 +60,7 @@ const AlertComponent: React.FC = () => {
           key={errorObj.message}
           type="error"
           message={errorObj.message}
+          showIcon={true}
           closable={true}
           onClose={() => handleClose(errorObj)}
         />

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -60,7 +60,7 @@ const AlertComponent: React.FC = () => {
       return t('Error');
     }
     else if (alert.type === 'info') {
-      return t('Info message here');
+      return t('Info');
     }
     else if (alert.type === 'warning') {
       return t('Warning');

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -19,6 +19,7 @@ import Alert from 'cuix/dist/components/Alert/Alert';
 
 import huePubSub from 'utils/huePubSub';
 import './AlertComponent.scss';
+import { i18nReact } from '../../utils/i18nReact';
 
 interface ErrorAlert {
   message: string;
@@ -52,6 +53,20 @@ const AlertComponent: React.FC = () => {
     setErrors(filteredErrors);
   };
 
+  const { t } = i18nReact.useTranslation();
+
+  const getHeader = (alert)=> {
+    if (alert.type === 'error') {
+      return t('Error');
+    }
+    else if (alert.type === 'info') {
+      return t('Info message here');
+    }
+    else if (alert.type === 'warning') {
+      return t('Warning');
+    }
+  }
+
   //TODO: add support for warnings and success messages
   return (
     <div className="hue-alert flash-messages cuix antd">
@@ -59,7 +74,7 @@ const AlertComponent: React.FC = () => {
         <Alert
           key={errorObj.message}
           type="error"
-          message="Error"
+          message={getHeader(errorObj)}
           description={errorObj.message}
           showIcon={true}
           closable={true}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently the error message alerts on Hue looks slightly different than what it should look like (in accordance with Cloudera's global design: https://design.cloudera.com/9f23dd142/p/05dada-alerts)
This PR is about making the two look alike.

## How was this patch tested?
Manually tested, making sure the Hue error alert messages we have in place matches with the alert message on the link below:
https://design.cloudera.com/9f23dd142/p/05dada-alerts

Screenshot of what we want (1), what we currently have in place (2) and what do we have currently via this PR (3):

Aim (1):
<img width="537" alt="Screenshot 2023-11-22 at 12 44 29 PM" src="https://github.com/cloudera/hue/assets/68558847/9f284aad-ef87-4039-a6c5-950b5616a853">
 
 Currently have (2):
<img width="534" alt="Screenshot 2023-12-06 at 6 10 27 PM" src="https://github.com/cloudera/hue/assets/68558847/2a9f674f-7c0e-415f-b99e-89b3f7df8a89">

Changes via this PR (3):
<img width="536" alt="Screenshot 2023-12-06 at 6 08 19 PM" src="https://github.com/cloudera/hue/assets/68558847/60b0f201-653e-4df0-b11c-255be4b00701">

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
