### PR TITLE
[core][cve] Bump sqlparse to 0.5.0

### DIFF
--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -63,7 +63,7 @@ ruff==0.3.7
 sasl==0.3.1  # Move to https://pypi.org/project/sasl3/ ?
 slack-sdk==3.2.0
 SQLAlchemy==1.3.8
-sqlparse==0.4.4
+sqlparse==0.5.0
 tablib==0.13.0
 tabulate==0.8.9
 trino==0.324.0  # Need to upgrade to the latest version but that requires requests>=2.31.0


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Bumping to the latest version fixes the following CVE:
  - https://github.com/cloudera/hue/security/dependabot/231

## How was this patch tested?

- Tested manually in local Hue setup