### PR TITLE
[jb] Various mini Job Browser improvements

### DIFF
--- a/apps/jobbrowser/src/jobbrowser/templates/mini_job_browser.mako
+++ b/apps/jobbrowser/src/jobbrowser/templates/mini_job_browser.mako
@@ -20,7 +20,6 @@ from desktop.conf import CUSTOM, IS_K8S_ONLY
 from desktop.views import commonheader, commonfooter
 from desktop.webpack_utils import get_hue_bundles
 from jobbrowser.conf import MAX_JOB_FETCH, ENABLE_QUERY_BROWSER
-from webpack_loader.templatetags.webpack_loader import render_bundle
 
 if sys.version_info[0] > 2:
   from django.utils.translation import gettext as _
@@ -53,10 +52,6 @@ ${ commonheader("Job Browser", "jobbrowser", user, request) | n,unicode }
   <link rel="stylesheet" href="${ static('desktop/ext/css/bootstrap-timepicker.min.css') }">
   <link rel="stylesheet" href="${ static('desktop/css/bootstrap-spinedit.css') }">
   <link rel="stylesheet" href="${ static('desktop/css/bootstrap-slider.css') }">
-  
-  % for bundle in get_hue_bundles('miniJobBrowser'):
-    ${ render_bundle(bundle) | n,unicode }
-  % endfor
   
   <script src="${ static('desktop/ext/js/bootstrap-datepicker.min.js') }" type="text/javascript" charset="utf-8"></script>
   <script src="${ static('desktop/ext/js/bootstrap-timepicker.min.js') }" type="text/javascript" charset="utf-8"></script>

--- a/desktop/core/src/desktop/js/apps/jobBrowser/miniJobBrowser.js
+++ b/desktop/core/src/desktop/js/apps/jobBrowser/miniJobBrowser.js
@@ -27,7 +27,7 @@ import './eventListeners';
 import JobBrowserViewModel from './knockout/JobBrowserViewModel';
 import Job from './knockout/Job';
 
-$(document).ready(() => {
+export const initializeMiniJobBrowser = () => {
   const jobBrowserViewModel = new JobBrowserViewModel(true);
   const openJob = id => {
     if (jobBrowserViewModel.job() == null) {
@@ -96,4 +96,4 @@ $(document).ready(() => {
       huePubSub.publish('open.link', '/jobbrowser/#!' + jobBrowserViewModel.interface());
     }
   });
-});
+};

--- a/desktop/core/src/desktop/js/apps/jobBrowser/miniJobBrowser.js
+++ b/desktop/core/src/desktop/js/apps/jobBrowser/miniJobBrowser.js
@@ -39,31 +39,9 @@ export const initializeMiniJobBrowser = () => {
 
   ko.applyBindings(jobBrowserViewModel, $('#jobbrowserMiniComponents')[0]);
 
-  huePubSub.subscribe(
-    'app.gained.focus',
-    app => {
-      if (app === 'jobbrowser') {
-        huePubSub.publish('graph.draw.arrows');
-        loadHash();
-      }
-    },
-    'jobbrowser'
-  );
-
-  const loadHash = () => {
-    if (window.location.pathname.indexOf('jobbrowser') > -1) {
-      jobBrowserViewModel.load();
-    }
-  };
-
-  window.onhashchange = () => {
-    loadHash();
-  };
-
   const configUpdated = clusterConfig => {
     jobBrowserViewModel.appConfig(clusterConfig && clusterConfig['app_config']);
     jobBrowserViewModel.clusterType(clusterConfig && clusterConfig['cluster_type']);
-    loadHash();
   };
 
   huePubSub.subscribe('cluster.config.set.config', configUpdated);

--- a/desktop/core/src/desktop/js/jest/koTestUtils.js
+++ b/desktop/core/src/desktop/js/jest/koTestUtils.js
@@ -56,10 +56,6 @@ export const koSetup = () => {
               const origSetTimeout = window.setTimeout;
               if (instantTimeout) {
                 window.setTimeout = cb => cb();
-                comp.createViewModel(data, { element: element });
-                window.setTimeout = origSetTimeout;
-              } else {
-                comp.createViewModel(data, { element: element });
               }
 
               ko.applyBindings(
@@ -69,6 +65,10 @@ export const koSetup = () => {
                 },
                 wrapper
               );
+
+              if (instantTimeout) {
+                window.setTimeout = origSetTimeout;
+              }
             } else {
               reject('no createViewModel function found on component ' + name);
             }

--- a/desktop/core/src/desktop/js/ko/components/ko.jobBrowserLinks.test.js
+++ b/desktop/core/src/desktop/js/ko/components/ko.jobBrowserLinks.test.js
@@ -17,19 +17,59 @@
 import $ from 'jquery';
 import { koSetup } from 'jest/koTestUtils';
 import { NAME } from './ko.jobBrowserLinks';
+import huePubSub from 'utils/huePubSub';
+
+import { initializeMiniJobBrowser } from 'apps/jobBrowser/miniJobBrowser';
+jest.mock('apps/jobBrowser/miniJobBrowser');
 
 describe('ko.jobBrowserLinks.js', () => {
   const setup = koSetup();
+  let fakeMiniPanel;
 
-  it('should render component', async () => {
+  beforeEach(() => {
     jest.spyOn($, 'post').mockImplementation(url => {
       if (url === '/jobbrowser/jobs/') {
         return $.Deferred().resolve({ jobs: [] }).promise();
       }
     });
 
+    // This element gets created during runtime via an ajax call that gets the raw
+    // html contents including scripts and styles.
+    fakeMiniPanel = document.createElement('div');
+    fakeMiniPanel.setAttribute('id', 'jobsPanel');
+    document.body.appendChild(fakeMiniPanel);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    fakeMiniPanel.remove();
+  });
+
+  it('should render component', async () => {
     const element = await setup.renderComponent(NAME, {});
 
     expect(element.innerHTML).toMatchSnapshot();
+  });
+
+  it('should initialize the mini job browser on first open', async () => {
+    window.HAS_JOB_BROWSER = true;
+    window.getLastKnownConfig = () => ({});
+    jest.spyOn($, 'post').mockImplementation(url => {
+      if (url === '/jobbrowser/jobs/') {
+        return Promise.resolve({ jobs: [] }).promise();
+      }
+    });
+    await setup.renderComponent(NAME, {});
+    expect(initializeMiniJobBrowser.mock.calls).toHaveLength(0);
+
+    // First open
+    huePubSub.publish('show.jobs.panel');
+    expect(initializeMiniJobBrowser.mock.calls).toHaveLength(1);
+
+    huePubSub.publish('hide.jobs.panel');
+
+    // Second open
+    huePubSub.publish('show.jobs.panel');
+    expect(initializeMiniJobBrowser.mock.calls).toHaveLength(1);
   });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,11 +37,7 @@ const config = {
       import: './desktop/core/src/desktop/js/apps/storageBrowser/app.js',
       dependOn: 'hue'
     },
-    jobBrowser: { import: './desktop/core/src/desktop/js/apps/jobBrowser/app.js', dependOn: 'hue' },
-    miniJobBrowser: {
-      import: './desktop/core/src/desktop/js/apps/jobBrowser/miniApp.js',
-      dependOn: 'hue'
-    }
+    jobBrowser: { import: './desktop/core/src/desktop/js/apps/jobBrowser/app.js', dependOn: 'hue' }
   },
   mode: 'development',
   module: {


### PR DESCRIPTION
With this change I removed the dedicated mini Job Browser webpack entry and changed is so that the mini Job Browser JS gets initialized on first open instead of on document ready as before. This hopefully takes care of race condition issue with loading the config before the csrf token logic is attached.

On top of this I've also made sure that the component gets properly disposed and I fixed an issue that's been there for a while where the mini Job Browser reacts to URL hashes from the main Job Browser page.

Tested manually as well as a simple unit test to make sure it gets initialized only once.