### PR TITLE
[frontend] Dismiss info alert popup messages after 3 seconds (along with Unit Test)

### DIFF
--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.test.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.test.tsx
@@ -21,7 +21,6 @@ import userEvent from '@testing-library/user-event';
 import huePubSub from '../../utils/huePubSub';
 
 import AlertComponent from './AlertComponent';
-jest.useFakeTimers(); // Enable fake timers
 
 describe('AlertComponent', () => {
   test('it should show a global error message', async () => {
@@ -92,6 +91,7 @@ describe('AlertComponent', () => {
   });
 
   test('info alerts should close automatically after 3 seconds', async () => {
+    jest.useFakeTimers();
     render(<AlertComponent />);
     expect(screen.queryAllByRole('alert')).toHaveLength(0);
     act(() => huePubSub.publish('hue.global.info', { message: 'info' }));
@@ -104,5 +104,7 @@ describe('AlertComponent', () => {
     //After 3.1 seconds, it should really be closed
     jest.advanceTimersByTime(1000);
     expect(screen.queryAllByRole('alert')).toHaveLength(0);
+
+    jest.useRealTimers();
   });
 });

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.test.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.test.tsx
@@ -89,4 +89,19 @@ describe('AlertComponent', () => {
     expect(alertsAfterClosing[0]).toHaveTextContent('Error 1');
     expect(alertsAfterClosing[1]).toHaveTextContent('Error 3');
   });
+
+  test('info alerts should close automatically after 3 seconds', async () => {
+    render(<AlertComponent />);
+    expect(screen.queryAllByRole('alert')).toHaveLength(0);
+    act(() => huePubSub.publish('hue.global.info', { message: 'info' }));
+    expect(screen.queryAllByRole('alert')).toHaveLength(1);
+
+    //It should still be open after 2 seconds
+    jest.advanceTimersByTime(2000);
+    expect(screen.queryAllByRole('alert')).toHaveLength(1);
+
+    //After 3.1 seconds, it should really be closed
+    jest.advanceTimersByTime(1000);
+    expect(screen.queryAllByRole('alert')).toHaveLength(0);
+  });
 });

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.test.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.test.tsx
@@ -21,6 +21,7 @@ import userEvent from '@testing-library/user-event';
 import huePubSub from '../../utils/huePubSub';
 
 import AlertComponent from './AlertComponent';
+jest.useFakeTimers(); // Enable fake timers
 
 describe('AlertComponent', () => {
   test('it should show a global error message', async () => {

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -45,9 +45,9 @@ const AlertComponent: React.FC = () => {
         return activeAlerts;
       }
 
-      const newAlert:VisibleAlert = { alert, type };
+      const newAlert: VisibleAlert = { alert, type };
 
-      if(type === 'info') {
+      if (type === 'info') {
         setTimeout(() => {
           handleClose(newAlert);
         }, 3000);

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -25,15 +25,16 @@ interface HueAlert {
   message: string;
 }
 
+type alertType = 'error' | 'info' | 'warning';
 interface VisibleAlert {
   alert: HueAlert;
-  type: 'error' | 'info' | 'warning';
+  type: alertType;
 }
 
 const AlertComponent: React.FC = () => {
   const [alert, setAlerts] = useState<VisibleAlert[]>([]);
 
-  const updateAlerts = (alert, type) => {
+  const updateAlerts = (alert: HueAlert, type: alertType) => {
     if (!alert.message) {
       return;
     }
@@ -43,7 +44,16 @@ const AlertComponent: React.FC = () => {
       if (activeAlerts.some(activeAlerts => activeAlerts.alert.message === alert.message)) {
         return activeAlerts;
       }
-      return [...activeAlerts, { alert, type }];
+
+      const newAlert:VisibleAlert = { alert, type };
+
+      if(type === 'info') {
+        setTimeout(() => {
+          handleClose(newAlert);
+        }, 3000);
+      }
+
+      return [...activeAlerts, newAlert];
     });
   };
 
@@ -74,14 +84,14 @@ const AlertComponent: React.FC = () => {
     };
   }, []);
 
-  const handleClose = (alertObjToClose: HueAlert) => {
-    const filteredAlerts = alert.filter(alertObj => alertObj.alert !== alertObjToClose);
+  const handleClose = (alertObjToClose: VisibleAlert) => {
+    const filteredAlerts = alert.filter(alertObj => alertObj !== alertObjToClose);
     setAlerts(filteredAlerts);
   };
 
   const { t } = i18nReact.useTranslation();
 
-  const getHeader = alert => {
+  const getHeader = (alert: VisibleAlert) => {
     if (alert.type === 'error') {
       return t('Error');
     } else if (alert.type === 'info') {
@@ -101,7 +111,7 @@ const AlertComponent: React.FC = () => {
           description={alertObj.alert.message}
           showIcon={true}
           closable={true}
-          onClose={() => handleClose(alertObj.alert)}
+          onClose={() => handleClose(alertObj)}
         />
       ))}
     </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?
The info alert popup messages will automatically go after 3 seconds from when it is shown. Since, the error and warning messages are important and we want the user to close them themselves, so such a timer is only used for the info messages.

## How was this patch tested?
Attached a demo video. 
The patch is manually tested on the Hue UI using a stopwatch of 3 seconds.

https://github.com/cloudera/hue/assets/68558847/c1610f97-0ad8-48a9-bd79-ef9a8892b933


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
