### PR TITLE
[ui-tablebrowser] Fix viewSQL tab for Hive

### DIFF
--- a/desktop/core/src/desktop/js/apps/tableBrowser/metastoreTable.js
+++ b/desktop/core/src/desktop/js/apps/tableBrowser/metastoreTable.js
@@ -321,9 +321,7 @@ class MetastoreTable {
           const found =
             analysis.properties &&
             analysis.properties.some(property => {
-              if (
-                viewSqlPropertyColumnNames.has(property.col_name.toLowerCase())
-              ) {
+              if (viewSqlPropertyColumnNames.has(property.col_name.toLowerCase())) {
                 apiHelper
                   .formatSql({ statements: property.data_type })
                   .then(formatResponse => {

--- a/desktop/core/src/desktop/js/apps/tableBrowser/metastoreTable.js
+++ b/desktop/core/src/desktop/js/apps/tableBrowser/metastoreTable.js
@@ -320,7 +320,9 @@ class MetastoreTable {
           const found =
             analysis.properties &&
             analysis.properties.some(property => {
-              if (['view original text:', 'original query:'].includes(property.col_name.toLowerCase())) {
+              if (
+                ['view original text:', 'original query:'].includes(property.col_name.toLowerCase())
+              ) {
                 apiHelper
                   .formatSql({ statements: property.data_type })
                   .then(formatResponse => {

--- a/desktop/core/src/desktop/js/apps/tableBrowser/metastoreTable.js
+++ b/desktop/core/src/desktop/js/apps/tableBrowser/metastoreTable.js
@@ -320,7 +320,7 @@ class MetastoreTable {
           const found =
             analysis.properties &&
             analysis.properties.some(property => {
-              if (property.col_name.toLowerCase() === 'view original text:') {
+              if (['view original text:', 'original query:'].includes(property.col_name.toLowerCase())) {
                 apiHelper
                   .formatSql({ statements: property.data_type })
                   .then(formatResponse => {

--- a/desktop/core/src/desktop/js/apps/tableBrowser/metastoreTable.js
+++ b/desktop/core/src/desktop/js/apps/tableBrowser/metastoreTable.js
@@ -316,12 +316,13 @@ class MetastoreTable {
             this.partitions.loading(false);
             this.partitions.loaded(true);
           }
-
+          // Currently checking for Impala and Hive
+          const viewSqlPropertyColumnNames = new Set(['view original text:', 'original query:']);
           const found =
             analysis.properties &&
             analysis.properties.some(property => {
               if (
-                ['view original text:', 'original query:'].includes(property.col_name.toLowerCase())
+                viewSqlPropertyColumnNames.has(property.col_name.toLowerCase())
               ) {
                 apiHelper
                   .formatSql({ statements: property.data_type })


### PR DESCRIPTION
## What changes were proposed in this pull request?

- View SQL option was visible for Impala but not for Hive. 
- It turns out we were correctly parsing the describe view response for Impala and checking for correct view SQL property.
- This was missing for Hive describe view response and now we are checking for Hive related property also with this change.

## How was this patch tested?

- Manually