### PR TITLE
[core] update node.js from 14 to 20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
               export DEBIAN_FRONTEND=noninteractive
               sudo apt-get update
               sudo apt-get install -y gcc g++ build-essential python3.8-dev python3.8-venv python3.8-distutils asciidoc rsync curl libkrb5-dev libldap2-dev libsasl2-dev libxml2-dev libxslt-dev  libsasl2-modules-gssapi-mit libsnappy-dev libffi-dev
-              curl -sL https://deb.nodesource.com/setup_14.x | sudo bash - && sudo apt-get install -y nodejs
+              curl -sL https://deb.nodesource.com/setup_20.x | sudo bash - && sudo apt-get install -y nodejs
               curl -sL https://bootstrap.pypa.io/get-pip.py | sudo python3.8
               sudo apt-get install -y libncursesw5-dev libgdbm-dev libc6-dev libssl-dev openssl
             fi

--- a/.github/workflows/commitflow-frontend.yml
+++ b/.github/workflows/commitflow-frontend.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Caching npm with setup node
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
         cache: 'npm'
 
     - name: Install npm dependencies

--- a/.github/workflows/commitflow-py3.yml
+++ b/.github/workflows/commitflow-py3.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc g++ build-essential python${{ matrix.python-version }}-dev python${{ matrix.python-version }}-venv python${{ matrix.python-version }}-distutils asciidoc rsync curl sudo libkrb5-dev libldap2-dev libsasl2-dev libxml2-dev libxslt-dev  libsasl2-modules-gssapi-mit libsnappy-dev libffi-dev # This should not be needed as some point
-        sudo curl -sL https://deb.nodesource.com/setup_14.x | sudo bash - && sudo apt-get install -y nodejs
+        sudo curl -sL https://deb.nodesource.com/setup_20.x | sudo bash - && sudo apt-get install -y nodejs
         sudo curl -sL https://bootstrap.pypa.io/get-pip.py | sudo python${{ matrix.python-version }}
         sudo apt-get install -y python3-setuptools
         sudo apt-get install -y libncursesw5-dev libgdbm-dev libc6-dev libssl-dev openssl

--- a/docs/docs-site/content/administrator/installation/dependencies/_index.md
+++ b/docs/docs-site/content/administrator/installation/dependencies/_index.md
@@ -287,15 +287,15 @@ On macOS 10.15.x
 
 e.g. how to install on Ubuntu:
 
-    curl -sL https://deb.nodesource.com/setup_14.x | sudo bash -
+    curl -sL https://deb.nodesource.com/setup_20.x | sudo bash -
     sudo apt-get install -y nodejs
 
 For Centos / Red Hat use this source:
 
-    curl -sL https://rpm.nodesource.com/setup_14.x | sudo bash -
+    curl -sL https://rpm.nodesource.com/setup_20.x | sudo bash -
     sudo yum install -y nodejs
 
-Upgrade to npm 7+:
+Upgrade to npm 10+:
 
     npm install --global npm
 

--- a/docs/docs-site/content/developer/development/_index.md
+++ b/docs/docs-site/content/developer/development/_index.md
@@ -15,7 +15,7 @@ This section goes into greater detail on how to build and reuse the components o
 * The OS specific packages are listed in the [install guide](/administrator/installation/dependencies/)
 * Python 3.8/3.9 and Django 3.2
 * Vue.js 3
-* Node.js ([14.0+](https://deb.nodesource.com/setup_10.x))
+* Node.js ([20.0+](https://deb.nodesource.com/setup_20.x))
 
 ### Build & Start
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -138,7 +138,7 @@
         "webpack-cli": "4.7.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=20.10.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "Apache-2.0",
   "private": false,
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=20.10.0"
   },
   "dependencies": {
     "@ant-design/icons": "5.0.1",

--- a/tools/cloudera/build_hue_cloudera.sh
+++ b/tools/cloudera/build_hue_cloudera.sh
@@ -46,6 +46,7 @@ function install_prerequisite() {
     export FORCEINSTALL=0
     export SQLITE3_PATH="$TOOLS_HOME/sqlite/bin/sqlite3"
     redhat7_ppc_install
+     # NODEJS install
     source /opt/rh/rh-nodejs14/enable
   fi
 
@@ -60,6 +61,7 @@ function install_prerequisite() {
     export PYTHON38_PATH=/opt/cloudera/cm-agent
     export pip38_bin="$PYTHON38_PATH/bin/pip3.8"
     centos7_install
+     # NODEJS install
     source /opt/rh/rh-nodejs14/enable
   elif [[ $1 == "redhat8" ]]; then
     redhat8_install

--- a/tools/cloudera/build_hue_common.sh
+++ b/tools/cloudera/build_hue_common.sh
@@ -55,7 +55,7 @@ function redhat7_ppc_install() {
       xmlsec1 \
       xmlsec1-openssl \
       unzip'
-    # NODEJS 14 install
+    # NODEJS install
     sudo -- sh -c 'yum install -y rh-nodejs14-runtime-3.6-1.el7.ppc64le.rpm \
       rh-nodejs14-npm-6.14.15-14.18.2.1.el7.ppc64le.rpm \
       rh-nodejs14-nodejs-14.18.2-1.el7.ppc64le.rpm'
@@ -105,7 +105,7 @@ function redhat8_ppc_install() {
       ncurses-devel'
     # MySQLdb install
     sudo -- sh -c 'yum install -y python3-mysqlclient'
-    # NODEJS 14 install
+    # NODEJS install
     sudo -- sh -c 'yum install -y nodejs npm'
     # Pip modules install
     sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv=='${VIRTUAL_ENV_VERSION}' virtualenv-make-relocatable=='${VIRTUAL_ENV_RELOCATABLE_VERSION}' mysqlclient==2.1.1'
@@ -135,7 +135,7 @@ function redhat9_ppc_install() {
       ncurses-devel'
     # MySQLdb install
     sudo -- sh -c 'yum install -y python3-mysqlclient'
-    # NODEJS 14 install
+    # NODEJS install
     sudo -- sh -c 'yum install -y nodejs npm'
     # Pip modules install
     sudo pip39_bin=${pip39_bin} -- sh -c '${pip39_bin} install virtualenv=='${VIRTUAL_ENV_VERSION}' virtualenv-make-relocatable=='${VIRTUAL_ENV_RELOCATABLE_VERSION}' mysqlclient==2.1.1'
@@ -166,7 +166,7 @@ function sles12_install() {
       xmlsec1 xmlsec1-devel  xmlsec1-openssl-devel'
     # MySQLdb install
     sudo -- sh -c 'zypper install -y libmysqlclient-devel libmysqlclient18 libmysqld18 libmysqld-devel'
-    # NODEJS 14 install
+    # NODEJS install
     sudo -- sh -c 'zypper install -y npm14 nodejs14'
     # Pip modules install
     sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv=='${VIRTUAL_ENV_VERSION}' virtualenv-make-relocatable=='${VIRTUAL_ENV_RELOCATABLE_VERSION}' mysqlclient==2.1.1'
@@ -195,7 +195,7 @@ function sles15_install() {
       xmlsec1 xmlsec1-devel  xmlsec1-openssl-devel'
     # MySQLdb install
     sudo -- sh -c 'zypper install -y libmariadb-devel mariadb-client python3-mysqlclient'
-    # NODEJS 14 install
+    # NODEJS install
     sudo -- sh -c 'zypper install -y nodejs18 npm16'
     # Pip modules install
     sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv=='${VIRTUAL_ENV_VERSION}' virtualenv-make-relocatable=='${VIRTUAL_ENV_RELOCATABLE_VERSION}' mysqlclient==2.1.1'
@@ -228,7 +228,7 @@ function centos7_install() {
     sudo -- sh -c 'curl -sSLO https://dev.mysql.com/get/mysql80-community-release-el7-5.noarch.rpm && \
         rpm -ivh mysql80-community-release-el7-5.noarch.rpm && \
         yum install -y mysql-community-libs mysql-community-client-plugins mysql-community-common'
-    # NODEJS 14 install
+    # NODEJS install
     sudo -- sh -c 'yum install -y rh-nodejs14-nodejs'
     # sqlite3 install
     sudo -- sh -c 'curl -o sqlite-autoconf-3350500.tar.gz https://www.sqlite.org/2021/sqlite-autoconf-3350500.tar.gz && \
@@ -265,8 +265,8 @@ function redhat8_install() {
       ncurses-c++-libs'
     # MySQLdb install
     sudo -- sh -c 'yum install -y python3-mysqlclient'
-    # NODEJS 14 install
-    sudo -- sh -c 'curl -sL https://rpm.nodesource.com/setup_14.x | bash - && yum install -y nodejs'
+    # NODEJS install
+    sudo -- sh -c 'curl -sL https://rpm.nodesource.com/setup_20.x | bash - && yum install -y nodejs'
     # Pip modules install
     sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv=='${VIRTUAL_ENV_VERSION}' virtualenv-make-relocatable=='${VIRTUAL_ENV_RELOCATABLE_VERSION}' mysqlclient==2.1.1'
     sudo pip38_bin=${pip38_bin} -- sh -c 'ln -fs ${pip38_bin} $(dirname ${pip38_bin})/pip'
@@ -308,8 +308,8 @@ function ubuntu18_install() {
         zlibc'
     # MySQLdb install
     # It is pre-installed
-    # NODEJS 14 install
-    sudo -- sh -c 'curl -sL https://deb.nodesource.com/setup_14.x | sudo bash - && \
+    # NODEJS install
+    sudo -- sh -c 'curl -sL https://deb.nodesource.com/setup_20.x | sudo bash - && \
       apt -y install nodejs'
     # Pip modules install
     sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv=='${VIRTUAL_ENV_VERSION}' virtualenv-make-relocatable=='${VIRTUAL_ENV_RELOCATABLE_VERSION}' mysqlclient==2.1.1'
@@ -355,8 +355,8 @@ function ubuntu20_install() {
         util-linux'
     # MySQLdb install
     # It is pre-installed
-    # NODEJS 14 install
-    sudo -- sh -c 'curl -sL https://deb.nodesource.com/setup_14.x | sudo bash - && \
+    # NODEJS install
+    sudo -- sh -c 'curl -sL https://deb.nodesource.com/setup_20.x | sudo bash - && \
       apt -y install nodejs'
     # Pip modules install
     sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv=='${VIRTUAL_ENV_VERSION}' virtualenv-make-relocatable=='${VIRTUAL_ENV_RELOCATABLE_VERSION}' mysqlclient==2.1.1'
@@ -386,8 +386,8 @@ function redhat9_install() {
       ncurses-c++-libs'
     # MySQLdb install
     sudo -- sh -c 'yum install -y python3-mysqlclient'
-    # NODEJS 14 install
-    sudo -- sh -c 'curl -sL https://rpm.nodesource.com/setup_14.x | bash - && yum install -y nodejs'
+    # NODEJS install
+    sudo -- sh -c 'curl -sL https://rpm.nodesource.com/setup_20.x | bash - && yum install -y nodejs'
     # Pip modules install
     sudo pip39_bin=${pip39_bin} -- sh -c '${pip39_bin} install virtualenv=='${VIRTUAL_ENV_VERSION}' virtualenv-make-relocatable=='${VIRTUAL_ENV_RELOCATABLE_VERSION}' mysqlclient==2.1.1'
     sudo pip39_bin=${pip39_bin} -- sh -c 'ln -fs ${pip39_bin} $(dirname ${pip39_bin})/pip'

--- a/tools/docker/hue/Dockerfile
+++ b/tools/docker/hue/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update -y && apt-get install -y \
 ADD . /hue
 
 RUN pip3 install --upgrade --no-cache-dir setuptools virtualenv pip && \
-  curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+  curl -sL https://deb.nodesource.com/setup_20.x | bash - && \
   apt-get install -y nodejs && \
   addgroup hue && \
   useradd -r -u 1001 -g hue hue && \

--- a/tools/docker/hue/Dockerfile.py2
+++ b/tools/docker/hue/Dockerfile.py2
@@ -46,7 +46,7 @@ RUN rm desktop/conf/*
 COPY desktop/conf.dist desktop/conf
 
 # Need recent version for Ubuntu
-RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo bash - \
+RUN curl -sL https://deb.nodesource.com/setup_20.x | sudo bash - \
   && apt-get install -y nodejs
 
 RUN PREFIX=/usr/share make install


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Update node.js from 14 to 20 (LTS is currently at 20.10.0). NPM will be on 10.
- engines node in 'package.json' does not enforce, it is a recommendation that can show a warning if not met. 
- gihub actions
- circle CI
- docs
- docker files
- build scripts (only modified the scripts using nodesource.com where I could verify that the node version existed)

### TODO:
Not all OS build scripts have been updated due to the difference in installing node. Depending on OS there are different package managers (yum, zypper, apt) and we sometimes use the latest (unspecified) version of node from the package manager and sometimes we specify a specific package as a parameter to the package manager. In some cases we specifically download a major version from nodesource.com and install that one.

@ranade1 We need to investigate how we can install node.js v 20 on all these OS. 

## How was this patch tested?

On MacOS
1. Install node 20 LTS ("nvm use 20")
2. Verify successful frontend build with "npm run weback"
3. Verify successful frontend dev build with "npm run dev"
4. Verify unit tests passing

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
