### PR TITLE
[DO_NOT_MERGE][raz] Enable boto2 debug logging by default

### DIFF
--- a/desktop/conf/log.conf
+++ b/desktop/conf/log.conf
@@ -43,7 +43,7 @@ propogate=False
 qualname=django.db.backends
 
 [logger_boto]
-level=ERROR
+level=DEBUG
 handlers=errorlog
 qualname=boto
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- When someone enables debug logging in Hue, we should try showing debug logging from boto2 as well for better log visibility and faster debugging.

## How was this patch tested?

- Manual testing in live setup