### PR TITLE
[api] Add new /content_summary public api

### DIFF
--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -135,10 +135,10 @@ def rename(request):
 @error_handler
 def content_summary(request, path):
   path = _normalize_path(path)
-  response = {'summary': None}
+  response = {}
 
   if not path:
-    raise Exception(_('Path parameter is required to fetch content summary'))
+    raise Exception(_('Path parameter is required to fetch content summary.'))
 
   if not request.fs.exists(path):
     return JsonResponse(response, status=404)

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -229,6 +229,11 @@ def storage_rename(request):
   django_request = get_django_request(request)
   return filebrowser_api.rename(django_request)
 
+@api_view(["GET"])
+def storage_content_summary(request, path):
+  django_request = get_django_request(request)
+  return filebrowser_api.content_summary(django_request, path)
+
 # Importer
 
 @api_view(["POST"])

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -98,7 +98,8 @@ urlpatterns += [
   re_path(r'^storage/upload/file/?$', api_public.storage_upload_file, name='storage_upload_file'),
   re_path(r'^storage/mkdir$', api_public.storage_mkdir, name='storage_mkdir'),
   re_path(r'^storage/touch$', api_public.storage_touch, name='storage_touch'),
-  re_path(r'^storage/rename$', api_public.storage_rename, name='storage_rename')
+  re_path(r'^storage/rename$', api_public.storage_rename, name='storage_rename'),
+  re_path(r'^storage/content_summary=(?P<path>.*)$', api_public.storage_content_summary, name='storage_content_summary'),
 ]
 
 urlpatterns += [


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Implement a dedicated /content_summary API method tailored for new storage browser.
- Removed redundant exceptions not relevant to API
- This separates the old method for existing file browser to not have regressions + much cleaner new method.

## How was this patch tested?

- Manually

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
