### PR TITLE
[raz][s3] Fix encoding for special chars in directory name listing 1000+ keys

### DIFF
--- a/desktop/core/src/desktop/lib/raz/raz_client.py
+++ b/desktop/core/src/desktop/lib/raz/raz_client.py
@@ -256,11 +256,12 @@ class RazClient(object):
 
     # In GET operations with non-ascii chars, only the non-ascii part is URL encoded.
     # We need to unquote the path fully before making a signed request for RAZ.
-    if method == 'GET' and 'prefix' in url_params and '%' in url_params['prefix']:
-      if sys.version_info[0] < 3 and isinstance(url_params['prefix'], unicode):
-        url_params['prefix'] = url_params['prefix'].encode()
+    if method == 'GET':
+      if url_params.get('prefix') and '%' in url_params['prefix']:
+        url_params['prefix'] = lib_urlunquote(url_params['prefix'])
 
-      url_params['prefix'] = lib_urlunquote(url_params['prefix'])
+      if url_params.get('marker') and '%' in url_params['marker']:
+        url_params['marker'] = lib_urlunquote(url_params['marker'])
 
     allparams = [raz_signer.StringListStringMapProto(key=key, value=[val]) for key, val in url_params.items()]
     allparams.extend([raz_signer.StringListStringMapProto(key=key, value=[val]) for key, val in params.items()])


### PR DESCRIPTION
## What changes were proposed in this pull request?

- If a directory has 1000+ keys, then when listing the objects using the GET request, it also required a `marker` header to fetch more keys.
- This `marker` headers needs to be unquoted when sent to RAZ but left unchanged when sent to S3 to have proper access on the path from RAZ side.

## How was this patch tested?

- Manual E2E testing in live setup.