### PR TITLE
[docker] Upgrade PostgresSQL version from 11 to 13

### DIFF
--- a/tools/container/base/hue/Dockerfile
+++ b/tools/container/base/hue/Dockerfile
@@ -43,7 +43,7 @@ RUN set -eux; \
       /usr/bin/pip3.8 install supervisor \
       && curl -s https://files.pythonhosted.org/packages/45/78/4621eb7085162bc4d2252ad92af1cc5ccacbd417a50e2ee74426331aad18/psycopg2_binary-2.9.3-cp38-cp38-musllinux_1_1_x86_64.whl -o /tmp/psycopg2_binary-2.9.3-cp38-cp38-musllinux_1_1_x86_64.whl \
       && dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
-      && yum install -y postgresql11 \
+      && yum install -y postgresql13 \
       && curl -sL https://rpm.nodesource.com/setup_14.x | bash - \
         && yum install -y nodejs \
         && yum clean all -y  \


### PR DESCRIPTION
## What changes were proposed in this pull request?

RDS Postgres server 11 will be EOF soon. Upgrade PostgresSQL to version 13

## How was this patch tested?

Deployed the Canary docker build and run pg_dump/pg_restore

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
