### PR TITLE
Check csrf to see if it has value before setting it up

### DIFF
--- a/apps/beeswax/gen-py/TCLIService/TCLIService.py
+++ b/apps/beeswax/gen-py/TCLIService/TCLIService.py
@@ -224,15 +224,16 @@ def add_xff_header(func):
       configuration = args[1].__dict__['configuration']
     if configuration is not None and 'X-Forwarded-For' in configuration:
         xff = configuration.get('X-Forwarded-For')
-    try:
-        if hasattr(self._oprot.trans, 'TFramedTransport'):
-          trans_client = self._oprot.trans._TFramedTransport__trans
-        else:
-          trans_client = self._oprot.trans._TBufferedTransport__trans
+    if xff:
+      try:
+          if hasattr(self._oprot.trans, 'TFramedTransport'):
+            trans_client = self._oprot.trans._TFramedTransport__trans
+          else:
+            trans_client = self._oprot.trans._TBufferedTransport__trans
 
-        trans_client.setCustomHeaders({'X-Forwarded-For': xff})
-    except AttributeError as e:
-        LOG.error('Could not set HTTP-X-FORWARDED-FOR header: %s' % smart_str(e))
+          trans_client.setCustomHeaders({'X-Forwarded-For': xff})
+      except AttributeError as e:
+          LOG.error('Could not set HTTP-X-FORWARDED-FOR header: %s' % smart_str(e))
 
     return func(*args, **kwargs)
   return wraps(func)(decorate)
@@ -246,15 +247,16 @@ def add_csrf_header(func):
       configuration = args[1].__dict__['configuration']
     if configuration is not None and 'X-CSRF-TOKEN' in configuration:
         csrf = configuration.get('X-CSRF-TOKEN')
-    try:
-        if hasattr(self._oprot.trans, 'TFramedTransport'):
-          trans_client = self._oprot.trans._TFramedTransport__trans
-        else:
-          trans_client = self._oprot.trans._TBufferedTransport__trans
+    if csrf:
+      try:
+          if hasattr(self._oprot.trans, 'TFramedTransport'):
+            trans_client = self._oprot.trans._TFramedTransport__trans
+          else:
+            trans_client = self._oprot.trans._TBufferedTransport__trans
 
-        trans_client.setCustomHeaders({'X-CSRF-TOKEN': csrf})
-    except AttributeError as e:
-        LOG.error('Could not set CSRF header: %s' % smart_str(e))
+          trans_client.setCustomHeaders({'X-CSRF-TOKEN': csrf})
+      except AttributeError as e:
+          LOG.error('Could not set CSRF header: %s' % smart_str(e))
 
     return func(*args, **kwargs)
   return wraps(func)(decorate)


### PR DESCRIPTION
Internal Jira: CDPD-65034

Seeing the exception:
thrift_util  ERROR    Thrift saw exception (this may be expected).
Traceback (most recent call last):
  File “/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p0.44702451/lib/hue/desktop/core/src/desktop/lib/thrift_util.py”, line 522, in wrapper
    ret = res(*args, **kwargs)
  File “/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p0.44702451/lib/hue/apps/beeswax/gen-py/TCLIService/TCLIService.py”, line 255, in decorate
    trans_client.setCustomHeaders({‘X-CSRF-TOKEN’: csrf})
TypeError: ‘NoneType’ object is not callable

and

  File “/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p0.44702451/lib/hue/desktop/core/src/desktop/lib/thrift_util.py”, line 522, in wrapper
    ret = res(*args, **kwargs)
  File “/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p0.44702451/lib/hue/apps/beeswax/gen-py/TCLIService/TCLIService.py”, line 233, in decorate
    trans_client.setCustomHeaders({‘X-Forwarded-For’: xff})
TypeError: ‘NoneType’ object is not callable

## What changes were proposed in this pull request?

Check if empty for xff and csrf before setting up the value

## How was this patch tested?

Manual test with Sreenath.
