### PR TITLE
[frontend] Implement placeholder for empty table scenario

### DIFF
--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.scss
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.scss
@@ -17,6 +17,7 @@
 @use 'mixins';
 
 $cell-height: 40px;
+$table-placeholder-height: 100px;
 
 .hue-storage-browser__table {
   @include mixins.hue-svg-icon__d3-conflict;
@@ -26,6 +27,11 @@ $cell-height: 40px;
   .hue-storage-browser__table-cell-icon {
     color: vars.$fluidx-blue-700;
     margin-right: 6px;
+  }
+
+  .ant-table-placeholder {
+    height: $table-placeholder-height;
+    text-align: center;
   }
 
   thead {

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.tsx
@@ -179,6 +179,11 @@ const StorageBrowserTable: React.FC<StorageBrowserTableProps> = ({
     };
   }, []);
 
+  //function removes ..(previous folder) and .(current folder) from table data
+  const removeDots = (dataSource: StorageBrowserTableData[]) => {
+    return dataSource.length > 2 ? dataSource.slice(2) : [];
+  };
+
   const locale = {
     emptyText: t('Folder is empty')
   };
@@ -189,7 +194,7 @@ const StorageBrowserTable: React.FC<StorageBrowserTableProps> = ({
         <Table
           className={className}
           columns={getColumns(dataSource[0])}
-          dataSource={dataSource.length > 2 ? dataSource.slice(2) : []}
+          dataSource={removeDots(dataSource)}
           onRow={onRowClicked}
           pagination={false}
           rowClassName={rowClassName}

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTable/StorageBrowserTable.tsx
@@ -179,19 +179,24 @@ const StorageBrowserTable: React.FC<StorageBrowserTableProps> = ({
     };
   }, []);
 
+  const locale = {
+    emptyText: t('Folder is empty')
+  };
+
   if (dataSource && pageStats) {
     return (
       <>
         <Table
           className={className}
           columns={getColumns(dataSource[0])}
-          dataSource={dataSource}
+          dataSource={dataSource.length > 2 ? dataSource.slice(2) : []}
           onRow={onRowClicked}
           pagination={false}
           rowClassName={rowClassName}
           rowKey={(record, index) => record.path + '' + index}
           scroll={{ y: tableHeight }}
           data-testid={`${testId}`}
+          locale={locale}
           {...restProps}
         ></Table>
         <Pagination


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add a "Folder is empty" placeholder for storage browser table.
- Removes the previous folder and current folder entry in the table. (i.e .. and . folders)

## How was this patch tested?

- Manually

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
