### PR TITLE
[frontend] Fixing the timer for the alert messages

### DIFF
--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -50,6 +50,10 @@ const AlertComponent: React.FC = () => {
   const handleClose = (errorObjToClose: ErrorAlert) => {
     const filteredErrors = errors.filter(errorObj => errorObj !== errorObjToClose);
     setErrors(filteredErrors);
+
+    setTimeout(() => {
+      setErrors(prevErrors => prevErrors.filter(errorObj => errorObj !== errorObjToClose));
+    }, 10000);
   };
 
   //TODO: add support for warnings and success messages


### PR DESCRIPTION
## What changes were proposed in this pull request?
The alert popup messages don't disappear automatically after those are shown on the screen. This PR is about setting the timer for some milliseconds to make the alert popup messages disappear automatically after some thousand milliseconds/seconds.

## How was this patch tested?
Manually tested on the UI by bringing the alert message on the screen and checking that it goes automatically after sometime.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
