### PR TITLE
[Taskserver] Set timezone-aware datetimes to False

### DIFF
--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -766,7 +766,7 @@ if desktop.conf.TASK_SERVER_V2.ENABLED.get() or desktop.conf.TASK_SERVER_V2.BEAT
   if desktop.conf.TASK_SERVER_V2.BEAT_ENABLED.get():
     INSTALLED_APPS.append('django_celery_beat')
     INSTALLED_APPS.append('timezone_field')
-    USE_TZ = True
+    USE_TZ = False
 
 
 PROMETHEUS_EXPORT_MIGRATIONS = False  # Needs to be there even when enable_prometheus is not enabled


### PR DESCRIPTION
Celery's USE_TZ setting is overriding Django's timezone-aware datetimes setting. Due to this, time zone support is active in timestamps and written in the same format in hue tables like UserProfile. Certain configs in hue cannot process the timestamp if the timezone support is active like 

```
[[auth]]
idle_session_timeout=200
```


## What changes were proposed in this pull request?

Set the USE_TZ=False in Celery settings. 

## How was this patch tested?

Tested on local machine, Kubernetes deployment. 

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
