### PR TITLE
[core] Upgrade the request_kerberos lib for python3.10 support

### DIFF
--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -57,7 +57,7 @@ pytidylib==0.3.2
 pytz==2021.3
 PyJWT==2.4.0
 PyYAML==6.0.1
-requests-kerberos==0.12.0
+requests-kerberos==0.14.0
 rsa==4.7.2
 ruff==0.3.7
 sasl==0.3.1  # Move to https://pypi.org/project/sasl3/ ?


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Upgrading from 0.12.0 to 0.14.0 

## How was this patch tested?

- E2E downstream
