### PR TITLE
[ldap] Fix LDAP sync group without import posix group users

### DIFF
--- a/apps/useradmin/src/useradmin/ldap_access.py
+++ b/apps/useradmin/src/useradmin/ldap_access.py
@@ -306,8 +306,8 @@ class LdapConnection(object):
                      'is memberUid or group did not contain any members' % group_name)
             ldap_info['members'] = []
 
-          if 'posixgroup' in (item.lower() for item in data['objectClass']) and 'memberUid' in data:
-            ldap_info['posix_members'] = data['memberUid']
+          if 'posixgroup' in [item.lower().decode("utf-8") for item in data['objectClass']] and 'memberuid' in data:
+            ldap_info['posix_members'] = data['memberuid']
           else:
             LOG.warning('Skipping import of posix users from group %s since posixGroup '
                      'not an objectClass or no memberUids found' % group_name)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix LDAP sync group without import posix group users. The group info fetch from LDAP server are binary string, and keys in CaseInsensitiveDict are lowercases.

## How was this patch tested?

tested LDAP with posix groups and users on DC cluster.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
