### PR TITLE
Update the corrdinator URL pattern in Impala mini job browser

### DIFF
--- a/apps/impala/src/impala/conf.py
+++ b/apps/impala/src/impala/conf.py
@@ -127,7 +127,8 @@ CONFIG_WHITELIST = Config(
 USER_SCRATCH_DIR_PERMISSION = Config(
   key="user_scratch_dir_permission",
   help=_t("Due to IMPALA-10272, the importer fails with READ permissions."
-          "Setting this to True, means setting the scratch directory and its file to 777 so the importer does not fail with permission issue."),
+          "Setting this to True, means setting the scratch directory and its file to 777 so the importer "
+          "does not fail with permission issue."),
   type=coerce_bool,
   default=False
 )

--- a/apps/impala/src/impala/conf.py
+++ b/apps/impala/src/impala/conf.py
@@ -73,6 +73,12 @@ IMPERSONATION_ENABLED = Config(
   type=coerce_bool,
   dynamic_default=is_impersonation_enabled)
 
+COORDINATOR_UI_SPNEGO = Config(
+  key='coordinator_ui_spnego',
+  help=_t("Impala Coordinator Web Server has Spnego enabled."),
+  type=coerce_bool,
+  default=False)
+
 QUERYCACHE_ROWS = Config(
   key='querycache_rows',
   help=_t("Number of initial rows of a resultset to ask Impala to cache in order to"

--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -1506,6 +1506,9 @@ submit_to=True
 # Turn on/off impersonation mechanism when talking to Impala
 ## impersonation_enabled=False
 
+# Impala Coordinator Web Server has Spnego enabled
+## coordinator_ui_spnego=false
+
 # Number of initial rows of a result set to ask Impala to cache in order
 # to support re-fetching them for downloading them.
 # Set to 0 for disabling the option and backward compatibility.

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -1488,6 +1488,9 @@
   # Turn on/off impersonation mechanism when talking to Impala
   ## impersonation_enabled=False
 
+  # Impala Coordinator Web Server has Spnego enabled
+  ## coordinator_ui_spnego=false
+
   # Number of initial rows of a result set to ask Impala to cache in order
   # to support re-fetching them for downloading them.
   # Set to 0 for disabling the option and backward compatibility.


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the Impala coordinator web UI has Spnego enabled, clicking on the link in the mini job browser will result in 400 bad request, because there missing parameters in the link.

Example is the hyperlink under ID [fd477439047f4d91:fefe506000000000] in the screenshot.
<img width="1172" alt="image" src="https://github.com/cloudera/hue/assets/106372/a9e89e0a-8865-4ddd-a6b9-e825415b5a95">

## How was this patch tested?

- Manual test and unit test

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
