### PR TITLE
[core][cve] Remove werkzeug package

### DIFF
--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -70,7 +70,6 @@ trino==0.324.0  # Need to upgrade to the latest version but that requires reques
 git+https://github.com/gethue/thrift.git
 thrift-sasl==0.4.3
 git+https://github.com/gethue/django-babel.git
-werkzeug==2.3.6  # Should remove it here and from devtools.mk
 django-utils-six==2.0
 six==1.16.0
 psutil==5.8.0

--- a/desktop/devtools.mk
+++ b/desktop/devtools.mk
@@ -23,8 +23,7 @@ DEVTOOLS += \
 	ipdb[0.13.9] \
 	nose[1.3.7] \
 	coverage[4.4.2] \
-	nosetty[0.4] \
-	werkzeug[2.3.6]
+	nosetty[0.4]
 
 PYPI_MIRROR ?= https://pypi.python.org/simple/
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- This package is having CVEs and I tried to where it is used in the Hue codebase but didnt get any dependency references so looks like its better to remove it.

## How was this patch tested?

- Tested locally