### PR TITLE
[useradmin] Add new "set_user_as_active" and improve "promote_to_superuser" commands

### DIFF
--- a/apps/useradmin/src/useradmin/management/commands/promote_to_superuser.py
+++ b/apps/useradmin/src/useradmin/management/commands/promote_to_superuser.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import time
+import datetime
+import re
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+from django.contrib.auth.models import User
+
+import desktop.conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
+
+LOG = logging.getLogger(__name__)
+
+class Command(BaseCommand):
+    """
+    Handler for promoting a user to superuser
+    """    
+    def add_arguments(self, parser):
+        parser.add_argument("--usernames", help=_t("User(s) to promote to superuser."), nargs='+', action="store",required=True)
+    
+    def handle(self, *args, **options):
+        if options["usernames"]:
+            try:
+                LOG.warn("Promoting user %s to superuser" % options['usernames'])
+                
+                user_exist = []
+                user_not_exist = []
+                usernames = options["usernames"]
+                
+                for user in usernames:
+                    isExist = User.objects.filter(username=user).exists()
+                    if (isExist):
+                        new_super = User.objects.get(username = user)
+                        new_super.is_superuser = True
+                        new_super.save()
+                        user_exist.append(user)
+                    else:
+                        user_not_exist.append(user)
+                
+                LOG.info("User(s) promoted to superuser: %s" % user_exist)
+                LOG.info("User(s) does not exist: %s" % user_not_exist)
+            except Exception as e:
+                LOG.error("EXCEPTION: promoting user %s to superuser failed: %s" % (options['username'], e))

--- a/apps/useradmin/src/useradmin/management/commands/promote_to_superuser.py
+++ b/apps/useradmin/src/useradmin/management/commands/promote_to_superuser.py
@@ -1,3 +1,20 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import sys
 import time
@@ -10,12 +27,9 @@ from django.contrib.auth.models import User
 
 import desktop.conf
 
-if sys.version_info[0] > 2:
-  from django.utils.translation import gettext_lazy as _t, gettext as _
-else:
-  from django.utils.translation import ugettext_lazy as _t, ugettext as _
+from django.utils.translation import gettext_lazy as _t, gettext as _
 
-LOG = logging.getLogger(__name__)
+LOG = logging.getLogger()
 
 class Command(BaseCommand):
     """
@@ -25,7 +39,7 @@ class Command(BaseCommand):
         parser.add_argument("--usernames", help=_t("User(s) to promote to superuser."), nargs='+', action="store",required=True)
     
     def handle(self, *args, **options):
-        if options["usernames"]:
+        if options.get("usernames"):
             try:
                 LOG.warn("Promoting user %s to superuser" % options['usernames'])
                 
@@ -34,8 +48,8 @@ class Command(BaseCommand):
                 usernames = options["usernames"]
                 
                 for user in usernames:
-                    isExist = User.objects.filter(username=user).exists()
-                    if (isExist):
+                    is_exist = User.objects.filter(username=user).exists()
+                    if (is_exist):
                         new_super = User.objects.get(username = user)
                         new_super.is_superuser = True
                         new_super.save()
@@ -43,7 +57,11 @@ class Command(BaseCommand):
                     else:
                         user_not_exist.append(user)
                 
-                LOG.info("User(s) promoted to superuser: %s" % user_exist)
-                LOG.info("User(s) does not exist: %s" % user_not_exist)
+                if (user_exist):
+                    LOG.info("User(s) promoted to superuser: %s" % user_exist)
+                
+                if (user_not_exist):
+                    LOG.info("User(s) does not exist: %s" % user_not_exist)
+            
             except Exception as e:
                 LOG.error("EXCEPTION: promoting user %s to superuser failed: %s" % (options['username'], e))

--- a/apps/useradmin/src/useradmin/management/commands/promote_to_superuser.py
+++ b/apps/useradmin/src/useradmin/management/commands/promote_to_superuser.py
@@ -31,37 +31,38 @@ from django.utils.translation import gettext_lazy as _t, gettext as _
 
 LOG = logging.getLogger()
 
+
 class Command(BaseCommand):
   """
   Handler for promoting a user to superuser
-  """  
+  """
   def add_arguments(self, parser):
     parser.add_argument("--usernames", help=_t("User(s) to promote to superuser."), nargs='+', action="store", required=True)
-  
+
   def handle(self, *args, **options):
     if options.get("usernames"):
       try:
         LOG.warn("Promoting user %s to superuser" % options['usernames'])
-        
+
         user_exist = []
         user_not_exist = []
         usernames = options["usernames"]
-        
+
         for user in usernames:
           is_exist = User.objects.filter(username=user).exists()
           if (is_exist):
-            new_super=User.objects.get(username = user)
+            new_super = User.objects.get(username=user)
             new_super.is_superuser = True
             new_super.save()
             user_exist.append(user)
           else:
             user_not_exist.append(user)
-        
+
         if (user_exist):
           LOG.info("User(s) promoted to superuser: %s" % user_exist)
-        
+
         if (user_not_exist):
           LOG.info("User(s) does not exist: %s" % user_not_exist)
-      
+
       except Exception as e:
         LOG.error("EXCEPTION: promoting user %s to superuser failed: %s" % (options['username'], e))

--- a/apps/useradmin/src/useradmin/management/commands/promote_to_superuser.py
+++ b/apps/useradmin/src/useradmin/management/commands/promote_to_superuser.py
@@ -7,7 +7,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,36 +32,36 @@ from django.utils.translation import gettext_lazy as _t, gettext as _
 LOG = logging.getLogger()
 
 class Command(BaseCommand):
-    """
-    Handler for promoting a user to superuser
-    """    
-    def add_arguments(self, parser):
-        parser.add_argument("--usernames", help=_t("User(s) to promote to superuser."), nargs='+', action="store",required=True)
-    
-    def handle(self, *args, **options):
-        if options.get("usernames"):
-            try:
-                LOG.warn("Promoting user %s to superuser" % options['usernames'])
-                
-                user_exist = []
-                user_not_exist = []
-                usernames = options["usernames"]
-                
-                for user in usernames:
-                    is_exist = User.objects.filter(username=user).exists()
-                    if (is_exist):
-                        new_super = User.objects.get(username = user)
-                        new_super.is_superuser = True
-                        new_super.save()
-                        user_exist.append(user)
-                    else:
-                        user_not_exist.append(user)
-                
-                if (user_exist):
-                    LOG.info("User(s) promoted to superuser: %s" % user_exist)
-                
-                if (user_not_exist):
-                    LOG.info("User(s) does not exist: %s" % user_not_exist)
-            
-            except Exception as e:
-                LOG.error("EXCEPTION: promoting user %s to superuser failed: %s" % (options['username'], e))
+  """
+  Handler for promoting a user to superuser
+  """  
+  def add_arguments(self, parser):
+    parser.add_argument("--usernames", help=_t("User(s) to promote to superuser."), nargs='+', action="store", required=True)
+  
+  def handle(self, *args, **options):
+    if options.get("usernames"):
+      try:
+        LOG.warn("Promoting user %s to superuser" % options['usernames'])
+        
+        user_exist = []
+        user_not_exist = []
+        usernames = options["usernames"]
+        
+        for user in usernames:
+          is_exist = User.objects.filter(username=user).exists()
+          if (is_exist):
+            new_super=User.objects.get(username = user)
+            new_super.is_superuser = True
+            new_super.save()
+            user_exist.append(user)
+          else:
+            user_not_exist.append(user)
+        
+        if (user_exist):
+          LOG.info("User(s) promoted to superuser: %s" % user_exist)
+        
+        if (user_not_exist):
+          LOG.info("User(s) does not exist: %s" % user_not_exist)
+      
+      except Exception as e:
+        LOG.error("EXCEPTION: promoting user %s to superuser failed: %s" % (options['username'], e))

--- a/apps/useradmin/src/useradmin/management/commands/set_user_as_active.py
+++ b/apps/useradmin/src/useradmin/management/commands/set_user_as_active.py
@@ -31,23 +31,24 @@ from django.utils.translation import gettext_lazy as _t, gettext as _
 
 LOG = logging.getLogger()
 
+
 class Command(BaseCommand):
   """
   Handler for making user(s) active.
   """
 
   def add_arguments(self, parser):
-    parser.add_argument("--usernames", help=_t("One or more user(s) to make active."),nargs='+', action="store", required=True)
+    parser.add_argument("--usernames", help=_t("One or more user(s) to make active."), nargs='+', action="store", required=True)
 
   def handle(self, *args, **options):
     if options.get("usernames"):
       try:
         LOG.info("Setting user %s as active" % options['usernames'])
-        
+
         user_exist = []
         user_not_exist = []
         usernames = options["usernames"]
-        
+
         for user in usernames:
           is_exist = User.objects.filter(username=user).exists()
           if (is_exist):
@@ -57,12 +58,12 @@ class Command(BaseCommand):
             user_exist.append(user)
           else:
             user_not_exist.append(user)
-        
+
         if (user_exist):
           LOG.info("User(s) set as Active: %s" % user_exist)
 
         if (user_not_exist):
           LOG.info("User(s) does not exist: %s" % user_not_exist)
-        
+
       except Exception as e:
         LOG.error("EXCEPTION: setting user %s as active failed: %s" % (options['usernames'], e))

--- a/apps/useradmin/src/useradmin/management/commands/set_user_as_active.py
+++ b/apps/useradmin/src/useradmin/management/commands/set_user_as_active.py
@@ -1,3 +1,20 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import sys
 import time
@@ -10,12 +27,9 @@ from django.contrib.auth.models import User
 
 import desktop.conf
 
-if sys.version_info[0] > 2:
-  from django.utils.translation import gettext_lazy as _t, gettext as _
-else:
-  from django.utils.translation import ugettext_lazy as _t, ugettext as _
+from django.utils.translation import gettext_lazy as _t, gettext as _
 
-LOG = logging.getLogger(__name__)
+LOG = logging.getLogger()
 
 class Command(BaseCommand):
     """
@@ -26,7 +40,7 @@ class Command(BaseCommand):
         parser.add_argument("--usernames", help=_t("One or more user(s) to make active."),nargs='+', action="store",required=True)
 
     def handle(self, *args, **options):
-        if options["usernames"]:
+        if options.get("usernames"):
             try:
                 LOG.info("Setting user %s as active" % options['usernames'])
                 
@@ -35,8 +49,8 @@ class Command(BaseCommand):
                 usernames = options["usernames"]
                 
                 for user in usernames:
-                    isExist = User.objects.filter(username=user).exists()
-                    if (isExist):
+                    is_exist = User.objects.filter(username=user).exists()
+                    if (is_exist):
                         active_user = User.objects.get(username=user)
                         active_user.is_active = True
                         active_user.save()
@@ -44,7 +58,11 @@ class Command(BaseCommand):
                     else:
                         user_not_exist.append(user)
                 
-                LOG.info("User(s) set as Active: %s" % user_exist)
-                LOG.info("User(s) does not exist: %s" % user_not_exist)
+                if (user_exist):
+                    LOG.info("User(s) set as Active: %s" % user_exist)
+
+                if (user_not_exist):
+                    LOG.info("User(s) does not exist: %s" % user_not_exist)
+                
             except Exception as e:
                 LOG.error("EXCEPTION: setting user %s as active failed: %s" % (options['usernames'], e))

--- a/apps/useradmin/src/useradmin/management/commands/set_user_as_active.py
+++ b/apps/useradmin/src/useradmin/management/commands/set_user_as_active.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import time
+import datetime
+import re
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+from django.contrib.auth.models import User
+
+import desktop.conf
+
+if sys.version_info[0] > 2:
+  from django.utils.translation import gettext_lazy as _t, gettext as _
+else:
+  from django.utils.translation import ugettext_lazy as _t, ugettext as _
+
+LOG = logging.getLogger(__name__)
+
+class Command(BaseCommand):
+    """
+    Handler for making user(s) active.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument("--usernames", help=_t("One or more user(s) to make active."),nargs='+', action="store",required=True)
+
+    def handle(self, *args, **options):
+        if options["usernames"]:
+            try:
+                LOG.info("Setting user %s as active" % options['usernames'])
+                
+                user_exist = []
+                user_not_exist = []
+                usernames = options["usernames"]
+                
+                for user in usernames:
+                    isExist = User.objects.filter(username=user).exists()
+                    if (isExist):
+                        active_user = User.objects.get(username=user)
+                        active_user.is_active = True
+                        active_user.save()
+                        user_exist.append(user)
+                    else:
+                        user_not_exist.append(user)
+                
+                LOG.info("User(s) set as Active: %s" % user_exist)
+                LOG.info("User(s) does not exist: %s" % user_not_exist)
+            except Exception as e:
+                LOG.error("EXCEPTION: setting user %s as active failed: %s" % (options['usernames'], e))

--- a/apps/useradmin/src/useradmin/management/commands/set_user_as_active.py
+++ b/apps/useradmin/src/useradmin/management/commands/set_user_as_active.py
@@ -7,7 +7,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,37 +32,37 @@ from django.utils.translation import gettext_lazy as _t, gettext as _
 LOG = logging.getLogger()
 
 class Command(BaseCommand):
-    """
-    Handler for making user(s) active.
-    """
+  """
+  Handler for making user(s) active.
+  """
 
-    def add_arguments(self, parser):
-        parser.add_argument("--usernames", help=_t("One or more user(s) to make active."),nargs='+', action="store",required=True)
+  def add_arguments(self, parser):
+    parser.add_argument("--usernames", help=_t("One or more user(s) to make active."),nargs='+', action="store", required=True)
 
-    def handle(self, *args, **options):
-        if options.get("usernames"):
-            try:
-                LOG.info("Setting user %s as active" % options['usernames'])
-                
-                user_exist = []
-                user_not_exist = []
-                usernames = options["usernames"]
-                
-                for user in usernames:
-                    is_exist = User.objects.filter(username=user).exists()
-                    if (is_exist):
-                        active_user = User.objects.get(username=user)
-                        active_user.is_active = True
-                        active_user.save()
-                        user_exist.append(user)
-                    else:
-                        user_not_exist.append(user)
-                
-                if (user_exist):
-                    LOG.info("User(s) set as Active: %s" % user_exist)
+  def handle(self, *args, **options):
+    if options.get("usernames"):
+      try:
+        LOG.info("Setting user %s as active" % options['usernames'])
+        
+        user_exist = []
+        user_not_exist = []
+        usernames = options["usernames"]
+        
+        for user in usernames:
+          is_exist = User.objects.filter(username=user).exists()
+          if (is_exist):
+            active_user = User.objects.get(username=user)
+            active_user.is_active = True
+            active_user.save()
+            user_exist.append(user)
+          else:
+            user_not_exist.append(user)
+        
+        if (user_exist):
+          LOG.info("User(s) set as Active: %s" % user_exist)
 
-                if (user_not_exist):
-                    LOG.info("User(s) does not exist: %s" % user_not_exist)
-                
-            except Exception as e:
-                LOG.error("EXCEPTION: setting user %s as active failed: %s" % (options['usernames'], e))
+        if (user_not_exist):
+          LOG.info("User(s) does not exist: %s" % user_not_exist)
+        
+      except Exception as e:
+        LOG.error("EXCEPTION: setting user %s as active failed: %s" % (options['usernames'], e))


### PR DESCRIPTION


## What changes were proposed in this pull request?

- added new command **set_user_as_active**, and moved & improvised custom_command **promote_to_superuser** to useradmin command. 
- **set_user_as_active** script will mark a given set of users as active.
- currently, **promote_to_superuser** is part of _custom_command_ and only handles the use case to promote a single user to superuser at a time. I have improvised this script to be part of hue useradmin commands and to promote single or multiple users to a superuser in a single go.

## How was this patch tested?

- manual testing

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
