### PR TITLE
[lint] Ignore deleted files for Ruff linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ ignore = [
     "E111",
     "E114",
     "W191",
-    "E902", # Skip it because of deleted staged files
 ]
 
 [tool.ruff.format]

--- a/tools/ci/check_for_python_lint.sh
+++ b/tools/ci/check_for_python_lint.sh
@@ -20,7 +20,7 @@
 HOME=${1:-"."}
 FOUND_ISSUE=-1
 
-files=`git diff --name-only origin/master --diff-filter=b | egrep .py$` 
+files=`git diff --name-only origin/master --diff-filter=bd | egrep .py$` 
 
 cd $HOME
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- We were ignoring the `E902` rule earlier because it was triggering for deleted files.
- Instead, this PR ignores the deleted files and not use them for lint checks to avoid further triggering such rules.

## How was this patch tested?

- Locally running lint checks.