### PR TITLE
[frontend] added 'hue' to metastore url prefix when running Knox

### DIFF
--- a/desktop/core/src/desktop/js/apps/tableBrowser/metastoreViewModel.js
+++ b/desktop/core/src/desktop/js/apps/tableBrowser/metastoreViewModel.js
@@ -181,10 +181,9 @@ class MetastoreViewModel {
     });
 
     huePubSub.subscribe('metastore.url.change', () => {
-      const prefix =
-        window.HUE_BASE_URL && window.HUE_BASE_URL.length
-          ? window.HUE_BASE_URL + '/metastore/'
-          : '/hue/metastore/';
+      const possibleKnoxUrlPathPrefix = window.HUE_BASE_URL;
+      const prefix = possibleKnoxUrlPathPrefix + '/hue/metastore/';
+
       if (this.source() && this.source().namespace()) {
         const params = {
           source_type: this.source().type


### PR DESCRIPTION
Previously the hue prefix was only added if Knox was not running, 
which caused the back button to trigger a 404.

## What changes were proposed in this pull request?

- Updated the metastore.url.change in metastoreViewModel.js

@wing2fly this change will overwrite some of you changes here https://github.com/cloudera/hue/pull/2111 but I think it will still work since all parts called 'hue' are removed before actually loading the data.

## How was this patch tested?
- Tested by manually temporary modifying the window.HUE_BASE_URL in  metastoreViewModel.js and changeURL.ts to verify that HUE_BASE_URL = '/hue' would result in a url containing two 'hue' in the path. E.g. looking like _hue/hue/metastore/table/default/sample_07?source_type=hive_ when navigating in the table browser. Because that is how the base url looks in a Knox enabled setup.



- Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
