### PR TITLE
[frontend] Implement new file and folder creation

### DIFF
--- a/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.scss
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.scss
@@ -1,0 +1,34 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+@use 'variables' as vars;
+@use 'mixins';
+
+.hue-input-modal {
+  @include mixins.hue-svg-icon__d3-conflict;
+
+  .hue-input-modal__description {
+    color: vars.$fluidx-black;
+    margin-bottom: 14px;
+  }
+
+  .hue-input-modal__input {
+    height: 32px;
+  }
+}
+
+.hue-input-modal__input-label {
+  color: vars.$fluidx-gray-700;
+}

--- a/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.scss
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.scss
@@ -25,7 +25,7 @@
   }
 
   .hue-input-modal__input {
-    height: 32px;
+    height: vars.$fluidx-spacing-l;
   }
 }
 

--- a/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.test.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.test.tsx
@@ -1,0 +1,187 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import InputModal from './InputModal';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // Deprecated
+    removeListener: jest.fn(), // Deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn()
+  }))
+});
+
+describe('InputModal', () => {
+  test('renders custom modal title', () => {
+    const inputModal = render(
+      <InputModal
+        title={'Custom title'}
+        inputLabel={'Enter File name here'}
+        submitText={'Create'}
+        showModal={true}
+        onSubmit={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+    expect(inputModal.getByText('Custom title')).toBeVisible();
+  });
+
+  test('renders custom input label', () => {
+    const inputModal = render(
+      <InputModal
+        title={'Create New File'}
+        inputLabel={'Custom input label'}
+        submitText={'Create'}
+        showModal={true}
+        onSubmit={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+    expect(inputModal.getByText('Custom input label')).toBeVisible();
+  });
+
+  test('calls onSubmit when create button is clicked', async () => {
+    const onCloseMock = jest.fn();
+    const onSubmitMock = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <InputModal
+        title={'Create New File'}
+        inputLabel={'Enter File name here'}
+        submitText={'Create'}
+        showModal={true}
+        onSubmit={onSubmitMock}
+        onClose={onCloseMock}
+      />
+    );
+    const submitButton = screen.getByRole('button', { name: 'Create' });
+
+    expect(onSubmitMock).not.toHaveBeenCalled();
+    await user.click(submitButton);
+    expect(onSubmitMock).toHaveBeenCalled();
+  });
+
+  test('calls onClose after submission when submit button is clicked', async () => {
+    const onCloseMock = jest.fn();
+    const onSubmitMock = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <InputModal
+        title={'Create New File'}
+        inputLabel={'Enter File name here'}
+        submitText={'Create'}
+        showModal={true}
+        onSubmit={onSubmitMock}
+        onClose={onCloseMock}
+      />
+    );
+    const submitButton = screen.getByRole('button', { name: 'Create' });
+
+    await user.click(submitButton);
+    expect(onSubmitMock).toHaveBeenCalled();
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+
+  test('calls onClose when close button is clicked', async () => {
+    const onCloseMock = jest.fn();
+    const onSubmitMock = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <InputModal
+        title={'Create New File'}
+        inputLabel={'Enter File name here'}
+        submitText={'Create'}
+        showModal={true}
+        onSubmit={onSubmitMock}
+        onClose={onCloseMock}
+      />
+    );
+    const closeButton = screen.getByRole('button', { name: 'Cancel' });
+
+    expect(onCloseMock).not.toHaveBeenCalled();
+    await user.click(closeButton);
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+
+  test('renders modal with input visible', () => {
+    render(
+      <InputModal
+        title={'Create New File'}
+        inputLabel={'Custom input label'}
+        submitText={'Create'}
+        showModal={true}
+        onSubmit={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveClass('hue-input-modal__input');
+    expect(input).toBeVisible();
+  });
+
+  test('renders modal with empty input value', () => {
+    render(
+      <InputModal
+        title={'Create New File'}
+        inputLabel={'Custom input label'}
+        submitText={'Create'}
+        showModal={true}
+        onSubmit={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+    expect(screen.getByRole('textbox')).toHaveValue('');
+  });
+
+  test('accepts tab focus on input elements placed in the drawer', async () => {
+    const user = userEvent.setup();
+    render(
+      <InputModal
+        title={'Create New File'}
+        inputLabel={'Custom input label'}
+        submitText={'Create'}
+        showModal={true}
+        onSubmit={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+    const inputModal = screen.getByRole('dialog', { name: 'Create New File' });
+    const closeIconButton = within(inputModal).getByRole('button', { name: 'Close' });
+    const inputTextBox = within(inputModal).getByRole('textbox');
+    const submitButton = within(inputModal).getByRole('button', { name: 'Create' });
+    const cancelButton = within(inputModal).getByRole('button', { name: 'Cancel' });
+
+    await user.tab();
+    expect(closeIconButton).toHaveFocus();
+    await user.tab();
+    expect(inputTextBox).toHaveFocus();
+    await user.tab();
+    expect(submitButton).toHaveFocus();
+    await user.tab();
+    expect(cancelButton).toHaveFocus();
+  });
+});

--- a/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.tsx
@@ -22,41 +22,41 @@ import './InputModal.scss';
 interface InputModalProps {
   cancelText?: string;
   inputLabel: string;
-  okText?: string;
+  submitText?: string;
   onClose: () => void;
-  onCreate: (name: string) => void;
+  onCreate: (value: string) => void;
   showModal: boolean;
   title: string;
 }
 
 const defaultProps = {
   cancelText: 'Cancel',
-  okText: 'Submit'
+  submitText: 'Submit'
 };
 
 const InputModal: React.FC<InputModalProps> = ({
   cancelText,
   inputLabel,
-  okText,
+  submitText,
   onClose,
   onCreate,
   showModal,
   title
 }): JSX.Element => {
-  const [textInput, setTextInput] = useState<string>('');
+  const [value, setValue] = useState<string>('');
 
   return (
     <Modal
       cancelText={cancelText}
       className="hue-input-modal"
-      okText={okText}
+      okText={submitText}
       onCancel={() => {
-        setTextInput('');
+        setValue('');
         onClose();
       }}
       onOk={() => {
-        onCreate(textInput);
-        setTextInput('');
+        onCreate(value);
+        setValue('');
         onClose();
       }}
       open={showModal}
@@ -65,9 +65,9 @@ const InputModal: React.FC<InputModalProps> = ({
       <div className="hue-input-modal__input-label">{inputLabel}</div>
       <Input
         className="hue-input-modal__input"
-        value={textInput}
+        value={value}
         onInput={e => {
-          setTextInput((e.target as HTMLInputElement).value);
+          setValue((e.target as HTMLInputElement).value);
         }}
       />
     </Modal>

--- a/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.tsx
@@ -42,7 +42,7 @@ const InputModal: React.FC<InputModalProps> = ({
 }): JSX.Element => {
   const [value, setValue] = useState<string>('');
   const { t } = i18nReact.useTranslation();
-  const { cancelText = t('Close'), submitText = t('Submit') } = i18n;
+  const { cancelText = t('Cancel'), submitText = t('Submit') } = i18n;
 
   return (
     <Modal

--- a/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.tsx
@@ -22,9 +22,7 @@ import './InputModal.scss';
 
 interface InputModalProps {
   cancelText?: string;
-  description: string;
   inputLabel: string;
-  inputPlaceholder?: string;
   okText?: string;
   onClose: () => void;
   onCreate: (name: string) => void;
@@ -34,15 +32,12 @@ interface InputModalProps {
 
 const defaultProps = {
   cancelText: 'Cancel',
-  inputPlaceholder: 'Enter text here',
   okText: 'Submit'
 };
 
 const InputModal: React.FC<InputModalProps> = ({
   cancelText,
-  description,
   inputLabel,
-  inputPlaceholder,
   okText,
   onClose,
   onCreate,
@@ -69,7 +64,6 @@ const InputModal: React.FC<InputModalProps> = ({
       open={showModal}
       title={t(title)}
     >
-      <div className="hue-input-modal__description">{t(description)}</div>
       <div className="hue-input-modal__input-label">{t(inputLabel)}</div>
       <Input
         className="hue-input-modal__input"
@@ -77,7 +71,6 @@ const InputModal: React.FC<InputModalProps> = ({
         onInput={e => {
           setTextInput((e.target as HTMLInputElement).value);
         }}
-        placeholder={t(inputPlaceholder)}
       />
     </Modal>
   );

--- a/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.tsx
@@ -1,0 +1,81 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import React, { useRef } from 'react';
+import Modal from 'cuix/dist/components/Modal';
+import { Input, InputRef } from 'antd';
+import { i18nReact } from '../../../utils/i18nReact';
+
+import './InputModal.scss';
+
+interface InputModalProps {
+  cancelText?: string;
+  description: string;
+  inputLabel: string;
+  inputPlaceholder?: string;
+  okText?: string;
+  onCancel: () => void;
+  onOk: (name: string) => void;
+  showModal: boolean;
+  title: string;
+}
+
+const defaultProps = {
+  cancelText: 'Cancel',
+  inputPlaceholder: 'Enter text here',
+  okText: 'Submit'
+};
+
+const InputModal: React.FC<InputModalProps> = ({
+  cancelText,
+  description,
+  inputLabel,
+  inputPlaceholder,
+  okText,
+  onCancel,
+  onOk,
+  showModal,
+  title
+}): JSX.Element => {
+  const { t } = i18nReact.useTranslation();
+  const textInput = useRef<InputRef>(null);
+
+  const extractText = (): string => {
+    let nameText: string;
+    if (textInput.current !== null) {
+      nameText = textInput.current.input.value;
+    }
+    return nameText;
+  };
+
+  return (
+    <Modal
+      cancelText={t(cancelText)}
+      className="hue-input-modal"
+      okText={t(okText)}
+      onCancel={onCancel}
+      onOk={() => onOk(extractText())}
+      open={showModal}
+      title={t(title)}
+    >
+      <div className="hue-input-modal__description">{t(description)}</div>
+      <div className="hue-input-modal__input-label">{t(inputLabel)}</div>
+      <Input className="hue-input-modal__input" ref={textInput} placeholder={t(inputPlaceholder)} />
+    </Modal>
+  );
+};
+
+InputModal.defaultProps = defaultProps;
+export default InputModal;

--- a/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.tsx
@@ -17,33 +17,32 @@ import React, { useState } from 'react';
 import Modal from 'cuix/dist/components/Modal';
 import { Input } from 'antd';
 
+import { i18nReact } from '../../../utils/i18nReact';
+
 import './InputModal.scss';
 
+//TODO: Add unit tests
 interface InputModalProps {
   cancelText?: string;
   inputLabel: string;
   submitText?: string;
   onClose: () => void;
-  onCreate: (value: string) => void;
+  onSubmit: (value: string) => void;
   showModal: boolean;
   title: string;
 }
 
-const defaultProps = {
-  cancelText: 'Cancel',
-  submitText: 'Submit'
-};
-
 const InputModal: React.FC<InputModalProps> = ({
-  cancelText,
   inputLabel,
-  submitText,
   onClose,
-  onCreate,
+  onSubmit,
   showModal,
-  title
+  title,
+  ...i18n
 }): JSX.Element => {
   const [value, setValue] = useState<string>('');
+  const { t } = i18nReact.useTranslation();
+  const { cancelText = t('Close'), submitText = t('Submit') } = i18n;
 
   return (
     <Modal
@@ -55,7 +54,7 @@ const InputModal: React.FC<InputModalProps> = ({
         onClose();
       }}
       onOk={() => {
-        onCreate(value);
+        onSubmit(value);
         setValue('');
         onClose();
       }}
@@ -74,5 +73,4 @@ const InputModal: React.FC<InputModalProps> = ({
   );
 };
 
-InputModal.defaultProps = defaultProps;
 export default InputModal;

--- a/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.tsx
@@ -13,9 +13,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import React, { useRef } from 'react';
+import React, { useState } from 'react';
 import Modal from 'cuix/dist/components/Modal';
-import { Input, InputRef } from 'antd';
+import { Input } from 'antd';
 import { i18nReact } from '../../../utils/i18nReact';
 
 import './InputModal.scss';
@@ -26,8 +26,8 @@ interface InputModalProps {
   inputLabel: string;
   inputPlaceholder?: string;
   okText?: string;
-  onCancel: () => void;
-  onOk: (name: string) => void;
+  onClose: () => void;
+  onCreate: (name: string) => void;
   showModal: boolean;
   title: string;
 }
@@ -44,35 +44,41 @@ const InputModal: React.FC<InputModalProps> = ({
   inputLabel,
   inputPlaceholder,
   okText,
-  onCancel,
-  onOk,
+  onClose,
+  onCreate,
   showModal,
   title
 }): JSX.Element => {
   const { t } = i18nReact.useTranslation();
-  const textInput = useRef<InputRef>(null);
-
-  const extractText = (): string => {
-    let nameText: string;
-    if (textInput.current !== null) {
-      nameText = textInput.current.input.value;
-    }
-    return nameText;
-  };
+  const [textInput, setTextInput] = useState<string>('');
 
   return (
     <Modal
       cancelText={t(cancelText)}
       className="hue-input-modal"
       okText={t(okText)}
-      onCancel={onCancel}
-      onOk={() => onOk(extractText())}
+      onCancel={() => {
+        setTextInput('');
+        onClose();
+      }}
+      onOk={() => {
+        onCreate(textInput);
+        setTextInput('');
+        onClose();
+      }}
       open={showModal}
       title={t(title)}
     >
       <div className="hue-input-modal__description">{t(description)}</div>
       <div className="hue-input-modal__input-label">{t(inputLabel)}</div>
-      <Input className="hue-input-modal__input" ref={textInput} placeholder={t(inputPlaceholder)} />
+      <Input
+        className="hue-input-modal__input"
+        value={textInput}
+        onInput={e => {
+          setTextInput((e.target as HTMLInputElement).value);
+        }}
+        placeholder={t(inputPlaceholder)}
+      />
     </Modal>
   );
 };

--- a/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/InputModal/InputModal.tsx
@@ -16,7 +16,6 @@
 import React, { useState } from 'react';
 import Modal from 'cuix/dist/components/Modal';
 import { Input } from 'antd';
-import { i18nReact } from '../../../utils/i18nReact';
 
 import './InputModal.scss';
 
@@ -44,14 +43,13 @@ const InputModal: React.FC<InputModalProps> = ({
   showModal,
   title
 }): JSX.Element => {
-  const { t } = i18nReact.useTranslation();
   const [textInput, setTextInput] = useState<string>('');
 
   return (
     <Modal
-      cancelText={t(cancelText)}
+      cancelText={cancelText}
       className="hue-input-modal"
-      okText={t(okText)}
+      okText={okText}
       onCancel={() => {
         setTextInput('');
         onClose();
@@ -62,9 +60,9 @@ const InputModal: React.FC<InputModalProps> = ({
         onClose();
       }}
       open={showModal}
-      title={t(title)}
+      title={title}
     >
-      <div className="hue-input-modal__input-label">{t(inputLabel)}</div>
+      <div className="hue-input-modal__input-label">{inputLabel}</div>
       <Input
         className="hue-input-modal__input"
         value={textInput}

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
@@ -252,20 +252,20 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
           sortOrder={sortOrder}
         />
         <InputModal
-          title={'Create New Folder'}
-          inputLabel={'Enter folder name here'}
-          okText={'Create'}
+          title={t('Create New Folder')}
+          inputLabel={t('Enter folder name here')}
+          okText={t('Create')}
           showModal={showNewFolderModal}
           onCreate={handleCreateNewFolder}
-          onClose={() => setShowNewFolderModal(!showNewFolderModal)}
+          onClose={() => setShowNewFolderModal(false)}
         />
         <InputModal
-          title={'Create New File'}
-          inputLabel={'Enter file name here'}
-          okText={'Create'}
+          title={t('Create New File')}
+          inputLabel={t('Enter file name here')}
+          okText={t('Create')}
           showModal={showNewFileModal}
           onCreate={handleCreateNewFile}
-          onClose={() => setShowNewFileModal(!showNewFileModal)}
+          onClose={() => setShowNewFileModal(false)}
         />
       </div>
     </Spin>

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
@@ -32,8 +32,9 @@ import PlusCircleIcon from '@cloudera/cuix-core/icons/react/PlusCircleIcon';
 import { FileOutlined } from '@ant-design/icons';
 
 import PathBrowser from '../../../../reactComponents/FileChooser/PathBrowser/PathBrowser';
+import InputModal from '../../InputModal/InputModal';
 import StorageBrowserTable from '../StorageBrowserTable/StorageBrowserTable';
-import { fetchFiles } from '../../../../reactComponents/FileChooser/api';
+import { fetchFiles, mkdir } from '../../../../reactComponents/FileChooser/api';
 import {
   PathAndFileData,
   StorageBrowserTableData,
@@ -67,6 +68,8 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
   const [sortOrder, setSortOrder] = useState<SortOrder>(SortOrder.NONE);
   //TODO: Add filter functionality
   const [filterData] = useState<string>('');
+  const [showNewFolderModal, setShowNewFolderModal] = useState<boolean>();
+  const [refreshKey, setRefreshKey] = useState<number>(0);
 
   const { t } = i18nReact.useTranslation();
 
@@ -84,7 +87,10 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
         {
           icon: <FolderIcon />,
           key: 'new_folder',
-          label: t('New Folder')
+          label: t('New Folder'),
+          onClick: () => {
+            setShowNewFolderModal(true);
+          }
         }
       ]
     },
@@ -95,18 +101,8 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
       children: [
         {
           icon: <ImportIcon />,
-          key: 'upload_file',
-          label: t('File')
-        },
-        {
-          icon: <ImportIcon />,
-          key: 'upload_folder',
-          label: t('Folder')
-        },
-        {
-          icon: <ImportIcon />,
-          key: 'upload_zip',
-          label: t('Zip Folder')
+          key: 'upload',
+          label: t('New Upload')
         }
       ]
     }
@@ -135,6 +131,18 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
     }
   ];
 
+  //TODO:Add loading after calling mkdir api
+  const handleCreateNewFolder = (folderName: string) => {
+    mkdir(folderName, filePath)
+      .then(() => {
+        setRefreshKey(oldKey => oldKey + 1);
+      })
+      .catch(error => {
+        // eslint-disable-next-line no-restricted-syntax
+        console.log(error);
+      });
+  };
+
   useEffect(() => {
     setloadingFiles(true);
     fetchFiles(filePath, pageSize, pageNumber, filterData, sortByColumn, sortOrder)
@@ -161,7 +169,7 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
       .finally(() => {
         setloadingFiles(false);
       });
-  }, [filePath, pageSize, pageNumber, sortByColumn, sortOrder]);
+  }, [filePath, pageSize, pageNumber, sortByColumn, sortOrder, refreshKey]);
 
   return (
     <Spin spinning={loadingFiles}>
@@ -226,7 +234,16 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
           onSortOrderChange={setSortOrder}
           sortByColumn={sortByColumn}
           sortOrder={sortOrder}
-        ></StorageBrowserTable>
+        />
+        <InputModal
+          title={'Create New Folder'}
+          description={'You can add a new folder to your storage browser'}
+          inputLabel={'Enter folder name here'}
+          okText={'Create'}
+          showModal={showNewFolderModal}
+          onCreate={handleCreateNewFolder}
+          onClose={() => setShowNewFolderModal(!showNewFolderModal)}
+        />
       </div>
     </Spin>
   );

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
@@ -253,7 +253,6 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
         />
         <InputModal
           title={'Create New Folder'}
-          description={'You can add a new folder to your storage browser'}
           inputLabel={'Enter folder name here'}
           okText={'Create'}
           showModal={showNewFolderModal}
@@ -262,7 +261,6 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
         />
         <InputModal
           title={'Create New File'}
-          description={'You can add a new file to your storage browser'}
           inputLabel={'Enter file name here'}
           okText={'Create'}
           showModal={showNewFileModal}

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
@@ -34,7 +34,7 @@ import { FileOutlined } from '@ant-design/icons';
 import PathBrowser from '../../../../reactComponents/FileChooser/PathBrowser/PathBrowser';
 import InputModal from '../../InputModal/InputModal';
 import StorageBrowserTable from '../StorageBrowserTable/StorageBrowserTable';
-import { fetchFiles, mkdir } from '../../../../reactComponents/FileChooser/api';
+import { fetchFiles, mkdir, touch } from '../../../../reactComponents/FileChooser/api';
 import {
   PathAndFileData,
   StorageBrowserTableData,
@@ -69,6 +69,7 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
   //TODO: Add filter functionality
   const [filterData] = useState<string>('');
   const [showNewFolderModal, setShowNewFolderModal] = useState<boolean>();
+  const [showNewFileModal, setShowNewFileModal] = useState<boolean>();
   const [refreshKey, setRefreshKey] = useState<number>(0);
 
   const { t } = i18nReact.useTranslation();
@@ -82,7 +83,10 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
         {
           icon: <FileOutlined />,
           key: 'new_file',
-          label: t('New File')
+          label: t('New File'),
+          onClick: () => {
+            setShowNewFileModal(true);
+          }
         },
         {
           icon: <FolderIcon />,
@@ -131,9 +135,21 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
     }
   ];
 
-  //TODO:Add loading after calling mkdir api
   const handleCreateNewFolder = (folderName: string) => {
+    setloadingFiles(true);
     mkdir(folderName, filePath)
+      .then(() => {
+        setRefreshKey(oldKey => oldKey + 1);
+      })
+      .catch(error => {
+        // eslint-disable-next-line no-restricted-syntax
+        console.log(error);
+      });
+  };
+
+  const handleCreateNewFile = (fileName: string) => {
+    setloadingFiles(true);
+    touch(fileName, filePath)
       .then(() => {
         setRefreshKey(oldKey => oldKey + 1);
       })
@@ -243,6 +259,15 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
           showModal={showNewFolderModal}
           onCreate={handleCreateNewFolder}
           onClose={() => setShowNewFolderModal(!showNewFolderModal)}
+        />
+        <InputModal
+          title={'Create New File'}
+          description={'You can add a new file to your storage browser'}
+          inputLabel={'Enter file name here'}
+          okText={'Create'}
+          showModal={showNewFileModal}
+          onCreate={handleCreateNewFile}
+          onClose={() => setShowNewFileModal(!showNewFileModal)}
         />
       </div>
     </Spin>

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
@@ -68,8 +68,8 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
   const [sortOrder, setSortOrder] = useState<SortOrder>(SortOrder.NONE);
   //TODO: Add filter functionality
   const [filterData] = useState<string>('');
-  const [showNewFolderModal, setShowNewFolderModal] = useState<boolean>();
-  const [showNewFileModal, setShowNewFileModal] = useState<boolean>();
+  const [showNewFolderModal, setShowNewFolderModal] = useState<boolean>(false);
+  const [showNewFileModal, setShowNewFileModal] = useState<boolean>(false);
   const [refreshKey, setRefreshKey] = useState<number>(0);
 
   const { t } = i18nReact.useTranslation();
@@ -260,17 +260,17 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
         <InputModal
           title={t('Create New Folder')}
           inputLabel={t('Enter Folder name here')}
-          okText={t('Create')}
+          submitText={t('Create')}
           showModal={showNewFolderModal}
-          onCreate={handleCreateNewFolder}
+          onSubmit={handleCreateNewFolder}
           onClose={() => setShowNewFolderModal(false)}
         />
         <InputModal
           title={t('Create New File')}
           inputLabel={t('Enter File name here')}
-          okText={t('Create')}
+          submitText={t('Create')}
           showModal={showNewFileModal}
-          onCreate={handleCreateNewFile}
+          onSubmit={handleCreateNewFile}
           onClose={() => setShowNewFileModal(false)}
         />
       </div>

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
@@ -60,7 +60,7 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
   const [filePath, setFilePath] = useState<string>(user_home_dir);
   const [filesData, setFilesData] = useState<PathAndFileData>();
   const [files, setFiles] = useState<StorageBrowserTableData[]>();
-  const [loadingFiles, setloadingFiles] = useState(true);
+  const [loadingFiles, setLoadingFiles] = useState(true);
   const [pageStats, setPageStats] = useState<PageStats>();
   const [pageSize, setPageSize] = useState<number>(0);
   const [pageNumber, setPageNumber] = useState<number>(1);
@@ -136,7 +136,7 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
   ];
 
   const handleCreateNewFolder = (folderName: string) => {
-    setloadingFiles(true);
+    setLoadingFiles(true);
     mkdir(folderName, filePath)
       .then(() => {
         setRefreshKey(oldKey => oldKey + 1);
@@ -144,11 +144,14 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
       .catch(error => {
         // eslint-disable-next-line no-restricted-syntax
         console.log(error);
+      })
+      .finally(() => {
+        setLoadingFiles(false);
       });
   };
 
   const handleCreateNewFile = (fileName: string) => {
-    setloadingFiles(true);
+    setLoadingFiles(true);
     touch(fileName, filePath)
       .then(() => {
         setRefreshKey(oldKey => oldKey + 1);
@@ -156,11 +159,14 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
       .catch(error => {
         // eslint-disable-next-line no-restricted-syntax
         console.log(error);
+      })
+      .finally(() => {
+        setLoadingFiles(false);
       });
   };
 
   useEffect(() => {
-    setloadingFiles(true);
+    setLoadingFiles(true);
     fetchFiles(filePath, pageSize, pageNumber, filterData, sortByColumn, sortOrder)
       .then(responseFilesData => {
         setFilesData(responseFilesData);
@@ -183,7 +189,7 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
         console.error(error);
       })
       .finally(() => {
-        setloadingFiles(false);
+        setLoadingFiles(false);
       });
   }, [filePath, pageSize, pageNumber, sortByColumn, sortOrder, refreshKey]);
 
@@ -253,7 +259,7 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
         />
         <InputModal
           title={t('Create New Folder')}
-          inputLabel={t('Enter folder name here')}
+          inputLabel={t('Enter Folder name here')}
           okText={t('Create')}
           showModal={showNewFolderModal}
           onCreate={handleCreateNewFolder}
@@ -261,7 +267,7 @@ const StorageBrowserTabContent: React.FC<StorageBrowserTabContentProps> = ({
         />
         <InputModal
           title={t('Create New File')}
-          inputLabel={t('Enter file name here')}
+          inputLabel={t('Enter File name here')}
           okText={t('Create')}
           showModal={showNewFileModal}
           onCreate={handleCreateNewFile}

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.tsx
@@ -138,6 +138,7 @@ const StorageBrowserTable: React.FC<StorageBrowserTableProps> = ({
       onClick: () => {
         if (record.type === 'dir') {
           onFilepathChange(record.path);
+          onPageNumberChange(1);
         }
         //TODO: handle onclick file
       }

--- a/desktop/core/src/desktop/js/reactComponents/FileChooser/api.ts
+++ b/desktop/core/src/desktop/js/reactComponents/FileChooser/api.ts
@@ -13,13 +13,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+import axios, { AxiosResponse } from 'axios';
 import { get } from '../../api/utils';
 import { CancellablePromise } from '../../api/cancellablePromise';
 import { PathAndFileData, SortOrder } from './types';
 
 const FILESYSTEMS_API_URL = '/api/v1/storage/filesystems';
 const VIEWFILES_API_URl = '/api/v1/storage/view=';
+const MAKE_DIRECTORY_API_URL = '/api/v1/storage/mkdir';
 
 export interface ApiFileSystem {
   file_system: string;
@@ -64,4 +65,12 @@ export const fetchFiles = (
       '&descending=' +
       descending
   );
+};
+
+export const mkdir = async (folderName: string, path: string): Promise<AxiosResponse> => {
+  const createDirFormData = new FormData();
+  createDirFormData.append('name', folderName);
+  createDirFormData.append('path', path);
+  const response = await axios.post(MAKE_DIRECTORY_API_URL, createDirFormData);
+  return response;
 };

--- a/desktop/core/src/desktop/js/reactComponents/FileChooser/api.ts
+++ b/desktop/core/src/desktop/js/reactComponents/FileChooser/api.ts
@@ -21,6 +21,7 @@ import { PathAndFileData, SortOrder } from './types';
 const FILESYSTEMS_API_URL = '/api/v1/storage/filesystems';
 const VIEWFILES_API_URl = '/api/v1/storage/view=';
 const MAKE_DIRECTORY_API_URL = '/api/v1/storage/mkdir';
+const TOUCH_API_URL = '/api/v1/storage/touch';
 
 export interface ApiFileSystem {
   file_system: string;
@@ -72,5 +73,13 @@ export const mkdir = async (folderName: string, path: string): Promise<AxiosResp
   createDirFormData.append('name', folderName);
   createDirFormData.append('path', path);
   const response = await axios.post(MAKE_DIRECTORY_API_URL, createDirFormData);
+  return response;
+};
+
+export const touch = async (fileName: string, path: string): Promise<AxiosResponse> => {
+  const touchFormData = new FormData();
+  touchFormData.append('name', fileName);
+  touchFormData.append('path', path);
+  const response = await axios.post(TOUCH_API_URL, touchFormData);
   return response;
 };

--- a/desktop/core/src/desktop/js/reactComponents/FileChooser/api.ts
+++ b/desktop/core/src/desktop/js/reactComponents/FileChooser/api.ts
@@ -13,8 +13,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import axios, { AxiosResponse } from 'axios';
-import { get } from '../../api/utils';
+import { get, post } from '../../api/utils';
 import { CancellablePromise } from '../../api/cancellablePromise';
 import { PathAndFileData, SortOrder } from './types';
 
@@ -68,18 +67,10 @@ export const fetchFiles = (
   );
 };
 
-export const mkdir = async (folderName: string, path: string): Promise<AxiosResponse> => {
-  const createDirFormData = new FormData();
-  createDirFormData.append('name', folderName);
-  createDirFormData.append('path', path);
-  const response = await axios.post(MAKE_DIRECTORY_API_URL, createDirFormData);
-  return response;
+export const mkdir = async (folderName: string, path: string): Promise<void> => {
+  await post(MAKE_DIRECTORY_API_URL, { name: folderName, path: path });
 };
 
-export const touch = async (fileName: string, path: string): Promise<AxiosResponse> => {
-  const touchFormData = new FormData();
-  touchFormData.append('name', fileName);
-  touchFormData.append('path', path);
-  const response = await axios.post(TOUCH_API_URL, touchFormData);
-  return response;
+export const touch = async (fileName: string, path: string): Promise<void> => {
+  await post(TOUCH_API_URL, { name: fileName, path: path });
 };


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Implements create New file or folder modal 
- Allows new file or folder to be created
- Create new modal can be reused for creation of new buckets, renaming files and folders 

![Screenshot 2024-02-05 at 9 57 13 PM](https://github.com/cloudera/hue/assets/44032758/9b7a915e-f835-46ad-809e-00348ee8208a)

## How was this patch tested?

Manually


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
