### PR TITLE
[fb] Check for get attribute for ARCHIVE_UPLOAD_TEMPDIR config

### DIFF
--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -149,7 +149,7 @@ UPLOAD_CLASSES = {
     'local': LocalFineUploaderChunkedUpload,
 }
 
-if not os.path.exists(ARCHIVE_UPLOAD_TEMPDIR.get()):
+if hasattr(ARCHIVE_UPLOAD_TEMPDIR, 'get') and not os.path.exists(ARCHIVE_UPLOAD_TEMPDIR.get()):
   os.makedirs(ARCHIVE_UPLOAD_TEMPDIR.get())
 
 logger = logging.getLogger()


### PR DESCRIPTION
## What changes were proposed in this pull request?

- When filebrowser is blacklisted, we are getting the following error which is failing Hue startup:
```
  File "/opt/hive/desktop/core/src/desktop/urls.py", line 50, in <module>                                                                                                                                                                                             │
│     from desktop import api_public_urls_v1                                                                                                                                                                                                                            │
│   File "/opt/hive/desktop/core/src/desktop/api_public_urls_v1.py", line 20, in <module>                                                                                                                                                                               │
│     from desktop import api_public                                                                                                                                                                                                                                    │
│   File "/opt/hive/desktop/core/src/desktop/api_public.py", line 26, in <module>                                                                                                                                                                                       │
│     from filebrowser import views as filebrowser_views, api as filebrowser_api                                                                                                                                                                                        │
│   File "/opt/hive/apps/filebrowser/src/filebrowser/views.py", line 152, in <module>                                                                                                                                                                                   │
│     if not os.path.exists(ARCHIVE_UPLOAD_TEMPDIR.get()):                                                                                                                                                                                                              │
│ AttributeError: 'Config' object has no attribute 'get' 
```
- Checking for the `get` attribute before checking if the path exists resolves the issue.

## How was this patch tested?

- Tested manually by blacklisting filebrowser app