### PR TITLE
[Trino] Add ldap/basic username and password authentication support

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -1145,6 +1145,13 @@ tls=no
 #   name=Shell
 #   interface=oozie
 
+# [[[trino]]]
+#   name=Trino
+#   interface=trino
+#   ## username and password for LDAP enabled over HTTPS.
+#   options='{"url": "http://localhost:8080", "auth_username": "", "auth_password": ""}'
+
+
 # [[[presto]]]
 # name=Presto SQL
 # interface=presto

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -1128,6 +1128,12 @@
     #   name=Shell
     #   interface=oozie
 
+    # [[[trino]]]
+    #   name=Trino
+    #   interface=trino
+    #   ## username and password for LDAP enabled over HTTPS.
+    #   options='{"url": "http://localhost:8080", "auth_username": "", "auth_password": ""}'
+
     # [[[presto]]]
     # name=Presto SQL
     # interface=presto


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add ldap/basic username and password authentication support
- https://github.com/trinodb/trino-python-client?tab=readme-ov-file#basic-authentication

## How was this patch tested?

- Need secure trino cluster.
