### PR TITLE
[core] Change ext-py3 package installation path

### DIFF
--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -73,9 +73,9 @@ git+https://github.com/gethue/django-babel.git
 django-utils-six==2.0
 six==1.16.0
 psutil==5.8.0
--e file:///${ROOT}/desktop/core/ext-py3/requests-2.27.1
--e file:///${ROOT}/desktop/core/ext-py3/boto-2.49.0
--e file:///${ROOT}/desktop/core/ext-py3/django-axes-5.13.0
--e file:///${ROOT}/desktop/core/ext-py3/djangosaml2-0.18.0
--e file:///${ROOT}/desktop/core/ext-py3/eventlet-0.30.2
--e file:///${ROOT}/desktop/core/ext-py3/pysaml2-7.3.1
+-e file://${ROOT}/desktop/core/ext-py3/requests-2.27.1
+-e file://${ROOT}/desktop/core/ext-py3/boto-2.49.0
+-e file://${ROOT}/desktop/core/ext-py3/django-axes-5.13.0
+-e file://${ROOT}/desktop/core/ext-py3/djangosaml2-0.18.0
+-e file://${ROOT}/desktop/core/ext-py3/eventlet-0.30.2
+-e file://${ROOT}/desktop/core/ext-py3/pysaml2-7.3.1


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Giving old style file path was failing `./build/env/bin/pip freeze` with the following error:

```
harsh.gupta@Harshs-MacBook-Pro hue % ./build/env/bin/pip freeze                                       
ERROR: Exception:
Traceback (most recent call last):
  File "/Users/harsh.gupta/workspace/hue/upstream/hue/build/env/lib/python3.8/site-packages/pip/_internal/cli/base_command.py", line 180, in exc_logging_wrapper
    status = run_func(*args)
  File "/Users/harsh.gupta/workspace/hue/upstream/hue/build/env/lib/python3.8/site-packages/pip/_internal/commands/freeze.py", line 98, in run
    for line in freeze(
  File "/Users/harsh.gupta/workspace/hue/upstream/hue/build/env/lib/python3.8/site-packages/pip/_internal/operations/freeze.py", line 43, in freeze
    req = FrozenRequirement.from_dist(dist)
  File "/Users/harsh.gupta/workspace/hue/upstream/hue/build/env/lib/python3.8/site-packages/pip/_internal/operations/freeze.py", line 236, in from_dist
    editable = dist.editable
  File "/Users/harsh.gupta/workspace/hue/upstream/hue/build/env/lib/python3.8/site-packages/pip/_internal/metadata/base.py", line 338, in editable
    return bool(self.editable_project_location)
  File "/Users/harsh.gupta/workspace/hue/upstream/hue/build/env/lib/python3.8/site-packages/pip/_internal/metadata/base.py", line 179, in editable_project_location
    return url_to_path(direct_url.url)
  File "/Users/harsh.gupta/workspace/hue/upstream/hue/build/env/lib/python3.8/site-packages/pip/_internal/utils/urls.py", line 43, in url_to_path
    raise ValueError(
ValueError: non-local file URIs are not supported on this platform: 'file://Users/harsh.gupta/workspace/hue/upstream/hue/desktop/core/ext-py3/pysaml2-7.3.1'
```

- Using 2 slash file path is installing the packages + fixes the above error.

## How was this patch tested?

- Manually in local setup