### PR TITLE
[abfs] Fix none check for ABFSStat attributes

### DIFF
--- a/desktop/libs/azure/src/azure/abfs/abfsstats.py
+++ b/desktop/libs/azure/src/azure/abfs/abfsstats.py
@@ -33,14 +33,14 @@ class ABFSStat(object):
     self.isDir = isDir
     self.type = 'DIRECTORY' if isDir else 'FILE'
     try:
-      self.atime = abfsdatetime_to_timestamp(atime) if atime else None
-      self.mtime = abfsdatetime_to_timestamp(mtime) if mtime else None
+      self.atime = abfsdatetime_to_timestamp(atime) if atime else 0
+      self.mtime = abfsdatetime_to_timestamp(mtime) if mtime else 0
     except:
       self.atime = 0
       self.mtime = 0
     self.size = size
-    self.user = owner if owner is not None else ''
-    self.group = group
+    self.user = owner if owner else ''
+    self.group = group if group else ''
     self.mode = mode or (0o777 if isDir else 0o666)
     if self.isDir:
       self.mode |= stat.S_IFDIR

--- a/desktop/libs/azure/src/azure/abfs/abfsstats.py
+++ b/desktop/libs/azure/src/azure/abfs/abfsstats.py
@@ -39,7 +39,7 @@ class ABFSStat(object):
       self.atime = 0
       self.mtime = 0
     self.size = size
-    self.user = owner
+    self.user = owner if owner is not None else ''
     self.group = group
     self.mode = mode or (0o777 if isDir else 0o666)
     if self.isDir:


### PR DESCRIPTION
## What changes were proposed in this pull request?

- If user is set to None, it was failing a small edge case of sorting the file listing by user column with the following error:

```
Status code : 500 Internal Server Error
TypeError at /filebrowser/view=abfs://xyz
'<' not supported between instances of 'NoneType' and 'NoneType'
```

- Sorting is also failing when using the `group` and `date` column. 
- Better none check handling fixes the above issues.

## How was this patch tested?

- Manually tested