### PR TITLE
[docker] Upgrade PostgresSQL version from 13 to 15

### DIFF
--- a/tools/container/base/hue/Dockerfile
+++ b/tools/container/base/hue/Dockerfile
@@ -43,7 +43,7 @@ RUN set -eux; \
       /usr/bin/pip3.8 install supervisor \
       && curl -s https://files.pythonhosted.org/packages/45/78/4621eb7085162bc4d2252ad92af1cc5ccacbd417a50e2ee74426331aad18/psycopg2_binary-2.9.3-cp38-cp38-musllinux_1_1_x86_64.whl -o /tmp/psycopg2_binary-2.9.3-cp38-cp38-musllinux_1_1_x86_64.whl \
       && dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
-      && yum install -y postgresql13 \
+      && yum install -y postgresql15 \
       && curl -sL https://rpm.nodesource.com/setup_14.x | bash - \
         && yum install -y nodejs \
         && yum clean all -y  \


### PR DESCRIPTION
## What changes were proposed in this pull request?

To support Azure PostgreSQL Flexible Server 14.9

## How was this patch tested?

The image is being build locally correctly.

$(find / -name "pg_dump" -type f) --version
pg_dump (PostgreSQL) 15.6


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
