### PR TITLE
[log] Remove the comment of dev only in log conf files

### DIFF
--- a/desktop/conf.dist/gunicorn_log.conf
+++ b/desktop/conf.dist/gunicorn_log.conf
@@ -1,6 +1,5 @@
 ########################################
 # Definition for the different objects
-# - FOR DEVELOPMENT ONLY -
 #
 # Directories where log files are kept must already exist.
 # That's why we pick /tmp.

--- a/desktop/conf.dist/log.conf
+++ b/desktop/conf.dist/log.conf
@@ -1,6 +1,5 @@
 ########################################
 # Definition for the different objects
-# - FOR DEVELOPMENT ONLY -
 #
 # Directories where log files are kept must already exist.
 # That's why we pick /tmp.

--- a/desktop/conf/gunicorn_log.conf
+++ b/desktop/conf/gunicorn_log.conf
@@ -1,6 +1,5 @@
 ########################################
 # Definition for the different objects
-# - FOR DEVELOPMENT ONLY -
 #
 # Directories where log files are kept must already exist.
 # That's why we pick /tmp.

--- a/desktop/conf/log.conf
+++ b/desktop/conf/log.conf
@@ -1,6 +1,5 @@
 ########################################
 # Definition for the different objects
-# - FOR DEVELOPMENT ONLY -
 #
 # Directories where log files are kept must already exist.
 # That's why we pick /tmp.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removing dev-only comment to avoid confusion

## How was this patch tested?

Just comments, no test required

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
