### PR TITLE
[ruff] Skip logging subprocess exception as error

### DIFF
--- a/desktop/core/src/desktop/management/commands/runruff.py
+++ b/desktop/core/src/desktop/management/commands/runruff.py
@@ -133,5 +133,5 @@ class Command(BaseCommand):
       if ret.returncode != 0:
         sys.exit(1)
     except subprocess.CalledProcessError as e:
-      LOG.error(f"Error running ruff command: {e}")
+      LOG.debug(f"Ruff command: {e}")
       sys.exit(1)


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Raised exception is not always an actual error. Mostly it notifies about the violations.

## How was this patch tested?

- Manually.