### PR TITLE
[jb] Fix two bugs from the previous job browser migration to webpack

### DIFF
--- a/desktop/core/src/desktop/templates/global_js_constants.mako
+++ b/desktop/core/src/desktop/templates/global_js_constants.mako
@@ -187,7 +187,7 @@
   window.RAZ_IS_ENABLED = '${ RAZ.IS_ENABLED.get() }' === 'True';
 
   window.ENABLE_HISTORY_V2 = '${ hasattr(ENABLE_HISTORY_V2, 'get') and ENABLE_HISTORY_V2.get() }' === 'True';
-  window.ENABLE_HIVE_QUERY_BROWSER = '${ hasattr(ENABLE_QUERY_BROWSER, 'get') and ENABLE_QUERY_BROWSER.get() }' === 'True';
+  window.ENABLE_HIVE_QUERY_BROWSER = '${ hasattr(ENABLE_HIVE_QUERY_BROWSER, 'get') and ENABLE_HIVE_QUERY_BROWSER.get() }' === 'True';
   window.ENABLE_QUERY_BROWSER = '${ hasattr(ENABLE_QUERY_BROWSER, 'get') and ENABLE_QUERY_BROWSER.get() }' === 'True';
   window.ENABLE_QUERY_STORE = '${ hasattr(QUERY_STORE, 'IS_ENABLED') and hasattr(QUERY_STORE.IS_ENABLED, 'get') and QUERY_STORE.IS_ENABLED.get() }' === 'True'
   window.ENABLE_SQL_SYNTAX_CHECK = '${ conf.ENABLE_SQL_SYNTAX_CHECK.get() }' === 'True';

--- a/desktop/core/src/desktop/templates/job_browser_common.mako
+++ b/desktop/core/src/desktop/templates/job_browser_common.mako
@@ -1761,7 +1761,7 @@
           <div
             data-bind="visible:properties.plan && properties.plan().plan_json && properties.plan().plan_json.plan_nodes.length">
             <div class="query-plan" data-bind="
-               attr: { id: $root.contextId('queries-page-plan-graph') }
+               attr: { id: $root.contextId('queries-page-plan-graph') },
                impalaDagre: { value: properties.plan && properties.plan(), height: $root.isMini() ? 535 : 600 }
             ">
               <svg style="width:100%;height:100%;position:relative;"
@@ -1802,16 +1802,15 @@
         </div>
         <div class="tab-pane" data-bind="attr: { id: $root.contextId('queries-page-profile') }"
              data-profile="profile">
-          <button class="btn" type="button" data-clipboard-target="#query-impala-profile" style="float: right;"
-                  data-bind="
-                visible: properties.profile && properties.profile().profile,
-                clipboard: {
-                  onSuccess: function() {
-                    huePubSub.publish('hue.global.info', {
-                      message: "${ _("Profile copied to clipboard!") }"
-                    }
-                  }
-                }">
+          <button class="btn" type="button" data-clipboard-target="#query-impala-profile" style="float: right;" data-bind="
+            visible: properties.profile && properties.profile().profile,
+            clipboard: {
+              onSuccess: function() {
+                huePubSub.publish('hue.global.info', {
+                  message: '${ _("Profile copied to clipboard!") }'
+                })
+              }
+            }">
           <i class="fa fa-fw fa-clipboard"></i> ${ _('Clipboard') }
           </button>
           <button class="btn" type="button" style="float: right;" data-bind="


### PR DESCRIPTION
This takes care of two issues:

1. The Hive section was always enabled even though configured to be disabled
2. The knockout templates for details of an impala query contained syntax errors

Only manual testing. No unit tests on this one as the templates are still in mako files.