### PR TITLE
[api] Provide configs to control CORS

### DIFF
--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -1790,6 +1790,26 @@ DJANGO_EMAIL_BACKEND = Config(
   default="django.core.mail.backends.smtp.EmailBackend"
 )
 
+CORS_ENABLED = Config(
+  key="cors_enabled",
+  help=_("Enable or disable Cross-Origin Resource Sharing (CORS). Defaults to True."),
+  type=coerce_bool,
+  default=True
+)
+
+CORS_ALLOW_CREDENTIALS = Config(
+  key="cors_allow_credentials",
+  help=_("This value determines whether the server allows cookies in the cross-site HTTP requests. Defaults to True."),
+  type=coerce_bool,
+  default=True
+)
+
+CORS_ALLOWED_ORIGINS = Config(
+  key="cors_allowed_origins",
+  help=_("A comma separated list of origins allowed for CORS."),
+  type=coerce_csv
+)
+
 ENABLE_SQL_SYNTAX_CHECK = Config(
   key='enable_sql_syntax_check',
   default=True,

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -370,16 +370,16 @@ SERVER_EMAIL = desktop.conf.DJANGO_SERVER_EMAIL.get()
 EMAIL_BACKEND = desktop.conf.DJANGO_EMAIL_BACKEND.get()
 EMAIL_SUBJECT_PREFIX = 'Hue %s - ' % desktop.conf.CLUSTER_ID.get()
 
+if desktop.conf.CORS_ENABLED.get():
+  # Permissive CORS for public /api
+  INSTALLED_APPS.append('corsheaders')
+  MIDDLEWARE.insert(0, 'corsheaders.middleware.CorsMiddleware')
 
-# Permissive CORS for public /api
-INSTALLED_APPS.append('corsheaders')
-MIDDLEWARE.insert(0, 'corsheaders.middleware.CorsMiddleware')
-CORS_URLS_REGEX = r'^/api/.*$|/saml2/login/'
-CORS_ALLOW_CREDENTIALS = True
-if sys.version_info[0] > 2:
-  CORS_ALLOW_ALL_ORIGINS = True
-else:
-  CORS_ORIGIN_ALLOW_ALL = True
+  CORS_URLS_REGEX = r'^/api/.*$|/saml2/login/'
+  CORS_ALLOW_CREDENTIALS = desktop.conf.CORS_ALLOW_CREDENTIALS.get()
+
+  CORS_ALLOWED_ORIGINS = desktop.conf.CORS_ALLOWED_ORIGINS.get() or []
+  CORS_ALLOW_ALL_ORIGINS = not bool(CORS_ALLOWED_ORIGINS)
 
 # Configure database
 if os.getenv('DESKTOP_DB_CONFIG'):


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added 3 new configurations under [desktop] to control CORS. CORS must be enabled for public APIs and SAML login.
1. cors_enabled - Enable or disable Cross-Origin Resource Sharing (CORS). Defaults to True.
2. cors_allow_credentials - This value determines whether the server allows cookies in the cross-site HTTP requests. Defaults to True.
3. cors_allowed_origins - A comma separated list of origins allowed for CORS. If not set all origins are allowed.

## How was this patch tested?
- Hue was started locally on port 80
- Two new domains were added to /etc/hosts pointed to localhost - abc.com, def.com
- Logged into Hue via def.com domain.
- From browser dev tool, made a fetch request to abc.com - No error as **cors_allowed_origins** is not set.
- Set cors_allowed_origins=http://abc.com
- From browser dev tool, again made fetch request to abc.com - Got "Access to fetch ... has been blocked by CORS policy error" as expected. 
- Set cors_allowed_origins=http://def.com
- From browser dev tool, again made fetch request to abc.com - Preflight request went through and request progressed.