### PR TITLE
update nodejs version from 14 to 20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
             export DEBIAN_FRONTEND=noninteractive
             sudo apt-get update
             sudo apt-get install -y gcc g++ build-essential python3.8-dev python3.8-venv python3.8-distutils asciidoc rsync curl libkrb5-dev libldap2-dev libsasl2-dev libxml2-dev libxslt-dev  libsasl2-modules-gssapi-mit libsnappy-dev libffi-dev
-            curl -sL https://deb.nodesource.com/setup_14.x | sudo bash - && sudo apt-get install -y nodejs
+            curl -sL https://deb.nodesource.com/setup_20.x | sudo bash - && sudo apt-get install -y nodejs
             curl -sL https://bootstrap.pypa.io/get-pip.py | sudo python3.8
             sudo apt-get install -y libncursesw5-dev libgdbm-dev libc6-dev libssl-dev openssl
 

--- a/.github/workflows/commitflow-frontend.yml
+++ b/.github/workflows/commitflow-frontend.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Caching npm with setup node
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
         cache: 'npm'
 
     - name: Install npm dependencies

--- a/.github/workflows/commitflow-py3.yml
+++ b/.github/workflows/commitflow-py3.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc g++ build-essential python${{ matrix.python-version }}-dev python${{ matrix.python-version }}-venv python${{ matrix.python-version }}-distutils asciidoc rsync curl sudo libkrb5-dev libldap2-dev libsasl2-dev libxml2-dev libxslt-dev  libsasl2-modules-gssapi-mit libsnappy-dev libffi-dev # This should not be needed as some point
-        sudo curl -sL https://deb.nodesource.com/setup_14.x | sudo bash - && sudo apt-get install -y nodejs
+        sudo curl -sL https://deb.nodesource.com/setup_20.x | sudo bash - && sudo apt-get install -y nodejs
         sudo curl -sL https://bootstrap.pypa.io/get-pip.py | sudo python${{ matrix.python-version }}
         sudo apt-get install -y python3-setuptools
         sudo apt-get install -y libncursesw5-dev libgdbm-dev libc6-dev libssl-dev openssl

--- a/docs/docs-site/content/administrator/installation/dependencies/_index.md
+++ b/docs/docs-site/content/administrator/installation/dependencies/_index.md
@@ -287,15 +287,15 @@ On macOS 10.15.x
 
 e.g. how to install on Ubuntu:
 
-    curl -sL https://deb.nodesource.com/setup_14.x | sudo bash -
+    curl -sL https://deb.nodesource.com/setup_20.x | sudo bash -
     sudo apt-get install -y nodejs
 
 For Centos / Red Hat use this source:
 
-    curl -sL https://rpm.nodesource.com/setup_14.x | sudo bash -
+    curl -sL https://rpm.nodesource.com/setup_20.x | sudo bash -
     sudo yum install -y nodejs
 
-Upgrade to npm 7+:
+Upgrade to npm 10+:
 
     npm install --global npm
 

--- a/docs/docs-site/content/developer/development/_index.md
+++ b/docs/docs-site/content/developer/development/_index.md
@@ -15,7 +15,7 @@ This section goes into greater detail on how to build and reuse the components o
 * The OS specific packages are listed in the [install guide](/administrator/installation/dependencies/)
 * Python 3.8/3.9 and Django 3.2
 * Vue.js 3
-* Node.js ([14.0+](https://deb.nodesource.com/setup_10.x))
+* Node.js ([20.0+](https://deb.nodesource.com/setup_20.x))
 
 ### Build & Start
 

--- a/tools/cloudera/build_hue_cloudera.sh
+++ b/tools/cloudera/build_hue_cloudera.sh
@@ -46,7 +46,6 @@ function install_prerequisite() {
     export FORCEINSTALL=0
     export SQLITE3_PATH="$TOOLS_HOME/sqlite/bin/sqlite3"
     redhat7_ppc_install
-    source /opt/rh/rh-nodejs14/enable
   fi
 
   export SQLITE3_PATH=${SQLITE3_PATH:-"$TOOLS_HOME/sqlite/sqlite3"}
@@ -60,7 +59,6 @@ function install_prerequisite() {
     export PYTHON38_PATH=/opt/cloudera/cm-agent
     export pip38_bin="$PYTHON38_PATH/bin/pip3.8"
     centos7_install
-    source /opt/rh/rh-nodejs14/enable
   elif [[ $1 == "redhat8" ]]; then
     redhat8_install
   elif [[ $1 == "sles12" ]]; then

--- a/tools/cloudera/build_hue_common.sh
+++ b/tools/cloudera/build_hue_common.sh
@@ -55,10 +55,15 @@ function redhat7_ppc_install() {
       xmlsec1 \
       xmlsec1-openssl \
       unzip'
-    # NODEJS 14 install
-    sudo -- sh -c 'yum install -y rh-nodejs14-runtime-3.6-1.el7.ppc64le.rpm \
-      rh-nodejs14-npm-6.14.15-14.18.2.1.el7.ppc64le.rpm \
-      rh-nodejs14-nodejs-14.18.2-1.el7.ppc64le.rpm'
+    # NODEJS 16 install
+    # Upgrading to node-v16 because of the following CVE's in node-v14 "CVE-2021-3450, CVE-2021-44531, CVE-2023-32004, CVE-2023-32006"
+    # Node-v20-LTS is not supported by old OS'es - Redhat7_ppc, Centos7, Ubuntu18, Sles12. So upgrading to node-v16
+    sudo -- sh -c 'curl -fsSL https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-ppc64le.tar.gz -o node-v16.20.2-linux-ppc64le.tar.gz && \
+      mkdir -p /usr/local/lib/nodejs && \
+      tar -xzf node-v16.20.2-linux-ppc64le.tar.gz -C /usr/local/lib/nodejs'
+    echo 'export PATH=/usr/local/lib/nodejs/node-v16.20.2-linux-ppc64le/bin:$PATH' >> ~/.bashrc
+    source ~/.bashrc
+
     # sqlite3 install
     sudo TOOLS_HOME=${TOOLS_HOME} -- sh -c 'mkdir -p ${TOOLS_HOME} && \
       cd ${TOOLS_HOME} && \
@@ -105,8 +110,12 @@ function redhat8_ppc_install() {
       ncurses-devel'
     # MySQLdb install
     sudo -- sh -c 'yum install -y python3-mysqlclient'
-    # NODEJS 14 install
-    sudo -- sh -c 'yum install -y nodejs npm'
+    # NODEJS install
+    sudo sh -c 'curl -fsSL https://nodejs.org/dist/v20.11.0/node-v20.11.0-linux-ppc64le.tar.gz -o node-v20.11.0-linux-ppc64le.tar.gz && \
+      mkdir -p /usr/local/lib/nodejs && \
+      tar -xzf node-v20.11.0-linux-ppc64le.tar.gz -C /usr/local/lib/nodejs'
+    echo 'export PATH=/usr/local/lib/nodejs/node-v20.11.0-linux-ppc64le/bin:$PATH' >> ~/.bashrc
+    source ~/.bashrc
     # Pip modules install
     sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv=='${VIRTUAL_ENV_VERSION}' virtualenv-make-relocatable=='${VIRTUAL_ENV_RELOCATABLE_VERSION}' mysqlclient==2.1.1'
     sudo pip38_bin=${pip38_bin} -- sh -c 'ln -fs ${pip38_bin} $(dirname ${pip38_bin})/pip'
@@ -135,8 +144,12 @@ function redhat9_ppc_install() {
       ncurses-devel'
     # MySQLdb install
     sudo -- sh -c 'yum install -y python3-mysqlclient'
-    # NODEJS 14 install
-    sudo -- sh -c 'yum install -y nodejs npm'
+    # NODEJS install
+    sudo sh -c 'curl -fsSL https://nodejs.org/dist/v20.11.0/node-v20.11.0-linux-ppc64le.tar.gz -o node-v20.11.0-linux-ppc64le.tar.gz && \
+      mkdir -p /usr/local/lib/nodejs && \
+      tar -xzf node-v20.11.0-linux-ppc64le.tar.gz -C /usr/local/lib/nodejs'
+    echo 'export PATH=/usr/local/lib/nodejs/node-v20.11.0-linux-ppc64le/bin:$PATH' >> ~/.bashrc
+    source ~/.bashrc
     # Pip modules install
     sudo pip39_bin=${pip39_bin} -- sh -c '${pip39_bin} install virtualenv=='${VIRTUAL_ENV_VERSION}' virtualenv-make-relocatable=='${VIRTUAL_ENV_RELOCATABLE_VERSION}' mysqlclient==2.1.1'
     sudo pip39_bin=${pip39_bin} -- sh -c 'ln -fs ${pip39_bin} $(dirname ${pip39_bin})/pip'
@@ -166,8 +179,10 @@ function sles12_install() {
       xmlsec1 xmlsec1-devel  xmlsec1-openssl-devel'
     # MySQLdb install
     sudo -- sh -c 'zypper install -y libmysqlclient-devel libmysqlclient18 libmysqld18 libmysqld-devel'
-    # NODEJS 14 install
-    sudo -- sh -c 'zypper install -y npm14 nodejs14'
+    # NODEJS 16 install
+    # Upgrading to node-v16 because of the following CVE's in node-v14 "CVE-2021-3450, CVE-2021-44531, CVE-2023-32004, CVE-2023-32006"
+    # Node-v20-LTS is not supported by old OS'es - Redhat7_ppc, Centos7, Ubuntu18, Sles12. So upgrading to node-v16
+    sudo -- sh -c 'zypper install -y npm14 nodejs16'
     # Pip modules install
     sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv=='${VIRTUAL_ENV_VERSION}' virtualenv-make-relocatable=='${VIRTUAL_ENV_RELOCATABLE_VERSION}' mysqlclient==2.1.1'
     sudo pip38_bin=${pip38_bin} -- sh -c 'ln -fs ${pip38_bin} $(dirname ${pip38_bin})/pip'
@@ -195,7 +210,7 @@ function sles15_install() {
       xmlsec1 xmlsec1-devel  xmlsec1-openssl-devel'
     # MySQLdb install
     sudo -- sh -c 'zypper install -y libmariadb-devel mariadb-client python3-mysqlclient'
-    # NODEJS 14 install
+    # NODEJS 20 install
     sudo -- sh -c 'zypper install -y nodejs18 npm16'
     # Pip modules install
     sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv=='${VIRTUAL_ENV_VERSION}' virtualenv-make-relocatable=='${VIRTUAL_ENV_RELOCATABLE_VERSION}' mysqlclient==2.1.1'
@@ -228,8 +243,11 @@ function centos7_install() {
     sudo -- sh -c 'curl -sSLO https://dev.mysql.com/get/mysql80-community-release-el7-11.noarch.rpm && \
         rpm -ivh mysql80-community-release-el7-11.noarch.rpm && \
         yum install -y mysql-community-libs mysql-community-client-plugins mysql-community-common'
-    # NODEJS 14 install
-    sudo -- sh -c 'yum install -y rh-nodejs14-nodejs'
+    # NODEJS 16 install
+    # Upgrading to node-v16 because of the following CVE's in node-v14 "CVE-2021-3450, CVE-2021-44531, CVE-2023-32004, CVE-2023-32006"
+    # Node-v20-LTS is not supported by old OS'es - Redhat7_ppc, Centos7, Ubuntu18, Sles12. So upgrading to node-v16
+    sudo -- sh -c 'curl -fsSL https://rpm.nodesource.com/setup_16.x | sudo bash - && \
+        yum install -y nodejs npm'
     # sqlite3 install
     sudo -- sh -c 'curl -o sqlite-autoconf-3350500.tar.gz https://www.sqlite.org/2021/sqlite-autoconf-3350500.tar.gz && \
         tar zxvf sqlite-autoconf-3350500.tar.gz && \
@@ -265,8 +283,9 @@ function redhat8_install() {
       ncurses-c++-libs'
     # MySQLdb install
     sudo -- sh -c 'yum install -y python3-mysqlclient'
-    # NODEJS 14 install
-    sudo -- sh -c 'curl -sL https://rpm.nodesource.com/setup_14.x | bash - && yum install -y nodejs'
+    # NODEJS 20 install
+    sudo -- sh -c 'curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash - && \
+      yum install -y nodejs'
     # Pip modules install
     sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv=='${VIRTUAL_ENV_VERSION}' virtualenv-make-relocatable=='${VIRTUAL_ENV_RELOCATABLE_VERSION}' mysqlclient==2.1.1'
     sudo pip38_bin=${pip38_bin} -- sh -c 'ln -fs ${pip38_bin} $(dirname ${pip38_bin})/pip'
@@ -308,8 +327,10 @@ function ubuntu18_install() {
         zlibc'
     # MySQLdb install
     # It is pre-installed
-    # NODEJS 14 install
-    sudo -- sh -c 'curl -sL https://deb.nodesource.com/setup_14.x | sudo bash - && \
+    # NODEJS 16 install
+    # Upgrading to node-v16 because of the following CVE's in node-v14 "CVE-2021-3450, CVE-2021-44531, CVE-2023-32004, CVE-2023-32006"
+    # Node-v20-LTS is not supported by old OS'es - Redhat7_ppc, Centos7, Ubuntu18, Sles12. So upgrading to node-v16
+    sudo -- sh -c 'curl -sL https://deb.nodesource.com/setup_16.x | sudo bash - && \
       apt -y install nodejs'
     # Pip modules install
     sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv=='${VIRTUAL_ENV_VERSION}' virtualenv-make-relocatable=='${VIRTUAL_ENV_RELOCATABLE_VERSION}' mysqlclient==2.1.1'
@@ -355,9 +376,10 @@ function ubuntu20_install() {
         util-linux'
     # MySQLdb install
     # It is pre-installed
-    # NODEJS 14 install
-    sudo -- sh -c 'curl -sL https://deb.nodesource.com/setup_14.x | sudo bash - && \
-      apt -y install nodejs'
+    # NODEJS 20 install
+    sudo -- sh -c 'apt-get install -y curl && \
+      curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - && \
+      apt-get install -y nodejs'
     # Pip modules install
     sudo pip38_bin=${pip38_bin} -- sh -c '${pip38_bin} install virtualenv=='${VIRTUAL_ENV_VERSION}' virtualenv-make-relocatable=='${VIRTUAL_ENV_RELOCATABLE_VERSION}' mysqlclient==2.1.1'
     sudo pip38_bin=${pip38_bin} -- sh -c 'ln -fs ${pip38_bin} $(dirname ${pip38_bin})/pip'
@@ -386,8 +408,9 @@ function redhat9_install() {
       ncurses-c++-libs'
     # MySQLdb install
     sudo -- sh -c 'yum install -y python3-mysqlclient'
-    # NODEJS 14 install
-    sudo -- sh -c 'curl -sL https://rpm.nodesource.com/setup_14.x | bash - && yum install -y nodejs'
+    # NODEJS 20 install
+    sudo -- sh -c 'curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash - && \
+      yum install -y nodejs'
     # Pip modules install
     sudo pip39_bin=${pip39_bin} -- sh -c '${pip39_bin} install virtualenv=='${VIRTUAL_ENV_VERSION}' virtualenv-make-relocatable=='${VIRTUAL_ENV_RELOCATABLE_VERSION}' mysqlclient==2.1.1'
     sudo pip39_bin=${pip39_bin} -- sh -c 'ln -fs ${pip39_bin} $(dirname ${pip39_bin})/pip'

--- a/tools/docker/hue/Dockerfile
+++ b/tools/docker/hue/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-get update -y && apt-get install -y \
 ADD . /hue
 
 RUN pip3 install --upgrade --no-cache-dir setuptools virtualenv pip && \
-  curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+  apt-get install -y curl && \
+  curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - && \
   apt-get install -y nodejs && \
   addgroup hue && \
   useradd -r -u 1001 -g hue hue && \

--- a/tools/docker/hue/Dockerfile.py2
+++ b/tools/docker/hue/Dockerfile.py2
@@ -46,7 +46,9 @@ RUN rm desktop/conf/*
 COPY desktop/conf.dist desktop/conf
 
 # Need recent version for Ubuntu
-RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo bash - \
+# Upgrading to node-v16 because of the following CVE's in node-v14 "CVE-2021-3450, CVE-2021-44531, CVE-2023-32004, CVE-2023-32006"
+# Node-v20-LTS is not supported by old OS'es - Redhat7_ppc, Centos7, Ubuntu18, Sles12. So upgrading to node-v16
+RUN curl -sL https://deb.nodesource.com/setup_16.x | sudo bash - \
   && apt-get install -y nodejs
 
 RUN PREFIX=/usr/share make install


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Update node.js from 14 to 20 (LTS is currently at 20.10.0). NPM will be on 10.
- engines node in 'package.json' does not enforce, it is a recommendation that can show a warning if not met.
- gihub actions
- circle CI
- docs
- docker files
- build scripts (only modified the scripts using nodesource.com where I could verify that the node version existed)

## How was this patch tested?

Tested on redhat8, redhat9, ubi8 docker images. 'node -v' returns 'v20.10.0'. Using @bjornalm change for circle ci, github workflow images from PR: https://github.com/cloudera/hue/pull/3566. 

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
