### PR TITLE
[api] Add new /rename public api

### DIFF
--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -115,14 +115,16 @@ def rename(request):
   src_path = request.POST.get('src_path')
   dest_path = request.POST.get('dest_path')
 
-  """If dest_path doesn't have a directory specified, use same dir."""
   if "#" in dest_path:
     raise Exception(_(
       "Error renaming %s to %s. Hashes are not allowed in file or directory names." % (os.path.basename(src_path), dest_path)
       ))
+
+  # If dest_path doesn't have a directory specified, use same dir.
   if "/" not in dest_path:
     src_dir = os.path.dirname(src_path)
     dest_path = request.fs.join(src_dir, dest_path)
+
   if request.fs.exists(dest_path):
     raise Exception(_('The destination path "%s" already exists.') % dest_path)
 

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -224,6 +224,10 @@ def storage_touch(request):
   django_request = get_django_request(request)
   return filebrowser_api.touch(django_request)
 
+@api_view(["POST"])
+def storage_rename(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.rename(django_request)
 
 # Importer
 

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -97,7 +97,8 @@ urlpatterns += [
   re_path(r'^storage/download=(?P<path>.*)$', api_public.storage_download, name='storage_download'),
   re_path(r'^storage/upload/file/?$', api_public.storage_upload_file, name='storage_upload_file'),
   re_path(r'^storage/mkdir$', api_public.storage_mkdir, name='storage_mkdir'),
-  re_path(r'^storage/touch$', api_public.storage_touch, name='storage_touch')
+  re_path(r'^storage/touch$', api_public.storage_touch, name='storage_touch'),
+  re_path(r'^storage/rename$', api_public.storage_rename, name='storage_rename')
 ]
 
 urlpatterns += [


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Implement a dedicated /rename API method tailored for new storage browser.
- This separates the old method for existing filebrowser to not have regressions + much cleaner new method.

## How was this patch tested?

- Manually

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
