### PR TITLE
[frontend] Change typescript eslint rule from warning to error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,6 +61,7 @@ const jsTsVueRules = {
   '@typescript-eslint/no-explicit-any': 'error',
   '@typescript-eslint/no-this-alias': 'error',
   '@typescript-eslint/no-unused-vars': 'error',
+  '@typescript-eslint/explicit-module-boundary-types': 'error',
   'vue/max-attributes-per-line': [
     'error',
     {


### PR DESCRIPTION
This one checks missing return types and args, for some reason it's still a warning after the previous commit to change all warnings to errors.