### PR TITLE
[frontend] Implementation of sorting columns in Storage browser table

### DIFF
--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
@@ -55,6 +55,11 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
   user_home_dir,
   testId
 }): JSX.Element => {
+  enum SortEnum {
+    ASC = 'ascending',
+    DSC = 'descending',
+    NONE = 'none'
+  }
   const [filePath, setFilePath] = useState<string>(user_home_dir);
   const [filesData, setFilesData] = useState<PathAndFileData>();
   const [files, setFiles] = useState<StorageBrowserTableData[]>();
@@ -63,7 +68,7 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
   const [pageSize, setPageSize] = useState<number>();
   const [pageNumber, setPageNumber] = useState<number>(1);
   const [sortByColumn, setSortByColumn] = useState<string>('');
-  const [sortByDescending, setSortByDescending] = useState<boolean>(false);
+  const [sortOrder, setSortOrder] = useState<SortEnum>(SortEnum.NONE);
   //TODO: Add filter functionality
   const [filterData, setFilterData] = useState<string>('');
 
@@ -136,6 +141,14 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
 
   useEffect(() => {
     setloadingFiles(true);
+    let sortByDescending = false;
+    if (sortOrder === SortEnum.ASC) {
+      sortByDescending = false;
+    } else if (sortOrder === SortEnum.DSC) {
+      sortByDescending = true;
+    } else {
+      setSortByColumn('');
+    }
     fetchFiles(filePath, pageSize, pageNumber, filterData, sortByColumn, sortByDescending)
       .then(responseFilesData => {
         setFilesData(responseFilesData);
@@ -143,9 +156,9 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
           name: file.name,
           size: file.humansize,
           user: file.stats.user,
-          groups: file.stats.group,
+          group: file.stats.group,
           permission: file.rwx,
-          lastUpdated: file.mtime,
+          mtime: file.mtime,
           type: file.type,
           path: file.path
         }));
@@ -160,7 +173,7 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
       .finally(() => {
         setloadingFiles(false);
       });
-  }, [filePath, pageSize, pageNumber, sortByColumn, sortByDescending]);
+  }, [filePath, pageSize, pageNumber, sortByColumn, sortOrder]);
 
   return (
     <Spin spinning={loadingFiles}>
@@ -222,9 +235,9 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
           onPageSizeChange={setPageSize}
           onPageNumberChange={setPageNumber}
           onSortByColumnChange={setSortByColumn}
-          onSortByDescendingChange={setSortByDescending}
+          onSortOrderChange={setSortOrder}
           sortByColumn={sortByColumn}
-          sortByDescending={sortByDescending}
+          sortOrder={sortOrder}
         ></StorageBrowserTable>
       </div>
     </Spin>

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
@@ -62,6 +62,10 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
   const [pageStats, setPageStats] = useState<PageStats>();
   const [pageSize, setPageSize] = useState<number>();
   const [pageNumber, setPageNumber] = useState<number>(1);
+  const [sortByColumn, setSortByColumn] = useState<string>('');
+  const [sortByDescending, setSortByDescending] = useState<boolean>(false);
+  //TODO: Add filter functionality
+  const [filterData, setFilterData] = useState<string>('');
 
   const { t } = i18nReact.useTranslation();
 
@@ -132,7 +136,7 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
 
   useEffect(() => {
     setloadingFiles(true);
-    fetchFiles(filePath, pageSize, pageNumber)
+    fetchFiles(filePath, pageSize, pageNumber, filterData, sortByColumn, sortByDescending)
       .then(responseFilesData => {
         setFilesData(responseFilesData);
         const tableData: StorageBrowserTableData[] = responseFilesData.files.map(file => ({
@@ -156,7 +160,7 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
       .finally(() => {
         setloadingFiles(false);
       });
-  }, [filePath, pageSize, pageNumber]);
+  }, [filePath, pageSize, pageNumber, sortByColumn, sortByDescending]);
 
   return (
     <Spin spinning={loadingFiles}>
@@ -217,6 +221,10 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
           onFilepathChange={setFilePath}
           onPageSizeChange={setPageSize}
           onPageNumberChange={setPageNumber}
+          onSortByColumnChange={setSortByColumn}
+          onSortByDescendingChange={setSortByDescending}
+          sortByColumn={sortByColumn}
+          sortByDescending={sortByDescending}
         ></StorageBrowserTable>
       </div>
     </Spin>

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
@@ -37,7 +37,8 @@ import { fetchFiles } from '../../../../reactComponents/FileChooser/api';
 import {
   PathAndFileData,
   StorageBrowserTableData,
-  PageStats
+  PageStats,
+  SortOrder
 } from '../../../../reactComponents/FileChooser/types';
 
 import './StorageBrowserTabContent.scss';
@@ -55,11 +56,6 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
   user_home_dir,
   testId
 }): JSX.Element => {
-  enum SortEnum {
-    ASC = 'ascending',
-    DSC = 'descending',
-    NONE = 'none'
-  }
   const [filePath, setFilePath] = useState<string>(user_home_dir);
   const [filesData, setFilesData] = useState<PathAndFileData>();
   const [files, setFiles] = useState<StorageBrowserTableData[]>();
@@ -68,7 +64,7 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
   const [pageSize, setPageSize] = useState<number>();
   const [pageNumber, setPageNumber] = useState<number>(1);
   const [sortByColumn, setSortByColumn] = useState<string>('');
-  const [sortOrder, setSortOrder] = useState<SortEnum>(SortEnum.NONE);
+  const [sortOrder, setSortOrder] = useState<SortOrder>(SortOrder.NONE);
   //TODO: Add filter functionality
   const [filterData, setFilterData] = useState<string>('');
 
@@ -141,15 +137,7 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
 
   useEffect(() => {
     setloadingFiles(true);
-    let sortByDescending = false;
-    if (sortOrder === SortEnum.ASC) {
-      sortByDescending = false;
-    } else if (sortOrder === SortEnum.DSC) {
-      sortByDescending = true;
-    } else {
-      setSortByColumn('');
-    }
-    fetchFiles(filePath, pageSize, pageNumber, filterData, sortByColumn, sortByDescending)
+    fetchFiles(filePath, pageSize, pageNumber, filterData, sortByColumn, sortOrder)
       .then(responseFilesData => {
         setFilesData(responseFilesData);
         const tableData: StorageBrowserTableData[] = responseFilesData.files.map(file => ({

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.scss
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.scss
@@ -60,6 +60,10 @@ $cell-height: 40px;
   color: vars.$fluidx-blue-700;
 }
 
-.hue-storage-browser__table-column-title {
+.hue-storage-browser__table-column-header {
   display: flex;
+}
+
+.hue-storage-browser__table-column-title {
+  text-transform: capitalize;
 }

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.scss
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.scss
@@ -37,6 +37,10 @@ $cell-height: 40px;
   th.ant-table-cell {
     text-align: left;
   }
+
+  table {
+    width: 100%;
+  }
 }
 
 .hue-storage-browser__table-row {
@@ -54,4 +58,8 @@ $cell-height: 40px;
 
 .hue-storage-browser__table-cell-name {
   color: vars.$fluidx-blue-700;
+}
+
+.hue-storage-browser__table-column-title {
+  display: flex;
 }

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.tsx
@@ -19,6 +19,8 @@ import { i18nReact } from '../../../../utils/i18nReact';
 import Table from 'cuix/dist/components/Table';
 import { ColumnProps } from 'antd/lib/table';
 import FolderIcon from '@cloudera/cuix-core/icons/react/ProjectIcon';
+import SortAscending from '@cloudera/cuix-core/icons/react/SortAscendingIcon';
+import SortDescending from '@cloudera/cuix-core/icons/react/SortDescendingIcon';
 //TODO: Use cuix icon (Currently fileIcon does not exist in cuix)
 import { FileOutlined } from '@ant-design/icons';
 
@@ -33,8 +35,12 @@ interface StorageBrowserTableProps {
   onFilepathChange: (path: string) => void;
   onPageNumberChange: (pageNumber: number) => void;
   onPageSizeChange: (pageSize: number) => void;
+  onSortByColumnChange: (sortByColumn: string) => void;
+  onSortByDescendingChange: (sortByDescending: boolean) => void;
   pageSize: number;
   pageStats: PageStats;
+  sortByColumn: string;
+  sortByDescending: boolean;
   rowClassName?: string;
   testId?: string;
 }
@@ -51,6 +57,10 @@ const StorageBrowserTable: React.FC<StorageBrowserTableProps> = ({
   onFilepathChange,
   onPageNumberChange,
   onPageSizeChange,
+  onSortByColumnChange,
+  onSortByDescendingChange,
+  sortByColumn,
+  sortByDescending,
   pageSize,
   pageStats,
   rowClassName,
@@ -61,12 +71,39 @@ const StorageBrowserTable: React.FC<StorageBrowserTableProps> = ({
 
   const { t } = i18nReact.useTranslation();
 
+  const onColumnTitleClicked = (columnClicked: string) => {
+    if (columnClicked === sortByColumn) {
+      onSortByDescendingChange(!sortByDescending);
+    } else {
+      onSortByColumnChange(columnClicked);
+      if (sortByDescending) {
+        onSortByDescendingChange(false);
+      }
+    }
+  };
+
   const getColumns = file => {
     const columns: ColumnProps<unknown>[] = [];
     for (const [key] of Object.entries(file)) {
       const column: ColumnProps<unknown> = {
         dataIndex: `${key}`,
-        title: t(`${key}`.charAt(0).toUpperCase() + `${key}`.slice(1)),
+        title: (
+          <div
+            className="hue-storage-browser__table-column-title"
+            onClick={() => onColumnTitleClicked(key)}
+          >
+            <div>{t(`${key}`.charAt(0).toUpperCase() + `${key}`.slice(1))}</div>
+            {`${key}` === `${sortByColumn}` ? (
+              sortByDescending ? (
+                <SortDescending />
+              ) : (
+                <SortAscending />
+              )
+            ) : (
+              <div></div>
+            )}
+          </div>
+        ),
         key: `${key}`
       };
       if (key === 'name') {

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.tsx
@@ -24,16 +24,15 @@ import SortDescending from '@cloudera/cuix-core/icons/react/SortDescendingIcon';
 //TODO: Use cuix icon (Currently fileIcon does not exist in cuix)
 import { FileOutlined } from '@ant-design/icons';
 
-import { PageStats, StorageBrowserTableData } from '../../../../reactComponents/FileChooser/types';
+import {
+  PageStats,
+  StorageBrowserTableData,
+  SortOrder
+} from '../../../../reactComponents/FileChooser/types';
 import Pagination from '../../../../reactComponents/Pagination/Pagination';
 import './StorageBrowserTable.scss';
 import Tooltip from 'antd/es/tooltip';
 
-enum SortEnum {
-  ASC = 'ascending',
-  DSC = 'descending',
-  NONE = 'none'
-}
 interface StorageBrowserTableProps {
   className?: string;
   dataSource: StorageBrowserTableData[];
@@ -41,11 +40,11 @@ interface StorageBrowserTableProps {
   onPageNumberChange: (pageNumber: number) => void;
   onPageSizeChange: (pageSize: number) => void;
   onSortByColumnChange: (sortByColumn: string) => void;
-  onSortOrderChange: (sortOrder: SortEnum) => void;
+  onSortOrderChange: (sortOrder: SortOrder) => void;
   pageSize: number;
   pageStats: PageStats;
   sortByColumn: string;
-  sortOrder: SortEnum;
+  sortOrder: SortOrder;
   rowClassName?: string;
   testId?: string;
 }
@@ -78,19 +77,16 @@ const StorageBrowserTable: React.FC<StorageBrowserTableProps> = ({
 
   const onColumnTitleClicked = (columnClicked: string) => {
     if (columnClicked === sortByColumn) {
-      switch (sortOrder) {
-        case SortEnum.NONE:
-          onSortOrderChange(SortEnum.ASC);
-          break;
-        case SortEnum.ASC:
-          onSortOrderChange(SortEnum.DSC);
-          break;
-        default:
-          onSortOrderChange(SortEnum.NONE);
+      if (sortOrder === SortOrder.NONE) {
+        onSortOrderChange(SortOrder.ASC);
+      } else if (sortOrder === SortOrder.ASC) {
+        onSortOrderChange(SortOrder.DSC);
+      } else {
+        onSortOrderChange(SortOrder.NONE);
       }
     } else {
       onSortByColumnChange(columnClicked);
-      onSortOrderChange(SortEnum.ASC);
+      onSortOrderChange(SortOrder.ASC);
     }
   };
 
@@ -108,9 +104,9 @@ const StorageBrowserTable: React.FC<StorageBrowserTableProps> = ({
               {key === 'mtime' ? t('Last Updated') : t(key)}
             </div>
             {key === sortByColumn ? (
-              sortOrder === SortEnum.DSC ? (
+              sortOrder === SortOrder.DSC ? (
                 <SortDescending />
-              ) : sortOrder === SortEnum.ASC ? (
+              ) : sortOrder === SortOrder.ASC ? (
                 <SortAscending />
               ) : null
             ) : null}

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.tsx
@@ -29,6 +29,11 @@ import Pagination from '../../../../reactComponents/Pagination/Pagination';
 import './StorageBrowserTable.scss';
 import Tooltip from 'antd/es/tooltip';
 
+enum SortEnum {
+  ASC = 'ascending',
+  DSC = 'descending',
+  NONE = 'none'
+}
 interface StorageBrowserTableProps {
   className?: string;
   dataSource: StorageBrowserTableData[];
@@ -36,11 +41,11 @@ interface StorageBrowserTableProps {
   onPageNumberChange: (pageNumber: number) => void;
   onPageSizeChange: (pageSize: number) => void;
   onSortByColumnChange: (sortByColumn: string) => void;
-  onSortByDescendingChange: (sortByDescending: boolean) => void;
+  onSortOrderChange: (sortOrder: SortEnum) => void;
   pageSize: number;
   pageStats: PageStats;
   sortByColumn: string;
-  sortByDescending: boolean;
+  sortOrder: SortEnum;
   rowClassName?: string;
   testId?: string;
 }
@@ -58,9 +63,9 @@ const StorageBrowserTable: React.FC<StorageBrowserTableProps> = ({
   onPageNumberChange,
   onPageSizeChange,
   onSortByColumnChange,
-  onSortByDescendingChange,
+  onSortOrderChange,
   sortByColumn,
-  sortByDescending,
+  sortOrder,
   pageSize,
   pageStats,
   rowClassName,
@@ -73,12 +78,19 @@ const StorageBrowserTable: React.FC<StorageBrowserTableProps> = ({
 
   const onColumnTitleClicked = (columnClicked: string) => {
     if (columnClicked === sortByColumn) {
-      onSortByDescendingChange(!sortByDescending);
+      switch (sortOrder) {
+        case SortEnum.NONE:
+          onSortOrderChange(SortEnum.ASC);
+          break;
+        case SortEnum.ASC:
+          onSortOrderChange(SortEnum.DSC);
+          break;
+        default:
+          onSortOrderChange(SortEnum.NONE);
+      }
     } else {
       onSortByColumnChange(columnClicked);
-      if (sortByDescending) {
-        onSortByDescendingChange(false);
-      }
+      onSortOrderChange(SortEnum.ASC);
     }
   };
 
@@ -86,18 +98,22 @@ const StorageBrowserTable: React.FC<StorageBrowserTableProps> = ({
     const columns: ColumnProps<unknown>[] = [];
     for (const [key] of Object.entries(file)) {
       const column: ColumnProps<unknown> = {
-        dataIndex: `${key}`,
+        dataIndex: key,
         title: (
           <div
-            className="hue-storage-browser__table-column-title"
+            className="hue-storage-browser__table-column-header"
             onClick={() => onColumnTitleClicked(key)}
           >
-            <div>{t(`${key}`.charAt(0).toUpperCase() + `${key}`.slice(1))}</div>
-            {`${key}` === `${sortByColumn}` ? (
-              sortByDescending ? (
+            <div className="hue-storage-browser__table-column-title">
+              {key === 'mtime' ? t('Last Updated') : t(key)}
+            </div>
+            {key === sortByColumn ? (
+              sortOrder === SortEnum.DSC ? (
                 <SortDescending />
-              ) : (
+              ) : sortOrder === SortEnum.ASC ? (
                 <SortAscending />
+              ) : (
+                <></>
               )
             ) : (
               <div></div>
@@ -118,7 +134,7 @@ const StorageBrowserTable: React.FC<StorageBrowserTableProps> = ({
           </Tooltip>
         );
       } else {
-        column.width = key === 'lastUpdated' ? '15%' : '10%';
+        column.width = key === 'mtime' ? '15%' : '10%';
       }
       columns.push(column);
     }

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.tsx
@@ -112,12 +112,8 @@ const StorageBrowserTable: React.FC<StorageBrowserTableProps> = ({
                 <SortDescending />
               ) : sortOrder === SortEnum.ASC ? (
                 <SortAscending />
-              ) : (
-                <></>
-              )
-            ) : (
-              <div></div>
-            )}
+              ) : null
+            ) : null}
           </div>
         ),
         key: `${key}`

--- a/desktop/core/src/desktop/js/reactComponents/FileChooser/api.ts
+++ b/desktop/core/src/desktop/js/reactComponents/FileChooser/api.ts
@@ -16,7 +16,7 @@
 
 import { get } from '../../api/utils';
 import { CancellablePromise } from '../../api/cancellablePromise';
-import { PathAndFileData } from './types';
+import { PathAndFileData, SortOrder } from './types';
 
 const FILESYSTEMS_API_URL = '/api/v1/storage/filesystems';
 const VIEWFILES_API_URl = '/api/v1/storage/view=';
@@ -35,14 +35,21 @@ export const fetchFiles = (
   pagenum?: number,
   filter?: string,
   sortby?: string,
-  descending?: boolean
+  sortOrder?: SortOrder
 ): CancellablePromise<PathAndFileData> => {
+  let descending = false;
+  if (sortOrder === SortOrder.ASC) {
+    descending = false;
+  } else if (sortOrder === SortOrder.DSC) {
+    descending = true;
+  } else {
+    sortby = '';
+  }
   //If value is undefined default value is assigned.
   pagesize = pagesize || 10;
   pagenum = pagenum || 1;
   filter = filter || '';
   sortby = sortby || '';
-  descending = descending || false;
   return get(
     VIEWFILES_API_URl +
       filePath +

--- a/desktop/core/src/desktop/js/reactComponents/FileChooser/types.ts
+++ b/desktop/core/src/desktop/js/reactComponents/FileChooser/types.ts
@@ -79,3 +79,9 @@ export interface PathAndFileData {
   page: PageStats;
   pagesize: number;
 }
+
+export enum SortOrder {
+  ASC = 'ascending',
+  DSC = 'descending',
+  NONE = 'none'
+}

--- a/desktop/core/src/desktop/js/reactComponents/FileChooser/types.ts
+++ b/desktop/core/src/desktop/js/reactComponents/FileChooser/types.ts
@@ -50,9 +50,9 @@ export interface StorageBrowserTableData {
   name: string;
   size: string;
   user: string;
-  groups: string;
+  group: string;
   permission: string;
-  lastUpdated: string;
+  mtime: string;
   type: string;
   path: string;
 }


### PR DESCRIPTION
[##]([url](url)) What changes were proposed in this pull request?

- Allows sorting of columns in ascending or descending order based on toggle of the column header.


https://github.com/cloudera/hue/assets/44032758/3c09d580-2761-4e6d-98a6-d0a40264bce0



## How was this patch tested?

- Manually

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
