### PR TITLE
[frontend] increase muffet buffer size for dead link testing of docs

### DIFF
--- a/tools/ci/check_for_website_dead_links.sh
+++ b/tools/ci/check_for_website_dead_links.sh
@@ -46,6 +46,7 @@ if [ "$?" -eq "0" ];
           |http://demo.gethue.com*|https://twitter.com/gethue|https://github.com*|https://cdn.gethue.com/downloads/*|https://pypi.org*" \
         --ignore-fragments \
         --timeout 15 \
+        --buffer-size 8192 \
         --concurrency 10
     LINT_EXIT_CODE=$?
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the failing Github commitflow for documentation lint. For several new PRs it failed with error:
"..small read buffer. Increase ReadBufferSize."

Solution here is to double muffet buffer size to around 8 KB

## How was this patch tested?

- If the commitflow "run documentation lints" passes it should be ok


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
