### PR TITLE
[interpreters] Skip adding all available editors by default for every whitelisted app

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -1062,13 +1062,16 @@ tls=no
 [notebook]
 
 ## Show the notebook menu or not
-# show_notebooks=true
+# show_notebooks=false
 
 ## Flag to enable the selection of queries from files, saved queries into the editor or as snippet.
 # enable_external_statements=false
 
 ## Flag to enable the bulk submission of queries as a background task through Oozie.
 # enable_batch_execute=true
+
+## Flag to enable all interpreters (Hive and Impala are added by default) related to every whitelisted app.
+# enable_all_interpreters=false
 
 ## Flag to turn on the SQL indexer.
 # enable_sql_indexer=false

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -1055,7 +1055,7 @@
   # enable_batch_execute=false
 
   ## Flag to enable all interpreters (Hive and Impala are added by default) related to every whitelisted app.
-  # enable_all_interpreters=true
+  # enable_all_interpreters=false
 
   ## Flag to turn on the SQL indexer.
   # enable_sql_indexer=false

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -1046,13 +1046,16 @@
 [notebook]
 
   ## Show the notebook menu or not
-  # show_notebooks=true
+  # show_notebooks=false
 
   ## Flag to enable the selection of queries from files, saved queries into the editor or as snippet.
   # enable_external_statements=false
 
   ## Flag to enable the bulk submission of queries as a background task through Oozie.
   # enable_batch_execute=false
+
+  ## Flag to enable all interpreters (Hive and Impala are added by default) related to every whitelisted app.
+  # enable_all_interpreters=true
 
   ## Flag to turn on the SQL indexer.
   # enable_sql_indexer=false

--- a/desktop/core/src/desktop/tests.py
+++ b/desktop/core/src/desktop/tests.py
@@ -433,7 +433,7 @@ def test_error_handling():
 @pytest.mark.django_db
 def test_desktop_permissions():
   USERNAME = 'test_core_permissions'
-  GROUPNAME = 'default_core_permissions'
+  GROUPNAME = 'default'
 
   desktop.conf.REDIRECT_WHITELIST.set_for_testing(r'^\/.*$,^http:\/\/testserver\/.*$')
 

--- a/desktop/core/src/desktop/tests.py
+++ b/desktop/core/src/desktop/tests.py
@@ -432,7 +432,7 @@ def test_error_handling():
 @pytest.mark.django_db
 def test_desktop_permissions():
   USERNAME = 'test_core_permissions'
-  GROUPNAME = 'default'
+  GROUPNAME = 'default_core_permissions'
 
   desktop.conf.REDIRECT_WHITELIST.set_for_testing(r'^\/.*$,^http:\/\/testserver\/.*$')
 

--- a/desktop/core/src/desktop/tests.py
+++ b/desktop/core/src/desktop/tests.py
@@ -41,6 +41,7 @@ import desktop
 import desktop.conf
 import desktop.urls
 import desktop.views as views
+import notebook.conf
 import desktop.redaction as redaction
 from dashboard.conf import HAS_SQL_ENABLED
 from desktop.appmanager import DESKTOP_APPS
@@ -476,6 +477,9 @@ def test_app_permissions():
     check_app(401, 'spark')
     check_app(401, 'oozie')
 
+    # Clean INTERPRETERS_CACHE before every get_apps() call to have dynamic interpreters value for test_user
+    # because every testcase below needs clean INTERPRETERS_CACHE value as ENABLE_ALL_INTERPRETERS is now false by default.
+    notebook.conf.INTERPRETERS_CACHE = None
     apps = ClusterConfig(user=user).get_apps()
     assert 'hive' not in apps.get('editor', {}).get('interpreter_names', []), apps
     assert 'impala' not in apps.get('editor', {}).get('interpreter_names', []), apps
@@ -502,6 +506,7 @@ def test_app_permissions():
     check_app(401, 'spark')
     check_app(401, 'oozie')
 
+    notebook.conf.INTERPRETERS_CACHE = None
     apps = ClusterConfig(user=user).get_apps()
     assert 'hive' in apps.get('editor', {}).get('interpreter_names', []), apps
     assert 'impala' not in apps.get('editor', {}).get('interpreter_names', []), apps
@@ -525,6 +530,7 @@ def test_app_permissions():
     check_app(401, 'spark')
     check_app(401, 'oozie')
 
+    notebook.conf.INTERPRETERS_CACHE = None
     apps = ClusterConfig(user=user).get_apps()
     assert 'hive' in apps.get('editor', {}).get('interpreter_names', []), apps
     assert 'impala' not in apps.get('editor', {}).get('interpreter_names', []), apps
@@ -549,6 +555,7 @@ def test_app_permissions():
     check_app(401, 'spark')
     check_app(401, 'oozie')
 
+    notebook.conf.INTERPRETERS_CACHE = None
     apps = ClusterConfig(user=user).get_apps()
     assert 'hive' not in apps.get('editor', {}).get('interpreter_names', []), apps
     assert 'impala' not in apps.get('editor', {}).get('interpreter_names', []), apps
@@ -571,6 +578,7 @@ def test_app_permissions():
     check_app(401, 'spark')
     check_app(401, 'oozie')
 
+    notebook.conf.INTERPRETERS_CACHE = None
     apps = ClusterConfig(user=user).get_apps()
     assert 'hive' not in apps.get('editor', {}).get('interpreter_names', []), apps
     assert 'impala' in apps.get('editor', {}).get('interpreter_names', []), apps
@@ -593,6 +601,7 @@ def test_app_permissions():
     check_app(401, 'spark')
     check_app(200, 'oozie')
 
+    notebook.conf.INTERPRETERS_CACHE = None
     apps = ClusterConfig(user=user).get_apps()
     assert 'scheduler' in apps, apps
     assert 'browser' not in apps, apps  # Actually should be true, but logic not implemented
@@ -608,6 +617,7 @@ def test_app_permissions():
     check_app(401, 'spark')
     check_app(200, 'oozie')
 
+    notebook.conf.INTERPRETERS_CACHE = None
     apps = ClusterConfig(user=user).get_apps()
     assert 'hive' not in apps.get('editor', {}).get('interpreter_names', []), apps
     assert 'impala' in apps.get('editor', {}).get('interpreter_names', []), apps
@@ -625,6 +635,7 @@ def test_app_permissions():
       check_app(401, 'spark')
       check_app(200, 'oozie')
 
+      notebook.conf.INTERPRETERS_CACHE = None
       apps = ClusterConfig(user=user).get_apps()
       assert 'hive' not in apps.get('editor', {}).get('interpreter_names', []), apps
       assert 'impala' in apps.get('editor', {}).get('interpreter_names', []), apps
@@ -642,6 +653,7 @@ def test_app_permissions():
       check_app(200, 'spark')
       check_app(200, 'oozie')
 
+      notebook.conf.INTERPRETERS_CACHE = None
       apps = ClusterConfig(user=user).get_apps()
       assert 'hive' not in apps.get('editor', {}).get('interpreter_names', []), apps
       assert 'impala' in apps.get('editor', {}).get('interpreter_names', []), apps
@@ -656,6 +668,7 @@ def test_app_permissions():
   finally:
     for f in resets:
       f()
+    notebook.conf.INTERPRETERS_CACHE = None
 
 
 @pytest.mark.django_db

--- a/desktop/core/src/desktop/tests.py
+++ b/desktop/core/src/desktop/tests.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Licensed to Cloudera, Inc. under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,67 +15,51 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
-from builtins import range, object
-import json
-import logging
 import os
-import pytest
-import subprocess
 import sys
+import json
 import time
 import uuid
-
-import proxy.conf
+import logging
 import tempfile
+import subprocess
+from io import StringIO as string_io
+from unittest.mock import Mock, patch
 
+import pytest
 from configobj import ConfigObj
-from django.db.models import query, CharField, SmallIntegerField
 from django.core.management import call_command
 from django.core.paginator import Paginator
 from django.db import connection
-from django.urls import reverse
-from django.test.client import Client
-from django.views.static import serve
+from django.db.models import CharField, SmallIntegerField, query
 from django.http import HttpResponse
-
-from dashboard.conf import HAS_SQL_ENABLED
-from desktop.settings import DATABASES
-from useradmin.models import GroupPermission, User
+from django.test.client import Client
+from django.urls import re_path, reverse
+from django.views.static import serve
 
 import desktop
 import desktop.conf
 import desktop.urls
-import desktop.redaction as redaction
 import desktop.views as views
-
-from desktop.auth.backend import rewrite_user
+import desktop.redaction as redaction
+from dashboard.conf import HAS_SQL_ENABLED
 from desktop.appmanager import DESKTOP_APPS
+from desktop.auth.backend import rewrite_user
+from desktop.lib.conf import _configs_from_dir, validate_path
 from desktop.lib.django_test_util import make_logged_in_client
-from desktop.lib.conf import validate_path
 from desktop.lib.django_util import TruncatingModel
 from desktop.lib.exceptions_renderable import PopupException
-from desktop.lib.conf import _configs_from_dir
 from desktop.lib.paths import get_desktop_root
 from desktop.lib.python_util import force_dict_to_strings
 from desktop.lib.test_utils import grant_access
 from desktop.middleware import DJANGO_VIEW_AUTH_WHITELIST
-from desktop.models import Directory, Document, Document2, get_data_link, _version_from_properties, ClusterConfig, HUE_VERSION
+from desktop.models import HUE_VERSION, ClusterConfig, Directory, Document, Document2, _version_from_properties, get_data_link
 from desktop.redaction import logfilter
 from desktop.redaction.engine import RedactionPolicy, RedactionRule
-from desktop.views import check_config, home, generate_configspec, load_confs, collect_validation_messages, _get_config_errors
-
-if sys.version_info[0] > 2:
-  from io import StringIO as string_io
-  from unittest.mock import patch, Mock
-  from django.urls import re_path
-else:
-  from cStringIO import StringIO as string_io
-  from mock import patch, Mock
-  from django.conf.urls import url as re_path
-
+from desktop.settings import DATABASES
+from desktop.views import _get_config_errors, check_config, collect_validation_messages, generate_configspec, home, load_confs
+from notebook.conf import ENABLE_ALL_INTERPRETERS
+from useradmin.models import GroupPermission, User
 
 LOG = logging.getLogger()
 
@@ -91,6 +74,7 @@ def test_home():
   assert 200 == response.status_code
 
   from pig.models import PigScript
+
   script, created = PigScript.objects.get_or_create(owner=user)
   doc = Document.objects.link(script, owner=script.owner, name='test_home')
 
@@ -125,15 +109,18 @@ def test_home():
   tags = json.loads(response.context[0]['json_tags'])
   assert [] == tags['mine'][0]['docs'], tags
   assert [] == tags['trash']['docs'], tags
-  assert [] == tags['history']['docs'], tags # We currently don't fetch [doc.id]
+  assert [] == tags['history']['docs'], tags  # We currently don't fetch [doc.id]
+
 
 @pytest.mark.django_db
 def test_skip_wizard():
   pytest.skip("Skipping due to failures with pytest, investigation ongoing.")
-  c = make_logged_in_client() # is_superuser
+  c = make_logged_in_client()  # is_superuser
 
   response = c.get('/', follow=True)
-  assert ['admin_wizard.mako' in _template.filename for _template in response.templates], [_template.filename for _template in response.templates]
+  assert ['admin_wizard.mako' in _template.filename for _template in response.templates], [
+    _template.filename for _template in response.templates
+  ]
 
   c.cookies['hueLandingPage'] = 'home'
   response = c.get('/', follow=True)
@@ -141,8 +128,9 @@ def test_skip_wizard():
 
   c.cookies['hueLandingPage'] = ''
   response = c.get('/', follow=True)
-  assert ['admin_wizard.mako' in _template.filename for _template in response.templates], [_template.filename for _template in response.templates]
-
+  assert ['admin_wizard.mako' in _template.filename for _template in response.templates], [
+    _template.filename for _template in response.templates
+  ]
 
   c = make_logged_in_client(username="test_skip_wizard", password="test_skip_wizard", is_superuser=False)
 
@@ -157,6 +145,7 @@ def test_skip_wizard():
   response = c.get('/', follow=True)
   assert ['home.mako' in _template.filename for _template in response.templates], [_template.filename for _template in response.templates]
 
+
 @pytest.mark.django_db
 def test_public_views():
   c = Client()
@@ -168,6 +157,7 @@ def test_public_views():
       url = reverse(view)
     response = c.get(url)
     assert 200 == response.status_code
+
 
 def test_prometheus_view():
   if not desktop.conf.ENABLE_PROMETHEUS.get():
@@ -199,9 +189,10 @@ def test_prometheus_view():
   for metric in ALL_PROMETHEUS_METRICS:
     metric = metric if isinstance(metric, bytes) else metric.encode('utf-8')
     if metric not in desktop.metrics.ALLOWED_DJANGO_PROMETHEUS_METRICS:
-      assert not metric in response.content, 'metric: %s \n %s' % (metric, response.content)
+      assert metric not in response.content, 'metric: %s \n %s' % (metric, response.content)
     else:
       assert metric in response.content, 'metric: %s \n %s' % (metric, response.content)
+
 
 @pytest.mark.django_db
 def test_log_view():
@@ -227,6 +218,7 @@ def test_log_view():
   response = c.get(URL)
   assert 200 == response.status_code
 
+
 def test_download_log_view():
   pytest.skip("Skipping Test")
   c = make_logged_in_client()
@@ -234,29 +226,36 @@ def test_download_log_view():
   URL = reverse(views.download_log_view)
 
   LOG = logging.getLogger()
-  LOG.warning(u'une voix m’a réveillé')
+  LOG.warning('une voix m’a réveillé')
 
   # UnicodeDecodeError: 'ascii' codec can't decode byte... should not happen
   response = c.get(URL)
   assert "application/zip" == response.get('Content-Type', '')
+
 
 def hue_version():
   global HUE_VERSION
   HUE_VERSION_BAK = HUE_VERSION
 
   try:
-    assert 'cdh6.x-SNAPSHOT' == _version_from_properties(string_io(
-      """# Autogenerated build properties
+    assert 'cdh6.x-SNAPSHOT' == _version_from_properties(
+      string_io(
+        """# Autogenerated build properties
       version=3.9.0-cdh5.9.0-SNAPSHOT
       git.hash=f5fbe90b6a1d0c186b0ddc6e65ce5fc8d24725c8
       cloudera.cdh.release=cdh6.x-SNAPSHOT
-      cloudera.hash=f5fbe90b6a1d0c186b0ddc6e65ce5fc8d24725c8aaaaa"""))
+      cloudera.hash=f5fbe90b6a1d0c186b0ddc6e65ce5fc8d24725c8aaaaa"""
+      )
+    )
 
-    assert not _version_from_properties(string_io(
-      """# Autogenerated build properties
+    assert not _version_from_properties(
+      string_io(
+        """# Autogenerated build properties
       version=3.9.0-cdh5.9.0-SNAPSHOT
       git.hash=f5fbe90b6a1d0c186b0ddc6e65ce5fc8d24725c8
-      cloudera.hash=f5fbe90b6a1d0c186b0ddc6e65ce5fc8d24725c8aaaaa"""))
+      cloudera.hash=f5fbe90b6a1d0c186b0ddc6e65ce5fc8d24725c8aaaaa"""
+      )
+    )
 
     assert not _version_from_properties(string_io(''))
   finally:
@@ -296,7 +295,7 @@ def test_prefs():
 
   # Check non-existent value
   response = c.get('/desktop/api2/user_preferences/doesNotExist')
-  assert None == json.loads(response.content)['data']
+  assert None is json.loads(response.content)['data']
 
 
 @pytest.mark.django_db
@@ -312,8 +311,10 @@ def test_status_bar():
   views.register_status_bar_view(lambda _: HttpResponse("foo", status=200))
   views.register_status_bar_view(lambda _: HttpResponse("bar"))
   views.register_status_bar_view(lambda _: None)
+
   def f(r):
     raise Exception()
+
   views.register_status_bar_view(f)
 
   response = c.get("/desktop/status_bar")
@@ -326,6 +327,7 @@ def test_paginator():
   """
   Test that the paginator works with partial list.
   """
+
   def assert_page(page, data, start, end):
     assert page.object_list == data
     assert page.start_index() == start
@@ -353,11 +355,13 @@ def test_paginator():
   assert_page(pgn.page(1), list(range(20)), 1, 20)
   assert_page(pgn.page(2), list(range(20, 25)), 21, 25)
 
+
 @pytest.mark.django_db
 def test_thread_dump():
   c = make_logged_in_client()
   response = c.get("/desktop/debug/threads", HTTP_X_REQUESTED_WITH='XMLHttpRequest')
   assert b"test_thread_dump" in response.content
+
 
 def test_truncating_model():
   class TinyModel(TruncatingModel):
@@ -366,10 +370,10 @@ def test_truncating_model():
 
   a = TinyModel()
 
-  a.short_field = 'a' * 9 # One less than it's max length
+  a.short_field = 'a' * 9  # One less than it's max length
   assert a.short_field == 'a' * 9, 'Short-enough field does not get truncated'
 
-  a.short_field = 'a' * 11 # One more than it's max_length
+  a.short_field = 'a' * 11  # One more than it's max_length
   assert a.short_field == 'a' * 10, 'Too-long field gets truncated'
 
   a.non_string_field = 10**10
@@ -383,6 +387,7 @@ def test_error_handling():
   restore_500_debug = desktop.conf.HTTP_500_DEBUG_MODE.set_for_testing(False)
 
   exc_msg = "error_raising_view: Test earráid handling"
+
   def error_raising_view(request, *args, **kwargs):
     raise Exception(exc_msg)
 
@@ -390,14 +395,13 @@ def test_error_handling():
     raise PopupException(exc_msg, title="earráid", detail=exc_msg)
 
   # Add an error view
-  error_url_pat = [
-      re_path('^500_internal_error$', error_raising_view),
-      re_path('^popup_exception$', popup_exception_view)
-  ]
+  error_url_pat = [re_path('^500_internal_error$', error_raising_view), re_path('^popup_exception$', popup_exception_view)]
   desktop.urls.urlpatterns.extend(error_url_pat)
   try:
+
     def store_exc_info(*args, **kwargs):
       pass
+
     # Disable the test client's exception forwarding
     c = make_logged_in_client()
     c.store_exc_info = store_exc_info
@@ -430,7 +434,7 @@ def test_desktop_permissions():
   USERNAME = 'test_core_permissions'
   GROUPNAME = 'default'
 
-  desktop.conf.REDIRECT_WHITELIST.set_for_testing('^\/.*$,^http:\/\/testserver\/.*$')
+  desktop.conf.REDIRECT_WHITELIST.set_for_testing(r'^\/.*$,^http:\/\/testserver\/.*$')
 
   c = make_logged_in_client(USERNAME, groupname=GROUPNAME, recreate=True, is_superuser=False)
 
@@ -445,8 +449,9 @@ def test_app_permissions():
   USERNAME = 'test_app_permissions'
   GROUPNAME = 'impala_only'
   resets = [
-    desktop.conf.REDIRECT_WHITELIST.set_for_testing('^\/.*$,^http:\/\/testserver\/.*$'),
-    HAS_SQL_ENABLED.set_for_testing(False)
+    desktop.conf.REDIRECT_WHITELIST.set_for_testing(r'^\/.*$,^http:\/\/testserver\/.*$'),
+    HAS_SQL_ENABLED.set_for_testing(False),
+    ENABLE_ALL_INTERPRETERS.set_for_testing(True),
   ]
 
   try:
@@ -458,9 +463,7 @@ def test_app_permissions():
 
     def check_app(status_code, app_name):
       if app_name in DESKTOP_APPS:
-        assert (
-            status_code ==
-            c.get('/' + app_name, follow=True).status_code), 'status_code=%s app_name=%s' % (status_code, app_name)
+        assert status_code == c.get('/' + app_name, follow=True).status_code, 'status_code=%s app_name=%s' % (status_code, app_name)
 
     # Access to nothing
     check_app(401, 'beeswax')
@@ -473,16 +476,16 @@ def test_app_permissions():
     check_app(401, 'oozie')
 
     apps = ClusterConfig(user=user).get_apps()
-    assert not 'hive' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'impala' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'pig' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'solr' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'spark' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'browser' in apps, apps
-    assert not 'scheduler' in apps, apps
-    assert not 'dashboard' in apps, apps
-    assert not 'scheduler' in apps, apps
-    assert not 'sdkapps' in apps, apps
+    assert 'hive' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'impala' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'pig' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'solr' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'spark' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'browser' not in apps, apps
+    assert 'scheduler' not in apps, apps
+    assert 'dashboard' not in apps, apps
+    assert 'scheduler' not in apps, apps
+    assert 'sdkapps' not in apps, apps
 
     # Should always be enabled as it is a lib
     grant_access(USERNAME, GROUPNAME, "beeswax")
@@ -500,15 +503,15 @@ def test_app_permissions():
 
     apps = ClusterConfig(user=user).get_apps()
     assert 'hive' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'impala' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'pig' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'solr' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'spark' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'browser' in apps, apps
-    assert not 'scheduler' in apps, apps
-    assert not 'dashboard' in apps, apps
-    assert not 'scheduler' in apps, apps
-    assert not 'sdkapps' in apps, apps
+    assert 'impala' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'pig' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'solr' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'spark' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'browser' not in apps, apps
+    assert 'scheduler' not in apps, apps
+    assert 'dashboard' not in apps, apps
+    assert 'scheduler' not in apps, apps
+    assert 'sdkapps' not in apps, apps
 
     # Add access to hbase
     grant_access(USERNAME, GROUPNAME, "hbase")
@@ -523,17 +526,17 @@ def test_app_permissions():
 
     apps = ClusterConfig(user=user).get_apps()
     assert 'hive' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'impala' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'pig' in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'impala' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'pig' not in apps.get('editor', {}).get('interpreter_names', []), apps
     if 'hbase' not in desktop.conf.APP_BLACKLIST.get():
       assert 'browser' in apps, apps
       assert 'hbase' in apps['browser']['interpreter_names'], apps['browser']
-    assert not 'solr' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'spark' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'scheduler' in apps, apps
-    assert not 'dashboard' in apps, apps
-    assert not 'scheduler' in apps, apps
-    assert not 'sdkapps' in apps, apps
+    assert 'solr' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'spark' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'scheduler' not in apps, apps
+    assert 'dashboard' not in apps, apps
+    assert 'scheduler' not in apps, apps
+    assert 'sdkapps' not in apps, apps
 
     # Reset all perms
     GroupPermission.objects.filter(group__name=GROUPNAME).delete()
@@ -546,16 +549,16 @@ def test_app_permissions():
     check_app(401, 'oozie')
 
     apps = ClusterConfig(user=user).get_apps()
-    assert not 'hive' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'impala' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'pig' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'solr' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'spark' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'browser' in apps, apps
-    assert not 'scheduler' in apps, apps
-    assert not 'dashboard' in apps, apps
-    assert not 'scheduler' in apps, apps
-    assert not 'sdkapps' in apps, apps
+    assert 'hive' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'impala' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'pig' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'solr' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'spark' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'browser' not in apps, apps
+    assert 'scheduler' not in apps, apps
+    assert 'dashboard' not in apps, apps
+    assert 'scheduler' not in apps, apps
+    assert 'sdkapps' not in apps, apps
 
     # Test only impala perm
     grant_access(USERNAME, GROUPNAME, "impala")
@@ -568,16 +571,16 @@ def test_app_permissions():
     check_app(401, 'oozie')
 
     apps = ClusterConfig(user=user).get_apps()
-    assert not 'hive' in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'hive' not in apps.get('editor', {}).get('interpreter_names', []), apps
     assert 'impala' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'pig' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'solr' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'spark' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'browser' in apps, apps
-    assert not 'scheduler' in apps, apps
-    assert not 'dashboard' in apps, apps
-    assert not 'scheduler' in apps, apps
-    assert not 'sdkapps' in apps, apps
+    assert 'pig' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'solr' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'spark' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'browser' not in apps, apps
+    assert 'scheduler' not in apps, apps
+    assert 'dashboard' not in apps, apps
+    assert 'scheduler' not in apps, apps
+    assert 'sdkapps' not in apps, apps
 
     # Oozie Editor and Browser
     grant_access(USERNAME, GROUPNAME, "oozie")
@@ -591,9 +594,9 @@ def test_app_permissions():
 
     apps = ClusterConfig(user=user).get_apps()
     assert 'scheduler' in apps, apps
-    assert not 'browser' in apps, apps # Actually should be true, but logic not implemented
-    assert not 'solr' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'spark' in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'browser' not in apps, apps  # Actually should be true, but logic not implemented
+    assert 'solr' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'spark' not in apps.get('editor', {}).get('interpreter_names', []), apps
 
     grant_access(USERNAME, GROUPNAME, "pig")
     check_app(401, 'hive')
@@ -605,11 +608,11 @@ def test_app_permissions():
     check_app(200, 'oozie')
 
     apps = ClusterConfig(user=user).get_apps()
-    assert not 'hive' in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'hive' not in apps.get('editor', {}).get('interpreter_names', []), apps
     assert 'impala' in apps.get('editor', {}).get('interpreter_names', []), apps
     assert 'pig' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'solr' in apps.get('editor', {}).get('interpreter_names', []), apps
-    assert not 'spark' in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'solr' not in apps.get('editor', {}).get('interpreter_names', []), apps
+    assert 'spark' not in apps.get('editor', {}).get('interpreter_names', []), apps
 
     if 'search' not in desktop.conf.APP_BLACKLIST.get():
       grant_access(USERNAME, GROUPNAME, "search")
@@ -622,11 +625,11 @@ def test_app_permissions():
       check_app(200, 'oozie')
 
       apps = ClusterConfig(user=user).get_apps()
-      assert not 'hive' in apps.get('editor', {}).get('interpreter_names', []), apps
+      assert 'hive' not in apps.get('editor', {}).get('interpreter_names', []), apps
       assert 'impala' in apps.get('editor', {}).get('interpreter_names', []), apps
       assert 'pig' in apps.get('editor', {}).get('interpreter_names', []), apps
       assert 'solr' in apps.get('editor', {}).get('interpreter_names', []), apps
-      assert not 'spark' in apps.get('editor', {}).get('interpreter_names', []), apps
+      assert 'spark' not in apps.get('editor', {}).get('interpreter_names', []), apps
 
     if 'spark' not in desktop.conf.APP_BLACKLIST.get():
       grant_access(USERNAME, GROUPNAME, "spark")
@@ -639,7 +642,7 @@ def test_app_permissions():
       check_app(200, 'oozie')
 
       apps = ClusterConfig(user=user).get_apps()
-      assert not 'hive' in apps.get('editor', {}).get('interpreter_names', []), apps
+      assert 'hive' not in apps.get('editor', {}).get('interpreter_names', []), apps
       assert 'impala' in apps.get('editor', {}).get('interpreter_names', []), apps
       assert 'pig' in apps.get('editor', {}).get('interpreter_names', []), apps
       assert 'solr' in apps.get('editor', {}).get('interpreter_names', []), apps
@@ -701,6 +704,7 @@ def test_404_handling():
     view_name = view_name.encode('utf-8')
   assert view_name in response.content
 
+
 class RecordingHandler(logging.Handler):
   def __init__(self, *args, **kwargs):
     logging.Handler.__init__(self, *args, **kwargs)
@@ -708,6 +712,7 @@ class RecordingHandler(logging.Handler):
 
   def emit(self, r):
     self.records.append(r)
+
 
 @pytest.mark.django_db
 def test_log_event():
@@ -729,13 +734,12 @@ def test_log_event():
   assert "INFO" == handler.records[-1].levelname
   assert "Untrusted log event from user test: foo3" == handler.records[-1].message
 
-  c.post("/desktop/log_frontend_event", {
-    "message": "01234567" * 1024})
+  c.post("/desktop/log_frontend_event", {"message": "01234567" * 1024})
   assert "INFO" == handler.records[-1].levelname
-  assert ("Untrusted log event from user test: " ==
-    handler.records[-1].message)
+  assert "Untrusted log event from user test: " == handler.records[-1].message
 
   root.removeHandler(handler)
+
 
 def test_validate_path():
   with tempfile.NamedTemporaryFile() as local_file:
@@ -764,7 +768,7 @@ def test_config_check():
         desktop.conf.SECRET_KEY_SCRIPT.set_for_testing(present=False),
         desktop.conf.SSL_CERTIFICATE.set_for_testing(cert_file.name),
         desktop.conf.SSL_PRIVATE_KEY.set_for_testing(key_file.name),
-        desktop.conf.DEFAULT_SITE_ENCODING.set_for_testing('klingon')
+        desktop.conf.DEFAULT_SITE_ENCODING.set_for_testing('klingon'),
       )
 
       cli = make_logged_in_client()
@@ -781,6 +785,7 @@ def test_config_check():
       try:
         # Set HUE_CONF_DIR and make sure check_config returns appropriate conf
         os.environ["HUE_CONF_DIR"] = "/tmp/test_hue_conf_dir"
+
         def validate_by_spec(error_list):
           pass
 
@@ -797,6 +802,7 @@ def test_config_check():
         else:
           os.environ["HUE_CONF_DIR"] = prev_env_conf
         desktop.views.validate_by_spec = desktop.views.real_validate_by_spec
+
 
 def test_last_access_time():
   pytest.skip("Skipping Test")
@@ -864,22 +870,26 @@ def test_cx_Oracle():
 
   try:
     import cx_Oracle
+
     return
   except ImportError as ex:
     if "No module named" in ex.message:
-      assert (False, "cx_Oracle skipped its build. This happens if "
-          "env var ORACLE_HOME or ORACLE_INSTANTCLIENT_HOME is not defined. "
-          "So ignore this test failure if your build does not need to work "
-          "with an oracle backend.")
+      assert (
+        False,
+        "cx_Oracle skipped its build. This happens if "
+        "env var ORACLE_HOME or ORACLE_INSTANTCLIENT_HOME is not defined. "
+        "So ignore this test failure if your build does not need to work "
+        "with an oracle backend.",
+      )
+
 
 @pytest.mark.django_db
 class TestStrictRedirection(object):
-
   def setup_method(self):
     self.finish = desktop.conf.AUTH.BACKEND.set_for_testing(['desktop.auth.backend.AllowFirstUserDjangoBackend'])
     self.client = make_logged_in_client()
     self.user = dict(username="test", password="test")
-    desktop.conf.REDIRECT_WHITELIST.set_for_testing('^\/.*$,^http:\/\/example.com\/.*$')
+    desktop.conf.REDIRECT_WHITELIST.set_for_testing(r'^\/.*$,^http:\/\/example.com\/.*$')
 
   def teardown_method(self):
     self.finish()
@@ -887,21 +897,23 @@ class TestStrictRedirection(object):
   def test_redirection_blocked(self):
     # Redirection with code 301 should be handled properly
     # Redirection with Status code 301 example reference: http://www.somacon.com/p145.php
-    self._test_redirection(redirection_url='http://www.somacon.com/color/html_css_table_border_styles.php',
-                           expected_status_code=403)
+    self._test_redirection(redirection_url='http://www.somacon.com/color/html_css_table_border_styles.php', expected_status_code=403)
     # Redirection with code 302 should be handled properly
-    self._test_redirection(redirection_url='http://www.google.com',
-                           expected_status_code=403)
+    self._test_redirection(redirection_url='http://www.google.com', expected_status_code=403)
 
   def test_redirection_allowed(self):
     # Redirection to the host where Hue is running should be OK.
     self._test_redirection(redirection_url='/', expected_status_code=302)
     self._test_redirection(redirection_url='/pig', expected_status_code=302)
     self._test_redirection(redirection_url='http://testserver/', expected_status_code=302)
-    self._test_redirection(redirection_url='https://testserver/', expected_status_code=302, **{
-      'SERVER_PORT': '443',
-      'wsgi.url_scheme': 'https',
-    })
+    self._test_redirection(
+      redirection_url='https://testserver/',
+      expected_status_code=302,
+      **{
+        'SERVER_PORT': '443',
+        'wsgi.url_scheme': 'https',
+      },
+    )
     self._test_redirection(redirection_url='http://example.com/', expected_status_code=302)
 
   def _test_redirection(self, redirection_url, expected_status_code, **kwargs):
@@ -917,7 +929,6 @@ class TestStrictRedirection(object):
 
 
 class BaseTestPasswordConfig(object):
-
   SCRIPT = '%s -c "print(\'\\n password from script \\n\')"' % sys.executable
 
   def get_config_password(self):
@@ -961,9 +972,7 @@ class BaseTestPasswordConfig(object):
   def test_password_script_raises_exception(self):
     resets = [
       self.get_config_password().set_for_testing(present=False),
-      self.get_config_password_script().set_for_testing(
-          '%s -c "import sys; sys.exit(1)"' % sys.executable
-      ),
+      self.get_config_password_script().set_for_testing('%s -c "import sys; sys.exit(1)"' % sys.executable),
     ]
 
     try:
@@ -987,7 +996,6 @@ class BaseTestPasswordConfig(object):
 
 
 class TestSecretKeyConfig(BaseTestPasswordConfig):
-
   def get_config_password(self):
     return desktop.conf.SECRET_KEY
 
@@ -999,7 +1007,6 @@ class TestSecretKeyConfig(BaseTestPasswordConfig):
 
 
 class TestDatabasePasswordConfig(BaseTestPasswordConfig):
-
   def get_config_password(self):
     return desktop.conf.DATABASE.PASSWORD
 
@@ -1011,7 +1018,6 @@ class TestDatabasePasswordConfig(BaseTestPasswordConfig):
 
 
 class TestLDAPPasswordConfig(BaseTestPasswordConfig):
-
   def get_config_password(self):
     return desktop.conf.AUTH_PASSWORD
 
@@ -1028,7 +1034,6 @@ class TestLDAPPasswordConfig(BaseTestPasswordConfig):
 
 @pytest.mark.django_db
 class TestLDAPBindPasswordConfig(BaseTestPasswordConfig):
-
   def setup_method(self):
     self.finish = desktop.conf.LDAP.LDAP_SERVERS.set_for_testing({'test': {}})
 
@@ -1046,7 +1051,6 @@ class TestLDAPBindPasswordConfig(BaseTestPasswordConfig):
 
 
 class TestSMTPPasswordConfig(BaseTestPasswordConfig):
-
   def get_config_password(self):
     return desktop.conf.SMTP.PASSWORD
 
@@ -1059,7 +1063,6 @@ class TestSMTPPasswordConfig(BaseTestPasswordConfig):
 
 @pytest.mark.django_db
 class TestDocument(object):
-
   def setup_method(self):
     make_logged_in_client(username="original_owner", groupname="test_doc", recreate=True, is_superuser=False)
     self.user = User.objects.get(username="original_owner")
@@ -1067,19 +1070,10 @@ class TestDocument(object):
     make_logged_in_client(username="copy_owner", groupname="test_doc", recreate=True, is_superuser=False)
     self.copy_user = User.objects.get(username="copy_owner")
 
-    self.document2 = Document2.objects.create(
-        name='Test Document2',
-        type='search-dashboard',
-        owner=self.user,
-        description='Test Document2'
-    )
+    self.document2 = Document2.objects.create(name='Test Document2', type='search-dashboard', owner=self.user, description='Test Document2')
 
     self.document = Document.objects.link(
-        content_object=self.document2,
-        owner=self.user,
-        name='Test Document',
-        description='Test Document',
-        extra='test'
+      content_object=self.document2, owner=self.user, name='Test Document', description='Test Document', extra='test'
     )
 
     self.document.save()
@@ -1098,30 +1092,14 @@ class TestDocument(object):
 
   def test_document_trashed_and_restore(self):
     home_dir = Directory.objects.get_home_directory(self.user)
-    test_dir, created = Directory.objects.get_or_create(
-        parent_directory=home_dir,
-        owner=self.user,
-        name='test_dir'
-    )
+    test_dir, created = Directory.objects.get_or_create(parent_directory=home_dir, owner=self.user, name='test_dir')
     test_doc = Document2.objects.create(
-        name='Test Document2',
-        type='search-dashboard',
-        owner=self.user,
-        description='Test Document2',
-        parent_directory=test_dir
+      name='Test Document2', type='search-dashboard', owner=self.user, description='Test Document2', parent_directory=test_dir
     )
 
-    child_dir, created = Directory.objects.get_or_create(
-        parent_directory=test_dir,
-        owner=self.user,
-        name='child_dir'
-    )
+    child_dir, created = Directory.objects.get_or_create(parent_directory=test_dir, owner=self.user, name='child_dir')
     test_doc1 = Document2.objects.create(
-        name='Test Document2',
-        type='search-dashboard',
-        owner=self.user,
-        description='Test Document2',
-        parent_directory=child_dir
+      name='Test Document2', type='search-dashboard', owner=self.user, description='Test Document2', parent_directory=child_dir
     )
 
     assert not test_dir.is_trashed
@@ -1156,16 +1134,9 @@ class TestDocument(object):
       test_doc1.delete()
       child_dir.delete()
 
-
   def test_multiple_home_directories(self):
     home_dir = Directory.objects.get_home_directory(self.user)
-    test_doc1 = Document2.objects.create(
-        name='test-doc1',
-        type='query-hive',
-        owner=self.user,
-        description='',
-        parent_directory=home_dir
-    )
+    test_doc1 = Document2.objects.create(name='test-doc1', type='query-hive', owner=self.user, description='', parent_directory=home_dir)
 
     assert home_dir.children.exclude(name__in=['.Trash', 'Gist']).count() == 2
 
@@ -1175,11 +1146,7 @@ class TestDocument(object):
     assert Document2.objects.filter(owner=self.user, name=Document2.HOME_DIR).count() == 2
 
     test_doc2 = Document2.objects.create(
-        name='test-doc2',
-        type='query-hive',
-        owner=self.user,
-        description='',
-        parent_directory=second_home_dir
+      name='test-doc2', type='query-hive', owner=self.user, description='', parent_directory=second_home_dir
     )
     assert second_home_dir.children.count() == 1
 
@@ -1192,13 +1159,7 @@ class TestDocument(object):
 
   def test_multiple_trash_directories(self):
     home_dir = Directory.objects.get_home_directory(self.user)
-    test_doc1 = Document2.objects.create(
-        name='test-doc1',
-        type='query-hive',
-        owner=self.user,
-        description='',
-        parent_directory=home_dir
-    )
+    test_doc1 = Document2.objects.create(name='test-doc1', type='query-hive', owner=self.user, description='', parent_directory=home_dir)
 
     assert home_dir.children.count() == 3
 
@@ -1207,20 +1168,13 @@ class TestDocument(object):
     Document2.objects.filter(name='second_trash_dir').update(name=Document2.TRASH_DIR)
     assert Directory.objects.filter(owner=self.user, name=Document2.TRASH_DIR).count() == 2
 
-
-    test_doc2 = Document2.objects.create(
-        name='test-doc2',
-        type='query-hive',
-        owner=self.user,
-        description='',
-        parent_directory=home_dir
-    )
-    assert home_dir.children.count() == 5 # Including the second trash
+    test_doc2 = Document2.objects.create(name='test-doc2', type='query-hive', owner=self.user, description='', parent_directory=home_dir)
+    assert home_dir.children.count() == 5  # Including the second trash
     with pytest.raises(Document2.MultipleObjectsReturned):
-        Directory.objects.get(name=Document2.TRASH_DIR)
+      Directory.objects.get(name=Document2.TRASH_DIR)
 
     test_doc1.trash()
-    assert home_dir.children.count() == 3 # As trash documents are merged count is back to 3
+    assert home_dir.children.count() == 3  # As trash documents are merged count is back to 3
     merged_trash_dir = Directory.objects.get(name=Document2.TRASH_DIR, owner=self.user)
 
     test_doc2.trash()
@@ -1229,7 +1183,6 @@ class TestDocument(object):
     children_names = [child.name for child in children]
     assert test_doc2.name in children_names
     assert test_doc1.name in children_names
-
 
   def test_document_copy(self):
     pytest.skip("Skipping Test")
@@ -1265,13 +1218,14 @@ class TestDocument(object):
     assert Document.objects.filter(name=name).count() == 1
     assert doc.description == self.document.description
 
-
   def test_redact_statements(self):
     old_policies = redaction.global_redaction_engine.policies
     redaction.global_redaction_engine.policies = [
-      RedactionPolicy([
-        RedactionRule('', 'ssn=\d{3}-\d{2}-\d{4}', 'ssn=XXX-XX-XXXX'),
-      ])
+      RedactionPolicy(
+        [
+          RedactionRule('', r'ssn=\d{3}-\d{2}-\d{4}', 'ssn=XXX-XX-XXXX'),
+        ]
+      )
     ]
 
     logfilter.add_log_redaction_filter_to_logger(redaction.global_redaction_engine, logging.root)
@@ -1287,12 +1241,12 @@ class TestDocument(object):
           'sqlDialect': True,
           'snippetImage': '/static/beeswax/art/icon_beeswax_48.png',
           'placeHolder': 'Example: SELECT * FROM tablename, or press CTRL + space',
-          'aceMode': 'ace/mode/hive'
-         },
+          'aceMode': 'ace/mode/hive',
+        },
         'id': '10a29cda-063f-1439-4836-d0c460154075',
         'statement_raw': sensitive_query,
         'statement': sensitive_query,
-        'type': 'hive'
+        'type': 'hive',
       },
       {
         'status': 'ready',
@@ -1300,12 +1254,12 @@ class TestDocument(object):
           'sqlDialect': True,
           'snippetImage': '/static/impala/art/icon_impala_48.png',
           'placeHolder': 'Example: SELECT * FROM tablename, or press CTRL + space',
-          'aceMode': 'ace/mode/impala'
-         },
+          'aceMode': 'ace/mode/impala',
+        },
         'id': 'e17d195a-beb5-76bf-7489-a9896eeda67a',
         'statement_raw': sensitive_query,
         'statement': sensitive_query,
-        'type': 'impala'
+        'type': 'impala',
       },
       {
         'status': 'ready',
@@ -1313,12 +1267,12 @@ class TestDocument(object):
           'sqlDialect': True,
           'snippetImage': '/static/beeswax/art/icon_beeswax_48.png',
           'placeHolder': 'Example: SELECT * FROM tablename, or press CTRL + space',
-          'aceMode': 'ace/mode/hive'
-         },
+          'aceMode': 'ace/mode/hive',
+        },
         'id': '10a29cda-063f-1439-4836-d0c460154075',
         'statement_raw': nonsensitive_query,
         'statement': nonsensitive_query,
-        'type': 'hive'
+        'type': 'hive',
       },
     ]
 
@@ -1332,11 +1286,11 @@ class TestDocument(object):
       # Make sure redacted queries are redacted.
       assert redacted_query == saved_snippets[0]['statement']
       assert redacted_query == saved_snippets[0]['statement_raw']
-      assert True == saved_snippets[0]['is_redacted']
+      assert True is saved_snippets[0]['is_redacted']
 
       assert redacted_query == saved_snippets[1]['statement']
       assert redacted_query == saved_snippets[1]['statement_raw']
-      assert True == saved_snippets[1]['is_redacted']
+      assert True is saved_snippets[1]['is_redacted']
 
       document = Document2.objects.get(pk=self.document2.pk)
       assert redacted_query == document.search
@@ -1344,7 +1298,7 @@ class TestDocument(object):
       # Make sure unredacted queries are not redacted.
       assert nonsensitive_query == saved_snippets[2]['statement']
       assert nonsensitive_query == saved_snippets[2]['statement_raw']
-      assert not 'is_redacted' in saved_snippets[2]
+      assert 'is_redacted' not in saved_snippets[2]
     finally:
       redaction.global_redaction_engine.policies = old_policies
 
@@ -1352,6 +1306,7 @@ class TestDocument(object):
     c1 = make_logged_in_client(username='test_get_user', groupname='test_get_group', recreate=True, is_superuser=False)
     r1 = c1.get('/desktop/api/doc/get?id=1')
     assert -1, json.loads(r1.content)['status']
+
 
 def test_session_secure_cookie():
   with tempfile.NamedTemporaryFile() as cert_file:
@@ -1406,21 +1361,20 @@ def test_session_secure_cookie():
 
 
 def test_get_data_link():
-  assert None == get_data_link({})
+  assert None is get_data_link({})
   assert 'gethue.com' == get_data_link({'type': 'link', 'link': 'gethue.com'})
 
-  assert (
-    '/hbase/#Cluster/document_demo/query/20150527' ==
-    get_data_link({'type': 'hbase', 'table': 'document_demo', 'row_key': '20150527'}))
-  assert (
-      '/hbase/#Cluster/document_demo/query/20150527[f1]' ==
-      get_data_link({'type': 'hbase', 'table': 'document_demo', 'row_key': '20150527', 'fam': 'f1'}))
-  assert (
-      '/hbase/#Cluster/document_demo/query/20150527[f1:c1]' ==
-      get_data_link({'type': 'hbase', 'table': 'document_demo', 'row_key': '20150527', 'fam': 'f1', 'col': 'c1'}))
+  assert '/hbase/#Cluster/document_demo/query/20150527' == get_data_link({'type': 'hbase', 'table': 'document_demo', 'row_key': '20150527'})
+  assert '/hbase/#Cluster/document_demo/query/20150527[f1]' == get_data_link(
+    {'type': 'hbase', 'table': 'document_demo', 'row_key': '20150527', 'fam': 'f1'}
+  )
+  assert '/hbase/#Cluster/document_demo/query/20150527[f1:c1]' == get_data_link(
+    {'type': 'hbase', 'table': 'document_demo', 'row_key': '20150527', 'fam': 'f1', 'col': 'c1'}
+  )
 
   assert '/filebrowser/view=/data/hue/1' == get_data_link({'type': 'hdfs', 'path': '/data/hue/1'})
   assert '/metastore/table/default/sample_07' == get_data_link({'type': 'hive', 'database': 'default', 'table': 'sample_07'})
+
 
 def test_get_dn():
   assert ['*'] == desktop.conf.get_dn('')
@@ -1447,6 +1401,7 @@ def test_collect_validation_messages_default():
   finally:
     os.remove(configspec.name)
 
+
 def test_collect_validation_messages_extras():
   try:
     # Generate the spec file
@@ -1456,24 +1411,13 @@ def test_collect_validation_messages_extras():
     conf = load_confs(configspec.name, _configs_from_dir(config_dir))
 
     test_conf = ConfigObj()
-    test_conf['extrasection'] = {
-      'key1': 'value1',
-      'key2': 'value1'
-    }
-    extrasubsection = {
-      'key1': 'value1',
-      'key2': 'value1'
-    }
+    test_conf['extrasection'] = {'key1': 'value1', 'key2': 'value1'}
+    extrasubsection = {'key1': 'value1', 'key2': 'value1'}
     # Test with extrasections as well as existing subsection, keyvalues in existing section [desktop]
     test_conf['desktop'] = {
       'extrasubsection': extrasubsection,
       'extrakey': 'value1',
-      'auth': {
-        'ignore_username_case': 'true',
-        'extrasubsubsection': {
-          'extrakey': 'value1'
-        }
-      }
+      'auth': {'ignore_username_case': 'true', 'extrasubsubsection': {'extrakey': 'value1'}},
     }
     conf.merge(test_conf)
     error_list = []
@@ -1481,9 +1425,12 @@ def test_collect_validation_messages_extras():
   finally:
     os.remove(configspec.name)
   assert len(error_list) == 1
-  assert (u'Extra section, extrasection in the section: top level, Extra keyvalue, extrakey in the section: [desktop] , '
-      'Extra section, extrasubsection in the section: [desktop] , Extra section, extrasubsubsection in the section: [desktop] [[auth]] ' ==
-      error_list[0]['message'])
+  assert (
+    'Extra section, extrasection in the section: top level, Extra keyvalue, extrakey in the section: [desktop] , '
+    'Extra section, extrasubsection in the section: [desktop] , Extra section, extrasubsubsection in the section: [desktop] [[auth]] '
+    == error_list[0]['message']
+  )
+
 
 # Test db migration from 5.7,...,5.15 to latest
 @pytest.mark.django_db
@@ -1557,12 +1504,11 @@ def test_db_migrations_mysql():
 def test_forbidden_libs():
   if sys.version_info[0] > 2:
     pytest.skip("Skipping Test")
-  import chardet # chardet license (LGPL) is not compatible and should not be bundled
+  import chardet  # chardet license (LGPL) is not compatible and should not be bundled
 
 
 @pytest.mark.django_db
-class TestGetConfigErrors():
-
+class TestGetConfigErrors:
   def setup_method(self):
     self.client = make_logged_in_client(username="test", groupname="empty", recreate=True, is_superuser=False)
     self.user = User.objects.get(username="test")
@@ -1575,13 +1521,5 @@ class TestGetConfigErrors():
     request = Mock(user=self.user)
 
     with patch('desktop.views.appmanager') as appmanager:
-      appmanager.DESKTOP_MODULES = [
-        Mock(
-          conf=Mock(
-            config_validator=lambda user: [(u'Connector 1', 'errored because of ...')]
-          )
-        )
-      ]
-      assert (
-        [{'name': 'Connector 1', 'message': 'errored because of ...'}] ==
-        _get_config_errors(request, cache=False))
+      appmanager.DESKTOP_MODULES = [Mock(conf=Mock(config_validator=lambda user: [('Connector 1', 'errored because of ...')]))]
+      assert [{'name': 'Connector 1', 'message': 'errored because of ...'}] == _get_config_errors(request, cache=False)

--- a/desktop/core/src/desktop/tests.py
+++ b/desktop/core/src/desktop/tests.py
@@ -451,7 +451,7 @@ def test_app_permissions():
   resets = [
     desktop.conf.REDIRECT_WHITELIST.set_for_testing(r'^\/.*$,^http:\/\/testserver\/.*$'),
     HAS_SQL_ENABLED.set_for_testing(False),
-    ENABLE_ALL_INTERPRETERS.set_for_testing(False),
+    ENABLE_ALL_INTERPRETERS.set_for_testing(True),
     SHOW_NOTEBOOKS.set_for_testing(True)
   ]
 

--- a/desktop/core/src/desktop/tests.py
+++ b/desktop/core/src/desktop/tests.py
@@ -58,7 +58,7 @@ from desktop.redaction import logfilter
 from desktop.redaction.engine import RedactionPolicy, RedactionRule
 from desktop.settings import DATABASES
 from desktop.views import _get_config_errors, check_config, collect_validation_messages, generate_configspec, home, load_confs
-from notebook.conf import ENABLE_ALL_INTERPRETERS
+from notebook.conf import ENABLE_ALL_INTERPRETERS, SHOW_NOTEBOOKS
 from useradmin.models import GroupPermission, User
 
 LOG = logging.getLogger()
@@ -451,7 +451,8 @@ def test_app_permissions():
   resets = [
     desktop.conf.REDIRECT_WHITELIST.set_for_testing(r'^\/.*$,^http:\/\/testserver\/.*$'),
     HAS_SQL_ENABLED.set_for_testing(False),
-    ENABLE_ALL_INTERPRETERS.set_for_testing(True),
+    ENABLE_ALL_INTERPRETERS.set_for_testing(False),
+    SHOW_NOTEBOOKS.set_for_testing(True)
   ]
 
   try:

--- a/desktop/libs/notebook/src/notebook/api_tests.py
+++ b/desktop/libs/notebook/src/notebook/api_tests.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-## -*- coding: utf-8 -*-
 # Licensed to Cloudera, Inc. under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,44 +15,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import object
 import json
-import pytest
-import sys
-
 from collections import OrderedDict
+from unittest.mock import Mock, patch
 
+import pytest
 from django.test.client import Client
 from django.urls import reverse
-from azure.conf import is_adls_enabled
-
-from desktop import appmanager
-from desktop.conf import APP_BLACKLIST, ENABLE_CONNECTORS, ENABLE_PROMETHEUS
-from desktop.lib.django_test_util import make_logged_in_client
-from desktop.lib.test_utils import grant_access, add_permission
-from desktop.metrics import num_of_queries
-from desktop.models import Directory, Document, Document2
-from hadoop import cluster as originalCluster
-from useradmin.models import User
 
 import notebook.conf
 import notebook.connectors.hiveserver2
-
+from azure.conf import is_adls_enabled
+from desktop import appmanager
+from desktop.conf import APP_BLACKLIST, ENABLE_CONNECTORS, ENABLE_PROMETHEUS
+from desktop.lib.django_test_util import make_logged_in_client
+from desktop.lib.test_utils import add_permission, grant_access
+from desktop.metrics import num_of_queries
+from desktop.models import Directory, Document, Document2
+from hadoop import cluster as originalCluster
 from notebook.api import _historify
-from notebook.connectors.base import Notebook, QueryError, Api, QueryExpired
+from notebook.conf import ENABLE_ALL_INTERPRETERS, INTERPRETERS, INTERPRETERS_SHOWN_ON_WHEEL, get_ordered_interpreters
+from notebook.connectors.base import Api, Notebook, QueryError, QueryExpired
 from notebook.decorators import api_error_handler
-from notebook.conf import get_ordered_interpreters, INTERPRETERS_SHOWN_ON_WHEEL, INTERPRETERS
-
-
-if sys.version_info[0] > 2:
-  from unittest.mock import patch, Mock
-else:
-  from mock import patch, Mock
+from useradmin.models import User
 
 
 @pytest.mark.django_db
 class TestApi(object):
-
   def setup_method(self):
     self.client = make_logged_in_client(username="test", groupname="default", recreate=True, is_superuser=False)
     self.client_not_me = make_logged_in_client(username="not_perm_user", groupname="default", recreate=True, is_superuser=False)
@@ -61,7 +49,8 @@ class TestApi(object):
     self.user = User.objects.get(username="test")
     self.user_not_me = User.objects.get(username="not_perm_user")
 
-    self.notebook_json = """
+    self.notebook_json = (
+      """
       {
         "selectedSnippet": "hive",
         "showHistory": false,
@@ -76,26 +65,26 @@ class TestApi(object):
         ],
         "type": "query-hive",
         "id": 50010,
-        "snippets": [{"id":"2b7d1f46-17a0-30af-efeb-33d4c29b1055","type":"hive","status":"running","statement_raw":""" \
-        """"select * from default.web_logs where app = '${app_name}';","variables":[{"name":"app_name","value":"metastore"}],""" \
-        """"statement":"select * from default.web_logs where app = 'metastore';","properties":{"settings":[],"files":[],""" \
-        """"functions":[]},"result":{"id":"b424befa-f4f5-8799-a0b4-79753f2552b1","type":"table","handle":{"log_context":null,""" \
-        """"statements_count":1,"end":{"column":21,"row":0},"statement_id":0,"has_more_statements":false,""" \
-        """"start":{"column":0,"row":0},"secret":"rVRWw7YPRGqPT7LZ/TeFaA==an","has_result_set":true,"statement":""" \
-        """"select * from default.web_logs where app = 'metastore';","operation_type":0,"modified_row_count":null,""" \
-        """"guid":"7xm6+epkRx6dyvYvGNYePA==an"}},"lastExecuted": 1462554843817,"database":"default"}],
+        "snippets": [{"id":"2b7d1f46-17a0-30af-efeb-33d4c29b1055","type":"hive","status":"running","statement_raw":"""
+      """"select * from default.web_logs where app = '${app_name}';","variables":[{"name":"app_name","value":"metastore"}],"""
+      """"statement":"select * from default.web_logs where app = 'metastore';","properties":{"settings":[],"files":[],"""
+      """"functions":[]},"result":{"id":"b424befa-f4f5-8799-a0b4-79753f2552b1","type":"table","handle":{"log_context":null,"""
+      """"statements_count":1,"end":{"column":21,"row":0},"statement_id":0,"has_more_statements":false,"""
+      """"start":{"column":0,"row":0},"secret":"rVRWw7YPRGqPT7LZ/TeFaA==an","has_result_set":true,"statement":"""
+      """"select * from default.web_logs where app = 'metastore';","operation_type":0,"modified_row_count":null,"""
+      """"guid":"7xm6+epkRx6dyvYvGNYePA==an"}},"lastExecuted": 1462554843817,"database":"default"}],
         "uuid": "5982a274-de78-083c-2efc-74f53dce744c",
         "isSaved": false,
         "parentUuid": null
     }
     """
+    )
 
     self.notebook = json.loads(self.notebook_json)
     self.doc2 = Document2.objects.create(id=50010, name=self.notebook['name'], type=self.notebook['type'], owner=self.user)
     self.doc1 = Document.objects.link(
       self.doc2, owner=self.user, name=self.doc2.name, description=self.doc2.description, extra=self.doc2.type
     )
-
 
   def test_save_notebook(self):
     # Test that saving a new document with a new parent will set the parent_directory
@@ -116,7 +105,8 @@ class TestApi(object):
     assert new_dir.uuid == doc.parent_directory.uuid
 
     # Test that saving a new document with a no parent will map it to its home dir
-    notebook_json = """
+    notebook_json = (
+      """
       {
         "selectedSnippet": "hive",
         "showHistory": false,
@@ -131,18 +121,19 @@ class TestApi(object):
         ],
         "type": "query-hive",
         "id": null,
-        "snippets": [{"id":"2b7d1f46-17a0-30af-efeb-33d4c29b1055","type":"hive","status":"running","statement_raw":""" \
-        """"select * from default.web_logs where app = '${app_name}';","variables":""" \
-        """[{"name":"app_name","value":"metastore"}],"statement":""" \
-        """"select * from default.web_logs where app = 'metastore';","properties":{"settings":[],"files":[],"functions":[]},""" \
-        """"result":{"id":"b424befa-f4f5-8799-a0b4-79753f2552b1","type":"table","handle":{"log_context":null,""" \
-        """"statements_count":1,"end":{"column":21,"row":0},"statement_id":0,"has_more_statements":false,""" \
-        """"start":{"column":0,"row":0},"secret":"rVRWw7YPRGqPT7LZ/TeFaA==an","has_result_set":true,""" \
-        """"statement":"select * from default.web_logs where app = 'metastore';","operation_type":0,""" \
-        """"modified_row_count":null,"guid":"7xm6+epkRx6dyvYvGNYePA==an"}},"lastExecuted": 1462554843817,"database":"default"}],
+        "snippets": [{"id":"2b7d1f46-17a0-30af-efeb-33d4c29b1055","type":"hive","status":"running","statement_raw":"""
+      """"select * from default.web_logs where app = '${app_name}';","variables":"""
+      """[{"name":"app_name","value":"metastore"}],"statement":"""
+      """"select * from default.web_logs where app = 'metastore';","properties":{"settings":[],"files":[],"functions":[]},"""
+      """"result":{"id":"b424befa-f4f5-8799-a0b4-79753f2552b1","type":"table","handle":{"log_context":null,"""
+      """"statements_count":1,"end":{"column":21,"row":0},"statement_id":0,"has_more_statements":false,"""
+      """"start":{"column":0,"row":0},"secret":"rVRWw7YPRGqPT7LZ/TeFaA==an","has_result_set":true,"""
+      """"statement":"select * from default.web_logs where app = 'metastore';","operation_type":0,"""
+      """"modified_row_count":null,"guid":"7xm6+epkRx6dyvYvGNYePA==an"}},"lastExecuted": 1462554843817,"database":"default"}],
         "uuid": "d9efdee1-ef25-4d43-b8f9-1a170f69a05a"
     }
     """
+    )
 
     response = self.client.post(reverse('notebook:save_notebook'), {'notebook': notebook_json})
     data = json.loads(response.content)
@@ -156,7 +147,8 @@ class TestApi(object):
     assert doc.type == "query-hive"
 
   def test_type_when_saving_an_actual_notebook(self):
-    notebook_json = """
+    notebook_json = (
+      """
       {
         "selectedSnippet": "hive",
         "showHistory": false,
@@ -171,18 +163,19 @@ class TestApi(object):
         ],
         "type": "notebook",
         "id": null,
-        "snippets": [{"id":"2b7d1f46-17a0-30af-efeb-33d4c29b1055","type":"hive","status":"running","statement_raw":""" \
-                      """"select * from default.web_logs where app = '${app_name}';","variables":""" \
-                      """[{"name":"app_name","value":"metastore"}],"statement":""" \
-                      """"select 1;","properties":{"settings":[],"files":[],"functions":[]},""" \
-                      """"result":{"id":"b424befa-f4f5-8799-a0b4-79753f2552b1","type":"table","handle":{"log_context":null,""" \
-                      """"statements_count":1,"end":{"column":21,"row":0},"statement_id":0,"has_more_statements":false,""" \
-                      """"start":{"column":0,"row":0},"secret":"rVRWw7YPRGqPT7LZ/TeFaA==an","has_result_set":true,""" \
-                      """"statement":"select * from default.web_logs where app = 'metastore';","operation_type":0,""" \
-                      """"modified_row_count":null,"guid":"7xm6"}},"lastExecuted": 1462554843817,"database":"default"}],
+        "snippets": [{"id":"2b7d1f46-17a0-30af-efeb-33d4c29b1055","type":"hive","status":"running","statement_raw":"""
+      """"select * from default.web_logs where app = '${app_name}';","variables":"""
+      """[{"name":"app_name","value":"metastore"}],"statement":"""
+      """"select 1;","properties":{"settings":[],"files":[],"functions":[]},"""
+      """"result":{"id":"b424befa-f4f5-8799-a0b4-79753f2552b1","type":"table","handle":{"log_context":null,"""
+      """"statements_count":1,"end":{"column":21,"row":0},"statement_id":0,"has_more_statements":false,"""
+      """"start":{"column":0,"row":0},"secret":"rVRWw7YPRGqPT7LZ/TeFaA==an","has_result_set":true,"""
+      """"statement":"select * from default.web_logs where app = 'metastore';","operation_type":0,"""
+      """"modified_row_count":null,"guid":"7xm6"}},"lastExecuted": 1462554843817,"database":"default"}],
                       "uuid": "d9efdee1-ef25-4d43-b8f9-1a170f69a05a"
                   }
                   """
+    )
 
     response = self.client.post(reverse('notebook:save_notebook'), {'notebook': notebook_json})
     data = json.loads(response.content)
@@ -215,7 +208,6 @@ class TestApi(object):
     doc = Document2.objects.get(pk=data['id'])
     assert 'query-mysql' == doc.type
 
-
   def test_save_notebook_with_connector_on(self):
     if not ENABLE_CONNECTORS.get():
       pytest.skip("Skipping Test")
@@ -223,10 +215,7 @@ class TestApi(object):
     notebook_cp = self.notebook.copy()
     notebook_cp.pop('id')
 
-    connector = Connector.objects.create(
-        name='MySql',
-        dialect='mysql'
-    )
+    connector = Connector.objects.create(name='MySql', dialect='mysql')
 
     notebook_cp['snippets'][0]['connector'] = {
       'name': 'MySql',
@@ -244,7 +233,6 @@ class TestApi(object):
     assert 0 == data['status'], data
     doc = Document2.objects.get(pk=data['id'])
     assert 'query-mysql' == doc.type
-
 
   def test_historify(self):
     # Starts with no history
@@ -265,7 +253,6 @@ class TestApi(object):
     assert 2 == Document2.objects.filter(name__contains=self.notebook['name'], is_history=True).count()
     assert 3 == Document.objects.filter(name__contains=self.notebook['name']).count()
 
-
   def test_get_history(self):
     assert 0 == Document2.objects.filter(name__contains=self.notebook['name'], is_history=True).count()
     _historify(self.notebook, self.user)
@@ -285,7 +272,6 @@ class TestApi(object):
 
     # TODO: test that query history for shared query only returns docs accessible by current user
 
-
   def test_clear_history(self):
     assert 0 == Document2.objects.filter(name__contains=self.notebook['name'], is_history=True).count()
     _historify(self.notebook, self.user)
@@ -304,9 +290,9 @@ class TestApi(object):
     assert Document2.objects.filter(type='query-hive', is_history=False).exists()
     assert Document2.objects.filter(type='query-impala', is_history=True).exists()
 
-
   def test_delete_notebook(self):
-    trash_notebook_json = """
+    trash_notebook_json = (
+      """
         {
           "selectedSnippet": "hive",
           "showHistory": false,
@@ -321,12 +307,13 @@ class TestApi(object):
           ],
           "type": "query-hive",
           "id": null,
-          "snippets": [{"id": "e069ef32-5c95-4507-b961-e79c090b5abf","type":"hive","status":"ready","database":"default",""" \
-          """"statement":"select * from web_logs","statement_raw":"select * from web_logs","variables":[],"properties":""" \
-          """{"settings":[],"files":[],"functions":[]},"result":{}}],
+          "snippets": [{"id": "e069ef32-5c95-4507-b961-e79c090b5abf","type":"hive","status":"ready","database":"default","""
+      """"statement":"select * from web_logs","statement_raw":"select * from web_logs","variables":[],"properties":"""
+      """{"settings":[],"files":[],"functions":[]},"result":{}}],
           "uuid": "8a20da5f-b69c-4843-b17d-dea5c74c41d1"
       }
       """
+    )
 
     # Assert that the notebook is first saved
     response = self.client.post(reverse('notebook:save_notebook'), {'notebook': trash_notebook_json})
@@ -362,17 +349,19 @@ class TestApi(object):
         }
       ],
       "type": "query-hive",
-      "snippets": [{
-        "id": "e069ef32-5c95-4507-b961-e79c090b5abf",
-        "type": "hive",
-        "status": "ready",
-        "database": "default",
-        "statement": "select * from web_logs",
-        "statement_raw": "select * from web_logs",
-        "variables": [],
-         "properties": {"settings": [], "files": [], "functions": []},
-        "result": {}
-      }]
+      "snippets": [
+        {
+          "id": "e069ef32-5c95-4507-b961-e79c090b5abf",
+          "type": "hive",
+          "status": "ready",
+          "database": "default",
+          "statement": "select * from web_logs",
+          "statement_raw": "select * from web_logs",
+          "variables": [],
+          "properties": {"settings": [], "files": [], "functions": []},
+          "result": {},
+        }
+      ],
     }
     trash_notebooks = [nonexistant_doc]
     response = self.client.post(reverse('notebook:delete'), {'notebooks': json.dumps(trash_notebooks)})
@@ -381,39 +370,27 @@ class TestApi(object):
     assert 'Trashed 0 notebook(s) and failed to delete 1 notebook(s).' == data['message'], data
     assert ['ea22da5f-b69c-4843-b17d-dea5c74c41d1'] == data['errors']
 
-
   def test_query_error_encoding(self):
     @api_error_handler
     def send_exception(message):
       raise QueryError(message=message)
 
-    message = """SELECT
-a.key,
-a.*
-FROM customers c, c.addresses a"""
+    message = """SELECT a.key, a.* FROM customers c, c.addresses a"""
     response = send_exception(message)
     data = json.loads(response.content)
     assert 1 == data['status']
 
-    message = """SELECT
-\u2002\u2002a.key,
-\u2002\u2002a.*
-FROM customers c, c.addresses a"""
+    message = """SELECT \u2002\u2002a.key, \u2002\u2002a.* FROM customers c, c.addresses a"""
     response = send_exception(message)
     data = json.loads(response.content)
     assert 1 == data['status']
 
-    message = u"""SELECT
-a.key,
-a.*
-FROM déclenché c, c.addresses a"""
+    message = """SELECT a.key, a.* FROM déclenché c, c.addresses a"""
     response = send_exception(message)
     data = json.loads(response.content)
     assert 1 == data['status']
-
 
   def test_notebook_autocomplete(self):
-
     with patch('notebook.api.get_api') as get_api:
       get_api.return_value = Mock(
         autocomplete=Mock(
@@ -422,42 +399,28 @@ FROM déclenché c, c.addresses a"""
       )
 
       response = self.client.post(
-          reverse('notebook:api_autocomplete_tables', kwargs={'database': 'database'}),
-          {
-            'snippet': json.dumps({'type': 'hive'})
-          }
+        reverse('notebook:api_autocomplete_tables', kwargs={'database': 'database'}), {'snippet': json.dumps({'type': 'hive'})}
       )
 
       data = json.loads(response.content)
       assert data == {'status': 0}  # We get back empty instead of failure with QueryExpired to silence end user messages
 
-
   def test_autocomplete_functions(self):
     # Note: better test would be to mock autocomplete() and not get_api() with hive and mysql dialects
 
     with patch('notebook.api.get_api') as get_api:
-      get_api.return_value = Mock(
-        autocomplete=Mock(
-          return_value={
-            'functions': [
-              {'name': 'f1'}, {'name': 'f2'}, {'name': 'f3'}
-            ]
-          }
-        )
-      )
+      get_api.return_value = Mock(autocomplete=Mock(return_value={'functions': [{'name': 'f1'}, {'name': 'f2'}, {'name': 'f3'}]}))
 
-      response = self.client.post(reverse('notebook:api_autocomplete_databases'), {
-          'snippet': json.dumps({'type': 'hive', 'properties': {}}),
-          'operation': 'functions'
-      })
+      response = self.client.post(
+        reverse('notebook:api_autocomplete_databases'),
+        {'snippet': json.dumps({'type': 'hive', 'properties': {}}), 'operation': 'functions'},
+      )
 
       assert response.status_code == 200
       data = json.loads(response.content)
       assert data['status'] == 0
 
-      assert (
-        data['functions'] ==
-        [{'name': 'f1'}, {'name': 'f2'}, {'name': 'f3'}])
+      assert data['functions'] == [{'name': 'f1'}, {'name': 'f2'}, {'name': 'f3'}]
 
 
 class MockedApi(Api):
@@ -465,16 +428,7 @@ class MockedApi(Api):
     return {
       'sync': True,
       'has_result_set': True,
-      'result': {
-        'has_more': False,
-        'data': [['test']],
-        'meta': [{
-          'name': 'test',
-          'type': '',
-          'comment': ''
-        }],
-        'type': 'table'
-      }
+      'result': {'has_more': False, 'data': [['test']], 'meta': [{'name': 'test', 'type': '', 'comment': ''}], 'type': 'table'},
     }
 
   def close_statement(self, notebook, snippet):
@@ -486,7 +440,6 @@ class MockedApi(Api):
 
 class MockFs(object):
   def __init__(self, logical_name=None):
-
     self.fs_defaultfs = 'hdfs://curacao:8020'
     self.logical_name = logical_name if logical_name else ''
     self.DEFAULT_USER = 'test'
@@ -526,7 +479,6 @@ class MockFs(object):
 
 @pytest.mark.django_db
 class TestNotebookApiMocked(object):
-
   def setup_method(self):
     self.client = make_logged_in_client(username="test", groupname="default", recreate=True, is_superuser=False)
     self.client_not_me = make_logged_in_client(username="not_perm_user", groupname="default", recreate=True, is_superuser=False)
@@ -535,7 +487,7 @@ class TestNotebookApiMocked(object):
     self.user_not_me = User.objects.get(username="not_perm_user")
 
     # Beware: Monkey patch HS2API Mock API
-    if not hasattr(notebook.connectors.hiveserver2, 'original_HS2Api'): # Could not monkey patch base.get_api
+    if not hasattr(notebook.connectors.hiveserver2, 'original_HS2Api'):  # Could not monkey patch base.get_api
       notebook.connectors.hiveserver2.original_HS2Api = notebook.connectors.hiveserver2.HS2Api
     notebook.connectors.hiveserver2.HS2Api = MockedApi
 
@@ -558,10 +510,10 @@ class TestNotebookApiMocked(object):
       originalCluster.FS_CACHE = {}
     originalCluster.FS_CACHE["default"] = self.original_fs
 
-
   @pytest.mark.integration
   def test_export_result(self):
-    notebook_json = """
+    notebook_json = (
+      """
       {
         "selectedSnippet": "hive",
         "showHistory": false,
@@ -576,71 +528,82 @@ class TestNotebookApiMocked(object):
         ],
         "type": "query-hive",
         "id": null,
-        "snippets": [{"id":"2b7d1f46-17a0-30af-efeb-33d4c29b1055","type":"hive","status":"running","statement":""" \
-        """"select * from web_logs","properties":{"settings":[],"variables":[],"files":[],"functions":[]},""" \
-        """"result":{"id":"b424befa-f4f5-8799-a0b4-79753f2552b1","type":"table","handle":""" \
-        """{"log_context":null,"statements_count":1,"end":{"column":21,"row":0},"statement_id":0,""" \
-        """"has_more_statements":false,"start":{"column":0,"row":0},"secret":"rVRWw7YPRGqPT7LZ/TeFaA==an",""" \
-        """"has_result_set":true,"statement":"select * from web_logs","operation_type":0,"modified_row_count":""" \
-        """null,"guid":"7xm6+epkRx6dyvYvGNYePA==an"}},"lastExecuted": 1462554843817,"database":"default"}],
+        "snippets": [{"id":"2b7d1f46-17a0-30af-efeb-33d4c29b1055","type":"hive","status":"running","statement":"""
+      """"select * from web_logs","properties":{"settings":[],"variables":[],"files":[],"functions":[]},"""
+      """"result":{"id":"b424befa-f4f5-8799-a0b4-79753f2552b1","type":"table","handle":"""
+      """{"log_context":null,"statements_count":1,"end":{"column":21,"row":0},"statement_id":0,"""
+      """"has_more_statements":false,"start":{"column":0,"row":0},"secret":"rVRWw7YPRGqPT7LZ/TeFaA==an","""
+      """"has_result_set":true,"statement":"select * from web_logs","operation_type":0,"modified_row_count":"""
+      """null,"guid":"7xm6+epkRx6dyvYvGNYePA==an"}},"lastExecuted": 1462554843817,"database":"default"}],
         "uuid": "d9efdee1-ef25-4d43-b8f9-1a170f69a05a"
     }
     """
+    )
 
-    response = self.client.post(reverse('notebook:export_result'), {
+    response = self.client.post(
+      reverse('notebook:export_result'),
+      {
         'notebook': notebook_json,
         'snippet': json.dumps(json.loads(notebook_json)['snippets'][0]),
         'format': json.dumps('hdfs-file'),
         'destination': json.dumps('/user/hue'),
-        'overwrite': json.dumps(False)
-    })
+        'overwrite': json.dumps(False),
+      },
+    )
 
     data = json.loads(response.content)
     assert 0 == data['status'], data
     assert '/user/hue/Test Hive Query.csv' == data['watch_url']['destination'], data
 
-
-    response = self.client.post(reverse('notebook:export_result'), {
+    response = self.client.post(
+      reverse('notebook:export_result'),
+      {
         'notebook': notebook_json,
         'snippet': json.dumps(json.loads(notebook_json)['snippets'][0]),
         'format': json.dumps('hdfs-file'),
         'destination': json.dumps('/user/hue/path.csv'),
-        'overwrite': json.dumps(False)
-    })
+        'overwrite': json.dumps(False),
+      },
+    )
 
     data = json.loads(response.content)
     assert 0 == data['status'], data
     assert '/user/hue/path.csv' == data['watch_url']['destination'], data
 
     if is_adls_enabled():
-      response = self.client.post(reverse('notebook:export_result'), {
+      response = self.client.post(
+        reverse('notebook:export_result'),
+        {
           'notebook': notebook_json,
           'snippet': json.dumps(json.loads(notebook_json)['snippets'][0]),
           'format': json.dumps('hdfs-file'),
           'destination': json.dumps('adl:/user/hue/path.csv'),
-          'overwrite': json.dumps(False)
-      })
+          'overwrite': json.dumps(False),
+        },
+      )
 
       data = json.loads(response.content)
       assert 0 == data['status'], data
       assert 'adl:/user/hue/path.csv' == data['watch_url']['destination'], data
 
-
-    response = self.client.post(reverse('notebook:export_result'), {
-      'notebook': notebook_json,
-      'snippet': json.dumps(json.loads(notebook_json)['snippets'][0]),
-      'format': json.dumps('hdfs-directory'),
-      'destination': json.dumps('/user/hue/non_empty_directory'),
-      'overwrite': json.dumps(False)
-    })
+    response = self.client.post(
+      reverse('notebook:export_result'),
+      {
+        'notebook': notebook_json,
+        'snippet': json.dumps(json.loads(notebook_json)['snippets'][0]),
+        'format': json.dumps('hdfs-directory'),
+        'destination': json.dumps('/user/hue/non_empty_directory'),
+        'overwrite': json.dumps(False),
+      },
+    )
 
     data = json.loads(response.content)
     assert -1 == data['status'], data
     assert 'The destination is not an empty directory!' == data['message'], data
 
-
   def test_download_result(self):
-    notebook_json = """
+    notebook_json = (
+      """
       {
         "selectedSnippet": "hive",
         "showHistory": false,
@@ -655,69 +618,192 @@ class TestNotebookApiMocked(object):
         ],
         "type": "query-hive",
         "id": null,
-        "snippets": [{"id":"2b7d1f46-17a0-30af-efeb-33d4c29b1055","type":"hive","status":"running","statement":""" \
-        """"select * from web_logs","properties":{"settings":[],"variables":[],"files":[],"functions":[]},""" \
-        """"result":{"id":"b424befa-f4f5-8799-a0b4-79753f2552b1","type":"table","handle":{"log_context":null,""" \
-        """"statements_count":1,"end":{"column":21,"row":0},"statement_id":0,"has_more_statements":false,""" \
-        """"start":{"column":0,"row":0},"secret":"rVRWw7YPRGqPT7LZ/TeFaA==an","has_result_set":true,"statement":"""\
-        """"select * from web_logs","operation_type":0,"modified_row_count":null,"guid":"7xm6+epkRx6dyvYvGNYePA==an"}},""" \
-        """"lastExecuted": 1462554843817,"database":"default"}],
+        "snippets": [{"id":"2b7d1f46-17a0-30af-efeb-33d4c29b1055","type":"hive","status":"running","statement":"""
+      """"select * from web_logs","properties":{"settings":[],"variables":[],"files":[],"functions":[]},"""
+      """"result":{"id":"b424befa-f4f5-8799-a0b4-79753f2552b1","type":"table","handle":{"log_context":null,"""
+      """"statements_count":1,"end":{"column":21,"row":0},"statement_id":0,"has_more_statements":false,"""
+      """"start":{"column":0,"row":0},"secret":"rVRWw7YPRGqPT7LZ/TeFaA==an","has_result_set":true,"statement":"""
+      """"select * from web_logs","operation_type":0,"modified_row_count":null,"guid":"7xm6+epkRx6dyvYvGNYePA==an"}},"""
+      """"lastExecuted": 1462554843817,"database":"default"}],
         "uuid": "d9efdee1-ef25-4d43-b8f9-1a170f69a05a"
     }
     """
-    response = self.client.post(reverse('notebook:download'), {
-        'notebook': notebook_json,
-        'snippet': json.dumps(json.loads(notebook_json)['snippets'][0]),
-        'format': 'csv'
-    })
+    )
+    response = self.client.post(
+      reverse('notebook:download'),
+      {'notebook': notebook_json, 'snippet': json.dumps(json.loads(notebook_json)['snippets'][0]), 'format': 'csv'},
+    )
     content = b"".join(response)
     assert len(content) > 0
 
 
 def test_get_interpreters_to_show():
-  default_interpreters = OrderedDict((
-      ('hive', {
-          'name': 'Hive', 'displayName': 'Hive', 'interface': 'hiveserver2', 'type': 'hive', 'is_sql': True,
-          'options': {}, 'dialect_properties': {}, 'is_catalog': False, 'category': 'editor', 'dialect': 'hive'
-      }),
-      ('spark', {
-          'name': 'Scala', 'displayName': 'Scala', 'interface': 'livy', 'type': 'spark', 'is_sql': False, 'options': {},
-          'dialect_properties': {}, 'is_catalog': False, 'category': 'editor', 'dialect': 'spark'
-      }),
-      ('pig', {
-          'name': 'Pig', 'displayName': 'Pig', 'interface': 'pig', 'type': 'pig', 'is_sql': False, 'options': {},
-          'dialect_properties': {}, 'is_catalog': False, 'category': 'editor', 'dialect': 'pig'
-      }),
-      ('java', {
-          'name': 'Java', 'displayName': 'Java', 'interface': 'oozie', 'type': 'java', 'is_sql': False, 'options': {},
-          'dialect_properties': {}, 'is_catalog': False, 'category': 'editor', 'dialect': 'java'
-      })
-    ))
+  default_interpreters = OrderedDict(
+    (
+      (
+        'hive',
+        {
+          'name': 'Hive',
+          'displayName': 'Hive',
+          'interface': 'hiveserver2',
+          'type': 'hive',
+          'is_sql': True,
+          'options': {},
+          'dialect_properties': {},
+          'is_catalog': False,
+          'category': 'editor',
+          'dialect': 'hive',
+        },
+      ),
+      (
+        'impala',
+        {
+          'name': 'Impala',
+          'displayName': 'Impala',
+          'interface': 'hiveserver2',
+          'type': 'impala',
+          'is_sql': True,
+          'options': {},
+          'dialect_properties': {},
+          'is_catalog': False,
+          'category': 'editor',
+          'dialect': 'impala',
+        },
+      ),
+      (
+        'spark',
+        {
+          'name': 'Scala',
+          'displayName': 'Scala',
+          'interface': 'livy',
+          'type': 'spark',
+          'is_sql': False,
+          'options': {},
+          'dialect_properties': {},
+          'is_catalog': False,
+          'category': 'editor',
+          'dialect': 'spark',
+        },
+      ),
+      (
+        'pig',
+        {
+          'name': 'Pig',
+          'displayName': 'Pig',
+          'interface': 'pig',
+          'type': 'pig',
+          'is_sql': False,
+          'options': {},
+          'dialect_properties': {},
+          'is_catalog': False,
+          'category': 'editor',
+          'dialect': 'pig',
+        },
+      ),
+      (
+        'java',
+        {
+          'name': 'Java',
+          'displayName': 'Java',
+          'interface': 'oozie',
+          'type': 'java',
+          'is_sql': False,
+          'options': {},
+          'dialect_properties': {},
+          'is_catalog': False,
+          'category': 'editor',
+          'dialect': 'java',
+        },
+      ),
+    )
+  )
 
-  expected_interpreters = OrderedDict((
-      ('java', {
-        'name': 'Java', 'displayName': 'Java', 'interface': 'oozie', 'type': 'java', 'is_sql': False, 'options': {},
-        'dialect_properties': {}, 'is_catalog': False, 'category': 'editor', 'dialect': 'java'
-      }),
-      ('pig', {
-        'name': 'Pig', 'displayName': 'Pig', 'interface': 'pig', 'is_sql': False, 'type': 'pig', 'options': {},
-        'dialect_properties': {}, 'is_catalog': False, 'category': 'editor', 'dialect': 'pig'
-      }),
-      ('hive', {
-          'name': 'Hive', 'displayName': 'Hive', 'interface': 'hiveserver2', 'is_sql': True, 'type': 'hive',
-          'options': {}, 'dialect_properties': {}, 'is_catalog': False, 'category': 'editor', 'dialect': 'hive'
-      }),
-      ('spark', {
-          'name': 'Scala', 'displayName': 'Scala', 'interface': 'livy', 'type': 'spark', 'is_sql': False, 'options': {},
-          'dialect_properties': {}, 'is_catalog': False, 'category': 'editor', 'dialect': 'spark'
-      })
-    ))
+  expected_interpreters = OrderedDict(
+    (
+      (
+        'java',
+        {
+          'name': 'Java',
+          'displayName': 'Java',
+          'interface': 'oozie',
+          'type': 'java',
+          'is_sql': False,
+          'options': {},
+          'dialect_properties': {},
+          'is_catalog': False,
+          'category': 'editor',
+          'dialect': 'java',
+        },
+      ),
+      (
+        'pig',
+        {
+          'name': 'Pig',
+          'displayName': 'Pig',
+          'interface': 'pig',
+          'is_sql': False,
+          'type': 'pig',
+          'options': {},
+          'dialect_properties': {},
+          'is_catalog': False,
+          'category': 'editor',
+          'dialect': 'pig',
+        },
+      ),
+      (
+        'hive',
+        {
+          'name': 'Hive',
+          'displayName': 'Hive',
+          'interface': 'hiveserver2',
+          'is_sql': True,
+          'type': 'hive',
+          'options': {},
+          'dialect_properties': {},
+          'is_catalog': False,
+          'category': 'editor',
+          'dialect': 'hive',
+        },
+      ),
+      (
+        'impala',
+        {
+          'name': 'Impala',
+          'displayName': 'Impala',
+          'interface': 'hiveserver2',
+          'type': 'impala',
+          'is_sql': True,
+          'options': {},
+          'dialect_properties': {},
+          'is_catalog': False,
+          'category': 'editor',
+          'dialect': 'impala',
+        },
+      ),
+      (
+        'spark',
+        {
+          'name': 'Scala',
+          'displayName': 'Scala',
+          'interface': 'livy',
+          'type': 'spark',
+          'is_sql': False,
+          'options': {},
+          'dialect_properties': {},
+          'is_catalog': False,
+          'category': 'editor',
+          'dialect': 'spark',
+        },
+      ),
+    )
+  )
 
   try:
     resets = [
       INTERPRETERS.set_for_testing(default_interpreters),
       APP_BLACKLIST.set_for_testing(''),
-      ENABLE_CONNECTORS.set_for_testing(False)
+      ENABLE_CONNECTORS.set_for_testing(False),
+      ENABLE_ALL_INTERPRETERS.set_for_testing(False),
     ]
     appmanager.DESKTOP_MODULES = []
     appmanager.DESKTOP_APPS = None
@@ -725,13 +811,13 @@ def test_get_interpreters_to_show():
     notebook.conf.INTERPRETERS_CACHE = None
 
     # 'get_interpreters_to_show should return the same as get_interpreters when interpreters_shown_on_wheel is unset'
-    assert (
-      list(default_interpreters.values()) == get_ordered_interpreters())
+    assert list(default_interpreters.values()) == get_ordered_interpreters()
 
     resets.append(INTERPRETERS_SHOWN_ON_WHEEL.set_for_testing('java,pig'))
 
     assert (
-      list(expected_interpreters.values()) == get_ordered_interpreters()), 'get_interpreters_to_show did not return interpreters in the correct order expected'
+      list(expected_interpreters.values()) == get_ordered_interpreters()
+    ), 'get_interpreters_to_show did not return interpreters in the correct order expected'
   finally:
     for reset in resets:
       reset()
@@ -742,85 +828,108 @@ def test_get_interpreters_to_show():
 
 
 def test_get_ordered_interpreters():
-  default_interpreters = OrderedDict((
-    ('hive', {
-        'name': 'Hive', 'displayName': 'Hive', 'interface': 'hiveserver2', 'type': 'hive', 'is_sql': True,
-        'options': {}, 'dialect_properties': None, 'is_catalog': False, 'category': 'editor', 'dialect': 'hive'
-    }),
-    ('impala', {
-        'name': 'Impala', 'displayName': 'Impala', 'interface': 'hiveserver2', 'type': 'impala', 'is_sql': True,
-        'options': {}, 'dialect_properties': None, 'is_catalog': False, 'category': 'editor', 'dialect': 'impala'
-    }),
-    ('spark', {
-        'name': 'Scala', 'displayName': 'Scala', 'interface': 'livy', 'type': 'spark', 'is_sql': False, 'options': {},
-        'dialect_properties': None, 'is_catalog': False, 'category': 'editor', 'dialect': 'scala'
-    }),
-    ('pig', {
-        'name': 'Pig', 'displayName': 'Pig', 'interface': 'pig', 'type': 'pig', 'is_sql': False, 'options': {},
-        'dialect_properties': None, 'is_catalog': False, 'category': 'editor', 'dialect': 'pig'
-    }),
-    ('java', {
-        'name': 'Java', 'displayName': 'Java', 'interface': 'oozie', 'type': 'java', 'is_sql': False, 'options': {},
-        'dialect_properties': None, 'is_catalog': False, 'category': 'editor', 'dialect': 'java'
-    })
-  ))
-
   try:
-    resets = [APP_BLACKLIST.set_for_testing('')]
+    resets = [APP_BLACKLIST.set_for_testing(''), ENABLE_ALL_INTERPRETERS.set_for_testing(False)]
+    flag_reset = ENABLE_ALL_INTERPRETERS.set_for_testing(False)
     appmanager.DESKTOP_MODULES = []
     appmanager.DESKTOP_APPS = None
     appmanager.load_apps(APP_BLACKLIST.get())
 
-    with patch('notebook.conf.is_cm_managed') as is_cm_managed:
-      with patch('notebook.conf.appmanager.get_apps_dict') as get_apps_dict:
-        with patch('notebook.conf.has_connectors') as has_connectors:
-          get_apps_dict.return_value = {'hive': {}}
-          has_connectors.return_value = False
-          notebook.conf.INTERPRETERS_CACHE = None
+    with patch('notebook.conf.appmanager.get_apps_dict') as get_apps_dict:
+      with patch('notebook.conf.has_connectors') as has_connectors:
+        get_apps_dict.return_value = {'hive': {}}  # Impala blacklisted indirectly
+        has_connectors.return_value = False
+        notebook.conf.INTERPRETERS_CACHE = None
 
-          is_cm_managed.return_value = False
+        # No interpreters explicitly added
+        INTERPRETERS.set_for_testing(OrderedDict(()))
 
-          # No CM --> Verbatim
-          INTERPRETERS.set_for_testing(
-            OrderedDict((
-              ('phoenix', {
-                  'name': 'Phoenix', 'interface': 'sqlalchemy', 'dialect': 'phoenix'
-              }),)
-            )
-          )
-          assert [interpreter['dialect'] for interpreter in get_ordered_interpreters()] == ['phoenix']
+        assert [interpreter['name'] for interpreter in get_ordered_interpreters()] == ['Hive']
+        assert [interpreter['name'] for interpreter in get_ordered_interpreters()] == ['Hive']  # Check twice because of cache
+        notebook.conf.INTERPRETERS_CACHE = None
 
-          # Check twice because of cache(
-          assert [interpreter['dialect'] for interpreter in get_ordered_interpreters()] == ['phoenix']
+        # Interpreter added explicitly
+        INTERPRETERS.set_for_testing(OrderedDict((('phoenix', {'name': 'Phoenix', 'interface': 'sqlalchemy', 'dialect': 'phoenix'}),)))
+        assert [interpreter['name'] for interpreter in get_ordered_interpreters()] == ['Hive', 'Phoenix']
+        assert [interpreter['name'] for interpreter in get_ordered_interpreters()] == ['Hive', 'Phoenix']  # Check twice
+        notebook.conf.INTERPRETERS_CACHE = None
 
-          is_cm_managed.return_value = True
-          notebook.conf.INTERPRETERS_CACHE = None
+        # Add one of the spark editor explicitly when spark is blacklisted
+        INTERPRETERS.set_for_testing(OrderedDict((('pyspark', {'name': 'PySpark', 'interface': 'livy', 'dialect': 'pyspark'}),)))
+        # Explicitly added spark editor not seen when flag is False
+        assert [interpreter['name'] for interpreter in get_ordered_interpreters()] == ['Hive']
+        assert [interpreter['name'] for interpreter in get_ordered_interpreters()] == ['Hive']  # Check twice because of cache
+        notebook.conf.INTERPRETERS_CACHE = None
 
-          # CM --> Append []
-          INTERPRETERS.set_for_testing(
-            OrderedDict(()
-            )
-          )
+        # Whitelist spark app and no explicit interpreter added
+        get_apps_dict.return_value = {'hive': {}, 'spark': {}, 'oozie': {}}
 
-          assert [interpreter['dialect'] for interpreter in get_ordered_interpreters()] == ['hive']
-          # Check twice
-          assert [interpreter['dialect'] for interpreter in get_ordered_interpreters()] == ['hive']
+        INTERPRETERS.set_for_testing(OrderedDict(()))
+        # No spark interpreter because ENABLE_ALL_INTERPRETERS is currently False
+        assert [interpreter['name'] for interpreter in get_ordered_interpreters()] == ['Hive']
+        assert [interpreter['name'] for interpreter in get_ordered_interpreters()] == ['Hive']  # Check twice because of cache
+        notebook.conf.INTERPRETERS_CACHE = None
 
-          notebook.conf.INTERPRETERS_CACHE = None
+        # Add one of the spark editor explicitly
+        INTERPRETERS.set_for_testing(OrderedDict((('pyspark', {'name': 'PySpark', 'interface': 'livy', 'dialect': 'pyspark'}),)))
+        # Explicitly added spark editor seen even when flag is False
+        assert [interpreter['name'] for interpreter in get_ordered_interpreters()] == ['Hive', 'PySpark']
+        assert [interpreter['name'] for interpreter in get_ordered_interpreters()] == ['Hive', 'PySpark']  # Check twice because of cache
+        notebook.conf.INTERPRETERS_CACHE = None
 
-          # CM --> Append [Phoenix]
-          INTERPRETERS.set_for_testing(
-            OrderedDict((
-              ('phoenix', {
-                  'name': 'Phoenix', 'interface': 'sqlalchemy', 'dialect': 'phoenix'
-              }),)
-            )
-          )
-          assert [interpreter['dialect'] for interpreter in get_ordered_interpreters()] == ['hive', 'phoenix']
-           
-          # Check twice(
-          assert [interpreter['dialect'] for interpreter in get_ordered_interpreters()] == ['hive', 'phoenix']
+        flag_reset = ENABLE_ALL_INTERPRETERS.set_for_testing(True)  # Check interpreters when flag is True
+
+        INTERPRETERS.set_for_testing(OrderedDict(()))
+
+        assert [interpreter['name'] for interpreter in get_ordered_interpreters()] == [
+          'Hive',
+          'Scala',
+          'PySpark',
+          'R',
+          'Spark Submit Jar',
+          'Spark Submit Python',
+          'Text',
+          'Markdown',
+        ]
+        assert [interpreter['name'] for interpreter in get_ordered_interpreters()] == [
+          'Hive',
+          'Scala',
+          'PySpark',
+          'R',
+          'Spark Submit Jar',
+          'Spark Submit Python',
+          'Text',
+          'Markdown',
+        ]  # Check twice because of cache
+        notebook.conf.INTERPRETERS_CACHE = None
+
+        # Interpreter added explicitly when flag is True
+        INTERPRETERS.set_for_testing(OrderedDict((('phoenix', {'name': 'Phoenix', 'interface': 'sqlalchemy', 'dialect': 'phoenix'}),)))
+        assert [interpreter['name'] for interpreter in get_ordered_interpreters()] == [
+          'Hive',
+          'Scala',
+          'PySpark',
+          'R',
+          'Spark Submit Jar',
+          'Spark Submit Python',
+          'Text',
+          'Markdown',
+          'Phoenix',
+        ]
+        assert [interpreter['name'] for interpreter in get_ordered_interpreters()] == [
+          'Hive',
+          'Scala',
+          'PySpark',
+          'R',
+          'Spark Submit Jar',
+          'Spark Submit Python',
+          'Text',
+          'Markdown',
+          'Phoenix',
+        ]  # Check twice because of cache
+
   finally:
+    flag_reset()
     for reset in resets:
       reset()
     appmanager.DESKTOP_MODULES = []
@@ -830,7 +939,6 @@ def test_get_ordered_interpreters():
 
 
 class TestQueriesMetrics(object):
-
   def test_queries_num(self):
     with patch('desktop.models.Document2.objects') as doc2_value_mock:
       doc2_value_mock.filter.return_value.count.return_value = 12500
@@ -847,7 +955,6 @@ class TestQueriesMetrics(object):
 
 @pytest.mark.django_db
 class TestEditor(object):
-
   def setup_method(self):
     self.client = make_logged_in_client(username="test", groupname="empty", recreate=True, is_superuser=False)
 
@@ -858,10 +965,7 @@ class TestEditor(object):
   def test_open_saved_impala_query_when_no_hive_interepreter(self):
     try:
       doc, created = Document2.objects.get_or_create(
-          name='open_saved_query_with_hive_not_present',
-          type='query-impala',
-          owner=self.user,
-          data={}
+        name='open_saved_query_with_hive_not_present', type='query-impala', owner=self.user, data={}
       )
 
       with patch('desktop.middleware.fsmanager') as fsmanager:

--- a/desktop/libs/notebook/src/notebook/conf.py
+++ b/desktop/libs/notebook/src/notebook/conf.py
@@ -296,7 +296,8 @@ def _default_interpreters(user):
       ('impala', {'name': 'Impala', 'interface': 'hiveserver2', 'options': {}}),
     )
 
-  # Behind a flag for supporting old scenario. We can always remove this config and stop supporting the old scenario.
+  # Other interpreters are behind a flag to not enable them by default. Users need to explicitly add configs for enabling them or
+  # if they want to revert to old scenario, they can disable the flag which will show all default interpreters for every whitelisted app.
   if ENABLE_ALL_INTERPRETERS.get():
     if 'pig' in apps:
       interpreters.append(('pig', {'name': 'Pig', 'interface': 'oozie', 'options': {}}))

--- a/desktop/libs/notebook/src/notebook/conf.py
+++ b/desktop/libs/notebook/src/notebook/conf.py
@@ -17,22 +17,15 @@
 
 import json
 import logging
-import sys
-
 from collections import OrderedDict
 
 from django.test.client import Client
 from django.urls import reverse
+from django.utils.translation import gettext as _, gettext_lazy as _t
 
 from desktop import appmanager
-from desktop.conf import is_oozie_enabled, has_connectors, is_cm_managed, ENABLE_UNIFIED_ANALYTICS, get_clusters
-from desktop.lib.conf import Config, UnspecifiedConfigSection, ConfigSection, coerce_json_dict, coerce_bool, coerce_csv
-
-if sys.version_info[0] > 2:
-  from django.utils.translation import gettext_lazy as _t, gettext as _
-else:
-  from django.utils.translation import ugettext_lazy as _t, ugettext as _
-
+from desktop.conf import ENABLE_UNIFIED_ANALYTICS, get_clusters, has_connectors, is_oozie_enabled
+from desktop.lib.conf import Config, ConfigSection, UnspecifiedConfigSection, coerce_bool, coerce_csv, coerce_json_dict
 
 LOG = logging.getLogger()
 
@@ -40,12 +33,7 @@ LOG = logging.getLogger()
 INTERPRETERS_CACHE = None
 
 
-SHOW_NOTEBOOKS = Config(
-    key="show_notebooks",
-    help=_t("Show the notebook menu or not"),
-    type=coerce_bool,
-    default=False
-)
+SHOW_NOTEBOOKS = Config(key="show_notebooks", help=_t("Show the notebook menu or not"), type=coerce_bool, default=False)
 
 
 def _remove_duplications(a_list):
@@ -56,24 +44,26 @@ def check_has_missing_permission(user, interpreter, user_apps=None):
   # TODO: port to cluster config
   if user_apps is None:
     user_apps = appmanager.get_apps_dict(user)  # Expensive method
-  return (interpreter == 'hive' and 'hive' not in user_apps) or \
-         (interpreter == 'impala' and 'impala' not in user_apps) or \
-         (interpreter == 'pig' and 'pig' not in user_apps) or \
-         (interpreter == 'solr' and 'search' not in user_apps) or \
-         (interpreter in ('spark', 'pyspark', 'r', 'jar', 'py', 'sparksql') and 'spark' not in user_apps) or \
-         (interpreter in ('java', 'spark2', 'mapreduce', 'shell', 'sqoop1', 'distcp') and 'oozie' not in user_apps)
+  return (
+    (interpreter == 'hive' and 'hive' not in user_apps)
+    or (interpreter == 'impala' and 'impala' not in user_apps)
+    or (interpreter == 'pig' and 'pig' not in user_apps)
+    or (interpreter == 'solr' and 'search' not in user_apps)
+    or (interpreter in ('spark', 'pyspark', 'r', 'jar', 'py', 'sparksql') and 'spark' not in user_apps)
+    or (interpreter in ('java', 'spark2', 'mapreduce', 'shell', 'sqoop1', 'distcp') and 'oozie' not in user_apps)
+  )
 
 
 def _connector_to_interpreter(connector):
   return {
-      'name': connector['nice_name'],
-      'type': connector['name'],  # Aka id
-      'dialect': connector['dialect'],
-      'category': connector['category'],
-      'is_sql': connector['dialect_properties']['is_sql'],
-      'interface': connector['interface'],
-      'options': {setting['name']: setting['value'] for setting in connector['settings']},
-      'dialect_properties': connector['dialect_properties'],
+    'name': connector['nice_name'],
+    'type': connector['name'],  # Aka id
+    'dialect': connector['dialect'],
+    'category': connector['category'],
+    'is_sql': connector['dialect_properties']['is_sql'],
+    'interface': connector['interface'],
+    'options': {setting['name']: setting['value'] for setting in connector['settings']},
+    'dialect_properties': connector['dialect_properties'],
   }
 
 
@@ -94,9 +84,9 @@ def get_ordered_interpreters(user=None):
 
   if has_connectors():
     from desktop.lib.connectors.api import _get_installed_connectors
+
     interpreters = [
-      _connector_to_interpreter(connector)
-      for connector in _get_installed_connectors(categories=['editor', 'catalogs'], user=user)
+      _connector_to_interpreter(connector) for connector in _get_installed_connectors(categories=['editor', 'catalogs'], user=user)
     ]
   else:
     if INTERPRETERS_CACHE is None:
@@ -125,16 +115,18 @@ def get_ordered_interpreters(user=None):
 
     reordered_interpreters = interpreters_shown_on_wheel + [i for i in user_interpreters if i not in interpreters_shown_on_wheel]
 
-    interpreters = [{
+    interpreters = [
+      {
         'name': INTERPRETERS_CACHE[i].NAME.get(),
         'type': i,
         'interface': INTERPRETERS_CACHE[i].INTERFACE.get(),
-        'options': INTERPRETERS_CACHE[i].OPTIONS.get()
+        'options': INTERPRETERS_CACHE[i].OPTIONS.get(),
       }
       for i in reordered_interpreters
     ]
 
-  return [{
+  return [
+    {
       "name": i.get('nice_name', i['name']),
       'displayName': displayName(i.get('dialect', i['name']).lower(), i.get('nice_name', i['name'])),
       "type": i['type'],
@@ -143,13 +135,14 @@ def get_ordered_interpreters(user=None):
       'dialect': i.get('dialect', i['type']).lower(),
       'dialect_properties': i.get('dialect_properties') or {},  # Empty when connectors off
       'category': i.get('category', 'editor'),
-      "is_sql": i.get('is_sql') or \
-          i['interface'] in ["hiveserver2", "rdbms", "jdbc", "solr", "sqlalchemy", "ksql", "flink", "trino"] or \
-          i['type'] in ["sql", "sparksql"],
-      "is_catalog": i['interface'] in ["hms",],
+      "is_sql": i.get('is_sql')
+      or i['interface'] in ["hiveserver2", "rdbms", "jdbc", "solr", "sqlalchemy", "ksql", "flink", "trino"]
+      or i['type'] in ["sql", "sparksql"],
+      "is_catalog": i['interface'] in ["hms"],
     }
     for i in interpreters
   ]
+
 
 def computes_for_dialect(dialect, user):
   # import here due to avoid cyclic dependency
@@ -162,6 +155,7 @@ def computes_for_dialect(dialect, user):
 
   return ns_with_computes
 
+
 # cf. admin wizard too
 
 INTERPRETERS = UnspecifiedConfigSection(
@@ -171,76 +165,67 @@ INTERPRETERS = UnspecifiedConfigSection(
     help=_t("Define the name and how to connect and execute the language."),
     members=dict(
       NAME=Config(
-          "name",
-          help=_t("The name of the snippet."),
-          default="SQL",
-          type=str,
+        "name",
+        help=_t("The name of the snippet."),
+        default="SQL",
+        type=str,
       ),
       INTERFACE=Config(
-          "interface",
-          help="The backend connection to use to communicate with the server.",
-          default="hiveserver2",
-          type=str,
+        "interface",
+        help="The backend connection to use to communicate with the server.",
+        default="hiveserver2",
+        type=str,
       ),
-      OPTIONS=Config(
-        key='options',
-        help=_t('Specific options for connecting to the server.'),
-        type=coerce_json_dict,
-        default='{}'
-      )
-    )
-  )
+      OPTIONS=Config(key='options', help=_t('Specific options for connecting to the server.'), type=coerce_json_dict, default='{}'),
+    ),
+  ),
 )
 
 INTERPRETERS_SHOWN_ON_WHEEL = Config(
   key="interpreters_shown_on_wheel",
-  help=_t("Comma separated list of interpreters that should be shown on the wheel. "
-          "This list takes precedence over the order in which the interpreter entries appear. "
-          "Only the first 5 interpreters will appear on the wheel."),
+  help=_t(
+    "Comma separated list of interpreters that should be shown on the wheel. "
+    "This list takes precedence over the order in which the interpreter entries appear. "
+    "Only the first 5 interpreters will appear on the wheel."
+  ),
   type=coerce_csv,
-  default=[]
+  default=[],
 )
 
 ENABLE_ALL_INTERPRETERS = Config(
   key="enable_all_interpreters",
   help=_t("Flag to enable all interpreters (Hive and Impala are added by default) related to every whitelisted app."),
   type=coerce_bool,
-  default=False
+  default=False,
 )
 
 DEFAULT_INTERPRETER = Config(
   key="default_interpreter",
   help=_t("Set the default interpreter for all users. Starred interpreters at user level will get more priority than the value below."),
   type=str,
-  default=''
+  default='',
 )
 
 DEFAULT_LIMIT = Config(
-  "default_limit",
-  help="Default limit to use in SELECT statements if not present. Set to 0 to disable.",
-  default=5000,
-  type=int
+  "default_limit", help="Default limit to use in SELECT statements if not present. Set to 0 to disable.", default=5000, type=int
 )
 
 ENABLE_DBPROXY_SERVER = Config(
   key="enable_dbproxy_server",
   help=_t("Main flag to override the automatic starting of the DBProxy server."),
   type=coerce_bool,
-  default=True
+  default=True,
 )
 
 DBPROXY_EXTRA_CLASSPATH = Config(
   key="dbproxy_extra_classpath",
   help=_t("Additional classes to put on the dbproxy classpath when starting. Values separated by ':'"),
   type=str,
-  default=''
+  default='',
 )
 
 ENABLE_QUERY_BUILDER = Config(
-  key="enable_query_builder",
-  help=_t("Flag to enable the SQL query builder of the table assist."),
-  type=coerce_bool,
-  default=False
+  key="enable_query_builder", help=_t("Flag to enable the SQL query builder of the table assist."), type=coerce_bool, default=False
 )
 
 # Note: requires Oozie app
@@ -248,42 +233,34 @@ ENABLE_QUERY_SCHEDULING = Config(
   key="enable_query_scheduling",
   help=_t("Flag to enable the creation of a coordinator for the current SQL query."),
   type=coerce_bool,
-  default=False
+  default=False,
 )
 
 ENABLE_EXTERNAL_STATEMENT = Config(
   key="enable_external_statements",
   help=_t("Flag to enable the selection of queries from files, saved queries into the editor or as snippet."),
   type=coerce_bool,
-  default=False
+  default=False,
 )
 
 ENABLE_BATCH_EXECUTE = Config(
   key="enable_batch_execute",
   help=_t("Flag to enable the bulk submission of queries as a background task through Oozie."),
   type=coerce_bool,
-  dynamic_default=is_oozie_enabled
+  dynamic_default=is_oozie_enabled,
 )
 
-ENABLE_SQL_INDEXER = Config(
-  key="enable_sql_indexer",
-  help=_t("Flag to turn on the SQL indexer."),
-  type=coerce_bool,
-  default=False
-)
+ENABLE_SQL_INDEXER = Config(key="enable_sql_indexer", help=_t("Flag to turn on the SQL indexer."), type=coerce_bool, default=False)
 
 ENABLE_PRESENTATION = Config(
-  key="enable_presentation",
-  help=_t("Flag to turn on the Presentation mode of the editor."),
-  type=coerce_bool,
-  default=True
+  key="enable_presentation", help=_t("Flag to turn on the Presentation mode of the editor."), type=coerce_bool, default=True
 )
 
 ENABLE_QUERY_ANALYSIS = Config(
   key="enable_query_analysis",
   help=_t("Flag to turn on the built-in hints on Impala queries in the editor."),
   type=coerce_bool,
-  default=False
+  default=False,
 )
 
 
@@ -291,32 +268,15 @@ EXAMPLES = ConfigSection(
   key='examples',
   help=_t('Define which query and table examples can be automatically setup for the available dialects.'),
   members=dict(
-    AUTO_LOAD=Config(
-      'auto_load',
-      help=_t('If installing the examples automatically at startup.'),
-      type=coerce_bool,
-      default=False
-    ),
+    AUTO_LOAD=Config('auto_load', help=_t('If installing the examples automatically at startup.'), type=coerce_bool, default=False),
     AUTO_OPEN=Config(
-      'auto_open',
-      help=_t('If automatically loading the dialect example at Editor opening.'),
-      type=coerce_bool,
-      default=False
+      'auto_open', help=_t('If automatically loading the dialect example at Editor opening.'), type=coerce_bool, default=False
     ),
-    QUERIES=Config(
-      'queries',
-      help='Names of the saved queries to install. All if empty.',
-      type=coerce_csv,
-      default=[]
-    ),
-    TABLES=Config(
-      key='tables',
-      help=_t('Names of the tables to install. All if empty.'),
-      type=coerce_csv,
-      default=[]
-    )
-  )
+    QUERIES=Config('queries', help='Names of the saved queries to install. All if empty.', type=coerce_csv, default=[]),
+    TABLES=Config(key='tables', help=_t('Names of the tables to install. All if empty.'), type=coerce_csv, default=[]),
+  ),
 )
+
 
 def _default_interpreters(user):
   interpreters = []
@@ -324,83 +284,61 @@ def _default_interpreters(user):
 
   if 'hive' in apps:
     from beeswax.hive_site import get_hive_execution_engine
+
     interpreter_name = 'Impala' if get_hive_execution_engine() == 'impala' else 'Hive'  # Until using a proper dialect for 'FENG'
 
-    interpreters.append(('hive', {
-      'name': interpreter_name, 'interface': 'hiveserver2', 'options': {}
-    }),)
+    interpreters.append(
+      ('hive', {'name': interpreter_name, 'interface': 'hiveserver2', 'options': {}}),
+    )
 
   if 'impala' in apps:
-    interpreters.append(('impala', {
-      'name': 'Impala', 'interface': 'hiveserver2', 'options': {}
-    }),)
+    interpreters.append(
+      ('impala', {'name': 'Impala', 'interface': 'hiveserver2', 'options': {}}),
+    )
 
+  # Behind a flag for supporting old scenario. We can always remove this config and stop supporting the old scenario.
   if ENABLE_ALL_INTERPRETERS.get():
     if 'pig' in apps:
-      interpreters.append(('pig', {
-        'name': 'Pig', 'interface': 'oozie', 'options': {}
-      }))
+      interpreters.append(('pig', {'name': 'Pig', 'interface': 'oozie', 'options': {}}))
 
     if 'oozie' in apps and 'jobsub' in apps:
-      interpreters.extend((
-        ('java', {
-            'name': 'Java', 'interface': 'oozie', 'options': {}
-        }),
-        ('spark2', {
-            'name': 'Spark', 'interface': 'oozie', 'options': {}
-        }),
-        ('mapreduce', {
-            'name': 'MapReduce', 'interface': 'oozie', 'options': {}
-        }),
-        ('shell', {
-            'name': 'Shell', 'interface': 'oozie', 'options': {}
-        }),
-        ('sqoop1', {
-            'name': 'Sqoop 1', 'interface': 'oozie', 'options': {}
-        }),
-        ('distcp', {
-            'name': 'Distcp', 'interface': 'oozie', 'options': {}
-        }),
-      ))
+      interpreters.extend(
+        (
+          ('java', {'name': 'Java', 'interface': 'oozie', 'options': {}}),
+          ('spark2', {'name': 'Spark', 'interface': 'oozie', 'options': {}}),
+          ('mapreduce', {'name': 'MapReduce', 'interface': 'oozie', 'options': {}}),
+          ('shell', {'name': 'Shell', 'interface': 'oozie', 'options': {}}),
+          ('sqoop1', {'name': 'Sqoop 1', 'interface': 'oozie', 'options': {}}),
+          ('distcp', {'name': 'Distcp', 'interface': 'oozie', 'options': {}}),
+        )
+      )
 
     from dashboard.conf import get_properties  # Cyclic dependency
+
     dashboards = get_properties()
     if dashboards.get('solr') and dashboards['solr']['analytics']:
-      interpreters.append(('solr', {
-          'name': 'Solr SQL', 'interface': 'solr', 'options': {}
-      }),)
+      interpreters.append(
+        ('solr', {'name': 'Solr SQL', 'interface': 'solr', 'options': {}}),
+      )
 
     from desktop.models import Cluster  # Cyclic dependency
+
     cluster = Cluster(user)
     if cluster and cluster.get_type() == 'dataeng':
-      interpreters.append(('dataeng', {
-          'name': 'DataEng', 'interface': 'dataeng', 'options': {}
-      }))
+      interpreters.append(('dataeng', {'name': 'DataEng', 'interface': 'dataeng', 'options': {}}))
 
     if 'spark' in apps:
-      interpreters.extend((
-        ('spark', {
-            'name': 'Scala', 'interface': 'livy', 'options': {}
-        }),
-        ('pyspark', {
-            'name': 'PySpark', 'interface': 'livy', 'options': {}
-        }),
-        ('r', {
-            'name': 'R', 'interface': 'livy', 'options': {}
-        }),
-        ('jar', {
-            'name': 'Spark Submit Jar', 'interface': 'livy-batch', 'options': {}
-        }),
-        ('py', {
-            'name': 'Spark Submit Python', 'interface': 'livy-batch', 'options': {}
-        }),
-        ('text', {
-            'name': 'Text', 'interface': 'text', 'options': {}
-        }),
-        ('markdown', {
-            'name': 'Markdown', 'interface': 'text', 'options': {}
-        })
-      ))
+      interpreters.extend(
+        (
+          ('spark', {'name': 'Scala', 'interface': 'livy', 'options': {}}),
+          ('pyspark', {'name': 'PySpark', 'interface': 'livy', 'options': {}}),
+          ('r', {'name': 'R', 'interface': 'livy', 'options': {}}),
+          ('jar', {'name': 'Spark Submit Jar', 'interface': 'livy-batch', 'options': {}}),
+          ('py', {'name': 'Spark Submit Python', 'interface': 'livy-batch', 'options': {}}),
+          ('text', {'name': 'Text', 'interface': 'text', 'options': {}}),
+          ('markdown', {'name': 'Markdown', 'interface': 'text', 'options': {}}),
+        )
+      )
 
   INTERPRETERS.set_for_testing(OrderedDict(interpreters))
 
@@ -437,12 +375,7 @@ def config_validator(user, interpreters=None):
           msg += ' Failed to authenticate, check authentication configurations.'
 
         LOG.exception(msg)
-        res.append(
-          (
-            '%(name)s - %(dialect)s (%(type)s)' % interpreter,
-            _(msg) + (' %s' % trace[:100] + ('...' if len(trace) > 50 else ''))
-          )
-        )
+        res.append(('%(name)s - %(dialect)s (%(type)s)' % interpreter, _(msg) + (' %s' % trace[:100] + ('...' if len(trace) > 50 else ''))))
 
   return res
 
@@ -469,16 +402,13 @@ def _excute_test_query(client, connector_id, interpreter=None):
       "snippets": [{"id":"2b7d1f46-17a0-30af-efeb-33d4c29b1055","type":"%(connector_id)s","status":"running","statement":"select * from web_logs","properties":{"settings":[],"variables":[],"files":[],"functions":[]},"result":{"id":"b424befa-f4f5-8799-a0b4-79753f2552b1","type":"table","handle":{"log_context":null,"statements_count":1,"end":{"column":21,"row":0},"statement_id":0,"has_more_statements":false,"start":{"column":0,"row":0},"secret":"rVRWw7YPRGqPT7LZ/TeFaA==an","has_result_set":true,"statement":"select * from web_logs","operation_type":0,"modified_row_count":null,"guid":"7xm6+epkRx6dyvYvGNYePA==an"}},"lastExecuted": 1462554843817,"database":"default"}],
       "uuid": "d9efdee1-ef25-4d43-b8f9-1a170f69a05a"
   }
-  """ % {
+  """ % {  # noqa: E501
     'connector_id': connector_id,
   }
   snippet = json.loads(notebook_json)['snippets'][0]
   snippet['interpreter'] = interpreter
 
   return client.post(
-    reverse('notebook:api_sample_data', kwargs={'database': 'default', 'table': 'default'}), {
-      'notebook': notebook_json,
-      'snippet': json.dumps(snippet),
-      'is_async': json.dumps(True),
-      'operation': json.dumps('hello')
-  })
+    reverse('notebook:api_sample_data', kwargs={'database': 'default', 'table': 'default'}),
+    {'notebook': notebook_json, 'snippet': json.dumps(snippet), 'is_async': json.dumps(True), 'operation': json.dumps('hello')},
+  )

--- a/desktop/libs/notebook/src/notebook/conf.py
+++ b/desktop/libs/notebook/src/notebook/conf.py
@@ -44,7 +44,7 @@ SHOW_NOTEBOOKS = Config(
     key="show_notebooks",
     help=_t("Show the notebook menu or not"),
     type=coerce_bool,
-    default=True
+    default=False
 )
 
 
@@ -100,15 +100,9 @@ def get_ordered_interpreters(user=None):
     ]
   else:
     if INTERPRETERS_CACHE is None:
-      none_user = None # for getting full list of interpreters
-      if is_cm_managed():
-        extra_interpreters = INTERPRETERS.get()  # Combine the other apps interpreters
-        _default_interpreters(none_user)
-      else:
-        extra_interpreters = {}
-
-      if not INTERPRETERS.get():
-        _default_interpreters(none_user)
+      none_user = None  # For getting full list of interpreters
+      extra_interpreters = INTERPRETERS.get()  # Combine the other apps interpreters
+      _default_interpreters(none_user)
 
       INTERPRETERS_CACHE = INTERPRETERS.get()
       INTERPRETERS_CACHE.update(extra_interpreters)
@@ -205,6 +199,13 @@ INTERPRETERS_SHOWN_ON_WHEEL = Config(
           "Only the first 5 interpreters will appear on the wheel."),
   type=coerce_csv,
   default=[]
+)
+
+ENABLE_ALL_INTERPRETERS = Config(
+  key="enable_all_interpreters",
+  help=_t("Flag to enable all interpreters (Hive and Impala are added by default) related to every whitelisted app."),
+  type=coerce_bool,
+  default=False
 )
 
 DEFAULT_INTERPRETER = Config(
@@ -334,71 +335,72 @@ def _default_interpreters(user):
       'name': 'Impala', 'interface': 'hiveserver2', 'options': {}
     }),)
 
-  if 'pig' in apps:
-    interpreters.append(('pig', {
-      'name': 'Pig', 'interface': 'oozie', 'options': {}
-    }))
+  if ENABLE_ALL_INTERPRETERS.get():
+    if 'pig' in apps:
+      interpreters.append(('pig', {
+        'name': 'Pig', 'interface': 'oozie', 'options': {}
+      }))
 
-  if 'oozie' in apps and 'jobsub' in apps:
-    interpreters.extend((
-      ('java', {
-          'name': 'Java', 'interface': 'oozie', 'options': {}
-      }),
-      ('spark2', {
-          'name': 'Spark', 'interface': 'oozie', 'options': {}
-      }),
-      ('mapreduce', {
-          'name': 'MapReduce', 'interface': 'oozie', 'options': {}
-      }),
-      ('shell', {
-          'name': 'Shell', 'interface': 'oozie', 'options': {}
-      }),
-      ('sqoop1', {
-          'name': 'Sqoop 1', 'interface': 'oozie', 'options': {}
-      }),
-      ('distcp', {
-          'name': 'Distcp', 'interface': 'oozie', 'options': {}
-      }),
-    ))
+    if 'oozie' in apps and 'jobsub' in apps:
+      interpreters.extend((
+        ('java', {
+            'name': 'Java', 'interface': 'oozie', 'options': {}
+        }),
+        ('spark2', {
+            'name': 'Spark', 'interface': 'oozie', 'options': {}
+        }),
+        ('mapreduce', {
+            'name': 'MapReduce', 'interface': 'oozie', 'options': {}
+        }),
+        ('shell', {
+            'name': 'Shell', 'interface': 'oozie', 'options': {}
+        }),
+        ('sqoop1', {
+            'name': 'Sqoop 1', 'interface': 'oozie', 'options': {}
+        }),
+        ('distcp', {
+            'name': 'Distcp', 'interface': 'oozie', 'options': {}
+        }),
+      ))
 
-  from dashboard.conf import get_properties  # Cyclic dependency
-  dashboards = get_properties()
-  if dashboards.get('solr') and dashboards['solr']['analytics']:
-    interpreters.append(('solr', {
-        'name': 'Solr SQL', 'interface': 'solr', 'options': {}
-    }),)
+    from dashboard.conf import get_properties  # Cyclic dependency
+    dashboards = get_properties()
+    if dashboards.get('solr') and dashboards['solr']['analytics']:
+      interpreters.append(('solr', {
+          'name': 'Solr SQL', 'interface': 'solr', 'options': {}
+      }),)
 
-  from desktop.models import Cluster  # Cyclic dependency
-  cluster = Cluster(user)
-  if cluster and cluster.get_type() == 'dataeng':
-    interpreters.append(('dataeng', {
-        'name': 'DataEng', 'interface': 'dataeng', 'options': {}
-    }))
+    from desktop.models import Cluster  # Cyclic dependency
+    cluster = Cluster(user)
+    if cluster and cluster.get_type() == 'dataeng':
+      interpreters.append(('dataeng', {
+          'name': 'DataEng', 'interface': 'dataeng', 'options': {}
+      }))
 
-  if 'spark' in apps:
-    interpreters.extend((
-      ('spark', {
-          'name': 'Scala', 'interface': 'livy', 'options': {}
-      }),
-      ('pyspark', {
-          'name': 'PySpark', 'interface': 'livy', 'options': {}
-      }),
-      ('r', {
-          'name': 'R', 'interface': 'livy', 'options': {}
-      }),
-      ('jar', {
-          'name': 'Spark Submit Jar', 'interface': 'livy-batch', 'options': {}
-      }),
-      ('py', {
-          'name': 'Spark Submit Python', 'interface': 'livy-batch', 'options': {}
-      }),
-      ('text', {
-          'name': 'Text', 'interface': 'text', 'options': {}
-      }),
-      ('markdown', {
-          'name': 'Markdown', 'interface': 'text', 'options': {}
-      })
-    ))
+    if 'spark' in apps:
+      interpreters.extend((
+        ('spark', {
+            'name': 'Scala', 'interface': 'livy', 'options': {}
+        }),
+        ('pyspark', {
+            'name': 'PySpark', 'interface': 'livy', 'options': {}
+        }),
+        ('r', {
+            'name': 'R', 'interface': 'livy', 'options': {}
+        }),
+        ('jar', {
+            'name': 'Spark Submit Jar', 'interface': 'livy-batch', 'options': {}
+        }),
+        ('py', {
+            'name': 'Spark Submit Python', 'interface': 'livy-batch', 'options': {}
+        }),
+        ('text', {
+            'name': 'Text', 'interface': 'text', 'options': {}
+        }),
+        ('markdown', {
+            'name': 'Markdown', 'interface': 'text', 'options': {}
+        })
+      ))
 
   INTERPRETERS.set_for_testing(OrderedDict(interpreters))
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- This change ensures that if a user needs an interpreter X, then user needs to add its config under `[[interpreters]]` section. This way Hue won't be showing all unneeded interpreters and confuse users whenever any app is whitelisted.
- If user still wants to add all default available interpreters for every whitelisted app (old scenario), then they can set the flag `enable_all_interpreters` to `True` in the Hue configs.

## How was this patch tested?

- Manually tested different scenarios of Hue config and verified the editors available on the Hue UI.
- Added new unit tests and updated existing ones.