### PR TITLE
[DO_NOT_MERGE] Adding data-testid attribute to the Hue page HTML elements 

### DIFF
--- a/apps/oozie/src/oozie/templates/editor2/bundle_editor.mako
+++ b/apps/oozie/src/oozie/templates/editor2/bundle_editor.mako
@@ -52,7 +52,7 @@ ${ commonheader(_("Bundle Editor"), "Oozie", user, request) | n,unicode }
     </a>
 
 
-    <div class="dropdown pull-right margin-left-10">
+    <div class="dropdown pull-right margin-left-10" data-testid = "data-toggle-dropdown-button">
       <a class="btn" data-toggle="dropdown" href="javascript: void(0)">
         <i class="fa fa-fw fa-ellipsis-v"></i>
       </a>

--- a/apps/oozie/src/oozie/templates/editor2/coordinator_editor.mako
+++ b/apps/oozie/src/oozie/templates/editor2/coordinator_editor.mako
@@ -54,7 +54,7 @@ ${ commonheader(_("Coordinator Editor"), "Oozie", user, request) | n,unicode }
       <i class="fa fa-save"></i>
     </a>
 
-    <div class="dropdown pull-right margin-left-10">
+    <div class="dropdown pull-right margin-left-10" data-testid = "data-toggle-dropdown-button">
       <a class="btn" data-toggle="dropdown" href="javascript: void(0)">
         <i class="fa fa-fw fa-ellipsis-v"></i>
       </a>

--- a/apps/oozie/src/oozie/templates/editor2/workflow_editor.mako
+++ b/apps/oozie/src/oozie/templates/editor2/workflow_editor.mako
@@ -57,7 +57,7 @@ ${ commonheader(_("Workflow Editor"), "Oozie", user, request, "40px") | n,unicod
       <i class="fa fa-fw fa-save"></i>
     </a>
 
-    <div class="dropdown pull-right margin-left-10">
+    <div class="dropdown pull-right margin-left-10" data-testid = "data-toggle-dropdown-button">
       <a class="btn" data-toggle="dropdown" href="javascript: void(0)">
         <i class="fa fa-fw fa-ellipsis-v"></i>
       </a>

--- a/desktop/core/src/desktop/js/apps/editor/components/aceEditor/__snapshots__/AceEditor.test.ts.snap
+++ b/desktop/core/src/desktop/js/apps/editor/components/aceEditor/__snapshots__/AceEditor.test.ts.snap
@@ -13,6 +13,7 @@ exports[`AceEditor.vue should render 1`] = `
       autocapitalize="off"
       autocorrect="off"
       class="ace_text-input"
+      data-testid = "query-input-box"
       spellcheck="false"
       style="opacity: 0;"
       wrap="off"

--- a/desktop/core/src/desktop/js/components/sidebar/AccordionItem.vue
+++ b/desktop/core/src/desktop/js/components/sidebar/AccordionItem.vue
@@ -28,7 +28,8 @@
     @focusout="onFocusOut"
   >
     <button
-      class="sidebar-base-btn sidebar-sidebar-item" data-testid = "sidebar-query-editor-button"
+      class="sidebar-base-btn sidebar-sidebar-item"
+      data-testid="sidebar-query-editor-button"
       :aria-label="item.displayName"
       :class="{ 'sidebar-active': isActive, 'sidebar-accordion-item-btn-open': tooltip }"
       @click="toggleOpen"

--- a/desktop/core/src/desktop/js/components/sidebar/AccordionItem.vue
+++ b/desktop/core/src/desktop/js/components/sidebar/AccordionItem.vue
@@ -28,7 +28,7 @@
     @focusout="onFocusOut"
   >
     <button
-      class="sidebar-base-btn sidebar-sidebar-item"
+      class="sidebar-base-btn sidebar-sidebar-item" data-testid = "sidebar-query-editor-button"
       :aria-label="item.displayName"
       :class="{ 'sidebar-active': isActive, 'sidebar-accordion-item-btn-open': tooltip }"
       @click="toggleOpen"

--- a/desktop/core/src/desktop/js/ko/components/assist/ko.assistDbPanel.js
+++ b/desktop/core/src/desktop/js/ko/components/assist/ko.assistDbPanel.js
@@ -292,7 +292,7 @@ const TEMPLATE =
       <!-- ko if: selectedSource().selectedNamespace() -->
       <!-- ko if: selectedSource().selectedNamespace().selectedDatabase() -->
       <a data-bind="click: back, appAwareTemplateContextMenu: { template: 'sql-context-items', viewModel: selectedSource().selectedNamespace().selectedDatabase() }">
-        <i class="fa fa-chevron-left assist-breadcrumb-back" ></i>
+        <i class="fa fa-chevron-left assist-breadcrumb-back" data-testid = "database-select-back-button" ></i>
         <i class="fa assist-breadcrumb-text" data-bind="css: { 'fa-server': nonSqlType, 'fa-database': !nonSqlType }"></i>
         <span class="assist-breadcrumb-text" data-bind="text: breadcrumb, attr: {'title': breadcrumbTitle }"></span>
       </a>
@@ -300,14 +300,14 @@ const TEMPLATE =
       <!-- ko ifnot: selectedSource().selectedNamespace().selectedDatabase() -->
       <!-- ko if: window.HAS_MULTI_CLUSTER-->
       <a data-bind="click: back">
-        <i class="fa fa-chevron-left assist-breadcrumb-back"></i>
+        <i class="fa fa-chevron-left assist-breadcrumb-back" data-testid = "database-select-back-button"></i>
         <i class="fa fa-snowflake-o assist-breadcrumb-text"></i>
         <span class="assist-breadcrumb-text" data-bind="text: breadcrumb, attr: {'title': breadcrumbTitle }"></span>
       </a>
       <!-- /ko -->
       <!-- ko ifnot: window.HAS_MULTI_CLUSTER -->
       <a data-bind="click: back">
-        <i class="fa fa-chevron-left assist-breadcrumb-back"></i>
+        <i class="fa fa-chevron-left assist-breadcrumb-back" data-testid = "database-select-back-button"></i>
         <i class="fa fa-server assist-breadcrumb-text"></i>
         <span class="assist-breadcrumb-text" data-bind="text: breadcrumb"></span>
       </a>
@@ -316,7 +316,7 @@ const TEMPLATE =
       <!-- /ko -->
       <!-- ko ifnot: selectedSource().selectedNamespace() -->
       <a data-bind="click: back">
-        <i class="fa fa-chevron-left assist-breadcrumb-back"></i>
+        <i class="fa fa-chevron-left assist-breadcrumb-back" data-testid = "database-select-back-button"></i>
         <i class="fa fa-server assist-breadcrumb-text"></i>
         <span class="assist-breadcrumb-text" data-bind="text: breadcrumb"></span>
       </a>
@@ -348,7 +348,7 @@ const TEMPLATE =
       <!-- ko ifnot: loading -->
       <span class="assist-tables-counter">(<span data-bind="text: filteredNamespaces().length"></span>)</span>
       <!-- ko if: window.HAS_MULTI_CLUSTER -->
-      <a class="inactive-action" href="javascript:void(0)" data-bind="click: triggerRefresh"><i class="pointer fa fa-refresh" data-bind="css: { 'fa-spin blue' : loading }" title="${I18n(
+      <a class="inactive-action" href="javascript:void(0)" data-bind="click: triggerRefresh"><i class="pointer fa fa-refresh" data-testid = "table-refresh-button" data-bind="css: { 'fa-spin blue' : loading }" title="${I18n(
         'Refresh'
       )}"></i></a>
       <!-- /ko -->
@@ -384,7 +384,7 @@ const TEMPLATE =
         <i class="pointer fa fa-plus" title="${I18n('Create index')}"></i>
       </a>
       <!-- /ko -->
-      <a class="inactive-action" href="javascript:void(0)" data-bind="click: triggerRefresh"><i class="pointer fa fa-refresh" data-bind="css: { 'fa-spin blue' : loading }" title="${I18n(
+      <a class="inactive-action" href="javascript:void(0)" data-bind="click: triggerRefresh"><i class="pointer fa fa-refresh" data-testid = "table-refresh-button" data-bind="css: { 'fa-spin blue' : loading }" title="${I18n(
         'Refresh'
       )}"></i></a>
       <!-- /ko -->

--- a/desktop/core/src/desktop/js/ko/components/assist/ko.assistDocumentsPanel.js
+++ b/desktop/core/src/desktop/js/ko/components/assist/ko.assistDocumentsPanel.js
@@ -163,7 +163,7 @@ const TEMPLATE = `
             </li>
           </ul>
       </span>
-      <a class="inactive-action" href="javascript:void(0)" data-bind="click: function () { huePubSub.publish('${ REFRESH_DOC_ASSIST_EVENT }'); }"><i class="pointer fa fa-refresh" data-bind="css: { 'fa-spin blue' : loading }" title="${I18n(
+      <a class="inactive-action" href="javascript:void(0)" data-bind="click: function () { huePubSub.publish('${ REFRESH_DOC_ASSIST_EVENT }'); }"><i class="pointer fa fa-refresh" data-testid = "table-refresh-button" data-bind="css: { 'fa-spin blue' : loading }" title="${I18n(
         'Manual refresh'
       )}"></i></a>
     </div>

--- a/desktop/core/src/desktop/js/ko/components/assist/ko.assistGitPanel.js
+++ b/desktop/core/src/desktop/js/ko/components/assist/ko.assistGitPanel.js
@@ -29,7 +29,7 @@ const TEMPLATE = `
 
   <script type="text/html" id="assist-git-header-actions">
     <div class="assist-db-header-actions">
-      <a class="inactive-action" href="javascript:void(0)" data-bind="click: function () { huePubSub.publish('assist.git.refresh'); }"><i class="pointer fa fa-refresh" data-bind="css: { 'fa-spin blue' : loading }" title="${I18n(
+      <a class="inactive-action" href="javascript:void(0)" data-bind="click: function () { huePubSub.publish('assist.git.refresh'); }"><i class="pointer fa fa-refresh" data-testid = "table-refresh-button" data-bind="css: { 'fa-spin blue' : loading }" title="${I18n(
         'Manual refresh'
       )}"></i></a>
     </div>

--- a/desktop/core/src/desktop/js/ko/components/assist/ko.assistHBasePanel.js
+++ b/desktop/core/src/desktop/js/ko/components/assist/ko.assistHBasePanel.js
@@ -38,7 +38,7 @@ const TEMPLATE = `
   
   <script type="text/html" id="assist-hbase-header-actions">
     <div class="assist-db-header-actions">
-      <a class="inactive-action" href="javascript:void(0)" data-bind="click: function () { huePubSub.publish('assist.hbase.refresh'); }"><i class="pointer fa fa-refresh" data-bind="css: { 'fa-spin blue' : loading }" title="${I18n(
+      <a class="inactive-action" href="javascript:void(0)" data-bind="click: function () { huePubSub.publish('assist.hbase.refresh'); }"><i class="pointer fa fa-refresh" data-testid = "table-refresh-button" data-bind="css: { 'fa-spin blue' : loading }" title="${I18n(
         'Manual refresh'
       )}"></i></a>
     </div>

--- a/desktop/core/src/desktop/js/ko/components/assist/ko.assistPanel.js
+++ b/desktop/core/src/desktop/js/ko/components/assist/ko.assistPanel.js
@@ -45,7 +45,7 @@ const TEMPLATE = `
     <!-- ko if: availablePanels().length > 1 -->
     <div class="assist-panel-switches">
       <!-- ko foreach: availablePanels -->
-      <div class="inactive-action assist-type-switch" data-bind="click: function () { $parent.visiblePanel($data); }, css: { 'blue': $parent.visiblePanel() === $data }, style: { 'float': rightAlignIcon ? 'right' : 'left' },  attr: { 'title': name }">
+      <div class="inactive-action assist-type-switch" data-testid = "sql-database-button" data-bind="click: function () { $parent.visiblePanel($data); }, css: { 'blue': $parent.visiblePanel() === $data }, style: { 'float': rightAlignIcon ? 'right' : 'left' },  attr: { 'title': name }">
         <!-- ko if: iconSvg --><span style="font-size:22px;"><svg class="hi"><use data-bind="attr: {'href': iconSvg }" href=''></use></svg></span><!-- /ko -->
         <!-- ko if: !iconSvg --><i class="fa fa-fw valign-middle" data-bind="css: icon"></i><!-- /ko -->
       </div>

--- a/desktop/core/src/desktop/js/ko/components/assist/ko.assistStoragePanel.js
+++ b/desktop/core/src/desktop/js/ko/components/assist/ko.assistStoragePanel.js
@@ -83,7 +83,7 @@ const TEMPLATE = `
       <!-- /ko -->
       <a class="inactive-action" href="javascript:void(0)" data-bind="click: function () { huePubSub.publish('assist.storage.refresh'); }" title="${I18n(
         'Manual refresh'
-      )}"><i class="pointer fa fa-refresh" data-bind="css: { 'fa-spin blue' : loading }"></i></a>
+      )}"><i class="pointer fa fa-refresh" data-testid = "table-refresh-button" data-bind="css: { 'fa-spin blue' : loading }"></i></a>
     </div>
   </script>
 

--- a/desktop/core/src/desktop/js/ko/components/ko.dropDown.js
+++ b/desktop/core/src/desktop/js/ko/components/ko.dropDown.js
@@ -24,7 +24,7 @@ export const HUE_DROP_DOWN_COMPONENT = 'hue-drop-down';
 
 const TEMPLATE = `
   <!-- ko if: !menuOnly && (!dropDownVisible() || !searchable) -->
-  <a class="inactive-action hue-drop-down-active" href="javascript:void(0)" data-bind="toggle: dropDownVisible, css: { 'blue': dropDownVisible }">
+  <a class="inactive-action hue-drop-down-active" href="javascript:void(0)" data-testid = "database-selection-dropdown" data-bind="toggle: dropDownVisible, css: { 'blue': dropDownVisible }">
     <!-- ko if: icon --><i class="fa" data-bind="css: icon"></i><!-- /ko -->
     <!-- ko if: !noLabel && value -->
     <span class="hue-drop-down-selected" data-bind="text: value() && typeof value()[labelAttribute] !== 'undefined' ? value()[labelAttribute] : value(), visible: ! dropDownVisible() || !searchable, attr: { 'title': titleTooltip }" ></span>
@@ -33,11 +33,11 @@ const TEMPLATE = `
   </a>
   <!-- /ko -->
   <!-- ko if: !menuOnly && (dropDownVisible() && searchable) -->
-  <input class="hue-drop-down-input" type="text" data-bind="textInput: filter, attr: { 'placeHolder': inputPlaceHolder }, visible: dropDownVisible, style: { color: filterEdited() ? '#000' : '#AAA', 'min-height': '22px', 'margin-left': '10px' }"/>
+  <input class="hue-drop-down-input" type="text" data-testid = "hue-database-drop-down-input-textbox" data-bind="textInput: filter, attr: { 'placeHolder': inputPlaceHolder }, visible: dropDownVisible, style: { color: filterEdited() ? '#000' : '#AAA', 'min-height': '22px', 'margin-left': '10px' }"/>
   <i class="fa fa-caret-down"></i>
   <!-- /ko -->
   <div class="hue-drop-down-container" data-bind="css: { 'open' : dropDownVisible, 'hue-drop-down-fixed': fixedPosition, 'hue-drop-down-container-searchable': searchable }, dropDownKeyUp: { onEsc: onEsc, onEnter: onEnter, dropDownVisible: dropDownVisible }">
-    <div style="overflow-y: auto;" class="dropdown-menu" data-bind="visible: filteredEntries().length > 0">
+    <div style="overflow-y: auto;" class="dropdown-menu" data-testid = "filter-database-search-input-textbox" data-bind="visible: filteredEntries().length > 0">
       <!-- ko if: foreachVisible -->
       <ul class="hue-inner-drop-down" data-bind="foreachVisible: { data: filteredEntries, minHeight: 34, container: '.dropdown-menu' }">
         <!-- ko if: typeof $data.divider !== 'undefined' && $data.divider -->

--- a/desktop/core/src/desktop/templates/document_browser.mako
+++ b/desktop/core/src/desktop/templates/document_browser.mako
@@ -184,7 +184,7 @@ else:
                 </div>
                 <!-- /ko -->
 
-                <div class="dropdown pull-right margin-left-10">
+                <div class="dropdown pull-right margin-left-10" data-testid = "data-toggle-dropdown-button">
                   <a class="btn" data-toggle="dropdown" href="javascript: void(0)">
                     <i class="fa fa-fw fa-ellipsis-v"></i>
                   </a>

--- a/desktop/libs/dashboard/src/dashboard/templates/common_search.mako
+++ b/desktop/libs/dashboard/src/dashboard/templates/common_search.mako
@@ -191,7 +191,7 @@ else:
         </div>
       % endif
 
-      <div class="dropdown pull-right margin-left-10">
+      <div class="dropdown pull-right margin-left-10" data-testid = "data-toggle-dropdown-button">
         <a class="btn" data-toggle="dropdown" href="javascript: void(0)" data-bind="click: function() { showPlusButtonHint(false); }">
           <i class="fa fa-fw fa-ellipsis-v"></i>
         </a>

--- a/desktop/libs/notebook/src/notebook/templates/editor2.mako
+++ b/desktop/libs/notebook/src/notebook/templates/editor2.mako
@@ -113,7 +113,7 @@ There is no bridge to KO for components using this integration. Example using in
     <!-- ko template: { ifnot: editorMode() || isPresentationMode(), name: 'editor-execution-actions' }--><!-- /ko -->
 
     <!-- ko ifnot: isPresentationMode() -->
-    <div class="dropdown pull-right margin-left-10">
+    <div class="dropdown pull-right margin-left-10" data-testid = "data-toggle-dropdown-button">
       <a class="btn" data-toggle="dropdown" href="javascript: void(0)">
         <i class="fa fa-fw fa-ellipsis-v"></i>
       </a>

--- a/desktop/libs/notebook/src/notebook/templates/editor_components.mako
+++ b/desktop/libs/notebook/src/notebook/templates/editor_components.mako
@@ -243,7 +243,7 @@ ${ sqlSyntaxDropdown.sqlSyntaxDropdown() }
     <!-- ko template: { ifnot: editorMode() || isPresentationMode(), name: 'notebook-actions' }--><!-- /ko -->
 
     <!-- ko ifnot: isPresentationMode() -->
-    <div class="dropdown pull-right margin-left-10">
+    <div class="dropdown pull-right margin-left-10" data-testid = "data-toggle-dropdown-button">
       <a class="btn" data-toggle="dropdown" href="javascript: void(0)">
         <i class="fa fa-fw fa-ellipsis-v"></i>
       </a>
@@ -603,9 +603,9 @@ ${ sqlSyntaxDropdown.sqlSyntaxDropdown() }
     <div data-bind="delayedOverflow: 'slow', css: resultsKlass" style="margin-top: 5px; position: relative;">
       <ul class="nav nav-tabs nav-tabs-editor">
         <li data-bind="click: function(){ currentQueryTab('queryHistory'); }, css: {'active': currentQueryTab() == 'queryHistory'}, onClickOutside: function () { if ($parent.historyFilterVisible() && $parent.historyFilter() === '') { $parent.historyFilterVisible(false) } }">
-          <a class="inactive-action" style="display:inline-block" href="#queryHistory" data-toggle="tab">${_('Query History')}</a>
+          <a class="inactive-action" data-testid = "query-history-tab" style="display:inline-block" href="#queryHistory" data-toggle="tab">${_('Query History')}</a>
           <div style="margin-left: -15px;" class="inline-block inactive-action pointer visible-on-hover" title="${_('Search the query history')}" data-bind="click: function(data, e){ $parent.historyFilterVisible(!$parent.historyFilterVisible()); if ($parent.historyFilterVisible()) { window.setTimeout(function(){ $(e.target).parent().siblings('input').focus(); }, 0); } else { $parent.historyFilter('') }}"><i class="snippet-icon fa fa-search"></i></div>
-          <input class="input-small inline-tab-filter" type="text" data-bind="visible: $parent.historyFilterVisible, clearable: $parent.historyFilter, valueUpdate:'afterkeydown'" placeholder="${ _('Search...') }">
+          <input class="input-small inline-tab-filter" type="text" data-testid = "query-history-search-input-textbox" data-bind="visible: $parent.historyFilterVisible, clearable: $parent.historyFilter, valueUpdate:'afterkeydown'" placeholder="${ _('Search...') }">
           <div class="dropdown inline-block inactive-action pointer visible-on-hover">
             <a class="" data-toggle="dropdown" href="javascript: void(0)">
               <i class="fa fa-fw fa-ellipsis-v"></i>
@@ -625,9 +625,9 @@ ${ sqlSyntaxDropdown.sqlSyntaxDropdown() }
           </div>
         </li>
         <li class="margin-right-20" data-bind="click: function(){ currentQueryTab('savedQueries'); }, css: {'active': currentQueryTab() == 'savedQueries'}, onClickOutside: function () { if (queriesFilterVisible() && queriesFilter() === '') { queriesFilterVisible(false) } }">
-          <a class="inactive-action" style="display:inline-block" href="#savedQueries" data-toggle="tab">${_('Saved Queries')}</a>
+          <a class="inactive-action" data-testid = "saved-queries-tab" style="display:inline-block" href="#savedQueries" data-toggle="tab">${_('Saved Queries')}</a>
           <div style="margin-left: -15px;" class="inline-block inactive-action pointer visible-on-hover" title="${_('Search the saved queries')}" data-bind="visible: !queriesHasErrors(), click: function(data, e){ queriesFilterVisible(!queriesFilterVisible()); if (queriesFilterVisible()) { window.setTimeout(function(){ $(e.target).parent().siblings('input').focus(); }, 0); } else { queriesFilter('') }}"><i class="snippet-icon fa fa-search"></i></div>
-          <input class="input-small inline-tab-filter" type="text" data-bind="visible: queriesFilterVisible, clearable: queriesFilter, valueUpdate:'afterkeydown'" placeholder="${ _('Search...') }">
+          <input class="input-small inline-tab-filter" type="text" data-testid = "query-history-search-input-textbox" data-bind="visible: queriesFilterVisible, clearable: queriesFilter, valueUpdate:'afterkeydown'" placeholder="${ _('Search...') }">
         </li>
         % if ENABLE_QUERY_BUILDER.get():
         <!-- ko if: isSqlDialect -->
@@ -1718,7 +1718,7 @@ ${ sqlSyntaxDropdown.sqlSyntaxDropdown() }
 <script type ="text/html" id="snippet-execution-controls${ suffix }">
   <div class="snippet-actions" style="position: absolute; bottom: 0">
     <!-- ko if: status() == 'loading' -->
-    <a class="snippet-side-btn blue" style="cursor: default;" title="${ _('Creating session') }">
+    <a class="snippet-side-btn blue" data-testid = "query-run-button" style="cursor: default;" title="${ _('Creating session') }">
       <i class="fa fa-fw fa-spinner fa-spin"></i>
     </a>
     <!-- /ko -->


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adding data-testid attribute to the Hue page elements so that it is easy for the Quality Engineering (QE) team during the testing or in any kind of debugging.

## How was this patch tested?
This is tested manually using Google Chrome's inspect element and checking if the data-testid attribute is in the right place.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
