### PR TITLE
[docker] fix Huefrontend pod going to carshloopbackoff state

### DIFF
--- a/tools/container/huelb/Dockerfile
+++ b/tools/container/huelb/Dockerfile
@@ -47,4 +47,4 @@ STOPSIGNAL SIGINT
 USER hive
 ENV USER hive
 WORKDIR ${HUE_HOME}
-CMD ["run_httpd.sh"]
+CMD ["./run_httpd.sh"]


### PR DESCRIPTION
## What changes were proposed in this pull request?

fix Huefrontend pod going to carshloopbackoff state

## How was this patch tested?

backport internal fix

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
