### PR TITLE
[idbroker] Refactor IDBroker with improved HA support and giving more preference to RAZ when both are configured in Hue

### DIFF
--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -2623,9 +2623,8 @@ def is_cm_managed():
 def is_gs_enabled():
   from desktop.lib.idbroker import conf as conf_idbroker # Circular dependencies  desktop.conf -> idbroker.conf -> desktop.conf
 
-  return ('default' in list(GC_ACCOUNTS.keys()) and GC_ACCOUNTS['default'].JSON_CREDENTIALS.get()) or \
-      conf_idbroker.is_idbroker_enabled('gs') or \
-      is_raz_gs()
+  return ('default' in list(GC_ACCOUNTS.keys()) and GC_ACCOUNTS['default'].JSON_CREDENTIALS.get()) or is_raz_gs() or \
+    conf_idbroker.is_idbroker_enabled('gs')
 
 def has_gs_access(user):
   from desktop.auth.backend import is_admin

--- a/desktop/core/src/desktop/lib/idbroker/conf.py
+++ b/desktop/core/src/desktop/lib/idbroker/conf.py
@@ -48,6 +48,8 @@ def _handle_idbroker_ha(fs=None):
 
   response = None
   for idb in idbroker_addr_list:
+    LOG.info('Attempting to connect to IDBroker URL: %s' % idb)
+
     try:
       response = requests.get(idb.rstrip('/') + '/dt/knoxtoken/api/v1/token', auth=HTTPKerberosAuth(), verify=False)
     except Exception as e:

--- a/desktop/core/src/desktop/lib/idbroker/tests.py
+++ b/desktop/core/src/desktop/lib/idbroker/tests.py
@@ -13,63 +13,65 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
-
 import logging
 import unittest
-import sys
 
-from nose.tools import assert_equal, assert_true
+from nose.tools import assert_equal
+from unittest.mock import patch
 
 from desktop.lib.idbroker.client import IDBroker
 
-if sys.version_info[0] > 2:
-  from unittest.mock import patch
-else:
-  from mock import patch
 
 LOG = logging.getLogger()
+
 
 class TestIDBroker(unittest.TestCase):
   def test_username_authentication(self):
     with patch('desktop.lib.idbroker.conf.get_conf') as conf:
       with patch('desktop.lib.idbroker.client.resource.Resource.invoke') as invoke:
         with patch('desktop.lib.idbroker.client.http_client.HttpClient.set_basic_auth') as set_basic_auth:
-          conf.return_value = {
-            'fs.s3a.ext.cab.address': 'address',
-            'fs.s3a.ext.cab.dt.path': 'dt_path',
-            'fs.s3a.ext.cab.path': 'path',
-            'fs.s3a.ext.cab.username': 'username',
-            'fs.s3a.ext.cab.password': 'password'
-          }
-          invoke.return_value = {
-             'Credentials': 'Credentials'
-          }
-          client = IDBroker.from_core_site('s3a', 'test')
+          with patch('desktop.lib.idbroker.conf.get_cab_address') as get_cab_address:
+            conf.return_value = {
+              'fs.s3a.ext.cab.address': 'address',
+              'fs.s3a.ext.cab.dt.path': 'dt_path',
+              'fs.s3a.ext.cab.path': 'path',
+              'fs.s3a.ext.cab.username': 'username',
+              'fs.s3a.ext.cab.password': 'password'
+            }
+            invoke.return_value = {
+              'Credentials': 'Credentials'
+            }
+            get_cab_address.return_value = 'address'
 
-          cab = client.get_cab()
-          assert_equal(invoke.call_count, 2) # get_cab calls twice
-          assert_equal(cab.get('Credentials'), 'Credentials')
-          assert_equal(set_basic_auth.call_count, 1)
+            client = IDBroker.from_core_site('s3a', 'test')
+            cab = client.get_cab()
+
+            assert_equal(invoke.call_count, 2) # get_cab calls twice
+            assert_equal(cab.get('Credentials'), 'Credentials')
+            assert_equal(set_basic_auth.call_count, 1)
+
 
   def test_kerberos_authentication(self):
     with patch('desktop.lib.idbroker.conf.get_conf') as conf:
       with patch('desktop.lib.idbroker.client.is_kerberos_enabled') as is_kerberos_enabled:
         with patch('desktop.lib.idbroker.client.resource.Resource.invoke') as invoke:
           with patch('desktop.lib.idbroker.client.http_client.HttpClient.set_kerberos_auth') as set_kerberos_auth:
-            is_kerberos_enabled.return_value = True
-            conf.return_value = {
-              'fs.s3a.ext.cab.address': 'address',
-              'fs.s3a.ext.cab.dt.path': 'dt_path',
-              'fs.s3a.ext.cab.path': 'path',
-              'hadoop.security.authentication': 'kerberos',
-            }
-            invoke.return_value = {
-              'Credentials': 'Credentials'
-            }
-            client = IDBroker.from_core_site('s3a', 'test')
+            with patch('desktop.lib.idbroker.conf.get_cab_address') as get_cab_address:
+              is_kerberos_enabled.return_value = True
+              conf.return_value = {
+                'fs.s3a.ext.cab.address': 'address',
+                'fs.s3a.ext.cab.dt.path': 'dt_path',
+                'fs.s3a.ext.cab.path': 'path',
+                'hadoop.security.authentication': 'kerberos',
+              }
+              invoke.return_value = {
+                'Credentials': 'Credentials'
+              }
+              get_cab_address.return_value = 'address'
 
-            cab = client.get_cab()
-            assert_equal(invoke.call_count, 2) # get_cab calls twice
-            assert_equal(cab.get('Credentials'), 'Credentials')
-            assert_equal(set_kerberos_auth.call_count, 1)
+              client = IDBroker.from_core_site('s3a', 'test')
+              cab = client.get_cab()
+
+              assert_equal(invoke.call_count, 2) # get_cab calls twice
+              assert_equal(cab.get('Credentials'), 'Credentials')
+              assert_equal(set_kerberos_auth.call_count, 1)

--- a/desktop/libs/aws/src/aws/conf.py
+++ b/desktop/libs/aws/src/aws/conf.py
@@ -273,8 +273,8 @@ AWS_ACCOUNTS = UnspecifiedConfigSection(
 def is_enabled():
   return ('default' in list(AWS_ACCOUNTS.keys()) and AWS_ACCOUNTS['default'].get_raw() and AWS_ACCOUNTS['default'].ACCESS_KEY_ID.get()) or \
       has_iam_metadata() or \
-      conf_idbroker.is_idbroker_enabled('s3a') or \
-      is_raz_s3()
+      is_raz_s3() or \
+      conf_idbroker.is_idbroker_enabled('s3a')
 
 
 def is_ec2_instance():

--- a/desktop/libs/aws/src/aws/tests.py
+++ b/desktop/libs/aws/src/aws/tests.py
@@ -13,10 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
-
 import logging
-import sys
 import unittest
 
 from nose.tools import assert_equal, assert_true, assert_not_equal
@@ -28,10 +25,8 @@ from desktop.lib.fsmanager import get_client, clear_cache
 from desktop.lib.python_util import current_ms_from_utc
 from desktop.conf import RAZ
 
-if sys.version_info[0] > 2:
-  from unittest.mock import patch
-else:
-  from mock import patch
+from unittest.mock import patch
+
 
 LOG = logging.getLogger()
 
@@ -54,85 +49,101 @@ class TestAWS(unittest.TestCase):
       clear_cache()
       conf.clear_cache()
 
+
   def test_with_idbroker(self):
     try:
       finish = conf.AWS_ACCOUNTS.set_for_testing({}) # Set empty to test when no configs are set
       with patch('aws.client.conf_idbroker.get_conf') as get_conf:
-        with patch('aws.client.Client.get_s3_connection'):
-          with patch('aws.client.IDBroker.get_cab') as get_cab:
-            with patch('aws.client.aws_conf.has_iam_metadata') as has_iam_metadata:
-              get_conf.return_value = {
-                'fs.s3a.ext.cab.address': 'address'
-              }
-              get_cab.return_value = {
-                'Credentials': {'AccessKeyId': 'AccessKeyId', 'Expiration': 0}
-              }
-              has_iam_metadata.return_value = True
-              provider = get_credential_provider('default', 'hue')
-              assert_equal(provider.get_credentials().get('AccessKeyId'), 'AccessKeyId')
-              client1 = get_client(name='default', fs='s3a', user='hue')
-              client2 = get_client(name='default', fs='s3a', user='hue')
-              assert_not_equal(client1, client2) # Test that with Expiration 0 clients not equal
+        with patch('aws.client.conf_idbroker.get_cab_address') as get_cab_address:
+          with patch('aws.client.Client.get_s3_connection'):
+            with patch('aws.client.IDBroker.get_cab') as get_cab:
+              with patch('aws.client.aws_conf.has_iam_metadata') as has_iam_metadata:
+                get_conf.return_value = {
+                  'fs.s3a.ext.cab.address': 'address'
+                }
+                get_cab_address.return_value = 'address'
+                get_cab.return_value = {
+                  'Credentials': {'AccessKeyId': 'AccessKeyId', 'Expiration': 0}
+                }
+                has_iam_metadata.return_value = True
+                provider = get_credential_provider('default', 'hue')
 
-              get_cab.return_value = {
-                'Credentials': {'AccessKeyId': 'AccessKeyId', 'Expiration': int(current_ms_from_utc()) + 10*1000}
-              }
-              client3 = get_client(name='default', fs='s3a', user='hue')
-              client4 = get_client(name='default', fs='s3a', user='hue')
-              client5 = get_client(name='default', fs='s3a', user='test')
-              assert_equal(client3, client4) # Test that with 10 sec expiration, clients equal
-              assert_not_equal(client4, client5) # Test different user have different clients
+                assert_equal(provider.get_credentials().get('AccessKeyId'), 'AccessKeyId')
+
+                client1 = get_client(name='default', fs='s3a', user='hue')
+                client2 = get_client(name='default', fs='s3a', user='hue')
+
+                assert_not_equal(client1, client2) # Test that with Expiration 0 clients not equal
+
+                get_cab.return_value = {
+                  'Credentials': {'AccessKeyId': 'AccessKeyId', 'Expiration': int(current_ms_from_utc()) + 10*1000}
+                }
+                client3 = get_client(name='default', fs='s3a', user='hue')
+                client4 = get_client(name='default', fs='s3a', user='hue')
+                client5 = get_client(name='default', fs='s3a', user='test')
+
+                assert_equal(client3, client4) # Test that with 10 sec expiration, clients equal
+                assert_not_equal(client4, client5) # Test different user have different clients
     finally:
       finish()
       clear_cache()
       conf.clear_cache()
+
 
   def test_with_idbroker_and_config(self):
     try:
       finish = conf.AWS_ACCOUNTS.set_for_testing({'default': {'region': 'ap-northeast-1'}})
       with patch('aws.client.conf_idbroker.get_conf') as get_conf:
-        with patch('aws.client.Client.get_s3_connection'):
-          with patch('aws.client.IDBroker.get_cab') as get_cab:
-            with patch('aws.client.aws_conf.has_iam_metadata') as has_iam_metadata:
-              get_conf.return_value = {
-                'fs.s3a.ext.cab.address': 'address'
-              }
-              get_cab.return_value = {
-                'Credentials': {'AccessKeyId': 'AccessKeyId', 'Expiration': 0}
-              }
-              has_iam_metadata.return_value = True
-              provider = get_credential_provider('default', 'hue')
-              assert_equal(provider.get_credentials().get('AccessKeyId'), 'AccessKeyId')
+        with patch('aws.client.conf_idbroker.get_cab_address') as get_cab_address:
+          with patch('aws.client.Client.get_s3_connection'):
+            with patch('aws.client.IDBroker.get_cab') as get_cab:
+              with patch('aws.client.aws_conf.has_iam_metadata') as has_iam_metadata:
+                get_conf.return_value = {
+                  'fs.s3a.ext.cab.address': 'address'
+                }
+                get_cab_address.return_value = 'address'
+                get_cab.return_value = {
+                  'Credentials': {'AccessKeyId': 'AccessKeyId', 'Expiration': 0}
+                }
+                has_iam_metadata.return_value = True
 
-              client = Client.from_config(conf.AWS_ACCOUNTS['default'], get_credential_provider('default', 'hue'))
-              assert_equal(client._region, 'ap-northeast-1')
+                provider = get_credential_provider('default', 'hue')
+                assert_equal(provider.get_credentials().get('AccessKeyId'), 'AccessKeyId')
+
+                client = Client.from_config(conf.AWS_ACCOUNTS['default'], get_credential_provider('default', 'hue'))
+                assert_equal(client._region, 'ap-northeast-1')
     finally:
       finish()
       clear_cache()
       conf.clear_cache()
+
 
   def test_with_idbroker_on_ec2(self):
     try:
       finish = conf.AWS_ACCOUNTS.set_for_testing({}) # Set empty to test when no configs are set
       with patch('aws.client.aws_conf.get_region') as get_region:
         with patch('aws.client.conf_idbroker.get_conf') as get_conf:
-          with patch('aws.client.Client.get_s3_connection'):
-            with patch('aws.client.IDBroker.get_cab') as get_cab:
-              with patch('aws.client.aws_conf.has_iam_metadata') as has_iam_metadata:
-                get_region.return_value = 'us-west-1'
-                get_conf.return_value = {
-                  'fs.s3a.ext.cab.address': 'address'
-                }
-                get_cab.return_value = {
-                  'Credentials': {'AccessKeyId': 'AccessKeyId', 'Expiration': 0}
-                }
-                has_iam_metadata.return_value = True
-                client = Client.from_config(None, get_credential_provider('default', 'hue'))
-                assert_equal(client._region, 'us-west-1') # Test different user have different clients
+          with patch('aws.client.conf_idbroker.get_cab_address') as get_cab_address:
+            with patch('aws.client.Client.get_s3_connection'):
+              with patch('aws.client.IDBroker.get_cab') as get_cab:
+                with patch('aws.client.aws_conf.has_iam_metadata') as has_iam_metadata:
+                  get_region.return_value = 'us-west-1'
+                  get_conf.return_value = {
+                    'fs.s3a.ext.cab.address': 'address'
+                  }
+                  get_cab_address.return_value = 'address'
+                  get_cab.return_value = {
+                    'Credentials': {'AccessKeyId': 'AccessKeyId', 'Expiration': 0}
+                  }
+                  has_iam_metadata.return_value = True
+                  client = Client.from_config(None, get_credential_provider('default', 'hue'))
+
+                  assert_equal(client._region, 'us-west-1') # Test different user have different clients
     finally:
       finish()
       clear_cache()
       conf.clear_cache()
+
 
   def test_with_raz_enabled(self):
     with patch('aws.client.RazS3Connection') as raz_s3_connection:

--- a/desktop/libs/azure/src/azure/conf.py
+++ b/desktop/libs/azure/src/azure/conf.py
@@ -166,9 +166,9 @@ def is_adls_enabled():
     or (conf_idbroker.is_idbroker_enabled('azure') and has_azure_metadata())) and 'default' in list(ADLS_CLUSTERS.keys())
 
 def is_abfs_enabled():
-  return ('default' in list(AZURE_ACCOUNTS.keys()) and AZURE_ACCOUNTS['default'].get_raw() and AZURE_ACCOUNTS['default'].CLIENT_ID.get() \
-    or (conf_idbroker.is_idbroker_enabled('azure') and has_azure_metadata())) and 'default' in list(ABFS_CLUSTERS.keys()) \
-    or is_raz_abfs()
+  return is_raz_abfs() or \
+    ('default' in list(AZURE_ACCOUNTS.keys()) and AZURE_ACCOUNTS['default'].get_raw() and AZURE_ACCOUNTS['default'].CLIENT_ID.get() or \
+    (conf_idbroker.is_idbroker_enabled('azure') and has_azure_metadata())) and 'default' in list(ABFS_CLUSTERS.keys())
 
 def has_adls_access(user):
   from desktop.conf import RAZ  # Must be imported dynamically in order to have proper value

--- a/desktop/libs/azure/src/azure/tests.py
+++ b/desktop/libs/azure/src/azure/tests.py
@@ -13,25 +13,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
-
 import logging
-import sys
 import unittest
 
-from nose.plugins.skip import SkipTest
-from nose.tools import assert_equal, assert_true, assert_not_equal
+from nose.tools import assert_equal, assert_not_equal
+from unittest.mock import patch
 
 from azure import conf
 from azure.client import get_credential_provider
 
-from desktop.lib.fsmanager import get_client, clear_cache, is_enabled
+from desktop.lib.fsmanager import get_client, clear_cache
 from desktop.lib.python_util import current_ms_from_utc
 
-if sys.version_info[0] > 2:
-  from unittest.mock import patch
-else:
-  from mock import patch
 
 LOG = logging.getLogger()
 
@@ -48,7 +41,11 @@ class TestAzureAdl(unittest.TestCase):
             with patch('azure.conf.core_site.get_conf') as core_site_get_conf:
               get_token.return_value = {'access_token': 'access_token', 'token_type': '', 'expires_on': None}
               get_conf.return_value = {}
-              core_site_get_conf.return_value = {'dfs.adls.oauth2.client.id': 'client_id', 'dfs.adls.oauth2.credential': 'client_secret', 'dfs.adls.oauth2.refresh.url': 'refresh_url'}
+              core_site_get_conf.return_value = {
+                'dfs.adls.oauth2.client.id': 'client_id',
+                'dfs.adls.oauth2.credential': 'client_secret',
+                'dfs.adls.oauth2.refresh.url': 'refresh_url'
+              }
               client1 = get_client(name='default', fs='adl')
               client2 = get_client(name='default', fs='adl', user='test')
 
@@ -60,10 +57,15 @@ class TestAzureAdl(unittest.TestCase):
         f()
       clear_cache()
 
+
   def test_with_credentials(self):
     try:
-      finish = (conf.AZURE_ACCOUNTS.set_for_testing({'default': {'client_id':'client_id', 'client_secret': 'client_secret', 'tenant_id': 'tenant_id'}}),
-                conf.ADLS_CLUSTERS.set_for_testing({'default': {'fs_defaultfs': 'fs_defaultfs', 'webhdfs_url': 'webhdfs_url'}}))
+      finish = (
+        conf.AZURE_ACCOUNTS.set_for_testing({
+          'default': {'client_id': 'client_id', 'client_secret': 'client_secret', 'tenant_id': 'tenant_id'}
+        }),
+        conf.ADLS_CLUSTERS.set_for_testing({'default': {'fs_defaultfs': 'fs_defaultfs', 'webhdfs_url': 'webhdfs_url'}})
+      )
       with patch('azure.client.conf_idbroker.get_conf') as get_conf:
         with patch('azure.client.WebHdfs.get_client'):
           with patch('azure.client.ActiveDirectory.get_token') as get_token:
@@ -83,31 +85,41 @@ class TestAzureAdl(unittest.TestCase):
 
   def test_with_idbroker(self):
     try:
-      finish = (conf.AZURE_ACCOUNTS.set_for_testing({}),
-                conf.ADLS_CLUSTERS.set_for_testing({'default': {'fs_defaultfs': 'fs_defaultfs', 'webhdfs_url': 'webhdfs_url'}}))
+      finish = (
+        conf.AZURE_ACCOUNTS.set_for_testing({}),
+        conf.ADLS_CLUSTERS.set_for_testing({'default': {'fs_defaultfs': 'fs_defaultfs', 'webhdfs_url': 'webhdfs_url'}})
+      )
       with patch('azure.client.conf_idbroker.get_conf') as get_conf:
-        with patch('azure.client.WebHdfs.get_client'):
-          with patch('azure.client.IDBroker.get_cab') as get_cab:
-            with patch('azure.client.conf.has_azure_metadata') as has_azure_metadata:
-              get_conf.return_value = {
-                'fs.azure.ext.cab.address': 'address'
-              }
-              has_azure_metadata.return_value = True
-              get_cab.return_value = { 'access_token': 'access_token', 'token_type': 'token_type', 'expires_on': 0 }
-              provider = get_credential_provider('default', 'hue')
-              assert_equal(provider.get_credentials().get('access_token'), 'access_token')
-              client1 = get_client(name='default', fs='adl', user='hue')
-              client2 = get_client(name='default', fs='adl', user='hue')
-              assert_not_equal(client1, client2) # Test that with Expiration 0 clients not equal
+        with patch('azure.client.conf_idbroker.get_cab_address') as get_cab_address:
+          with patch('azure.client.WebHdfs.get_client'):
+            with patch('azure.client.IDBroker.get_cab') as get_cab:
+              with patch('azure.client.conf.has_azure_metadata') as has_azure_metadata:
+                get_conf.return_value = {
+                  'fs.azure.ext.cab.address': 'address'
+                }
+                get_cab_address.return_value = 'address'
+                has_azure_metadata.return_value = True
+                get_cab.return_value = {'access_token': 'access_token', 'token_type': 'token_type', 'expires_on': 0}
+                provider = get_credential_provider('default', 'hue')
 
-              get_cab.return_value = {
-                'Credentials': {'access_token': 'access_token', 'token_type': 'token_type', 'expires_on': int(current_ms_from_utc()) + 10*1000}
-              }
-              client3 = get_client(name='default', fs='adl', user='hue')
-              client4 = get_client(name='default', fs='adl', user='hue')
-              client5 = get_client(name='default', fs='adl', user='test')
-              assert_equal(client3, client4) # Test that with 10 sec expiration, clients equal
-              assert_not_equal(client4, client5) # Test different user have different clients
+                assert_equal(provider.get_credentials().get('access_token'), 'access_token')
+
+                client1 = get_client(name='default', fs='adl', user='hue')
+                client2 = get_client(name='default', fs='adl', user='hue')
+
+                assert_not_equal(client1, client2) # Test that with Expiration 0 clients not equal
+
+                get_cab.return_value = {
+                  'Credentials': {
+                    'access_token': 'access_token', 'token_type': 'token_type', 'expires_on': int(current_ms_from_utc()) + 10*1000
+                  }
+                }
+                client3 = get_client(name='default', fs='adl', user='hue')
+                client4 = get_client(name='default', fs='adl', user='hue')
+                client5 = get_client(name='default', fs='adl', user='test')
+
+                assert_equal(client3, client4) # Test that with 10 sec expiration, clients equal
+                assert_not_equal(client4, client5) # Test different user have different clients
     finally:
       for f in finish:
         f()
@@ -126,7 +138,11 @@ class TestAzureAbfs(unittest.TestCase):
             with patch('azure.conf.core_site.get_conf') as core_site_get_conf:
               get_token.return_value = {'access_token': 'access_token', 'token_type': '', 'expires_on': None}
               get_conf.return_value = {}
-              core_site_get_conf.return_value = {'fs.azure.account.oauth2.client.id': 'client_id', 'fs.azure.account.oauth2.client.secret': 'client_secret', 'fs.azure.account.oauth2.client.endpoint': 'refresh_url'}
+              core_site_get_conf.return_value = {
+                'fs.azure.account.oauth2.client.id': 'client_id',
+                'fs.azure.account.oauth2.client.secret': 'client_secret',
+                'fs.azure.account.oauth2.client.endpoint': 'refresh_url'
+              }
               client1 = get_client(name='default', fs='abfs')
               client2 = get_client(name='default', fs='abfs', user='test')
 
@@ -138,10 +154,15 @@ class TestAzureAbfs(unittest.TestCase):
         f()
       clear_cache()
 
+
   def test_with_credentials(self):
     try:
-      finish = (conf.AZURE_ACCOUNTS.set_for_testing({'default': {'client_id':'client_id', 'client_secret': 'client_secret', 'tenant_id': 'tenant_id'}}),
-                conf.ABFS_CLUSTERS.set_for_testing({'default': {'fs_defaultfs': 'fs_defaultfs', 'webhdfs_url': 'webhdfs_url'}}))
+      finish = (
+        conf.AZURE_ACCOUNTS.set_for_testing({
+          'default': {'client_id': 'client_id', 'client_secret': 'client_secret', 'tenant_id': 'tenant_id'}
+        }),
+        conf.ABFS_CLUSTERS.set_for_testing({'default': {'fs_defaultfs': 'fs_defaultfs', 'webhdfs_url': 'webhdfs_url'}})
+      )
       with patch('azure.client.conf_idbroker.get_conf') as get_conf:
         with patch('azure.client.ABFS.get_client'):
           with patch('azure.client.ActiveDirectory.get_token') as get_token:
@@ -161,31 +182,41 @@ class TestAzureAbfs(unittest.TestCase):
 
   def test_with_idbroker(self):
     try:
-      finish = (conf.AZURE_ACCOUNTS.set_for_testing({}),
-                conf.ABFS_CLUSTERS.set_for_testing({'default': {'fs_defaultfs': 'fs_defaultfs', 'webhdfs_url': 'webhdfs_url'}}))
+      finish = (
+        conf.AZURE_ACCOUNTS.set_for_testing({}),
+        conf.ABFS_CLUSTERS.set_for_testing({'default': {'fs_defaultfs': 'fs_defaultfs', 'webhdfs_url': 'webhdfs_url'}})
+      )
       with patch('azure.client.conf_idbroker.get_conf') as get_conf:
-        with patch('azure.client.ABFS.get_client'):
-          with patch('azure.client.IDBroker.get_cab') as get_cab:
-            with patch('azure.client.conf.has_azure_metadata') as has_azure_metadata:
-              get_conf.return_value = {
-                'fs.azure.ext.cab.address': 'address'
-              }
-              has_azure_metadata.return_value = True
-              get_cab.return_value = { 'access_token': 'access_token', 'token_type': 'token_type', 'expires_on': 0 }
-              provider = get_credential_provider('default', 'hue')
-              assert_equal(provider.get_credentials().get('access_token'), 'access_token')
-              client1 = get_client(name='default', fs='abfs', user='hue')
-              client2 = get_client(name='default', fs='abfs', user='hue')
-              assert_not_equal(client1, client2) # Test that with Expiration 0 clients not equal
+        with patch('azure.client.conf_idbroker.get_cab_address') as get_cab_address:
+          with patch('azure.client.ABFS.get_client'):
+            with patch('azure.client.IDBroker.get_cab') as get_cab:
+              with patch('azure.client.conf.has_azure_metadata') as has_azure_metadata:
+                get_conf.return_value = {
+                  'fs.azure.ext.cab.address': 'address'
+                }
+                get_cab_address.return_value = 'address'
+                has_azure_metadata.return_value = True
+                get_cab.return_value = {'access_token': 'access_token', 'token_type': 'token_type', 'expires_on': 0}
+                provider = get_credential_provider('default', 'hue')
 
-              get_cab.return_value = {
-                'Credentials': {'access_token': 'access_token', 'token_type': 'token_type', 'expires_on': int(current_ms_from_utc()) + 10*1000}
-              }
-              client3 = get_client(name='default', fs='abfs', user='hue')
-              client4 = get_client(name='default', fs='abfs', user='hue')
-              client5 = get_client(name='default', fs='abfs', user='test')
-              assert_equal(client3, client4) # Test that with 10 sec expiration, clients equal
-              assert_not_equal(client4, client5) # Test different user have different clients
+                assert_equal(provider.get_credentials().get('access_token'), 'access_token')
+
+                client1 = get_client(name='default', fs='abfs', user='hue')
+                client2 = get_client(name='default', fs='abfs', user='hue')
+
+                assert_not_equal(client1, client2) # Test that with Expiration 0 clients not equal
+
+                get_cab.return_value = {
+                  'Credentials': {
+                    'access_token': 'access_token', 'token_type': 'token_type', 'expires_on': int(current_ms_from_utc()) + 10*1000
+                  }
+                }
+                client3 = get_client(name='default', fs='abfs', user='hue')
+                client4 = get_client(name='default', fs='abfs', user='hue')
+                client5 = get_client(name='default', fs='abfs', user='test')
+
+                assert_equal(client3, client4) # Test that with 10 sec expiration, clients equal
+                assert_not_equal(client4, client5) # Test different user have different clients
     finally:
       for f in finish:
         f()


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Refactor IDBroker support and give more preference to RAZ when both are configured in Hue.
- Improved IDBroker HA code section to switchover to healthy instance correctly and not depend only on the first one for every scenario. This should improve Hue page loading performance also.

## How was this patch tested?

- Tested manually in a live E2E setup with RAZ enabled to check for no regressions + correct IDBroker switchover + improved Hue page load time.
- Update existing unit tests.
- Adding new unit tests for IDBroker HA.