### PR TITLE
[ui-metrics] Converted the Metrics page within Admin Server in ReactJS

### DIFF
--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
@@ -21,7 +21,7 @@
   padding: 0 24px 24px 24px;
 }
 
-.antd h4 {
+.antd .metrics-heading {
   color: $fluidx-gray-700;
   padding-left: $font-size-lg;
   font-size: $fluidx-heading-h4-size;

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
@@ -31,7 +31,19 @@
   .metrics-filter {
     margin: $font-size-sm;
     width: 30%;
+    // .ant-input:focus {
+    //   outline: none;
+    //   border-color: transparent;
+    // }
+    // .ant-input-prefix 
+    .ant-input {
+      &:focus {
+        outline: none !important;
+        border-color: transparent !important;
+        box-shadow: none !important;
+      }
   }
+}
 
   .metrics-table th {
     width: 30%;

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
@@ -31,6 +31,8 @@
   .metrics-filter {
     margin: $font-size-sm;
     width: 30%;
+    box-shadow: none !important;
+    -webkit-box-shadow: none !important;
   }
 
   .metrics-table th {

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
@@ -29,7 +29,6 @@
   }
 
   .metrics-filter {
-    margin-bottom: $font-size-xl;
     margin: $font-size-sm;
     width: 30%;
   }

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
@@ -31,7 +31,12 @@
   .metrics-filter {
     margin: $font-size-sm;
     width: 30%;
-  }
+
+    input {
+      box-shadow: none;
+      -webkit-box-shadow: none;
+    }
+}
 
   .metrics-table th {
     width: 30%;
@@ -42,5 +47,6 @@
     border-radius: $border-radius-base;
     background-color: $fluidx-white;
     min-width: 200px;
+    height: 32px;
   }
 }

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
@@ -36,7 +36,7 @@
       box-shadow: none;
       -webkit-box-shadow: none;
     }
-}
+  }
 
   .metrics-table th {
     width: 30%;

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
@@ -31,8 +31,6 @@
   .metrics-filter {
     margin: $font-size-sm;
     width: 30%;
-    box-shadow: none !important;
-    -webkit-box-shadow: none !important;
   }
 
   .metrics-table th {

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
@@ -1,0 +1,50 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// 'License'); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@import '../../components/styles/variables';
+
+.metrics-component {
+  background-color: $fluidx-gray-100;
+  padding: 0px 24px 24px 24px; 
+}
+
+.antd h4 {
+  color: $fluidx-gray-700;
+  padding-left: $font-size-lg;
+  font-size: $fluidx-heading-h4-size;
+  line-height: $fluidx-heading-h4-line-height;
+  font-weight: $fluidx-heading-h4-weight;
+}
+
+.antd .ant-table-wrapper {
+  margin-bottom: $font-size-xl;
+}
+
+.antd .ant-input-affix-wrapper {
+  margin: $font-size-sm;
+  width: 30%;
+}
+
+.antd .ant-table th {
+  width: 30%;
+}
+
+.antd .ant-select {
+  border: 1px solid $fluidx-gray-600;
+  border-radius: $border-radius-base;
+  background-color: $fluidx-white;
+  min-width: 200px;
+}

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
@@ -19,32 +19,32 @@
 .metrics-component {
   background-color: $fluidx-gray-100;
   padding: 0 24px 24px 24px;
-}
 
-.antd .metrics-heading {
-  color: $fluidx-gray-700;
-  padding-left: $font-size-lg;
-  font-size: $fluidx-heading-h4-size;
-  line-height: $fluidx-heading-h4-line-height;
-  font-weight: $fluidx-heading-h4-weight;
-}
+  .metrics-heading {
+    color: $fluidx-gray-700;
+    padding-left: $font-size-lg;
+    font-size: $fluidx-heading-h4-size;
+    line-height: $fluidx-heading-h4-line-height;
+    font-weight: $fluidx-heading-h4-weight;
+  }
 
-.antd .ant-table-wrapper {
-  margin-bottom: $font-size-xl;
-}
+  .ant-table-wrapper {
+    margin-bottom: $font-size-xl;
+  }
 
-.antd .ant-input-affix-wrapper {
-  margin: $font-size-sm;
-  width: 30%;
-}
+  .ant-input-affix-wrapper {
+    margin: $font-size-sm;
+    width: 30%;
+  }
 
-.antd .ant-table th {
-  width: 30%;
-}
+  .metrics-table th {
+    width: 30%;
+  }
 
-.antd .ant-select {
-  border: 1px solid $fluidx-gray-600;
-  border-radius: $border-radius-base;
-  background-color: $fluidx-white;
-  min-width: 200px;
+  .ant-select {
+    border: 1px solid $fluidx-gray-600;
+    border-radius: $border-radius-base;
+    background-color: $fluidx-white;
+    min-width: 200px;
+  }
 }

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
@@ -18,7 +18,7 @@
 
 .metrics-component {
   background-color: $fluidx-gray-100;
-  padding: 0px 24px 24px 24px; 
+  padding: 0 24px 24px 24px;
 }
 
 .antd h4 {

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.scss
@@ -28,11 +28,8 @@
     font-weight: $fluidx-heading-h4-weight;
   }
 
-  .ant-table-wrapper {
+  .metrics-filter {
     margin-bottom: $font-size-xl;
-  }
-
-  .ant-input-affix-wrapper {
     margin: $font-size-sm;
     width: 30%;
   }
@@ -41,7 +38,7 @@
     width: 30%;
   }
 
-  .ant-select {
+  .metrics-select {
     border: 1px solid $fluidx-gray-600;
     border-radius: $border-radius-base;
     background-color: $fluidx-white;

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
@@ -1,0 +1,94 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// 'License'); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
+import MetricsComponent from './MetricsComponent';
+
+jest.mock('api/utils', () => ({
+  get: jest.fn(() =>
+    Promise.resolve({
+      metric: {
+        'queries.number': { value: 10 },
+        'requests.active': { count: 5 },
+        'requests.exceptions': { count: 2 },
+        'requests.response-time': {
+          '15m_rate': 20,
+          '1m_rate': 15,
+          '5m_rate': 18,
+          '75_percentile': 50,
+          '95_percentile': 60,
+          '999_percentile': 70,
+          '99_percentile': 55,
+          'avg': 25,
+          'count': 100,
+          'max': 30,
+          'mean_rate': 22,
+          'min': 20,
+          'std_dev': 5,
+          'sum': 2500
+        },
+        'threads.daemon': { value: 3 },
+        'threads.total': { value: 6 },
+        'users': { value: 50 },
+        'users.active': { value: 30 },
+        'users.active.total': { value: 40 }
+      }
+    })
+  )
+}));
+
+//1. Test for filtering metrics based on input
+describe('MetricsComponent', () => {
+  test('Filtering metrics based on name column value', async () => {
+    render(<MetricsComponent />);
+
+    const filterInput = screen.getByPlaceholderText('Filter metrics...');
+    fireEvent.change(filterInput, { target: { value: 'value' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('queries.number')).toBeInTheDocument();
+      expect(screen.getByText('threads.daemon')).toBeInTheDocument();
+      expect(screen.getByText('threads.total')).toBeInTheDocument();
+      expect(screen.getByText('users')).toBeInTheDocument();
+      expect(screen.getByText('users.active')).toBeInTheDocument();
+      expect(screen.getByText('users.active.total')).toBeInTheDocument();
+
+      expect(screen.queryByText('requests.active')).toBeNull();
+      expect(screen.queryByText('requests.exceptions')).toBeNull();
+      expect(screen.queryByText('requests.response-time')).toBeNull();
+    });
+  });
+
+  //2. Test for selecting a specific metric from the dropdown:
+  test('Selecting a specific metric from the dropdown', async () => {
+    render(<MetricsComponent />);
+
+    const dropdown = screen.getByPlaceholderText('Choose a metric');
+    fireEvent.change(dropdown, { target: { value: 'users' } });
+
+    await waitFor(() => {
+      expect(screen.queryByText('queries.number')).toBeNull();
+      expect(screen.queryByText('requests.active')).toBeNull();
+      expect(screen.queryByText('requests.exceptions')).toBeNull();
+      expect(screen.queryByText('threads.daemon')).toBeNull();
+      expect(screen.queryByText('threads.total')).toBeNull();
+      expect(screen.getByText('users')).toBeInTheDocument();
+      expect(screen.queryByText('users.active')).toBeNull();
+      expect(screen.queryByText('users.active.total')).toBeNull();
+    });
+  });
+});

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
@@ -19,21 +19,6 @@ import { render, waitFor, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import MetricsComponent from './MetricsComponent';
 
-// Mock matchMedia for compatibility with certain UI libraries
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: jest.fn().mockImplementation(query => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(), // Deprecated
-    removeListener: jest.fn(), // Deprecated
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn()
-  }))
-});
-
 // Mock the API call to return sample metrics data
 jest.mock('api/utils', () => ({
   get: jest.fn(() =>

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
@@ -98,7 +98,7 @@ describe('MetricsComponent', () => {
 
     const select = screen.getByTestId('metric-select').firstElementChild;
     if (select) {
-      fireEvent.click(select);
+      fireEvent.mouseDown(select);
     }
 
     // Query for the dropdown menu which is now in the document

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
@@ -214,45 +214,30 @@ describe('MetricsComponent', () => {
   });
 
   // Test for selecting a specific metric from the dropdown
-  test('selecting a specific metric from the dropdown filters the data', async () => {
-    render(<MetricsComponent />);
+
+// MetricsComponent.test.tsx (218-250)
+test('selecting a specific metric from the dropdown filters the data using click events', async () => {
+  render(<MetricsComponent />);
   
-    // Wait for data to load and ensure 'queries.number' is present
-    await waitFor(() => screen.getByText('queries.number'));
+  // Wait for data to load and ensure 'queries.number' is present
+  await waitFor(() => screen.getByText('queries.number'));
   
-    // Open the dropdown
-    const dropdown = screen.getByRole('combobox');
-    fireEvent.mouseDown(dropdown); // Use fireEvent to open the dropdown
+  const select = screen.getByTestId('metric-select').firstElementChild;
+  if (select) {
+    fireEvent.mouseDown(select);
+  }
+
+  // Query for the dropdown menu which is now in the document
+  const dropdown = document.querySelector('.ant-select-dropdown:not(.ant-select-dropdown-hidden)');
   
-    // Wait for the dropdown options to be rendered
-    const dropdownOptions = await waitFor(() => screen.getByRole('listbox'));
-  
-    // Refine selection by targeting dropdown options within the listbox
-    const options = within(dropdownOptions).getAllByRole('option');
-    expect(options.length).toBeGreaterThan(0); // Ensure at least one option is available
-    console.log('Dropdown options:', options.map(o => o.textContent));
-  
-    // Select the first item in the dropdown (excluding the "All" option)
-    const firstOption = options[1]; // Ensure to skip the "All" option
-    console.log('First option selected:', firstOption.textContent);
-    console.log('options:', options);
-    // expect(firstOption).toBeDefined();
-    console.log('1',firstOption.parentElement?.innerHTML);
-    console.log('2',firstOption.innerHTML);
-    fireEvent.click(firstOption); // Use fireEvent to click the option
-    // TODO : Clicking in a dropDown doesn’t work. Will revisit later.
-  
-    // Wait for the UI to update and check the filtered data
+  // Click the first option
+  const secondOption = dropdown?.querySelectorAll('.ant-select-item')[1]; 
+  if (secondOption) {
+    fireEvent.click(secondOption);
     await waitFor(() => {
-      console.log('Waiting for headings to update...');
       const headings = screen.queryAllByRole('heading', { level: 4 });
-      console.log('Headings length after filter attempt:', headings.length);
-      expect(headings).toHaveLength(1); // Only one heading should be present after filtering
-      expect(headings[0]).toHaveTextContent(firstOption.textContent!); // The visible heading should match the selected option
-    });
-  
-    // Ensure that 'queries.number' is no longer present after filtering
-    expect(screen.queryByText('queries.number')).toBeNull();
-    console.log('queries.number is no longer present.');
-  });
+      expect(headings).toHaveLength(1); // This should fail if the filter does not work
+    }); // Increase the timeout if needed
+  }
+});
 });

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 import React from 'react';
-import { render, fireEvent, waitFor, screen } from '@testing-library/react';
+import { render, fireEvent, waitFor, screen, getByTitle, queryByTitle } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import MetricsComponent from './MetricsComponent';
 import userEvent from '@testing-library/user-event';
@@ -89,31 +89,67 @@ describe('MetricsComponent', () => {
   });
 
   //2. Test for selecting a specific metric from the dropdown:
-  test('selecting a specific metric from the dropdown filters the data', async () => {
-    const { queryAllByRole, getByRole, getByText, queryByText } = render(<MetricsComponent />);
 
-    // Data not loaded yet
-    let headings = queryAllByRole('heading', { level: 4 });
-    expect(queryByText('queries.number')).toBeNull();
-    expect(headings).toHaveLength(0);
+//   test('selecting a specific metric from the dropdown filters the data', async () => {
+//     const { queryAllByRole, getByRole, getByText, queryByText } = render(<MetricsComponent />);
 
-    // Wait for data to load
-    await waitFor(() => getByText('queries.number'));
+//     // Data not loaded yet
+//     let headings = queryAllByRole('heading', { level: 4 });
+//     expect(queryByText('queries.number')).toBeNull();
+//     expect(headings).toHaveLength(0);
 
-    // Verify that data is loaded and displayed
-    headings = queryAllByRole('heading', { level: 4 });
-    expect(headings).toHaveLength(9);
-    expect(queryByText('queries.number')).not.toBeNull();
+//     // Wait for data to load
+//     await waitFor(() => getByText('queries.number'));
 
-    // Filter data
-    const dropdown = getByRole('combobox');
-    await userEvent.click(dropdown); // Open the dropdown
-    const usersOption = getByText('Users');
-    await userEvent.click(usersOption); // Select the 'Users' option
+//     // Verify that data is loaded and displayed
+//     headings = queryAllByRole('heading', { level: 4 });
+//     expect(headings).toHaveLength(9);
+//     expect(queryByText('queries.number')).not.toBeNull();
 
-    // Check that the data is filtered
-    headings = queryAllByRole('heading', { level: 4 });
-    expect(headings).toHaveLength(1);
-    expect(queryByText('queries.number')).toBeNull();
-  });
+//     // Filter data
+//     const dropdown = getByRole('combobox');
+//     await userEvent.click(dropdown); // Open the dropdown
+//     // const usersOption = getByText('requests.active');
+//     const usersOption = queryByTitle('requests.active');
+//     await userEvent.click(usersOption); // Select the 'Users' option
+
+//     // Check that the data is filtered
+//     headings = queryAllByRole('heading', { level: 4 });
+//     expect(headings).toHaveLength(1);
+//     expect(queryByText('queries.number')).toBeNull();
+//   });
+// });
+
+test('selecting a specific metric from the dropdown filters the data', async () => {
+  const { queryAllByRole, getByRole, getByText, queryByText } = render(
+    <MetricsComponent />
+  );
+
+  // Data not loaded yet
+  let headings = queryAllByRole('heading', { level: 4 });
+  expect(queryByText('queries.number')).toBeNull();
+  expect(headings).toHaveLength(0);
+
+  // Wait for data to load
+  await waitFor(() => getByText('queries.number'));
+
+  // Verify that data is loaded and displayed
+  headings = queryAllByRole('heading', { level: 4 });
+  expect(headings).toHaveLength(9);
+  expect(queryByText('queries.number')).not.toBeNull();
+
+  // Filter data
+  const dropdown = getByRole('combobox');
+  await userEvent.click(dropdown); // Open the dropdown
+  // const usersOption = getByText('users');
+  const usersOption = screen.getByTitle('users');
+  await userEvent.click(usersOption); // Select the 'Users' option
+
+  // Check that the data is filtered
+  headings = queryAllByRole('heading', { level: 4 });
+  expect(headings).toHaveLength(1);
+  //heading has the text users now (only the first item out of headings list has the text)
+  // expect(queryByText('users')).toBeNull(); (uses the complete screen)
+  console.log(headings);
+});
 });

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
@@ -14,134 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// import React from 'react';
-// import { render, waitFor, screen, within, fireEvent } from '@testing-library/react';
-// import '@testing-library/jest-dom';
-// import MetricsComponent from './MetricsComponent';
-// import userEvent from '@testing-library/user-event';
-
-// // Mock matchMedia for compatibility with certain UI libraries
-// Object.defineProperty(window, 'matchMedia', {
-//   writable: true,
-//   value: jest.fn().mockImplementation(query => ({
-//     matches: false,
-//     media: query,
-//     onchange: null,
-//     addListener: jest.fn(), // Deprecated
-//     removeListener: jest.fn(), // Deprecated
-//     addEventListener: jest.fn(),
-//     removeEventListener: jest.fn(),
-//     dispatchEvent: jest.fn()
-//   }))
-// });
-
-// // Mock the API call to return sample metrics data
-// jest.mock('api/utils', () => ({
-//   get: jest.fn(() =>
-//     Promise.resolve({
-//       metric: {
-//         'queries.number': { value: 10 },
-//         'requests.active': { count: 5 },
-//         'requests.exceptions': { count: 2 },
-//         'requests.response-time': {
-//           '15m_rate': 20,
-//           '1m_rate': 15,
-//           '5m_rate': 18,
-//           '75_percentile': 50,
-//           '95_percentile': 60,
-//           '999_percentile': 70,
-//           '99_percentile': 55,
-//           avg: 25,
-//           count: 100,
-//           max: 30,
-//           mean_rate: 22,
-//           min: 20,
-//           std_dev: 5,
-//           sum: 2500
-//         },
-//         'threads.daemon': { value: 3 },
-//         'threads.total': { value: 6 },
-//         users: { value: 50 },
-//         'users.active': { value: 30 },
-//         'users.active.total': { value: 40 }
-//       }
-//     })
-//   )
-// }));
-
-// describe('MetricsComponent', () => {
-
-//   // Test for filtering metrics based on input
-//   test('Filtering metrics based on name column value', async () => {
-//     render(<MetricsComponent />);
-
-//     const filterInput = screen.getByPlaceholderText('Filter metrics...');
-//     fireEvent.change(filterInput, { target: { value: 'value' } });
-
-//     await waitFor(() => {
-//       expect(screen.getByText('queries.number')).toBeInTheDocument();
-//       expect(screen.getByText('threads.daemon')).toBeInTheDocument();
-//       expect(screen.getByText('threads.total')).toBeInTheDocument();
-//       expect(screen.getByText('users')).toBeInTheDocument();
-//       expect(screen.getByText('users.active')).toBeInTheDocument();
-//       expect(screen.getByText('users.active.total')).toBeInTheDocument();
-//       expect(screen.queryByText('requests.active')).not.toBeInTheDocument();
-//       expect(screen.queryByText('requests.exceptions')).toBeNull();
-//       expect(screen.queryByText('requests.response-time')).toBeNull();
-//     });
-//   });
-
-//   // Test for selecting a specific metric from the dropdown:
-//   test('selecting a specific metric from the dropdown filters the data', async () => {
-//     render(<MetricsComponent />);
-  
-//     // Wait for data to load and ensure 'queries.number' is present
-//     await waitFor(() => screen.getByText('queries.number'));
-  
-//     // Initial assertions to verify all data is loaded
-//     let headings = screen.queryAllByRole('heading', { level: 4 });
-//     console.log('Initial headings:', headings.map(h => h.textContent));
-//     expect(headings).toHaveLength(9); // There should be 9 headings initially
-  
-//     // Open the dropdown
-//     const dropdown = screen.getByRole('combobox');
-//     fireEvent.mouseDown(dropdown); // Use fireEvent to open the dropdown
-  
-//     // Wait for the dropdown options to be rendered
-//     const dropdownOptions = await waitFor(() => screen.getByRole('listbox'));
-  
-//     // Refine selection by targeting dropdown options within the listbox
-//     const options = within(dropdownOptions).getAllByRole('option');
-//     expect(options.length).toBeGreaterThan(0); // Ensure at least one option is available
-//     console.log('Dropdown options:', options.map(o => o.textContent));
-  
-//     // Select the first item in the dropdown (excluding the "All" option)
-//     const firstOption = options[1]; // Ensure to skip the "All" option
-//     console.log('First option selected:', firstOption.textContent);
-//     expect(firstOption).toBeDefined();
-  
-//     fireEvent.click(firstOption); // Use fireEvent to click the option
-  
-//     // Wait for the UI to update and check the filtered data
-//     await waitFor(() => {
-//       console.log('Waiting for headings to update...');
-//       headings = screen.queryAllByRole('heading', { level: 4 });
-//       console.log('Headings length after filter attempt:', headings.length);
-//       expect(headings).toHaveLength(1); // Only one heading should be present after filtering
-//       expect(headings[0]).toHaveTextContent(firstOption.textContent); // The visible heading should match the selected option
-//     });
-  
-//     // Ensure that 'queries.number' is no longer present after filtering
-//     expect(screen.queryByText('queries.number')).toBeNull();
-//     console.log('queries.number is no longer present.');
-//   });
-// });
-
 import React from 'react';
-import { render, waitFor, screen, within, fireEvent } from '@testing-library/react';
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import MetricsComponent from './MetricsComponent';
-import userEvent from '@testing-library/user-event';
 
 // Mock matchMedia for compatibility with certain UI libraries
 Object.defineProperty(window, 'matchMedia', {
@@ -214,30 +90,28 @@ describe('MetricsComponent', () => {
   });
 
   // Test for selecting a specific metric from the dropdown
+  test('selecting a specific metric from the dropdown filters the data using click events', async () => {
+    render(<MetricsComponent />);
 
-// MetricsComponent.test.tsx (218-250)
-test('selecting a specific metric from the dropdown filters the data using click events', async () => {
-  render(<MetricsComponent />);
-  
-  // Wait for data to load and ensure 'queries.number' is present
-  await waitFor(() => screen.getByText('queries.number'));
-  
-  const select = screen.getByTestId('metric-select').firstElementChild;
-  if (select) {
-    fireEvent.mouseDown(select);
-  }
+    // Wait for data to load and ensure any option like 'queries.number' is present
+    await waitFor(() => screen.getByText('queries.number'));
 
-  // Query for the dropdown menu which is now in the document
-  const dropdown = document.querySelector('.ant-select-dropdown:not(.ant-select-dropdown-hidden)');
-  
-  // Click the first option
-  const secondOption = dropdown?.querySelectorAll('.ant-select-item')[1]; 
-  if (secondOption) {
-    fireEvent.click(secondOption);
-    await waitFor(() => {
-      const headings = screen.queryAllByRole('heading', { level: 4 });
-      expect(headings).toHaveLength(1); // This should fail if the filter does not work
-    }); // Increase the timeout if needed
-  }
-});
+    const select = screen.getByTestId('metric-select').firstElementChild;
+    if (select) {
+      fireEvent.click(select);
+    }
+
+    // Query for the dropdown menu which is now in the document
+    const dropdown = document.querySelector('.ant-select');
+
+    // Choose any option like the 1st from the metrics and then click on it
+    const secondOption = dropdown?.querySelectorAll('.ant-select-item')[1];
+    if (secondOption) {
+      fireEvent.click(secondOption);
+      await waitFor(() => {
+        const headings = screen.queryAllByRole('heading', { level: 4 });
+        expect(headings).toHaveLength(1); // This should fail if the filter does not work
+      });
+    }
+  });
 });

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
@@ -33,17 +33,17 @@ jest.mock('api/utils', () => ({
           '95_percentile': 60,
           '999_percentile': 70,
           '99_percentile': 55,
-          'avg': 25,
-          'count': 100,
-          'max': 30,
-          'mean_rate': 22,
-          'min': 20,
-          'std_dev': 5,
-          'sum': 2500
+          avg: 25,
+          count: 100,
+          max: 30,
+          mean_rate: 22,
+          min: 20,
+          std_dev: 5,
+          sum: 2500
         },
         'threads.daemon': { value: 3 },
         'threads.total': { value: 6 },
-        'users': { value: 50 },
+        users: { value: 50 },
         'users.active': { value: 30 },
         'users.active.total': { value: 40 }
       }

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
@@ -16,10 +16,9 @@
 
 import React from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom';
 import MetricsComponent from './MetricsComponent';
 import userEvent from '@testing-library/user-event';
-import { Dropdown } from 'antd';
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
@@ -89,94 +88,32 @@ describe('MetricsComponent', () => {
     });
   });
 
-//   //2. Test for selecting a specific metric from the dropdown:
-//   test('Selecting a specific metric from the dropdown', async () => {
-//     render(<MetricsComponent />);
+  //2. Test for selecting a specific metric from the dropdown:
+  test('selecting a specific metric from the dropdown filters the data', async () => {
+    const { queryAllByRole, getByRole, getByText, queryByText } = render(<MetricsComponent />);
 
-//     // // const dropdown = screen.getByPlaceholderText('Choose a metric');
-//     // const dropdown = await screen.findByRole('combobox');
-//     // // console.log('dropdown', dropdown);
-//     // fireEvent.click(dropdown, { target: { value: 'users' } });
-//     // screen.debug();
+    // Data not loaded yet
+    let headings = queryAllByRole('heading', { level: 4 });
+    expect(queryByText('queries.number')).toBeNull();
+    expect(headings).toHaveLength(0);
 
-//     // const dropdown = await screen.findByRole('combobox');
-//     // userEvent.click(dropdown); // Open the dropdown
-    
-//     // const usersOption = await screen.findByText('users');
-//     // userEvent.click(usersOption); // Select the 'Users' option
+    // Wait for data to load
+    await waitFor(() => getByText('queries.number'));
 
+    // Verify that data is loaded and displayed
+    headings = queryAllByRole('heading', { level: 4 });
+    expect(headings).toHaveLength(9);
+    expect(queryByText('queries.number')).not.toBeNull();
 
-//     const periodSelect = screen.getByRole('combobox');
-//     // console.log(periodSelect);
+    // Filter data
+    const dropdown = getByRole('combobox');
+    await userEvent.click(dropdown); // Open the dropdown
+    const usersOption = getByText('Users');
+    await userEvent.click(usersOption); // Select the 'Users' option
 
-//     await userEvent.click(periodSelect);
-
-
-//     // await waitFor(() => screen.getByText('Users'));
-
-//     // fireEvent.click(screen.getByText('Users'));
-//     const option= await screen.getByText('Users');
-
-//     console.log(option)
-//     await userEvent.click(option);
-
-//     // screen.debug();
-
-//     // await waitFor(() => {
-//     //    const bla = screen.getByText('Users');
-//     //    console.log(bla);
-
-//     // });
-
-  
-//     // fireEvent.click(screen.getByText('% Dia'));
-
-//     // expect(handleChangeStub).toBeCalledWith('days', expect.anything());
-
-//     // console.log(fireEvent);
-//     // userEvent.selectOptions(dropdown, 'users');
-//     // const bla = await screen.findByText('users');
-//     // console.log(bla);
-
-//     await expect(screen.getByText('queries.number')).not.toBeVisible();
-//     // await waitFor(() => {
-      
-//     //   expect(screen.getByText('queries.number')).not.toBeVisible();
-//     //   // expect(screen.queryAllByText('requests.active')).toBeNull();
-//     //   // expect(screen.queryAllByText('requests.exceptions')).toBeNull();
-//     //   // expect(screen.queryAllByText('threads.daemon')).toBeNull();
-//     //   // expect(screen.queryAllByText('threads.total')).toBeNull();
-//     //   // expect(screen.queryAllByText('users')).toBeInTheDocument();
-//     //   // expect(screen.queryAllByText('users.active')).toBeNull();
-//     //   // expect(screen.queryAllByText('users.active.total')).toBeNull();
-//     //   // console.log(bla);
-//     // });
-
-//   });
-// });
-
-test('Selecting a specific metric from the dropdown', async () => {
-  render(<MetricsComponent />);
-
-  const dropdown = await screen.findByRole('combobox');
-  userEvent.click(dropdown); // Open the dropdown
-  
-  const usersOption = await screen.findByText('Users');
-  userEvent.click(usersOption); // Select the 'Users' option
-
-  // Introduce a delay before asserting the absence of the "queries.number" element
-  setTimeout(() => {
-    expect(screen.queryAllByText('queries.number')).toHaveLength(0);
-  }, 500); // Adjust the delay time as needed
-  
-  await waitFor(() => {
-    expect(screen.queryByText('requests.active')).toBeNull();
-    expect(screen.queryByText('requests.exceptions')).toBeNull();
-    expect(screen.queryByText('threads.daemon')).toBeNull();
-    expect(screen.queryByText('threads.total')).toBeNull();
-    expect(screen.getByText('users')).toBeInTheDocument();
-    expect(screen.queryByText('users.active')).toBeNull();
-    expect(screen.queryByText('users.active.total')).toBeNull();
+    // Check that the data is filtered
+    headings = queryAllByRole('heading', { level: 4 });
+    expect(headings).toHaveLength(1);
+    expect(queryByText('queries.number')).toBeNull();
   });
-});
 });

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
@@ -77,7 +77,8 @@ describe('MetricsComponent', () => {
   test('Selecting a specific metric from the dropdown', async () => {
     render(<MetricsComponent />);
 
-    const dropdown = screen.getByPlaceholderText('Choose a metric');
+    // const dropdown = screen.getByPlaceholderText('Choose a metric');
+    const dropdown = screen.getByTestId('metric-select');
     fireEvent.change(dropdown, { target: { value: 'users' } });
 
     await waitFor(() => {

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
@@ -78,7 +78,6 @@ describe('MetricsComponent', () => {
   test('selecting a specific metric from the dropdown filters the data using click events', async () => {
     render(<MetricsComponent />);
 
-    // Wait for data to load and ensure any option like 'queries.number' is present
     await waitFor(() => screen.getByText('queries.number'));
 
     const select = screen.getByTestId('metric-select').firstElementChild;
@@ -86,16 +85,14 @@ describe('MetricsComponent', () => {
       fireEvent.mouseDown(select);
     }
 
-    // Query for the dropdown menu which is now in the document
     const dropdown = document.querySelector('.ant-select');
 
-    // Choose any option like the 1st from the metrics and then click on it
     const secondOption = dropdown?.querySelectorAll('.ant-select-item')[1];
     if (secondOption) {
       fireEvent.click(secondOption);
       await waitFor(() => {
         const headings = screen.queryAllByRole('heading', { level: 4 });
-        expect(headings).toHaveLength(1); // This should fail if the filter does not work
+        expect(headings).toHaveLength(1);
       });
     }
   });

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
@@ -14,12 +14,136 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// import React from 'react';
+// import { render, waitFor, screen, within, fireEvent } from '@testing-library/react';
+// import '@testing-library/jest-dom';
+// import MetricsComponent from './MetricsComponent';
+// import userEvent from '@testing-library/user-event';
+
+// // Mock matchMedia for compatibility with certain UI libraries
+// Object.defineProperty(window, 'matchMedia', {
+//   writable: true,
+//   value: jest.fn().mockImplementation(query => ({
+//     matches: false,
+//     media: query,
+//     onchange: null,
+//     addListener: jest.fn(), // Deprecated
+//     removeListener: jest.fn(), // Deprecated
+//     addEventListener: jest.fn(),
+//     removeEventListener: jest.fn(),
+//     dispatchEvent: jest.fn()
+//   }))
+// });
+
+// // Mock the API call to return sample metrics data
+// jest.mock('api/utils', () => ({
+//   get: jest.fn(() =>
+//     Promise.resolve({
+//       metric: {
+//         'queries.number': { value: 10 },
+//         'requests.active': { count: 5 },
+//         'requests.exceptions': { count: 2 },
+//         'requests.response-time': {
+//           '15m_rate': 20,
+//           '1m_rate': 15,
+//           '5m_rate': 18,
+//           '75_percentile': 50,
+//           '95_percentile': 60,
+//           '999_percentile': 70,
+//           '99_percentile': 55,
+//           avg: 25,
+//           count: 100,
+//           max: 30,
+//           mean_rate: 22,
+//           min: 20,
+//           std_dev: 5,
+//           sum: 2500
+//         },
+//         'threads.daemon': { value: 3 },
+//         'threads.total': { value: 6 },
+//         users: { value: 50 },
+//         'users.active': { value: 30 },
+//         'users.active.total': { value: 40 }
+//       }
+//     })
+//   )
+// }));
+
+// describe('MetricsComponent', () => {
+
+//   // Test for filtering metrics based on input
+//   test('Filtering metrics based on name column value', async () => {
+//     render(<MetricsComponent />);
+
+//     const filterInput = screen.getByPlaceholderText('Filter metrics...');
+//     fireEvent.change(filterInput, { target: { value: 'value' } });
+
+//     await waitFor(() => {
+//       expect(screen.getByText('queries.number')).toBeInTheDocument();
+//       expect(screen.getByText('threads.daemon')).toBeInTheDocument();
+//       expect(screen.getByText('threads.total')).toBeInTheDocument();
+//       expect(screen.getByText('users')).toBeInTheDocument();
+//       expect(screen.getByText('users.active')).toBeInTheDocument();
+//       expect(screen.getByText('users.active.total')).toBeInTheDocument();
+//       expect(screen.queryByText('requests.active')).not.toBeInTheDocument();
+//       expect(screen.queryByText('requests.exceptions')).toBeNull();
+//       expect(screen.queryByText('requests.response-time')).toBeNull();
+//     });
+//   });
+
+//   // Test for selecting a specific metric from the dropdown:
+//   test('selecting a specific metric from the dropdown filters the data', async () => {
+//     render(<MetricsComponent />);
+  
+//     // Wait for data to load and ensure 'queries.number' is present
+//     await waitFor(() => screen.getByText('queries.number'));
+  
+//     // Initial assertions to verify all data is loaded
+//     let headings = screen.queryAllByRole('heading', { level: 4 });
+//     console.log('Initial headings:', headings.map(h => h.textContent));
+//     expect(headings).toHaveLength(9); // There should be 9 headings initially
+  
+//     // Open the dropdown
+//     const dropdown = screen.getByRole('combobox');
+//     fireEvent.mouseDown(dropdown); // Use fireEvent to open the dropdown
+  
+//     // Wait for the dropdown options to be rendered
+//     const dropdownOptions = await waitFor(() => screen.getByRole('listbox'));
+  
+//     // Refine selection by targeting dropdown options within the listbox
+//     const options = within(dropdownOptions).getAllByRole('option');
+//     expect(options.length).toBeGreaterThan(0); // Ensure at least one option is available
+//     console.log('Dropdown options:', options.map(o => o.textContent));
+  
+//     // Select the first item in the dropdown (excluding the "All" option)
+//     const firstOption = options[1]; // Ensure to skip the "All" option
+//     console.log('First option selected:', firstOption.textContent);
+//     expect(firstOption).toBeDefined();
+  
+//     fireEvent.click(firstOption); // Use fireEvent to click the option
+  
+//     // Wait for the UI to update and check the filtered data
+//     await waitFor(() => {
+//       console.log('Waiting for headings to update...');
+//       headings = screen.queryAllByRole('heading', { level: 4 });
+//       console.log('Headings length after filter attempt:', headings.length);
+//       expect(headings).toHaveLength(1); // Only one heading should be present after filtering
+//       expect(headings[0]).toHaveTextContent(firstOption.textContent); // The visible heading should match the selected option
+//     });
+  
+//     // Ensure that 'queries.number' is no longer present after filtering
+//     expect(screen.queryByText('queries.number')).toBeNull();
+//     console.log('queries.number is no longer present.');
+//   });
+// });
+
 import React from 'react';
 import { render, waitFor, screen, within, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import MetricsComponent from './MetricsComponent';
 import userEvent from '@testing-library/user-event';
 
+// Mock matchMedia for compatibility with certain UI libraries
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: jest.fn().mockImplementation(query => ({
@@ -34,6 +158,7 @@ Object.defineProperty(window, 'matchMedia', {
   }))
 });
 
+// Mock the API call to return sample metrics data
 jest.mock('api/utils', () => ({
   get: jest.fn(() =>
     Promise.resolve({
@@ -68,9 +193,7 @@ jest.mock('api/utils', () => ({
 }));
 
 describe('MetricsComponent', () => {
-
-//1. Test for filtering metrics based on input
-  
+  // Test for filtering metrics based on input
   test('Filtering metrics based on name column value', async () => {
     render(<MetricsComponent />);
 
@@ -90,59 +213,46 @@ describe('MetricsComponent', () => {
     });
   });
 
-//2. Test for selecting a specific metric from the dropdown:
-
+  // Test for selecting a specific metric from the dropdown
   test('selecting a specific metric from the dropdown filters the data', async () => {
-    const { queryAllByRole, getByRole, getByText, queryByText } = render(
-      <MetricsComponent />
-    );
-
-    // Wait for data to load
-    await waitFor(() => getByText('queries.number'));
-
-    // Verify that all data is loaded and displayed correctly
-    let headings = queryAllByRole('heading', { level: 4 });
-    console.log('Initial headings length:', headings.length);
-    expect(headings).toHaveLength(9); // Check that there are 9 headings initially
-
+    render(<MetricsComponent />);
+  
+    // Wait for data to load and ensure 'queries.number' is present
+    await waitFor(() => screen.getByText('queries.number'));
+  
     // Open the dropdown
-    const dropdown = getByRole('combobox');
-    console.log('Opening dropdown...');
-    await userEvent.click(dropdown); // Simulate click to open dropdown
-    
+    const dropdown = screen.getByRole('combobox');
+    fireEvent.mouseDown(dropdown); // Use fireEvent to open the dropdown
+  
     // Wait for the dropdown options to be rendered
-    const dropdownOptions = await waitFor(() => getByRole('listbox'));
-
-    // Log text content of each option for debugging
+    const dropdownOptions = await waitFor(() => screen.getByRole('listbox'));
+  
+    // Refine selection by targeting dropdown options within the listbox
     const options = within(dropdownOptions).getAllByRole('option');
-    options.forEach(option => {
-      console.log('Option:', option.textContent);
-    });
-
-    // Find and select the 'users' option
-    const usersOption = options.find(option => option.textContent && option.textContent.toLowerCase().includes('users'));
-    console.log('Users option found:', usersOption ? usersOption.textContent : 'None');
-    expect(usersOption).toBeDefined();
-
-    // Ensure the option is not undefined before clicking
-    if (usersOption) {
-      await userEvent.click(usersOption); // Select the 'users' option
-    }
-
+    expect(options.length).toBeGreaterThan(0); // Ensure at least one option is available
+    console.log('Dropdown options:', options.map(o => o.textContent));
+  
+    // Select the first item in the dropdown (excluding the "All" option)
+    const firstOption = options[1]; // Ensure to skip the "All" option
+    console.log('First option selected:', firstOption.textContent);
+    console.log('options:', options);
+    // expect(firstOption).toBeDefined();
+    console.log('1',firstOption.parentElement?.innerHTML);
+    console.log('2',firstOption.innerHTML);
+    fireEvent.click(firstOption); // Use fireEvent to click the option
+    // TODO : Clicking in a dropDown doesn’t work. Will revisit later.
+  
     // Wait for the UI to update and check the filtered data
     await waitFor(() => {
-      headings = queryAllByRole('heading', { level: 4 });
-      console.log('Headings length after filter:', headings.length);
-      return headings.length === 1;
+      console.log('Waiting for headings to update...');
+      const headings = screen.queryAllByRole('heading', { level: 4 });
+      console.log('Headings length after filter attempt:', headings.length);
+      expect(headings).toHaveLength(1); // Only one heading should be present after filtering
+      expect(headings[0]).toHaveTextContent(firstOption.textContent!); // The visible heading should match the selected option
     });
-
-    // Final assertions to ensure correct filtering
-    headings = queryAllByRole('heading', { level: 4 });
-    console.log('Final headings length:', headings.length);
-    expect(headings).toHaveLength(1); // Only one heading should be present after filtering
-    expect(headings[0]).toHaveTextContent('users'); // The visible heading should be 'users'
-
+  
     // Ensure that 'queries.number' is no longer present after filtering
-    expect(queryByText('queries.number')).toBeNull();
+    expect(screen.queryByText('queries.number')).toBeNull();
+    console.log('queries.number is no longer present.');
   });
 });

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.test.tsx
@@ -16,7 +16,24 @@
 
 import React from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
+import '@testing-library/jest-dom'
 import MetricsComponent from './MetricsComponent';
+import userEvent from '@testing-library/user-event';
+import { Dropdown } from 'antd';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // Deprecated
+    removeListener: jest.fn(), // Deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn()
+  }))
+});
 
 jest.mock('api/utils', () => ({
   get: jest.fn(() =>
@@ -66,30 +83,100 @@ describe('MetricsComponent', () => {
       expect(screen.getByText('users')).toBeInTheDocument();
       expect(screen.getByText('users.active')).toBeInTheDocument();
       expect(screen.getByText('users.active.total')).toBeInTheDocument();
-
-      expect(screen.queryByText('requests.active')).toBeNull();
+      expect(screen.queryByText('requests.active')).not.toBeInTheDocument();
       expect(screen.queryByText('requests.exceptions')).toBeNull();
       expect(screen.queryByText('requests.response-time')).toBeNull();
     });
   });
 
-  //2. Test for selecting a specific metric from the dropdown:
-  test('Selecting a specific metric from the dropdown', async () => {
-    render(<MetricsComponent />);
+//   //2. Test for selecting a specific metric from the dropdown:
+//   test('Selecting a specific metric from the dropdown', async () => {
+//     render(<MetricsComponent />);
 
-    // const dropdown = screen.getByPlaceholderText('Choose a metric');
-    const dropdown = screen.getByTestId('metric-select');
-    fireEvent.change(dropdown, { target: { value: 'users' } });
+//     // // const dropdown = screen.getByPlaceholderText('Choose a metric');
+//     // const dropdown = await screen.findByRole('combobox');
+//     // // console.log('dropdown', dropdown);
+//     // fireEvent.click(dropdown, { target: { value: 'users' } });
+//     // screen.debug();
 
-    await waitFor(() => {
-      expect(screen.queryByText('queries.number')).toBeNull();
-      expect(screen.queryByText('requests.active')).toBeNull();
-      expect(screen.queryByText('requests.exceptions')).toBeNull();
-      expect(screen.queryByText('threads.daemon')).toBeNull();
-      expect(screen.queryByText('threads.total')).toBeNull();
-      expect(screen.getByText('users')).toBeInTheDocument();
-      expect(screen.queryByText('users.active')).toBeNull();
-      expect(screen.queryByText('users.active.total')).toBeNull();
-    });
+//     // const dropdown = await screen.findByRole('combobox');
+//     // userEvent.click(dropdown); // Open the dropdown
+    
+//     // const usersOption = await screen.findByText('users');
+//     // userEvent.click(usersOption); // Select the 'Users' option
+
+
+//     const periodSelect = screen.getByRole('combobox');
+//     // console.log(periodSelect);
+
+//     await userEvent.click(periodSelect);
+
+
+//     // await waitFor(() => screen.getByText('Users'));
+
+//     // fireEvent.click(screen.getByText('Users'));
+//     const option= await screen.getByText('Users');
+
+//     console.log(option)
+//     await userEvent.click(option);
+
+//     // screen.debug();
+
+//     // await waitFor(() => {
+//     //    const bla = screen.getByText('Users');
+//     //    console.log(bla);
+
+//     // });
+
+  
+//     // fireEvent.click(screen.getByText('% Dia'));
+
+//     // expect(handleChangeStub).toBeCalledWith('days', expect.anything());
+
+//     // console.log(fireEvent);
+//     // userEvent.selectOptions(dropdown, 'users');
+//     // const bla = await screen.findByText('users');
+//     // console.log(bla);
+
+//     await expect(screen.getByText('queries.number')).not.toBeVisible();
+//     // await waitFor(() => {
+      
+//     //   expect(screen.getByText('queries.number')).not.toBeVisible();
+//     //   // expect(screen.queryAllByText('requests.active')).toBeNull();
+//     //   // expect(screen.queryAllByText('requests.exceptions')).toBeNull();
+//     //   // expect(screen.queryAllByText('threads.daemon')).toBeNull();
+//     //   // expect(screen.queryAllByText('threads.total')).toBeNull();
+//     //   // expect(screen.queryAllByText('users')).toBeInTheDocument();
+//     //   // expect(screen.queryAllByText('users.active')).toBeNull();
+//     //   // expect(screen.queryAllByText('users.active.total')).toBeNull();
+//     //   // console.log(bla);
+//     // });
+
+//   });
+// });
+
+test('Selecting a specific metric from the dropdown', async () => {
+  render(<MetricsComponent />);
+
+  const dropdown = await screen.findByRole('combobox');
+  userEvent.click(dropdown); // Open the dropdown
+  
+  const usersOption = await screen.findByText('Users');
+  userEvent.click(usersOption); // Select the 'Users' option
+
+  // Introduce a delay before asserting the absence of the "queries.number" element
+  setTimeout(() => {
+    expect(screen.queryAllByText('queries.number')).toHaveLength(0);
+  }, 500); // Adjust the delay time as needed
+  
+  await waitFor(() => {
+    expect(screen.queryByText('requests.active')).toBeNull();
+    expect(screen.queryByText('requests.exceptions')).toBeNull();
+    expect(screen.queryByText('threads.daemon')).toBeNull();
+    expect(screen.queryByText('threads.total')).toBeNull();
+    expect(screen.getByText('users')).toBeInTheDocument();
+    expect(screen.queryByText('users.active')).toBeNull();
+    expect(screen.queryByText('users.active.total')).toBeNull();
   });
+});
 });

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
@@ -137,11 +137,11 @@ const MetricsComponent = () => {
               onChange={handleFilterInputChange}
               prefix={<SearchOutlined />}
             />
-            <Select
+            <Select data-testid="metric-select"
               //to make sure antd class gets applied
               getPopupContainer={triggerNode => triggerNode.parentElement}
               ref={dropdownRef}
-              placeholder="Choose a metric"
+              // placeholder="Choose a metric"
               value={selectedMetric}
               onChange={handleMetricChange}
             >

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
@@ -62,6 +62,7 @@ const MetricsComponent: React.FC = (): JSX.Element => {
 
   const parseMetricsData = (data: MetricsResponse) => {
     return Object.keys(data.metric).map(key => ({
+      //skip all the caption starting with python.. and auth..
       caption: key,
       dataSource: Object.keys(data.metric[key]).map(subKey => ({
         name: subKey,

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
@@ -138,11 +138,9 @@ const MetricsComponent = () => {
               prefix={<SearchOutlined />}
             />
             <Select
-              data-testid="metric-select"
               //to make sure antd class gets applied
               getPopupContainer={triggerNode => triggerNode.parentElement}
               ref={dropdownRef}
-              // placeholder="Choose a metric"
               value={selectedMetric}
               onChange={handleMetricChange}
             >

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
@@ -69,7 +69,6 @@ const MetricsComponent: React.FC = (): JSX.Element => {
           !key.startsWith('python.gc')
       )
       .map(key => ({
-        //skip all the caption starting with python.. and auth..
         caption: key,
         dataSource: Object.keys(data.metric[key]).map(subKey => ({
           name: subKey,

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
@@ -61,7 +61,9 @@ const MetricsComponent: React.FC = (): JSX.Element => {
   }, [searchQuery, metrics]);
 
   const parseMetricsData = (data: MetricsResponse) => {
-    return Object.keys(data.metric).map(key => ({
+    return Object.keys(data.metric)
+    .filter(key => !key.startsWith('auth') && !key.startsWith('multiprocessing') && !key.startsWith('python.gc'))
+    .map(key => ({
       //skip all the caption starting with python.. and auth..
       caption: key,
       dataSource: Object.keys(data.metric[key]).map(subKey => ({
@@ -101,7 +103,9 @@ const MetricsComponent: React.FC = (): JSX.Element => {
             >
               <Option value="">All</Option>
               {metrics &&
-                Object.keys(metrics.metric).map(key => (
+                Object.keys(metrics.metric)
+                .filter(key => !key.startsWith('auth') && !key.startsWith('multiprocessing') && !key.startsWith('python.gc'))
+                .map(key => (
                   <Option key={key} value={key}>
                     {key}
                   </Option>

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
@@ -1,0 +1,183 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// 'License'); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, { useState, useEffect, useRef } from 'react';
+import MetricsTable, { MetricsResponse } from './MetricsTable';
+import { Spin, Input, Select, Alert } from 'antd';
+import { get } from 'api/utils';
+import { SearchOutlined } from '@ant-design/icons';
+import './MetricsComponent.scss';
+
+const { Option } = Select;
+
+const MetricsComponent = () => {
+  const [metrics, setMetrics] = useState<MetricsResponse>();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [searchQuery, setSearchQuery] = useState<string>('');
+  const [selectedMetric, setSelectedMetric] = useState<string>('');
+  const [showAllTables, setShowAllTables] = useState(true);
+  const [filteredMetricsData, setFilteredMetricsData] = useState<MetricsData[]>([]);
+  const dropdownRef = useRef(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await get<MetricsResponse>('/desktop/metrics/', { format: 'json' });
+        setMetrics(response);
+      } catch (error) {
+        setError(error.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  useEffect(() => {
+    if (!metrics) {
+      return;
+    }
+
+    const filteredData = parseMetricsData(metrics).filter(tableData =>
+      tableData.dataSource.some(data => data.name.toLowerCase().includes(searchQuery.toLowerCase()))
+    );
+
+    setFilteredMetricsData(filteredData);
+  }, [searchQuery, metrics]);
+
+  const parseMetricsData = (data: MetricsResponse) => {
+    const metricsData = [
+      {
+        caption: 'queries.number',
+        dataSource: [{ name: 'value', value: data.metric['queries.number'].value }]
+      },
+      {
+        caption: 'requests.active',
+        dataSource: [{ name: 'count', value: data.metric['requests.active'].count }]
+      },
+      {
+        caption: 'requests.exceptions',
+        dataSource: [{ name: 'count', value: data.metric['requests.exceptions'].count }]
+      },
+      {
+        caption: 'requests.response-time',
+        dataSource: [
+          { name: '15m_rate', value: data.metric['requests.response-time']['15m_rate'] },
+          { name: '1m_rate', value: data.metric['requests.response-time']['1m_rate'] },
+          { name: '5m_rate', value: data.metric['requests.response-time']['5m_rate'] },
+          { name: '75_percentile', value: data.metric['requests.response-time']['75_percentile'] },
+          { name: '95_percentile', value: data.metric['requests.response-time']['95_percentile'] },
+          {
+            name: '999_percentile',
+            value: data.metric['requests.response-time']['999_percentile']
+          },
+          { name: '99_percentile', value: data.metric['requests.response-time']['99_percentile'] },
+          { name: 'avg', value: data.metric['requests.response-time']['avg'] },
+          { name: 'count', value: data.metric['requests.response-time']['count'] },
+          { name: 'max', value: data.metric['requests.response-time']['max'] },
+          { name: 'mean_rate', value: data.metric['requests.response-time']['mean_rate'] },
+          { name: 'min', value: data.metric['requests.response-time']['min'] },
+          { name: 'std_dev', value: data.metric['requests.response-time']['std_dev'] },
+          { name: 'sum', value: data.metric['requests.response-time']['sum'] }
+        ]
+      },
+      {
+        caption: 'threads.daemon',
+        dataSource: [{ name: 'value', value: data.metric['threads.daemon'].value }]
+      },
+      {
+        caption: 'threads.total',
+        dataSource: [{ name: 'value', value: data.metric['threads.total'].value }]
+      },
+      { caption: 'users', dataSource: [{ name: 'value', value: data.metric['users'].value }] },
+      {
+        caption: 'users.active',
+        dataSource: [{ name: 'value', value: data.metric['users.active'].value }]
+      },
+      {
+        caption: 'users.active.total',
+        dataSource: [{ name: 'value', value: data.metric['users.active.total'].value }]
+      }
+    ];
+    return metricsData;
+  };
+
+  const handleMetricChange = (value: string) => {
+    setSelectedMetric(value);
+    setShowAllTables(value === '');
+  };
+
+  const handleFilterInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value);
+  };
+
+  return (
+    <div className="cuix antd metrics-component">
+      <Spin spinning={loading}>
+        {!error && (
+          <>
+            <Input
+              placeholder="Filter metrics..."
+              value={searchQuery}
+              onChange={handleFilterInputChange}
+              prefix={<SearchOutlined />}
+            />
+            <Select
+              //to make sure antd class gets applied
+              getPopupContainer={triggerNode => triggerNode.parentElement}
+              ref={dropdownRef}
+              placeholder="Choose a metric"
+              value={selectedMetric}
+              onChange={handleMetricChange}
+            >
+              <Option value="">All</Option>
+              <Option value="queries.number">Queries Number</Option>
+              <Option value="requests.active">Active Requests</Option>
+              <Option value="requests.exceptions">Exceptional Requests</Option>
+              <Option value="requests.response-time">Requests Response-time</Option>
+              <Option value="threads.daemon">Daemon Threads</Option>
+              <Option value="threads.total">Total Threads</Option>
+              <Option value="users">Users</Option>
+              <Option value="users.active">Active Users</Option>
+              <Option value="users.active.total">Total Active Users</Option>
+            </Select>
+          </>
+        )}
+
+        {error && (
+          <Alert
+            message={`Error: ${error}`}
+            description="Error in displaying the Metrics!"
+            type="error"
+          />
+        )}
+
+        {!error &&
+          filteredMetricsData.map((tableData, index) => (
+            <div key={index}>
+              {(showAllTables || selectedMetric === tableData.caption) && (
+                <MetricsTable caption={tableData.caption} dataSource={tableData.dataSource} />
+              )}
+            </div>
+          ))}
+      </Spin>
+    </div>
+  );
+};
+
+export default MetricsComponent;

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
@@ -143,6 +143,7 @@ const MetricsComponent = () => {
               ref={dropdownRef}
               value={selectedMetric}
               onChange={handleMetricChange}
+              data-testid="metric-select"
             >
               <Option value="">All</Option>
               <Option value="queries.number">Queries Number</Option>

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
@@ -90,14 +90,14 @@ const MetricsComponent: React.FC = (): JSX.Element => {
       <Spin spinning={loading}>
         {!error && (
           <>
-            <Input
+            <Input className = "metrics-filter"
               placeholder="Filter metrics..."
               value={searchQuery}
               onChange={handleFilterInputChange}
               prefix={<SearchOutlined />}
             />
 
-            <Select
+            <Select className="metrics-select"
               //to make sure antd class gets applied
               getPopupContainer={triggerNode => triggerNode.parentElement}
               ref={dropdownRef}

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
@@ -61,62 +61,14 @@ const MetricsComponent: React.FC = (): JSX.Element => {
   }, [searchQuery, metrics]);
 
   const parseMetricsData = (data: MetricsResponse) => {
-    const metricsData = [
-      {
-        caption: 'queries.number',
-        dataSource: [{ name: 'value', value: data.metric['queries.number'].value }]
-      },
-      {
-        caption: 'requests.active',
-        dataSource: [{ name: 'count', value: data.metric['requests.active'].count }]
-      },
-      {
-        caption: 'requests.exceptions',
-        dataSource: [{ name: 'count', value: data.metric['requests.exceptions'].count }]
-      },
-      {
-        caption: 'requests.response-time',
-        dataSource: [
-          { name: '15m_rate', value: data.metric['requests.response-time']['15m_rate'] },
-          { name: '1m_rate', value: data.metric['requests.response-time']['1m_rate'] },
-          { name: '5m_rate', value: data.metric['requests.response-time']['5m_rate'] },
-          { name: '75_percentile', value: data.metric['requests.response-time']['75_percentile'] },
-          { name: '95_percentile', value: data.metric['requests.response-time']['95_percentile'] },
-          {
-            name: '999_percentile',
-            value: data.metric['requests.response-time']['999_percentile']
-          },
-          { name: '99_percentile', value: data.metric['requests.response-time']['99_percentile'] },
-          { name: 'avg', value: data.metric['requests.response-time']['avg'] },
-          { name: 'count', value: data.metric['requests.response-time']['count'] },
-          { name: 'max', value: data.metric['requests.response-time']['max'] },
-          { name: 'mean_rate', value: data.metric['requests.response-time']['mean_rate'] },
-          { name: 'min', value: data.metric['requests.response-time']['min'] },
-          { name: 'std_dev', value: data.metric['requests.response-time']['std_dev'] },
-          { name: 'sum', value: data.metric['requests.response-time']['sum'] }
-        ]
-      },
-      {
-        caption: 'threads.daemon',
-        dataSource: [{ name: 'value', value: data.metric['threads.daemon'].value }]
-      },
-      {
-        caption: 'threads.total',
-        dataSource: [{ name: 'value', value: data.metric['threads.total'].value }]
-      },
-      { caption: 'users', dataSource: [{ name: 'value', value: data.metric['users'].value }] },
-      {
-        caption: 'users.active',
-        dataSource: [{ name: 'value', value: data.metric['users.active'].value }]
-      },
-      {
-        caption: 'users.active.total',
-        dataSource: [{ name: 'value', value: data.metric['users.active.total'].value }]
-      }
-    ];
-    return metricsData;
+    return Object.keys(data.metric).map(key => ({
+      caption: key,
+      dataSource: Object.keys(data.metric[key]).map(subKey => ({
+        name: subKey,
+        value: data.metric[key][subKey]
+      }))
+    }));
   };
-
   const handleMetricChange = (value: string) => {
     setSelectedMetric(value);
     setShowAllTables(value === '');
@@ -137,6 +89,7 @@ const MetricsComponent: React.FC = (): JSX.Element => {
               onChange={handleFilterInputChange}
               prefix={<SearchOutlined />}
             />
+
             <Select
               //to make sure antd class gets applied
               getPopupContainer={triggerNode => triggerNode.parentElement}
@@ -146,15 +99,12 @@ const MetricsComponent: React.FC = (): JSX.Element => {
               data-testid="metric-select"
             >
               <Option value="">All</Option>
-              <Option value="queries.number">Queries Number</Option>
-              <Option value="requests.active">Active Requests</Option>
-              <Option value="requests.exceptions">Exceptional Requests</Option>
-              <Option value="requests.response-time">Requests Response-time</Option>
-              <Option value="threads.daemon">Daemon Threads</Option>
-              <Option value="threads.total">Total Threads</Option>
-              <Option value="users">Users</Option>
-              <Option value="users.active">Active Users</Option>
-              <Option value="users.active.total">Total Active Users</Option>
+              {metrics &&
+                Object.keys(metrics.metric).map(key => (
+                  <Option key={key} value={key}>
+                    {key}
+                  </Option>
+                ))}
             </Select>
           </>
         )}

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
@@ -137,7 +137,8 @@ const MetricsComponent = () => {
               onChange={handleFilterInputChange}
               prefix={<SearchOutlined />}
             />
-            <Select data-testid="metric-select"
+            <Select
+              data-testid="metric-select"
               //to make sure antd class gets applied
               getPopupContainer={triggerNode => triggerNode.parentElement}
               ref={dropdownRef}

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
@@ -90,14 +90,16 @@ const MetricsComponent: React.FC = (): JSX.Element => {
       <Spin spinning={loading}>
         {!error && (
           <>
-            <Input className = "metrics-filter"
+            <Input
+              className="metrics-filter"
               placeholder="Filter metrics..."
               value={searchQuery}
               onChange={handleFilterInputChange}
               prefix={<SearchOutlined />}
             />
 
-            <Select className="metrics-select"
+            <Select
+              className="metrics-select"
               //to make sure antd class gets applied
               getPopupContainer={triggerNode => triggerNode.parentElement}
               ref={dropdownRef}

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
@@ -62,15 +62,20 @@ const MetricsComponent: React.FC = (): JSX.Element => {
 
   const parseMetricsData = (data: MetricsResponse) => {
     return Object.keys(data.metric)
-    .filter(key => !key.startsWith('auth') && !key.startsWith('multiprocessing') && !key.startsWith('python.gc'))
-    .map(key => ({
-      //skip all the caption starting with python.. and auth..
-      caption: key,
-      dataSource: Object.keys(data.metric[key]).map(subKey => ({
-        name: subKey,
-        value: data.metric[key][subKey]
-      }))
-    }));
+      .filter(
+        key =>
+          !key.startsWith('auth') &&
+          !key.startsWith('multiprocessing') &&
+          !key.startsWith('python.gc')
+      )
+      .map(key => ({
+        //skip all the caption starting with python.. and auth..
+        caption: key,
+        dataSource: Object.keys(data.metric[key]).map(subKey => ({
+          name: subKey,
+          value: data.metric[key][subKey]
+        }))
+      }));
   };
   const handleMetricChange = (value: string) => {
     setSelectedMetric(value);
@@ -104,12 +109,17 @@ const MetricsComponent: React.FC = (): JSX.Element => {
               <Option value="">All</Option>
               {metrics &&
                 Object.keys(metrics.metric)
-                .filter(key => !key.startsWith('auth') && !key.startsWith('multiprocessing') && !key.startsWith('python.gc'))
-                .map(key => (
-                  <Option key={key} value={key}>
-                    {key}
-                  </Option>
-                ))}
+                  .filter(
+                    key =>
+                      !key.startsWith('auth') &&
+                      !key.startsWith('multiprocessing') &&
+                      !key.startsWith('python.gc')
+                  )
+                  .map(key => (
+                    <Option key={key} value={key}>
+                      {key}
+                    </Option>
+                  ))}
             </Select>
           </>
         )}

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsComponent.tsx
@@ -23,7 +23,7 @@ import './MetricsComponent.scss';
 
 const { Option } = Select;
 
-const MetricsComponent = () => {
+const MetricsComponent: React.FC = (): JSX.Element => {
   const [metrics, setMetrics] = useState<MetricsResponse>();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
@@ -19,6 +19,9 @@ import Table from 'cuix/dist/components/Table/Table';
 import type { ColumnType } from 'antd/es/table';
 import './MetricsComponent.scss';
 
+interface MetricsValue {
+  value: number;
+}
 interface MetricsTime {
   '1m_rate': number;
   '5m_rate': number;
@@ -36,6 +39,9 @@ interface MetricsTime {
   sum: number;
 }
 
+interface MetricsCount {
+  count: number;
+}
 export interface MetricsResponse {
   metric: {
     'auth.ldap.auth-time': MetricsTime;
@@ -62,32 +68,30 @@ export interface MetricsResponse {
   };
 }
 
-interface MetricsValue {
-  value: number;
-}
-
-interface MetricsCount {
-  count: number;
+interface DataSourceItem {
+  name: string;
+  value: number | MetricsTime;
 }
 
 interface MetricsTableProps {
   caption: string;
-  dataSource: { name: string; value: any }[];
+  dataSource: DataSourceItem[];
 }
 
-const MetricsTable = ({ caption, dataSource }: MetricsTableProps) => {
-  const metricsColumns: ColumnType[] = [];
-
-  metricsColumns.push({
-    title: 'Name',
-    dataIndex: 'name',
-    key: 'name'
-  });
-  metricsColumns.push({
-    title: 'Value',
-    dataIndex: 'value',
-    key: 'value'
-  });
+const MetricsTable: React.FC<MetricsTableProps> = ({ caption, dataSource }) => {
+  const metricsColumns: ColumnType<DataSourceItem>[] = [
+    {
+      title: 'Name',
+      dataIndex: 'name',
+      key: 'name'
+    },
+    {
+      title: 'Value',
+      dataIndex: 'value',
+      key: 'value',
+      render: value => (typeof value === 'number' ? value : JSON.stringify(value))
+    }
+  ];
 
   return (
     <>

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
@@ -28,13 +28,13 @@ interface MetricsTime {
   '95_percentile': number;
   '99_percentile': number;
   '999_percentile': number;
-  'avg': number;
-  'count': number;
-  'max': number;
-  'mean_rate': number;
-  'min': number;
-  'std_dev': number;
-  'sum': number;
+  avg: number;
+  count: number;
+  max: number;
+  mean_rate: number;
+  min: number;
+  std_dev: number;
+  sum: number;
 }
 
 export interface MetricsResponse {
@@ -56,10 +56,10 @@ export interface MetricsResponse {
     'requests.response-time': MetricsTime;
     'threads.daemon': MetricsValue;
     'threads.total': MetricsValue;
-    'users': MetricsValue;
+    users: MetricsValue;
     'users.active': MetricsValue;
     'users.active.total': MetricsValue;
-    'timestamp': string;
+    timestamp: string;
   };
 }
 

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
@@ -92,12 +92,7 @@ const MetricsTable = ({ caption, dataSource }: MetricsTableProps) => {
   return (
     <>
       <h4>{caption}</h4>
-      <Table
-        dataSource={dataSource}
-        rowKey="name"
-        columns={metricsColumns}
-        pagination={false}
-      />
+      <Table dataSource={dataSource} rowKey="name" columns={metricsColumns} pagination={false} />
     </>
   );
 };

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
@@ -1,0 +1,107 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// 'License'); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, { CSSProperties } from 'react';
+import Table from 'cuix/dist/components/Table/Table';
+import type { ColumnType } from 'antd/es/table';
+import './MetricsComponent.scss';
+import 'cuix/dist/components/Table/Table.css';
+
+interface MetricsTime {
+  '1m_rate': number;
+  '5m_rate': number;
+  '15m_rate': number;
+  '75_percentile': number;
+  '95_percentile': number;
+  '99_percentile': number;
+  '999_percentile': number;
+  'avg': number;
+  'count': number;
+  'max': number;
+  'mean_rate': number;
+  'min': number;
+  'std_dev': number;
+  'sum': number;
+}
+
+export interface MetricsResponse {
+  metric: {
+    'auth.ldap.auth-time': MetricsTime;
+    'auth.oauth.auth-time': MetricsTime;
+    'auth.pam.auth-time': MetricsTime;
+    'auth.saml2.auth-time': MetricsTime;
+    'auth.spnego.auth-time': MetricsTime;
+    'multiprocessing.processes.daemon': MetricsValue;
+    'multiprocessing.processes.total': MetricsValue;
+    'python.gc.generation.0': MetricsValue;
+    'python.gc.generation.1': MetricsValue;
+    'python.gc.generation.2': MetricsValue;
+    'python.gc.objects': MetricsValue;
+    'queries.number': MetricsValue;
+    'requests.active': MetricsCount;
+    'requests.exceptions': MetricsCount;
+    'requests.response-time': MetricsTime;
+    'threads.daemon': MetricsValue;
+    'threads.total': MetricsValue;
+    'users': MetricsValue;
+    'users.active': MetricsValue;
+    'users.active.total': MetricsValue;
+    'timestamp': string;
+  };
+}
+
+interface MetricsValue {
+  value: number;
+}
+
+interface MetricsCount {
+  count: number;
+}
+
+interface MetricsTableProps {
+  caption: string;
+  dataSource: { name: string; value: any }[];
+}
+
+const MetricsTable = ({ caption, dataSource }: MetricsTableProps) => {
+  const metricsColumns: ColumnType[] = [];
+
+  metricsColumns.push({
+    title: 'Name',
+    dataIndex: 'name',
+    key: 'name'
+  });
+  metricsColumns.push({
+    title: 'Value',
+    dataIndex: 'value',
+    key: 'value'
+  });
+
+  return (
+    <>
+      <h4>{caption}</h4>
+      <Table
+        dataSource={dataSource}
+        rowKey="name"
+        columns={metricsColumns}
+        style={CSSProperties}
+        pagination={false}
+      />
+    </>
+  );
+};
+
+export default MetricsTable;

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
@@ -79,17 +79,6 @@ interface MetricsTableProps {
   dataSource: DataSourceItem[];
 }
 const metricLabels: { [key: string]: string } = {
-  'auth.ldap.auth-time': I18n('LDAP Authentication Time'),
-  'auth.oauth.auth-time': I18n('OAuth Authentication Time'),
-  'auth.pam.auth-time': I18n('PAM Authentication Time'),
-  'auth.saml2.auth-time': I18n('SAML2 Authentication Time'),
-  'auth.spnego.auth-time': I18n('SPNEGO Authentication Time'),
-  'multiprocessing.processes.daemon': I18n('Daemon Processes'),
-  'multiprocessing.processes.total': I18n('Total Processes'),
-  'python.gc.generation.0': I18n('Python GC Generation 0'),
-  'python.gc.generation.1': I18n('Python GC Generation 1'),
-  'python.gc.generation.2': I18n('Python GC Generation 2'),
-  'python.gc.objects': I18n('Python GC Objects'),
   'queries.number': I18n('Number of Queries'),
   'requests.active': I18n('Active Requests'),
   'requests.exceptions': I18n('Request Exceptions'),

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
@@ -127,7 +127,8 @@ const MetricsTable: React.FC<MetricsTableProps> = ({ caption, dataSource }) => {
   return (
     <>
       <h4 className="metrics-heading">{caption}</h4>
-      <Table
+      <Table 
+        className="metrics-table"
         dataSource={transformedDataSource}
         rowKey="name"
         columns={metricsColumns}

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import Table from 'cuix/dist/components/Table/Table';
 import type { ColumnType } from 'antd/es/table';
 import './MetricsComponent.scss';
+import I18n from 'utils/i18n';
 
 interface MetricsValue {
   value: number;
@@ -77,8 +78,38 @@ interface MetricsTableProps {
   caption: string;
   dataSource: DataSourceItem[];
 }
+const metricLabels: { [key: string]: string } = {
+  'auth.ldap.auth-time': I18n('LDAP Authentication Time'),
+  'auth.oauth.auth-time': I18n('OAuth Authentication Time'),
+  'auth.pam.auth-time': I18n('PAM Authentication Time'),
+  'auth.saml2.auth-time': I18n('SAML2 Authentication Time'),
+  'auth.spnego.auth-time': I18n('SPNEGO Authentication Time'),
+  'multiprocessing.processes.daemon': I18n('Daemon Processes'),
+  'multiprocessing.processes.total': I18n('Total Processes'),
+  'python.gc.generation.0': I18n('Python GC Generation 0'),
+  'python.gc.generation.1': I18n('Python GC Generation 1'),
+  'python.gc.generation.2': I18n('Python GC Generation 2'),
+  'python.gc.objects': I18n('Python GC Objects'),
+  'queries.number': I18n('Number of Queries'),
+  'requests.active': I18n('Active Requests'),
+  'requests.exceptions': I18n('Request Exceptions'),
+  'requests.response-time': I18n('Request Response Time'),
+  'threads.daemon': I18n('Daemon Threads'),
+  'threads.total': I18n('Total Threads'),
+  'users': I18n('Users'),
+  'users.active': I18n('Active Users'),
+  'users.active.total': I18n('Total Active Users')
+};
+
+const transformMetricNames = (dataSource: DataSourceItem[]): DataSourceItem[] =>
+  dataSource.map(item => ({
+    ...item,
+    name: metricLabels[item.name] || item.name
+  }));
 
 const MetricsTable: React.FC<MetricsTableProps> = ({ caption, dataSource }) => {
+  const transformedDataSource = transformMetricNames(dataSource);
+
   const metricsColumns: ColumnType<DataSourceItem>[] = [
     {
       title: 'Name',
@@ -96,7 +127,7 @@ const MetricsTable: React.FC<MetricsTableProps> = ({ caption, dataSource }) => {
   return (
     <>
       <h4 className='metrics-heading'>{caption}</h4>
-      <Table dataSource={dataSource} rowKey="name" columns={metricsColumns} pagination={false} />
+      <Table dataSource={transformedDataSource} rowKey="name" columns={metricsColumns} pagination={false} />
     </>
   );
 };

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
@@ -96,7 +96,7 @@ const metricLabels: { [key: string]: string } = {
   'requests.response-time': I18n('Request Response Time'),
   'threads.daemon': I18n('Daemon Threads'),
   'threads.total': I18n('Total Threads'),
-  'users': I18n('Users'),
+  users: I18n('Users'),
   'users.active': I18n('Active Users'),
   'users.active.total': I18n('Total Active Users')
 };
@@ -126,8 +126,13 @@ const MetricsTable: React.FC<MetricsTableProps> = ({ caption, dataSource }) => {
 
   return (
     <>
-      <h4 className='metrics-heading'>{caption}</h4>
-      <Table dataSource={transformedDataSource} rowKey="name" columns={metricsColumns} pagination={false} />
+      <h4 className="metrics-heading">{caption}</h4>
+      <Table
+        dataSource={transformedDataSource}
+        rowKey="name"
+        columns={metricsColumns}
+        pagination={false}
+      />
     </>
   );
 };

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
@@ -127,7 +127,7 @@ const MetricsTable: React.FC<MetricsTableProps> = ({ caption, dataSource }) => {
   return (
     <>
       <h4 className="metrics-heading">{caption}</h4>
-      <Table 
+      <Table
         className="metrics-table"
         dataSource={transformedDataSource}
         rowKey="name"

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
@@ -95,7 +95,7 @@ const MetricsTable: React.FC<MetricsTableProps> = ({ caption, dataSource }) => {
 
   return (
     <>
-      <h4>{caption}</h4>
+      <h4 className='metrics-heading'>{caption}</h4>
       <Table dataSource={dataSource} rowKey="name" columns={metricsColumns} pagination={false} />
     </>
   );

--- a/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/MetricsComponent/MetricsTable.tsx
@@ -14,11 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { CSSProperties } from 'react';
+import React from 'react';
 import Table from 'cuix/dist/components/Table/Table';
 import type { ColumnType } from 'antd/es/table';
 import './MetricsComponent.scss';
-import 'cuix/dist/components/Table/Table.css';
 
 interface MetricsTime {
   '1m_rate': number;
@@ -97,7 +96,6 @@ const MetricsTable = ({ caption, dataSource }: MetricsTableProps) => {
         dataSource={dataSource}
         rowKey="name"
         columns={metricsColumns}
-        style={CSSProperties}
         pagination={false}
       />
     </>

--- a/desktop/core/src/desktop/js/reactComponents/imports.js
+++ b/desktop/core/src/desktop/js/reactComponents/imports.js
@@ -1,4 +1,4 @@
-// ADD NEW RACT COMPONENTS HERE
+// ADD NEW REACT COMPONENTS HERE
 // We need a way to match an imported module with a component name
 // so we handle the imports dynamically for that reason.
 export async function loadComponent(name) {
@@ -9,6 +9,9 @@ export async function loadComponent(name) {
 
     case 'StorageBrowserPage':
       return (await import('../apps/storageBrowser/StorageBrowserPage/StorageBrowserPage')).default;
+
+    case 'MetricsComponent':
+      return (await import('./MetricsComponent/MetricsComponent')).default;
 
     // Application global components here
     case 'AppBanner':

--- a/desktop/core/src/desktop/templates/metrics.mako
+++ b/desktop/core/src/desktop/templates/metrics.mako
@@ -101,77 +101,15 @@ ${ commonheader(_('Metrics'), "about", user, request) | n,unicode }
 
 ${layout.menubar(section='metrics')}
 
-<div id="metricsComponents" class="container-fluid">
-  <div class="card card-small margin-top-10">
-    <!-- ko if: metrics() -->
-    <div data-bind="dockable: { scrollable: ${ MAIN_SCROLLABLE }, jumpCorrection: 0,topSnap: '${ TOP_SNAP }', triggerAdjust: ${ is_embeddable and "0" or "106" }}">
-      <ul class="nav nav-pills">
-        <li data-bind="css: { 'active': $root.selectedMetric() === 'All' }">
-          <a href="javascript:void(0)" data-bind="text: 'All', click: function(){ $root.selectedMetric('All') }"></a>
-        </li>
-        <!-- ko foreach: metricsKeys -->
-        <!-- ko ifnot: $root.isUnusedMetric($data)-->
-        <li data-bind="css: { 'active': $root.selectedMetric() === $data }">
-          <a href="javascript:void(0)" data-bind="text: $data, click: function(){ $root.selectedMetric($data) }"></a>
-        </li>
-        <!-- /ko -->
-        <!-- /ko -->
-      </ul>
-      <input type="text" data-bind="clearable: metricsFilter, valueUpdate: 'afterkeydown'"
-          class="input-xlarge pull-right margin-bottom-10" placeholder="${_('Filter metrics...')}">
-    </div>
+<script type="text/javascript">
+  (function () {
+    window.createReactComponents('#MetricsComponent');
+  })();
+</script>
 
-    <div class="margin-top-10">
-      <!-- ko if: $root.selectedMetric() === 'All' && $root.isMasterEmpty()-->
-      <table class="table table-condensed">
-        <thead>
-          <tr>
-            <th width="30%">${ _('Name') }</th>
-            <th>${ _('Value') }</th>
-          </tr>
-        </thead>
-        <tfoot>
-          <tr>
-              <td colspan="2">${ _('There are no metrics matching your filter') }</td>
-          </tr>
-        </tfoot>
-      </table>
-      <!-- /ko -->
-      <div data-bind="foreach: {data: Object.keys($root.filteredMetrics()).sort(), as: '_masterkey'}">
-      <!-- ko if: ($root.selectedMetric() === 'All' && $root.filteredMetrics()[_masterkey]) || $root.selectedMetric() === _masterkey-->
-      <!-- ko ifnot: $root.isUnusedMetric(_masterkey)-->
-      <h4 data-bind="text: _masterkey"></h4>
-      <table class="table table-condensed">
-        <thead>
-          <tr>
-            <th width="30%">${ _('Name') }</th>
-            <th>${ _('Value') }</th>
-          </tr>
-        </thead>
-        <!-- ko if: $root.filteredMetrics()[_masterkey] -->
-        <tbody data-bind="foreach: {'data': Object.keys($root.filteredMetrics()[_masterkey])}">
-          <tr>
-            <td data-bind="text: $data"></td>
-            <td data-bind="text: $root.filteredMetrics()[_masterkey][$data]"></td>
-          </tr>
-        </tbody>
-        <!-- /ko -->
-        <!-- ko ifnot: $root.filteredMetrics()[_masterkey] -->
-        <tfoot>
-          <tr>
-            <td colspan="2">${ _('There are no metrics matching your filter') }</td>
-          </tr>
-          </tfoot>
-        <!-- /ko -->
-        </table>
-        <!-- /ko -->
-        <!-- /ko -->
-      </div>
-    </div>
-  <!-- /ko -->
-  </div>
+<div id="MetricsComponent">
+<MetricsComponent data-reactcomponent='MetricsComponent'></MetricsComponent>
 </div>
-
 
 %if not is_embeddable:
 ${ commonfooter(request, messages) | n,unicode }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR is about shifting the entire code for the Metrics tab (page) in ReactJS i.e. adding Metrics as a react component. The Metrics page is present as a tab in the Administrator server.

## How was this patch tested?
I have added unit tests here. One for the selection dropDown and the other for filtering the metrics based on name.
The code is tested manually as well.

This is how the current Metrics page looks like.
<img width="1187" alt="Screenshot 2024-06-22 at 12 54 16 PM" src="https://github.com/cloudera/hue/assets/68558847/ac7bd7bf-8b35-4fdb-a3d0-846187bda40b">

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.

