### PR TITLE
[Trino] Reformatting the return of the show_table for autocomplete call

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/trino.py
+++ b/desktop/libs/notebook/src/notebook/connectors/trino.py
@@ -302,8 +302,13 @@ class TrinoApi(Api):
     query_client = TrinoQuery(self.db, 'SHOW TABLES')
     response = query_client.execute()
     tables = response.rows
-
-    return tables
+    return [{
+        'name': table[0],
+        'type': 'table',
+        'comment': '',
+      }
+      for table in tables
+    ]
 
 
   def _get_columns(self, database, table):


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Reformatting the return of the show_table for autocomplete call as the earlier format did not match our existing code.
- Due to a different format, samples for tables were missing in the left assist.

## How was this patch tested?

- Locally