### PR TITLE
[ci] Remove old py2 docker image based py3.8 CircleCI check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,21 +19,13 @@ commands:
       - run:
           name: compile
           command: |
-
-            if [ -d /usr/share/hue ]; then
-              # Running in gethue/hue Docker container
-              apt-get update
-              apt-get install -y python3.8-dev python3.8-venv python3.8-distutils libsnappy-dev # This should not be needed as some point
-              curl -sL https://bootstrap.pypa.io/get-pip.py | python3.8
-            else
-              sudo ln -fs /usr/share/zoneinfo/UTC /etc/localtime
-              export DEBIAN_FRONTEND=noninteractive
-              sudo apt-get update
-              sudo apt-get install -y gcc g++ build-essential python3.8-dev python3.8-venv python3.8-distutils asciidoc rsync curl libkrb5-dev libldap2-dev libsasl2-dev libxml2-dev libxslt-dev  libsasl2-modules-gssapi-mit libsnappy-dev libffi-dev
-              curl -sL https://deb.nodesource.com/setup_14.x | sudo bash - && sudo apt-get install -y nodejs
-              curl -sL https://bootstrap.pypa.io/get-pip.py | sudo python3.8
-              sudo apt-get install -y libncursesw5-dev libgdbm-dev libc6-dev libssl-dev openssl
-            fi
+            sudo ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+            export DEBIAN_FRONTEND=noninteractive
+            sudo apt-get update
+            sudo apt-get install -y gcc g++ build-essential python3.8-dev python3.8-venv python3.8-distutils asciidoc rsync curl libkrb5-dev libldap2-dev libsasl2-dev libxml2-dev libxslt-dev  libsasl2-modules-gssapi-mit libsnappy-dev libffi-dev
+            curl -sL https://deb.nodesource.com/setup_14.x | sudo bash - && sudo apt-get install -y nodejs
+            curl -sL https://bootstrap.pypa.io/get-pip.py | sudo python3.8
+            sudo apt-get install -y libncursesw5-dev libgdbm-dev libc6-dev libssl-dev openssl
 
             export PYTHON_VER=python3.8
             export ROOT=$PWD
@@ -76,17 +68,6 @@ commands:
 
 
 jobs:
-  build-py-38:
-    docker:
-      - image: gethue/hue:latest-py2 # Should be circleci/python:3.6 at some point
-
-    working_directory: ~/repo
-
-    steps:
-      - build-py-38-common:
-          go_arch: "amd64"
-          hugo_arch: "64bit"
-
   build-py-38-arm64:
     machine:
       image: ubuntu-2004:2023.07.1
@@ -103,11 +84,6 @@ workflows:
   version: 2
   build-python3:
     jobs:
-      - build-py-38:
-          filters:
-            branches:
-              ignore:
-                - master
       - build-py-38-arm64:
           filters:
             branches:


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Remove old py3.8 CircleCI check which is based on py2 docker image.
