### PR TITLE
[taskserver] Disable schedule tasks tab in job browser based on task_server_v2 configs

### DIFF
--- a/desktop/core/src/desktop/models.py
+++ b/desktop/core/src/desktop/models.py
@@ -52,7 +52,7 @@ from desktop.conf import (
   HUE_IMAGE_VERSION,
   IS_MULTICLUSTER_ONLY,
   RAZ,
-  TASK_SERVER_V2,
+  TASK_SERVER,
   get_clusters,
   has_connectors,
 )
@@ -2200,7 +2200,7 @@ class ClusterConfig(object):
         }
       ])
 
-    if TASK_SERVER_V2.BEAT_ENABLED.get():
+    if TASK_SERVER.BEAT_ENABLED.get():
       interpreters.append({
           'type': 'celery-beat',
           'displayName': _('Scheduled Tasks'),

--- a/desktop/libs/notebook/src/notebook/api.py
+++ b/desktop/libs/notebook/src/notebook/api.py
@@ -26,7 +26,7 @@ from django.urls import reverse
 from django.views.decorators.http import require_GET, require_POST
 
 from azure.abfs.__init__ import abfspath
-from desktop.conf import ENABLE_CONNECTORS, TASK_SERVER_V2
+from desktop.conf import ENABLE_CONNECTORS
 from desktop.lib.django_util import JsonResponse
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.i18n import smart_str

--- a/desktop/libs/notebook/src/notebook/connectors/base.py
+++ b/desktop/libs/notebook/src/notebook/connectors/base.py
@@ -27,7 +27,7 @@ from django.utils.encoding import smart_str
 
 from beeswax.common import find_compute, is_compute
 from desktop.auth.backend import is_admin
-from desktop.conf import TASK_SERVER_V2, has_connectors
+from desktop.conf import TASK_SERVER, has_connectors
 from desktop.lib import export_csvxls
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.i18n import smart_unicode
@@ -425,7 +425,7 @@ def patch_snippet_for_connector(snippet, user=None):
 def get_api(request, snippet):
   from notebook.connectors.oozie_batch import OozieApi
 
-  if snippet.get('wasBatchExecuted') and not TASK_SERVER_V2.ENABLED.get():
+  if snippet.get('wasBatchExecuted') and not TASK_SERVER.ENABLED.get():
     return OozieApi(user=request.user, request=request)
 
   if snippet.get('type') == 'report':

--- a/desktop/libs/notebook/src/notebook/models.py
+++ b/desktop/libs/notebook/src/notebook/models.py
@@ -30,7 +30,7 @@ from django.db.models import Count
 from django.db.models.functions import Trunc
 from django.utils.html import escape
 
-from desktop.conf import TASK_SERVER_V2, has_connectors
+from desktop.conf import has_connectors
 from desktop.lib.connectors.models import _get_installed_connectors
 from desktop.lib.i18n import smart_unicode
 from desktop.lib.paths import SAFE_CHARACTERS_URI


### PR DESCRIPTION
## What changes were proposed in this pull request?

Disable schedule tasks tab in job browser based on task_server_v2 configs. 
Also move back notebook tasks to be enabled based on old task_server configs. 
## How was this patch tested?

-Tested on local mac and hue from docker builds. 

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
