### PR TITLE
[core] Correct expression for python version comparison

### DIFF
--- a/tools/relocatable.sh
+++ b/tools/relocatable.sh
@@ -84,9 +84,8 @@ fi
 export PATH=$(dirname $ENV_PYTHON):$PATH
 
 PYVER=$($ENV_PYTHON -V 2>&1 | awk '{print $2}' | cut -d '.' -f 1,2)
-MIN_VERSION="3.8"
 # Step 1. Fix virtualenv
-if [[ $PYVER == $MIN_VERSION || $PYVER == $MIN_VERSION.* || $PYVER > $MIN_VERSION ]]; then
+if [[ "$PYVER" == "3."[8-9]* || "$PYVER" == "3.10" ]]; then
   echo "Python version is 3.8 or greater"
   pushd .
   cd $HUE_ROOT


### PR DESCRIPTION
## What changes were proposed in this pull request?

- It was considering "3.10" < "3.8" as it compares lexicographically
- Using correct expression for python version comparison

## How was this patch tested?

- E2E downstream