### PR TITLE
[filebrowser] updated file compression in hdfs to support py3

### DIFF
--- a/desktop/core/src/desktop/lib/tasks/compress_files/compress_in_hdfs.sh
+++ b/desktop/core/src/desktop/lib/tasks/compress_files/compress_in_hdfs.sh
@@ -19,8 +19,6 @@ UPLOAD_PATH=
 FILE_NAMES=
 ARCHIVE_NAME=
 
-PYTHON_VERSION=$(python -c 'import sys; print(sys.version_info[0])')
-
 function usage()
 {
     echo "Arguments '-u', '-f' and '-n' are mandatory."
@@ -91,12 +89,7 @@ done
 set +x
 if [ $exit_status == 0 ]
 then
-	if [ $PYTHON_VERSION -gt 2 ]
-	then
-		encoded_output_dir=`python -c "import urllib.parse;print(urllib.parse.quote(input()))" <<< "$temp_output_dir/$ARCHIVE_NAME"`
-	else
-		encoded_output_dir=`python -c "import urllib;print urllib.quote(raw_input())" <<< "$temp_output_dir/$ARCHIVE_NAME"`
-	fi
+	encoded_output_dir=`python -c "import urllib.parse;print(urllib.parse.quote(input()))" <<< "$temp_output_dir/$ARCHIVE_NAME"`
 	echo "Copying $encoded_output_dir to '$UPLOAD_PATH' in HDFS"
 	hadoop fs -put -f $encoded_output_dir "$UPLOAD_PATH"
 	exit_status=$(echo $?)

--- a/desktop/core/src/desktop/lib/tasks/compress_files/compress_in_hdfs.sh
+++ b/desktop/core/src/desktop/lib/tasks/compress_files/compress_in_hdfs.sh
@@ -19,6 +19,8 @@ UPLOAD_PATH=
 FILE_NAMES=
 ARCHIVE_NAME=
 
+PYTHON_VERSION=$(python -c 'import sys; print(sys.version_info[0])')
+
 function usage()
 {
     echo "Arguments '-u', '-f' and '-n' are mandatory."
@@ -89,7 +91,12 @@ done
 set +x
 if [ $exit_status == 0 ]
 then
-	encoded_output_dir=`python -c "import urllib;print urllib.quote(raw_input())" <<< "$temp_output_dir/$ARCHIVE_NAME"`
+	if [ $PYTHON_VERSION -gt 2 ]
+	then
+		encoded_output_dir=`python -c "import urllib.parse;print(urllib.parse.quote(input()))" <<< "$temp_output_dir/$ARCHIVE_NAME"`
+	else
+		encoded_output_dir=`python -c "import urllib;print urllib.quote(raw_input())" <<< "$temp_output_dir/$ARCHIVE_NAME"`
+	fi
 	echo "Copying $encoded_output_dir to '$UPLOAD_PATH' in HDFS"
 	hadoop fs -put -f $encoded_output_dir "$UPLOAD_PATH"
 	exit_status=$(echo $?)


### PR DESCRIPTION
## What changes were proposed in this pull request?

- In Python3, we need to use **urllib.parse** instead of **urllib**.
- Also, raw_input() was renamed to input(). Reference: https://docs.python.org/3/whatsnew/3.0.html#builtins
- Ref: CDPD-66706

## How was this patch tested?

- manually tested in CDP 7.1.9 and CDP 7.1.7 [SP1]

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
