### PR TITLE
[linting] precommit hooks for linting

### DIFF
--- a/setup-hooks.sh
+++ b/setup-hooks.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Source path of the precommit hook
+SOURCE_HOOK="tools/git-hooks/pre-commit"
+
+# Destination path of the pre-commit hook
+DEST_HOOK=".git/hooks/pre-commit"
+
+# Copy the precommit hook to .git/hooks directory
+cp "$SOURCE_HOOK" "$DEST_HOOK"
+
+# Make the pre-commit hook executable
+chmod +x "$DEST_HOOK"
+
+# Install ESLint and related dependencies
+npm install eslint -g
+
+echo "ESLint and related dependencies installed."
+echo "Pre-commit hook copied and made executable successfully!"

--- a/setup-hooks.sh
+++ b/setup-hooks.sh
@@ -1,19 +1,31 @@
 #!/bin/bash
 
-# Source path of the precommit hook
-SOURCE_HOOK="tools/git-hooks/pre-commit"
+# Function to install a git hook
+install_hook() {
+  local hook_name=$1
 
-# Destination path of the pre-commit hook
-DEST_HOOK=".git/hooks/pre-commit"
+  # Source and destination paths
+  local source_hook="tools/git-hooks/${hook_name}"
+  local dest_hook=".git/hooks/${hook_name}"
 
-# Copy the precommit hook to .git/hooks directory
-cp "$SOURCE_HOOK" "$DEST_HOOK"
+  # Copy the hook and make it executable
+  if [[ -e "${source_hook}" ]]; then
+    cp "${source_hook}" "${dest_hook}" && chmod +x "${dest_hook}"
+    echo "${hook_name} hook installed successfully."
+  else
+    echo "Error: The hook '${source_hook}' does not exist."
+    exit 1
+  fi
+}
 
-# Make the pre-commit hook executable
-chmod +x "$DEST_HOOK"
+# Select the hook to install based on argument or use default (pre-commit)
+hook_to_install=${1:-pre-commit}
 
-# Install ESLint and related dependencies
-npm install eslint -g
+# Install the selected hook
+install_hook "${hook_to_install}"
 
-echo "ESLint and related dependencies installed."
-echo "Pre-commit hook copied and made executable successfully!"
+# Install ESLint and related dependencies globally if pre-commit is the selected hook
+if ! npm list -g eslint --depth=0 >/dev/null 2>&1; then
+  npm install eslint -g
+  echo "ESLint and related dependencies installed."
+fi

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -19,7 +19,7 @@
 set -e
 ERRORS=false
 
-for FILE in `git diff --name-only` ; do
+for FILE in `git diff --cached --name-only` ; do
     if [[ "$FILE" =~ ^.+(py)$ ]]; then
         if [ "grep 'distinct()' $FILE" ]; then  # HUE-3191: Check if distinct() exists in any Python files
             ERRORS=true
@@ -29,6 +29,13 @@ for FILE in `git diff --name-only` ; do
         if [ "grep 'pdb.set_trace()' $FILE" ]; then
             ERRORS=true
             echo -e "[ERROR] $FILE: Found pdb.set_trace() debug statements in file.\n"
+        fi
+    elif [[ "$FILE" =~ ^.+(js|jsx|ts|tsx)$ ]]; then
+        echo "Running ESLint for $FILE..."
+        eslint "$FILE"  # Run ESLint for JavaScript/JSX files
+        if [ $? -ne 0 ]; then
+            ERRORS=true
+            echo -e "[ERROR] ESLint found issues in $FILE.\n"
         fi
     fi
 done

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -31,11 +31,14 @@ for FILE in `git diff --cached --name-only` ; do
             echo -e "[ERROR] $FILE: Found pdb.set_trace() debug statements in file.\n"
         fi
     elif [[ "$FILE" =~ ^.+(js|jsx|ts|tsx)$ ]]; then
+        FOLDERS_PATTERN="^(desktop/core/src/desktop/js|tools/sql-docs|tools/jison)/"
         echo "Running ESLint for $FILE..."
-        eslint "$FILE"  # Run ESLint for JavaScript/JSX files
-        if [ $? -ne 0 ]; then
-            ERRORS=true
-            echo -e "[ERROR] ESLint found issues in $FILE.\n"
+        if [[ "$FILE" =~ $FOLDERS_PATTERN ]]; then  # Check if file is inside one of the desired folders
+            eslint "$FILE"  # Run ESLint for JavaScript/JSX files
+            if [ $? -ne 0 ]; then
+                ERRORS=true
+                echo -e "[ERROR] ESLint found issues in $FILE.\n"
+            fi
         fi
     fi
 done

--- a/tools/git-hooks/pre-push
+++ b/tools/git-hooks/pre-push
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+ERRORS=false
+
+COMMITS=$(git log @{u}..HEAD --pretty=format:%h)
+
+for COMMIT in $COMMITS; do
+    FILES_IN_COMMIT=$(git diff-tree --no-commit-id --name-only -r $COMMIT)
+    for FILE in $FILES_IN_COMMIT; do
+        if [[ "$FILE" =~ ^.+(py)$ ]]; then
+            if [ "grep 'distinct()' $FILE" ]; then  # HUE-3191: Check if distinct() exists in any Python files
+                ERRORS=true
+                echo -e "[WARNING] $FILE: The file contains distinct() which case cause Oracle to fail if the object contains a TextField (CLOB). Ensure that you use defer() on any TextFields in the query or avoid distinct().\n"
+            fi
+
+            if [ "grep 'pdb.set_trace()' $FILE" ]; then
+                ERRORS=true
+                echo -e "[ERROR] $FILE: Found pdb.set_trace() debug statements in file.\n"
+            fi
+        elif [[ "$FILE" =~ ^.+(js|jsx|ts|tsx)$ ]]; then
+            FOLDERS_PATTERN="^(desktop/core/src/desktop/js|tools/sql-docs|tools/jison)/"
+            echo "Running ESLint for $FILE..."
+            if [[ "$FILE" =~ $FOLDERS_PATTERN ]]; then  # Check if file is inside one of the desired folders
+                eslint "$FILE"  # Run ESLint for JavaScript/JSX files
+                if [ $? -ne 0 ]; then
+                    ERRORS=true
+                    echo -e "[ERROR] ESLint found issues in $FILE.\n"
+                fi
+            fi
+        fi
+    done
+done
+
+if $ERRORS; then
+    echo -e "To ignore these warnings, commit with --no-verify\n"
+    exit 1
+fi
+
+exit


### PR DESCRIPTION
Add a Precommit hook for linting on the diff

Run the script ./setup-hooks.sh for this to work.


Example Runs only on diffs:
Running ESLint for desktop/core/src/desktop/js/jquery/plugins/jquery.filechooser.js...

/Users/tabraiz/Documents/cloudera/internal-hue/hue/desktop/core/src/desktop/js/jquery/plugins/jquery.filechooser.js
  791:4  error  Parsing error: Unexpected token, expected "," (791:4)

✖ 1 problem (1 error, 0 warnings)

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
