### PR TITLE
[ci] Run frontend CI for all PRs

### DIFF
--- a/.github/workflows/commitflow-frontend.yml
+++ b/.github/workflows/commitflow-frontend.yml
@@ -7,16 +7,6 @@ on:
   pull_request:
     branches:
     - master
-    paths:
-      - '**.js'
-      - '**.jsx'
-      - '**.ts'
-      - '**.tsx'
-      - '**.less'
-      - '**.scss'
-      - '**.vue'
-      - 'package*.json'
-      - '**commitflow-frontend.yml'
 
 jobs:
   build:


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Remove file extension restriction for frontend CI
- This is run the Ci check for all PR including backend specific PRs. Reason to go with this is to make frontend CI check as required so that its not skipped even for frontend focused PRs.
