### PR TITLE
[build] Update latest MySQL RPM for CentOS 7

### DIFF
--- a/tools/cloudera/build_hue_common.sh
+++ b/tools/cloudera/build_hue_common.sh
@@ -225,8 +225,8 @@ function centos7_install() {
       xmlsec1-openssl \
       unzip'
     # MySQLdb install
-    sudo -- sh -c 'curl -sSLO https://dev.mysql.com/get/mysql80-community-release-el7-5.noarch.rpm && \
-        rpm -ivh mysql80-community-release-el7-5.noarch.rpm && \
+    sudo -- sh -c 'curl -sSLO https://dev.mysql.com/get/mysql80-community-release-el7-11.noarch.rpm && \
+        rpm -ivh mysql80-community-release-el7-11.noarch.rpm && \
         yum install -y mysql-community-libs mysql-community-client-plugins mysql-community-common'
     # NODEJS 14 install
     sudo -- sh -c 'yum install -y rh-nodejs14-nodejs'


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Update latest MySQL RPM for CentOS 7 because old RPM installation failed with GPG key

## How was this patch tested?

Manual repro with old PRM and tested with new RPM

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
