### PR TITLE
[core] Change ext-py3 package installation path again

### DIFF
--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -73,10 +73,10 @@ git+https://github.com/gethue/django-babel.git
 django-utils-six==2.0
 six==1.16.0
 psutil==5.8.0
--e file:///${ROOT}/desktop/core/ext-py3/requests-2.27.1
--e file:///${ROOT}/desktop/core/ext-py3/boto-2.49.0
--e file:///${ROOT}/desktop/core/ext-py3/django-axes-5.13.0
--e file:///${ROOT}/desktop/core/ext-py3/djangosaml2-0.18.0
--e file:///${ROOT}/desktop/core/ext-py3/dnspython-1.16.0  # Required for eventlet==0.30.2 and python3.10
--e file:///${ROOT}/desktop/core/ext-py3/eventlet-0.30.2
--e file:///${ROOT}/desktop/core/ext-py3/pysaml2-7.3.1
+-e file://${ROOT}/desktop/core/ext-py3/requests-2.27.1
+-e file://${ROOT}/desktop/core/ext-py3/boto-2.49.0
+-e file://${ROOT}/desktop/core/ext-py3/django-axes-5.13.0
+-e file://${ROOT}/desktop/core/ext-py3/djangosaml2-0.18.0
+-e file://${ROOT}/desktop/core/ext-py3/dnspython-1.16.0  # Required for eventlet==0.30.2 and python3.10
+-e file://${ROOT}/desktop/core/ext-py3/eventlet-0.30.2
+-e file://${ROOT}/desktop/core/ext-py3/pysaml2-7.3.1


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Repeating the change done in https://github.com/cloudera/hue/pull/3720 because it was reverted by mistake as a part of https://github.com/cloudera/hue/pull/3719.

## How was this patch tested?

- Manually in local setup