### PR TITLE
[ui-metrics] Converted the Metrics page within Admin Server in ReactJS

### DIFF
--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.scss
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.scss
@@ -27,6 +27,14 @@
   flex-flow: column;
   row-gap: 10px;
 
+  .ant-alert {
+    padding-right: 12px;
+
+    .ant-alert-description {
+      display: inline;
+    }
+  }
+
   button:hover,
   button:focus {
     background-color: unset;
@@ -34,7 +42,6 @@
 
   button span {
     font-size: $font-size-sm;
-    padding-top: 5px;
   }
 
   button svg.cdp-icon-close {

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -24,13 +24,13 @@ interface HueAlert {
   message: string;
 }
 
-interface ShowAlert {
+interface VisibleAlert {
   alert: HueAlert;
   type: 'error' | 'info' | 'warning';
 }
 
 const AlertComponent: React.FC = () => {
-  const [alert, setAlerts] = useState<ShowAlert[]>([]);
+  const [alert, setAlerts] = useState<VisibleAlert[]>([]);
 
   const updateAlerts = (alert, type) => {
     if (!alert.message) {

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -81,14 +81,12 @@ const AlertComponent: React.FC = () => {
 
   const { t } = i18nReact.useTranslation();
 
-  const getHeader = (alert) => {
+  const getHeader = alert => {
     if (alert.type === 'error') {
       return t('Error');
-    } 
-    else if (alert.type === 'info') {
+    } else if (alert.type === 'info') {
       return t('Info');
-    } 
-    else if (alert.type === 'warning') {
+    } else if (alert.type === 'warning') {
       return t('Warning');
     }
   };

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -19,6 +19,7 @@ import Alert from 'cuix/dist/components/Alert/Alert';
 
 import huePubSub from 'utils/huePubSub';
 import './AlertComponent.scss';
+import { i18nReact } from '../../utils/i18nReact';
 
 interface HueAlert {
   message: string;
@@ -78,13 +79,29 @@ const AlertComponent: React.FC = () => {
     setAlerts(filteredErrors);
   };
 
+  const {t} = i18nReact.useTranslation();
+
+  const getHeader = (alert)=> {
+    if (alert.type === 'error') {
+      return t('Error');
+    }
+    else if (alert.type === 'info') {
+      return t('Info');
+    }
+    else if (alert.type === 'warning') {
+      return t('Warning');
+    }
+  }
+
   return (
     <div className="hue-alert flash-messages cuix antd">
       {alert.map(alertObj => (
         <Alert
           key={alertObj.alert.message}
           type={alertObj.type}
-          message={alertObj.alert.message}
+          message={getHeader(alertObj)}
+          description={alertObj.alert.message}
+          showIcon={true}
           closable={true}
           onClose={() => handleClose(alertObj)}
         />

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -81,12 +81,14 @@ const AlertComponent: React.FC = () => {
 
   const { t } = i18nReact.useTranslation();
 
-  const getHeader = alert => {
+  const getHeader = (alert) => {
     if (alert.type === 'error') {
       return t('Error');
-    } else if (alert.type === 'info') {
+    } 
+    else if (alert.type === 'info') {
       return t('Info');
-    } else if (alert.type === 'warning') {
+    } 
+    else if (alert.type === 'warning') {
       return t('Warning');
     }
   };

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -22,7 +22,6 @@ import './AlertComponent.scss';
 
 interface HueAlert {
   message: string;
-  type: 'error' | 'info' | 'warning';
 }
 
 interface ShowAlert {
@@ -40,7 +39,7 @@ const AlertComponent: React.FC = () => {
     setAlerts(activeAlerts => {
       // Prevent showing the same message multiple times.
       // TODO: Consider showing a count in the error notification when the same message is reported multiple times.
-      if (activeAlerts.some(activeAlerts => activeAlerts.alert.message === newAlert.alert.message)) {
+      if (activeAlerts.some(activeAlerts => activeAlerts.alert.message === alert.message)) {
         return activeAlerts;
       }
       return [...activeAlerts, { alert, type }];
@@ -66,8 +65,8 @@ const AlertComponent: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    const hueSub = huePubSub.subscribe('hue.global.warn', (newAlert: HueAlert) => {
-      updateAlerts(newAlert, 'warn');
+    const hueSub = huePubSub.subscribe('hue.global.warning', (newAlert: HueAlert) => {
+      updateAlerts(newAlert, 'warning');
     });
     return () => {
       hueSub.remove();

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -74,9 +74,9 @@ const AlertComponent: React.FC = () => {
     };
   }, []);
 
-  const handleClose = (errorObjToClose: HueAlert) => {
-    const filteredErrors = alert.filter(errorObj => errorObj !== errorObjToClose);
-    setAlerts(filteredErrors);
+  const handleClose = (alertObjToClose: HueAlert) => {
+    const filteredAlerts = alert.filter(alertObj => alertObj.alert !== alertObjToClose);
+    setAlerts(filteredAlerts);
   };
 
   const { t } = i18nReact.useTranslation();
@@ -103,7 +103,7 @@ const AlertComponent: React.FC = () => {
           description={alertObj.alert.message}
           showIcon={true}
           closable={true}
-          onClose={() => handleClose(alertObj)}
+          onClose={() => handleClose(alertObj.alert)}
         />
       ))}
     </div>

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -28,7 +28,7 @@ interface HueAlert {
 const AlertComponent: React.FC = () => {
   const [alerts, setAlerts] = useState<HueAlert[]>([]);
 
-    const updateAlerts(alerts,type) => {
+    const updateAlerts = (alerts,type) => {
       if (!alerts.message) {
         return;
       }

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -22,16 +22,29 @@ import './AlertComponent.scss';
 
 interface HueAlert {
   message: string;
-  type: 'error' | 'info' | 'success' | 'warning' | undefined;
+  type: 'error' | 'info' | 'warning';
+}
+
+interface ShowAlert {
+  alert: HueAlert;
+  type: 'error' | 'info' | 'warning';
 }
 
 const AlertComponent: React.FC = () => {
-  const [alerts, setAlerts] = useState<HueAlert[]>([]);
+  const [alert, setAlerts] = useState<ShowAlert[]>([]);
 
-  const updateAlerts = (alerts, type) => {
-    if (!alerts.message) {
+  const updateAlerts = (alert, type) => {
+    if (!alert.message) {
       return;
     }
+    setAlerts(activeAlerts => {
+      // Prevent showing the same message multiple times.
+      // TODO: Consider showing a count in the error notification when the same message is reported multiple times.
+      if (activeAlerts.some(activeAlerts => activeAlerts.alert.message === newAlert.alert.message)) {
+        return activeAlerts;
+      }
+      return [...activeAlerts, { alert, type }];
+    });
   };
 
   useEffect(() => {
@@ -62,17 +75,17 @@ const AlertComponent: React.FC = () => {
   }, []);
 
   const handleClose = (errorObjToClose: HueAlert) => {
-    const filteredErrors = alerts.filter(errorObj => errorObj !== errorObjToClose);
+    const filteredErrors = alert.filter(errorObj => errorObj !== errorObjToClose);
     setAlerts(filteredErrors);
   };
 
   return (
     <div className="hue-alert flash-messages cuix antd">
-      {alerts.map(alertObj => (
+      {alert.map(alertObj => (
         <Alert
-          key={alertObj.message}
+          key={alertObj.alert.message}
           type={alertObj.type}
-          message={alertObj.message}
+          message={alertObj.alert.message}
           closable={true}
           onClose={() => handleClose(alertObj)}
         />

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -20,48 +20,62 @@ import Alert from 'cuix/dist/components/Alert/Alert';
 import huePubSub from 'utils/huePubSub';
 import './AlertComponent.scss';
 
-interface ErrorAlert {
+interface HueAlert {
   message: string;
+  type: 'error' | 'info' | 'warn';
 }
 
 const AlertComponent: React.FC = () => {
-  const [errors, setErrors] = useState<ErrorAlert[]>([]);
+  const [alerts, setAlerts] = useState<HueAlert[]>([]);
 
-  useEffect(() => {
-    const hueSub = huePubSub.subscribe('hue.global.error', (newError: ErrorAlert) => {
-      if (!newError.message) {
+    const updateAlerts(alerts,type) => {
+      if (!alert.message) {
         return;
       }
+    }
 
-      setErrors(activeErrors => {
-        // Prevent showing the same message multiple times.
-        // TODO: Consider showing a count in the error notification when the same message is reported multiple times.
-        if (activeErrors.some(activeError => activeError.message === newError.message)) {
-          return activeErrors;
-        }
-        return [...activeErrors, newError];
-      });
+  useEffect(() => {
+    const hueSub = huePubSub.subscribe('hue.global.error', (newAlert: HueAlert) => {
+    updateAlerts(newAlert, 'error');
     });
     return () => {
       hueSub.remove();
     };
   }, []);
 
-  const handleClose = (errorObjToClose: ErrorAlert) => {
-    const filteredErrors = errors.filter(errorObj => errorObj !== errorObjToClose);
-    setErrors(filteredErrors);
+  useEffect(() => {
+    const hueSub = huePubSub.subscribe('hue.global.info', (newAlert: HueAlert) => {
+    updateAlerts(newAlert, 'info');
+    });
+    return () => {
+      hueSub.remove();
+    };
+  }, []);
+
+  useEffect(() => {
+    const hueSub = huePubSub.subscribe('hue.global.warn', (newAlert: HueAlert) => {
+    updateAlerts(newAlert, 'warn');
+    });
+    return () => {
+      hueSub.remove();
+    };
+  }, []);
+
+  const handleClose = (errorObjToClose: HueAlert) => {
+    const filteredErrors = alerts.filter(errorObj => errorObj !== errorObjToClose);
+    setAlerts(filteredErrors);
   };
 
   //TODO: add support for warnings and success messages
   return (
     <div className="hue-alert flash-messages cuix antd">
-      {errors.map(errorObj => (
+      {alerts.map(alertObj => (
         <Alert
-          key={errorObj.message}
-          type="error"
-          message={errorObj.message}
+          key={alertObj.message}
+          type={alertObj.type}
+          message={alertObj.message}
           closable={true}
-          onClose={() => handleClose(errorObj)}
+          onClose={() => handleClose(alertObj)}
         />
       ))}
     </div>

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -22,7 +22,7 @@ import './AlertComponent.scss';
 
 interface HueAlert {
   message: string;
-  type: 'error' | 'info' | 'warn';
+  type: "error" | "info" | "success" | "warning" | undefined;
 }
 
 const AlertComponent: React.FC = () => {

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -22,21 +22,21 @@ import './AlertComponent.scss';
 
 interface HueAlert {
   message: string;
-  type: "error" | "info" | "success" | "warning" | undefined;
+  type: 'error' | 'info' | 'success' | 'warning' | undefined;
 }
 
 const AlertComponent: React.FC = () => {
   const [alerts, setAlerts] = useState<HueAlert[]>([]);
 
-    const updateAlerts = (alerts,type) => {
-      if (!alerts.message) {
-        return;
-      }
+  const updateAlerts = (alerts, type) => {
+    if (!alerts.message) {
+      return;
     }
+  };
 
   useEffect(() => {
     const hueSub = huePubSub.subscribe('hue.global.error', (newAlert: HueAlert) => {
-    updateAlerts(newAlert, 'error');
+      updateAlerts(newAlert, 'error');
     });
     return () => {
       hueSub.remove();
@@ -45,7 +45,7 @@ const AlertComponent: React.FC = () => {
 
   useEffect(() => {
     const hueSub = huePubSub.subscribe('hue.global.info', (newAlert: HueAlert) => {
-    updateAlerts(newAlert, 'info');
+      updateAlerts(newAlert, 'info');
     });
     return () => {
       hueSub.remove();
@@ -54,7 +54,7 @@ const AlertComponent: React.FC = () => {
 
   useEffect(() => {
     const hueSub = huePubSub.subscribe('hue.global.warn', (newAlert: HueAlert) => {
-    updateAlerts(newAlert, 'warn');
+      updateAlerts(newAlert, 'warn');
     });
     return () => {
       hueSub.remove();

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -79,19 +79,17 @@ const AlertComponent: React.FC = () => {
     setAlerts(filteredErrors);
   };
 
-  const {t} = i18nReact.useTranslation();
+  const { t } = i18nReact.useTranslation();
 
-  const getHeader = (alert)=> {
+  const getHeader = alert => {
     if (alert.type === 'error') {
       return t('Error');
-    }
-    else if (alert.type === 'info') {
+    } else if (alert.type === 'info') {
       return t('Info');
-    }
-    else if (alert.type === 'warning') {
+    } else if (alert.type === 'warning') {
       return t('Warning');
     }
-  }
+  };
 
   return (
     <div className="hue-alert flash-messages cuix antd">

--- a/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/AlertComponent/AlertComponent.tsx
@@ -29,7 +29,7 @@ const AlertComponent: React.FC = () => {
   const [alerts, setAlerts] = useState<HueAlert[]>([]);
 
     const updateAlerts(alerts,type) => {
-      if (!alert.message) {
+      if (!alerts.message) {
         return;
       }
     }
@@ -66,7 +66,6 @@ const AlertComponent: React.FC = () => {
     setAlerts(filteredErrors);
   };
 
-  //TODO: add support for warnings and success messages
   return (
     <div className="hue-alert flash-messages cuix antd">
       {alerts.map(alertObj => (

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
@@ -1,0 +1,50 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// 'License'); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@import '../../components/styles/variables';
+
+.metrics-component {
+  background-color: $fluidx-gray-100;
+  padding: 0px 24px 24px 24px; 
+}
+
+.antd h4 {
+  color: $fluidx-gray-700;
+  padding-left: $font-size-lg;
+  font-size: $fluidx-heading-h4-size;
+  line-height: $fluidx-heading-h4-line-height;
+  font-weight: $fluidx-heading-h4-weight;
+}
+
+.antd .ant-table-wrapper {
+  margin-bottom: $font-size-xl;
+}
+
+.antd .ant-input-affix-wrapper {
+  margin: $font-size-sm;
+  width: 30%;
+}
+
+.antd .ant-table th {
+  width: 30%;
+}
+
+.antd .ant-select {
+  border: 1px solid $fluidx-gray-600;
+  border-radius: $border-radius-base;
+  background-color: $fluidx-white;
+  min-width: 200px;
+}

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
@@ -1,0 +1,94 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// 'License'); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
+import MetricsComponent from './MetricsComponent';
+
+jest.mock('api/utils', () => ({
+  get: jest.fn(() =>
+    Promise.resolve({
+      metric: {
+        'queries.number': { value: 10 },
+        'requests.active': { count: 5 },
+        'requests.exceptions': { count: 2 },
+        'requests.response-time': {
+          '15m_rate': 20,
+          '1m_rate': 15,
+          '5m_rate': 18,
+          '75_percentile': 50,
+          '95_percentile': 60,
+          '999_percentile': 70,
+          '99_percentile': 55,
+          'avg': 25,
+          'count': 100,
+          'max': 30,
+          'mean_rate': 22,
+          'min': 20,
+          'std_dev': 5,
+          'sum': 2500
+        },
+        'threads.daemon': { value: 3 },
+        'threads.total': { value: 6 },
+        'users': { value: 50 },
+        'users.active': { value: 30 },
+        'users.active.total': { value: 40 }
+      }
+    })
+  )
+}));
+
+//1. Test for filtering metrics based on input
+describe('MetricsComponent', () => {
+  test('Filtering metrics based on name column value', async () => {
+    render(<MetricsComponent />);
+
+    const filterInput = screen.getByPlaceholderText('Filter metrics...');
+    fireEvent.change(filterInput, { target: { value: 'value' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('queries.number')).toBeInTheDocument();
+      expect(screen.getByText('threads.daemon')).toBeInTheDocument();
+      expect(screen.getByText('threads.total')).toBeInTheDocument();
+      expect(screen.getByText('users')).toBeInTheDocument();
+      expect(screen.getByText('users.active')).toBeInTheDocument();
+      expect(screen.getByText('users.active.total')).toBeInTheDocument();
+
+      expect(screen.queryByText('requests.active')).toBeNull();
+      expect(screen.queryByText('requests.exceptions')).toBeNull();
+      expect(screen.queryByText('requests.response-time')).toBeNull();
+    });
+  });
+
+  //2. Test for selecting a specific metric from the dropdown:
+  test('Selecting a specific metric from the dropdown', async () => {
+    render(<MetricsComponent />);
+
+    const dropdown = screen.getByPlaceholderText('Choose a metric');
+    fireEvent.change(dropdown, { target: { value: 'users' } });
+
+    await waitFor(() => {
+      expect(screen.queryByText('queries.number')).toBeNull();
+      expect(screen.queryByText('requests.active')).toBeNull();
+      expect(screen.queryByText('requests.exceptions')).toBeNull();
+      expect(screen.queryByText('threads.daemon')).toBeNull();
+      expect(screen.queryByText('threads.total')).toBeNull();
+      expect(screen.getByText('users')).toBeInTheDocument();
+      expect(screen.queryByText('users.active')).toBeNull();
+      expect(screen.queryByText('users.active.total')).toBeNull();
+    });
+  });
+});

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
@@ -1,0 +1,183 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// 'License'); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, { useState, useEffect, useRef } from 'react';
+import MetricsTable, { MetricsResponse } from './MetricsTable';
+import { Spin, Input, Select, Alert } from 'antd';
+import { get } from 'api/utils';
+import { SearchOutlined } from '@ant-design/icons';
+import './MetricsComponent.scss';
+
+const { Option } = Select;
+
+const MetricsComponent = () => {
+  const [metrics, setMetrics] = useState<MetricsResponse>();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [searchQuery, setSearchQuery] = useState<string>('');
+  const [selectedMetric, setSelectedMetric] = useState<string>('');
+  const [showAllTables, setShowAllTables] = useState(true);
+  const [filteredMetricsData, setFilteredMetricsData] = useState<MetricsData[]>([]);
+  const dropdownRef = useRef(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await get<MetricsResponse>('/desktop/metrics/', { format: 'json' });
+        setMetrics(response);
+      } catch (error) {
+        setError(error.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  useEffect(() => {
+    if (!metrics) {
+      return;
+    }
+
+    const filteredData = parseMetricsData(metrics).filter(tableData =>
+      tableData.dataSource.some(data => data.name.toLowerCase().includes(searchQuery.toLowerCase()))
+    );
+
+    setFilteredMetricsData(filteredData);
+  }, [searchQuery, metrics]);
+
+  const parseMetricsData = (data: MetricsResponse) => {
+    const metricsData = [
+      {
+        caption: 'queries.number',
+        dataSource: [{ name: 'value', value: data.metric['queries.number'].value }]
+      },
+      {
+        caption: 'requests.active',
+        dataSource: [{ name: 'count', value: data.metric['requests.active'].count }]
+      },
+      {
+        caption: 'requests.exceptions',
+        dataSource: [{ name: 'count', value: data.metric['requests.exceptions'].count }]
+      },
+      {
+        caption: 'requests.response-time',
+        dataSource: [
+          { name: '15m_rate', value: data.metric['requests.response-time']['15m_rate'] },
+          { name: '1m_rate', value: data.metric['requests.response-time']['1m_rate'] },
+          { name: '5m_rate', value: data.metric['requests.response-time']['5m_rate'] },
+          { name: '75_percentile', value: data.metric['requests.response-time']['75_percentile'] },
+          { name: '95_percentile', value: data.metric['requests.response-time']['95_percentile'] },
+          {
+            name: '999_percentile',
+            value: data.metric['requests.response-time']['999_percentile']
+          },
+          { name: '99_percentile', value: data.metric['requests.response-time']['99_percentile'] },
+          { name: 'avg', value: data.metric['requests.response-time']['avg'] },
+          { name: 'count', value: data.metric['requests.response-time']['count'] },
+          { name: 'max', value: data.metric['requests.response-time']['max'] },
+          { name: 'mean_rate', value: data.metric['requests.response-time']['mean_rate'] },
+          { name: 'min', value: data.metric['requests.response-time']['min'] },
+          { name: 'std_dev', value: data.metric['requests.response-time']['std_dev'] },
+          { name: 'sum', value: data.metric['requests.response-time']['sum'] }
+        ]
+      },
+      {
+        caption: 'threads.daemon',
+        dataSource: [{ name: 'value', value: data.metric['threads.daemon'].value }]
+      },
+      {
+        caption: 'threads.total',
+        dataSource: [{ name: 'value', value: data.metric['threads.total'].value }]
+      },
+      { caption: 'users', dataSource: [{ name: 'value', value: data.metric['users'].value }] },
+      {
+        caption: 'users.active',
+        dataSource: [{ name: 'value', value: data.metric['users.active'].value }]
+      },
+      {
+        caption: 'users.active.total',
+        dataSource: [{ name: 'value', value: data.metric['users.active.total'].value }]
+      }
+    ];
+    return metricsData;
+  };
+
+  const handleMetricChange = (value: string) => {
+    setSelectedMetric(value);
+    setShowAllTables(value === '');
+  };
+
+  const handleFilterInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value);
+  };
+
+  return (
+    <div className="cuix antd metrics-component">
+      <Spin spinning={loading}>
+        {!error && (
+          <>
+            <Input
+              placeholder="Filter metrics..."
+              value={searchQuery}
+              onChange={handleFilterInputChange}
+              prefix={<SearchOutlined />}
+            />
+            <Select
+              //to make sure antd class gets applied
+              getPopupContainer={triggerNode => triggerNode.parentElement}
+              ref={dropdownRef}
+              placeholder="Choose a metric"
+              value={selectedMetric}
+              onChange={handleMetricChange}
+            >
+              <Option value="">All</Option>
+              <Option value="queries.number">Queries Number</Option>
+              <Option value="requests.active">Active Requests</Option>
+              <Option value="requests.exceptions">Exceptional Requests</Option>
+              <Option value="requests.response-time">Requests Response-time</Option>
+              <Option value="threads.daemon">Daemon Threads</Option>
+              <Option value="threads.total">Total Threads</Option>
+              <Option value="users">Users</Option>
+              <Option value="users.active">Active Users</Option>
+              <Option value="users.active.total">Total Active Users</Option>
+            </Select>
+          </>
+        )}
+
+        {error && (
+          <Alert
+            message={`Error: ${error}`}
+            description="Error in displaying the Metrics!"
+            type="error"
+          />
+        )}
+
+        {!error &&
+          filteredMetricsData.map((tableData, index) => (
+            <div key={index}>
+              {(showAllTables || selectedMetric === tableData.caption) && (
+                <MetricsTable caption={tableData.caption} dataSource={tableData.dataSource} />
+              )}
+            </div>
+          ))}
+      </Spin>
+    </div>
+  );
+};
+
+export default MetricsComponent;

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
@@ -1,0 +1,107 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// 'License'); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, { CSSProperties } from 'react';
+import Table from 'cuix/dist/components/Table/Table';
+import type { ColumnType } from 'antd/es/table';
+import './MetricsComponent.scss';
+import 'cuix/dist/components/Table/Table.css';
+
+interface MetricsTime {
+  '1m_rate': number;
+  '5m_rate': number;
+  '15m_rate': number;
+  '75_percentile': number;
+  '95_percentile': number;
+  '99_percentile': number;
+  '999_percentile': number;
+  'avg': number;
+  'count': number;
+  'max': number;
+  'mean_rate': number;
+  'min': number;
+  'std_dev': number;
+  'sum': number;
+}
+
+export interface MetricsResponse {
+  metric: {
+    'auth.ldap.auth-time': MetricsTime;
+    'auth.oauth.auth-time': MetricsTime;
+    'auth.pam.auth-time': MetricsTime;
+    'auth.saml2.auth-time': MetricsTime;
+    'auth.spnego.auth-time': MetricsTime;
+    'multiprocessing.processes.daemon': MetricsValue;
+    'multiprocessing.processes.total': MetricsValue;
+    'python.gc.generation.0': MetricsValue;
+    'python.gc.generation.1': MetricsValue;
+    'python.gc.generation.2': MetricsValue;
+    'python.gc.objects': MetricsValue;
+    'queries.number': MetricsValue;
+    'requests.active': MetricsCount;
+    'requests.exceptions': MetricsCount;
+    'requests.response-time': MetricsTime;
+    'threads.daemon': MetricsValue;
+    'threads.total': MetricsValue;
+    'users': MetricsValue;
+    'users.active': MetricsValue;
+    'users.active.total': MetricsValue;
+    'timestamp': string;
+  };
+}
+
+interface MetricsValue {
+  value: number;
+}
+
+interface MetricsCount {
+  count: number;
+}
+
+interface MetricsTableProps {
+  caption: string;
+  dataSource: { name: string; value: any }[];
+}
+
+const MetricsTable = ({ caption, dataSource }: MetricsTableProps) => {
+  const metricsColumns: ColumnType[] = [];
+
+  metricsColumns.push({
+    title: 'Name',
+    dataIndex: 'name',
+    key: 'name'
+  });
+  metricsColumns.push({
+    title: 'Value',
+    dataIndex: 'value',
+    key: 'value'
+  });
+
+  return (
+    <>
+      <h4>{caption}</h4>
+      <Table
+        dataSource={dataSource}
+        rowKey="name"
+        columns={metricsColumns}
+        style={CSSProperties}
+        pagination={false}
+      />
+    </>
+  );
+};
+
+export default MetricsTable;

--- a/desktop/core/src/desktop/js/reactComponents/imports.js
+++ b/desktop/core/src/desktop/js/reactComponents/imports.js
@@ -1,4 +1,4 @@
-// ADD NEW RACT COMPONENTS HERE
+// ADD NEW REACT COMPONENTS HERE
 // We need a way to match an imported module with a component name
 // so we handle the imports dynamically for that reason.
 export async function loadComponent(name) {
@@ -9,6 +9,9 @@ export async function loadComponent(name) {
 
     case 'StorageBrowserPage':
       return (await import('../apps/storageBrowser/StorageBrowserPage/StorageBrowserPage')).default;
+
+    case 'MetricsComponent':
+      return (await import('./MetricsComponent/MetricsComponent')).default;
 
     // Application global components here
     case 'AppBanner':

--- a/desktop/core/src/desktop/templates/metrics.mako
+++ b/desktop/core/src/desktop/templates/metrics.mako
@@ -101,77 +101,15 @@ ${ commonheader(_('Metrics'), "about", user, request) | n,unicode }
 
 ${layout.menubar(section='metrics')}
 
-<div id="metricsComponents" class="container-fluid">
-  <div class="card card-small margin-top-10">
-    <!-- ko if: metrics() -->
-    <div data-bind="dockable: { scrollable: ${ MAIN_SCROLLABLE }, jumpCorrection: 0,topSnap: '${ TOP_SNAP }', triggerAdjust: ${ is_embeddable and "0" or "106" }}">
-      <ul class="nav nav-pills">
-        <li data-bind="css: { 'active': $root.selectedMetric() === 'All' }">
-          <a href="javascript:void(0)" data-bind="text: 'All', click: function(){ $root.selectedMetric('All') }"></a>
-        </li>
-        <!-- ko foreach: metricsKeys -->
-        <!-- ko ifnot: $root.isUnusedMetric($data)-->
-        <li data-bind="css: { 'active': $root.selectedMetric() === $data }">
-          <a href="javascript:void(0)" data-bind="text: $data, click: function(){ $root.selectedMetric($data) }"></a>
-        </li>
-        <!-- /ko -->
-        <!-- /ko -->
-      </ul>
-      <input type="text" data-bind="clearable: metricsFilter, valueUpdate: 'afterkeydown'"
-          class="input-xlarge pull-right margin-bottom-10" placeholder="${_('Filter metrics...')}">
-    </div>
+<script type="text/javascript">
+  (function () {
+    window.createReactComponents('#MetricsComponent');
+  })();
+</script>
 
-    <div class="margin-top-10">
-      <!-- ko if: $root.selectedMetric() === 'All' && $root.isMasterEmpty()-->
-      <table class="table table-condensed">
-        <thead>
-          <tr>
-            <th width="30%">${ _('Name') }</th>
-            <th>${ _('Value') }</th>
-          </tr>
-        </thead>
-        <tfoot>
-          <tr>
-              <td colspan="2">${ _('There are no metrics matching your filter') }</td>
-          </tr>
-        </tfoot>
-      </table>
-      <!-- /ko -->
-      <div data-bind="foreach: {data: Object.keys($root.filteredMetrics()).sort(), as: '_masterkey'}">
-      <!-- ko if: ($root.selectedMetric() === 'All' && $root.filteredMetrics()[_masterkey]) || $root.selectedMetric() === _masterkey-->
-      <!-- ko ifnot: $root.isUnusedMetric(_masterkey)-->
-      <h4 data-bind="text: _masterkey"></h4>
-      <table class="table table-condensed">
-        <thead>
-          <tr>
-            <th width="30%">${ _('Name') }</th>
-            <th>${ _('Value') }</th>
-          </tr>
-        </thead>
-        <!-- ko if: $root.filteredMetrics()[_masterkey] -->
-        <tbody data-bind="foreach: {'data': Object.keys($root.filteredMetrics()[_masterkey])}">
-          <tr>
-            <td data-bind="text: $data"></td>
-            <td data-bind="text: $root.filteredMetrics()[_masterkey][$data]"></td>
-          </tr>
-        </tbody>
-        <!-- /ko -->
-        <!-- ko ifnot: $root.filteredMetrics()[_masterkey] -->
-        <tfoot>
-          <tr>
-            <td colspan="2">${ _('There are no metrics matching your filter') }</td>
-          </tr>
-          </tfoot>
-        <!-- /ko -->
-        </table>
-        <!-- /ko -->
-        <!-- /ko -->
-      </div>
-    </div>
-  <!-- /ko -->
-  </div>
+<div id="MetricsComponent">
+<MetricsComponent data-reactcomponent='MetricsComponent'></MetricsComponent>
 </div>
-
 
 %if not is_embeddable:
 ${ commonfooter(request, messages) | n,unicode }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR is about shifting the entire code for the Metrics tab (page) in ReactJS i.e. adding Metrics as a react component. The Metrics page is present as a tab in the Administrator server.

## How was this patch tested?
I have added unit tests here. One for the selection dropDown and the other for filtering the metrics based on name.
The code is tested manually as well.

This is how the current Metrics page looks like.
<img width="1725" alt="Screenshot 2024-04-15 at 9 31 11 PM" src="https://github.com/cloudera/hue/assets/68558847/77f31e38-19ff-43b2-ba02-d3f52a3bf16e">

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
