### PR TITLE
[jdbc] Remove Py2 syntax

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/jdbc.py
+++ b/desktop/libs/notebook/src/notebook/connectors/jdbc.py
@@ -24,11 +24,7 @@ from desktop.lib.i18n import force_unicode, smart_str
 from librdbms.jdbc import Jdbc, query_and_fetch
 
 from notebook.connectors.base import Api, QueryError, AuthenticationRequired, _get_snippet_name
-
-if sys.version_info[0] > 2:
-  from django.utils.translation import gettext as _
-else:
-  from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 LOG = logging.getLogger()
 
@@ -45,10 +41,7 @@ def query_error_handler(func):
     except Exception as e:
       message = force_unicode(smart_str(e))
       if 'error occurred while trying to connect to the Java server' in message:
-        if sys.version_info[0] > 2:
-          raise QueryError(_('%s: is the DB Proxy server running?') % message).with_traceback(sys.exc_info()[2])
-        else:
-          raise QueryError, _('%s: is the DB Proxy server running?') % message, sys.exc_info()[2]
+        raise QueryError(_('%s: is the DB Proxy server running?') % message).with_traceback(sys.exc_info()[2])
       elif 'Access denied' in message:
         raise AuthenticationRequired('').with_traceback(sys.exc_info()[2])
       else:


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Remove py2 excepton syntax and import section. It was breaking JDBC code on py3 env.

## How was this patch tested?

- Manually tested