### PR TITLE
[api] Add new /touch public api

### DIFF
--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -104,12 +104,7 @@ def touch(request):
   name = request.POST.get('name')
 
   if name and (posixpath.sep in name):
-    raise Exception(_("Could not name file \"%s\": Slashes are not allowed in filenames." % name))
+    raise Exception(_("Error creating %s file. Slashes are not allowed in filename." % name))
   
-  request.fs.create(
-    request.fs.join(
-      (path.encode('utf-8') if not isinstance(path, str) else path),
-      (name.encode('utf-8') if not isinstance(name, str) else name)
-    )
-  )
+  request.fs.create(request.fs.join(path, name))
   return HttpResponse(status=200)

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -97,3 +97,19 @@ def mkdir(request):
   request.fs.mkdir(request.fs.join(path, name))
   return HttpResponse(status=200)
 
+
+@error_handler
+def touch(request):
+  path = request.POST.get('path')
+  name = request.POST.get('name')
+
+  if name and (posixpath.sep in name):
+    raise Exception(_("Could not name file \"%s\": Slashes are not allowed in filenames." % name))
+  
+  request.fs.create(
+    request.fs.join(
+      (path.encode('utf-8') if not isinstance(path, str) else path),
+      (name.encode('utf-8') if not isinstance(name, str) else name)
+    )
+  )
+  return HttpResponse(status=200)

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -219,6 +219,11 @@ def storage_mkdir(request):
   django_request = get_django_request(request)
   return filebrowser_api.mkdir(django_request)
 
+@api_view(["POST"])
+def storage_touch(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.touch(django_request)
+
 
 # Importer
 

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -97,6 +97,7 @@ urlpatterns += [
   re_path(r'^storage/download=(?P<path>.*)$', api_public.storage_download, name='storage_download'),
   re_path(r'^storage/upload/file/?$', api_public.storage_upload_file, name='storage_upload_file'),
   re_path(r'^storage/mkdir$', api_public.storage_mkdir, name='storage_mkdir'),
+  re_path(r'^storage/touch$', api_public.storage_touch, name='storage_touch')
 ]
 
 urlpatterns += [


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Implement a dedicated /touch API method tailored for new storage browser.
- This separates the old method for existing filebrowser to not have regressions + much cleaner new method.

## How was this patch tested?

- Manually

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
