### PR TITLE
[lib] Pin krb5 to 0.5.1 for SLES12

### DIFF
--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -59,6 +59,7 @@ PyJWT==2.4.0
 PyYAML==6.0.1
 requests==2.32.3
 requests-kerberos==0.14.0
+krb5==0.5.1  # pinned for Sles12, dep of requests-kerberos 0.14.0
 rsa==4.7.2
 ruff==0.4.2
 sasl==0.3.1  # Move to https://pypi.org/project/sasl3/ ?


### PR DESCRIPTION
## What changes were proposed in this pull request?

Pin krb5 to 0.5.1 for SLES12

```
18:09:59 2024/07/23 01:09:59 INFO    :   Building wheel for krb5 (pyproject.toml): started
18:10:17 2024/07/23 01:10:17 INFO    :   Building wheel for krb5 (pyproject.toml): finished with status 'error'
18:10:17 2024/07/23 01:10:17 INFO    :   error: subprocess-exited-with-error
18:10:17 2024/07/23 01:10:17 INFO    : 
18:10:17 2024/07/23 01:10:17 INFO    :   × Building wheel for krb5 (pyproject.toml) did not run successfully.
18:10:17 2024/07/23 01:10:17 INFO    :   │ exit code: 1
18:10:17 2024/07/23 01:10:17 INFO    :   ╰─> [107 lines of output]
18:10:17 2024/07/23 01:10:17 INFO    :       Using krb5-config at 'krb5-config'
18:10:17 2024/07/23 01:10:17 INFO    :       Using libkrb5.so as Kerberos module for platform checks
18:10:17 2024/07/23 01:10:17 INFO    :       Compiling src/krb5/_ccache.pyx
18:10:17 2024/07/23 01:10:17 INFO    :       Compiling src/krb5/_ccache_mit.pyx
18:10:17 2024/07/23 01:10:17 INFO    :       Compiling src/krb5/_ccache_match.pyx
18:10:17 2024/07/23 01:10:17 INFO    :       Compiling src/krb5/_ccache_support_switch.pyx
18:10:17 2024/07/23 01:10:17 INFO    :       Compiling src/krb5/_cccol.pyx
18:10:17 2024/07/23 01:10:17 INFO    :       Compiling src/krb5/_context.pyx
18:10:17 2024/07/23 01:10:17 INFO    :       Compiling src/krb5/_context_mit.pyx
18:10:18 2024/07/23 01:10:17 INFO    :       Compiling src/krb5/_creds.pyx
18:10:18 2024/07/23 01:10:17 INFO    :       Skipping src/krb5/_creds_marshal_mit.pyx as it is not supported by the selected Kerberos implementation.
18:10:18 2024/07/23 01:10:17 INFO    :       Skipping src/krb5/_creds_mit.pyx as it is not supported by the selected Kerberos implementation.
18:10:18 2024/07/23 01:10:17 INFO    :       Compiling src/krb5/_creds_opt.pyx
18:10:18 2024/07/23 01:10:18 INFO    :       Skipping src/krb5/_creds_opt_heimdal.pyx as it is not supported by the selected Kerberos implementation.
18:10:18 2024/07/23 01:10:18 INFO    :       Compiling src/krb5/_creds_opt_mit.pyx
18:10:18 2024/07/23 01:10:18 INFO    :       Compiling src/krb5/_creds_opt_set_in_ccache.pyx
18:10:18 2024/07/23 01:10:18 INFO    :       Skipping src/krb5/_creds_opt_set_pac_request.pyx as it is not supported by the selected Kerberos implementation.
18:10:18 2024/07/23 01:10:18 INFO    :       Compiling src/krb5/_exceptions.pyx
18:10:18 2024/07/23 01:10:18 INFO    :       Compiling src/krb5/_keyblock.pyx
18:10:18 2024/07/23 01:10:18 INFO    :       Compiling src/krb5/_keyblock_mit.pyx
18:10:18 2024/07/23 01:10:18 INFO    :       Compiling src/krb5/_kt.pyx
18:10:18 2024/07/23 01:10:18 INFO    :       Compiling src/krb5/_kt_mit.pyx
18:10:18 2024/07/23 01:10:18 INFO    :       Skipping src/krb5/_kt_heimdal.pyx as it is not supported by the selected Kerberos implementation.
18:10:18 2024/07/23 01:10:18 INFO    :       Compiling src/krb5/_kt_have_content.pyx
18:10:18 2024/07/23 01:10:18 INFO    :       Compiling src/krb5/_principal.pyx
18:10:18 2024/07/23 01:10:18 INFO    :       Skipping src/krb5/_principal_heimdal.pyx as it is not supported by the selected Kerberos implementation.
18:10:18 2024/07/23 01:10:18 INFO    :       Compiling src/krb5/_string.pyx
18:10:18 2024/07/23 01:10:18 INFO    :       Compiling src/krb5/_string_mit.pyx
18:10:18 2024/07/23 01:10:18 INFO    :       running bdist_wheel
18:10:18 2024/07/23 01:10:18 INFO    :       running build
18:10:18 2024/07/23 01:10:18 INFO    :       running build_py
18:10:18 2024/07/23 01:10:18 INFO    :       creating build
18:10:18 2024/07/23 01:10:18 INFO    :       creating build/lib.linux-x86_64-cpython-38
18:10:18 2024/07/23 01:10:18 INFO    :       creating build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/__init__.py -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       running egg_info
18:10:18 2024/07/23 01:10:18 INFO    :       writing src/krb5.egg-info/PKG-INFO
18:10:18 2024/07/23 01:10:18 INFO    :       writing dependency_links to src/krb5.egg-info/dependency_links.txt
18:10:18 2024/07/23 01:10:18 INFO    :       writing top-level names to src/krb5.egg-info/top_level.txt
18:10:18 2024/07/23 01:10:18 INFO    :       reading manifest file 'src/krb5.egg-info/SOURCES.txt'
18:10:18 2024/07/23 01:10:18 INFO    :       reading manifest template 'MANIFEST.in'
18:10:18 2024/07/23 01:10:18 INFO    :       warning: no previously-included files found matching '.coverage'
18:10:18 2024/07/23 01:10:18 INFO    :       warning: no previously-included files found matching '.gitignore'
18:10:18 2024/07/23 01:10:18 INFO    :       warning: no previously-included files found matching '.pre-commit-config.yaml'
18:10:18 2024/07/23 01:10:18 INFO    :       warning: no previously-included files matching '*.pyc' found under directory 'tests'
18:10:18 2024/07/23 01:10:18 INFO    :       adding license file 'LICENSE'
18:10:18 2024/07/23 01:10:18 INFO    :       writing manifest file 'src/krb5.egg-info/SOURCES.txt'
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_ccache.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_ccache_match.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_ccache_mit.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_ccache_support_switch.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_cccol.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_context.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_context_mit.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_creds.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_creds_marshal_mit.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_creds_mit.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_creds_opt.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_creds_opt_heimdal.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_creds_opt_mit.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_creds_opt_set_in_ccache.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_creds_opt_set_pac_request.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_exceptions.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_keyblock.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_keyblock_mit.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_kt.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_kt_have_content.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_kt_heimdal.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_kt_mit.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_principal.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_principal_heimdal.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_string.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/_string_mit.pyi -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       copying src/krb5/py.typed -> build/lib.linux-x86_64-cpython-38/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       running build_ext
18:10:18 2024/07/23 01:10:18 INFO    :       building 'krb5._ccache' extension
18:10:18 2024/07/23 01:10:18 INFO    :       creating build/temp.linux-x86_64-cpython-38
18:10:18 2024/07/23 01:10:18 INFO    :       creating build/temp.linux-x86_64-cpython-38/src
18:10:18 2024/07/23 01:10:18 INFO    :       creating build/temp.linux-x86_64-cpython-38/src/krb5
18:10:18 2024/07/23 01:10:18 INFO    :       gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Isrc/krb5 -I/opt/workspace/workspace/sles12/SOURCES/hue/build/env/include -I/opt/tools/python3/Python-3.8.13/include/python3.8 -c src/krb5/_ccache.c -o build/temp.linux-x86_64-cpython-38/src/krb5/_ccache.o
18:10:18 2024/07/23 01:10:18 INFO    :       gcc -pth\|read -shared build/temp.linux-x86_64-cpython-38/src/krb5/_ccache.o -L/opt/tools/python3/Python-3.8.13/lib -lkrb5 -lk5crypto -lcom_err -o build/lib.linux-x86_64-cpython-38/krb5/_ccache.cpython-38-x86_64-linux-gnu.so
18:10:18 2024/07/23 01:10:18 INFO    :       building 'krb5._ccache_mit' extension
18:10:18 2024/07/23 01:10:18 INFO    :       gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Isrc/krb5 -I/opt/workspace/workspace/sles12/SOURCES/hue/build/env/include -I/opt/tools/python3/Python-3.8.13/include/python3.8 -c src/krb5/_ccache_mit.c -o build/temp.linux-x86_64-cpython-38/src/krb5/_ccache_mit.o
18:10:18 2024/07/23 01:10:18 INFO    :       gcc -pthread -shared build/temp.linux-x86_64-cpython-38/src/krb5/_ccache_mit.o -L/opt/tools/python3/Python-3.8.13/lib -lkrb5 -lk5crypto -lcom_err -o build/lib.linux-x86_64-cpython-38/krb5/_ccache_mit.cpython-38-x86_64-linux-gnu.so
18:10:18 2024/07/23 01:10:18 INFO    :       building 'krb5._ccache_match' extension
18:10:18 2024/07/23 01:10:18 INFO    :       gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Isrc/krb5 -I/opt/workspace/workspace/sles12/SOURCES/hue/build/env/include -I/opt/tools/python3/Python-3.8.13/include/python3.8 -c src/krb5/_ccache_match.c -o build/temp.linux-x86_64-cpython-38/src/krb5/_ccache_match.o
18:10:18 2024/07/23 01:10:18 INFO    :       gcc -pthread -shared build/temp.linux-x86_64-cpython-38/src/krb5/_ccache_match.o -L/opt/tools/python3/Python-3.8.13/lib -lkrb5 -lk5crypto -lcom_err -o build/lib.linux-x86_64-cpython-38/krb5/_ccache_match.cpython-38-x86_64-linux-gnu.so
18:10:18 2024/07/23 01:10:18 INFO    :       building 'krb5._ccache_support_switch' extension
18:10:18 2024/07/23 01:10:18 INFO    :       gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Isrc/krb5 -I/opt/workspace/workspace/sles12/SOURCES/hue/build/env/include -I/opt/tools/python3/Python-3.8.13/include/python3.8 -c src/krb5/_ccache_support_switch.c -o build/temp.linux-x86_64-cpython-38/src/krb5/_ccache_support_switch.o
18:10:18 2024/07/23 01:10:18 INFO    :       gcc -pthread -shared build/temp.linux-x86_64-cpython-38/src/krb5/_ccache_support_switch.o -L/opt/tools/python3/Python-3.8.13/lib -lkrb5 -lk5crypto -lcom_err -o build/lib.linux-x86_64-cpython-38/krb5/_ccache_support_switch.cpython-38-x86_64-linux-gnu.so
18:10:18 2024/07/23 01:10:18 INFO    :       building 'krb5._cccol' extension
18:10:18 2024/07/23 01:10:18 INFO    :       gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Isrc/krb5 -I/opt/workspace/workspace/sles12/SOURCES/hue/build/env/include -I/opt/tools/python3/Python-3.8.13/include/python3.8 -c src/krb5/_cccol.c -o build/temp.linux-x86_64-cpython-38/src/krb5/_cccol.o
18:10:18 2024/07/23 01:10:18 INFO    :       gcc -pthread -shared build/temp.linux-x86_64-cpython-38/src/krb5/_cccol.o -L/opt/tools/python3/Python-3.8.13/lib -lkrb5 -lk5crypto -lcom_err -o build/lib.linux-x86_64-cpython-38/krb5/_cccol.cpython-38-x86_64-linux-gnu.so
18:10:18 2024/07/23 01:10:18 INFO    :       building 'krb5._context' extension
18:10:18 2024/07/23 01:10:18 INFO    :       gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Isrc/krb5 -I/opt/workspace/workspace/sles12/SOURCES/hue/build/env/include -I/opt/tools/python3/Python-3.8.13/include/python3.8 -c src/krb5/_context.c -o build/temp.linux-x86_64-cpython-38/src/krb5/_context.o
18:10:18 2024/07/23 01:10:18 INFO    :       gcc -pthread -shared build/temp.linux-x86_64-cpython-38/src/krb5/_context.o -L/opt/tools/python3/Python-3.8.13/lib -lkrb5 -lk5crypto -lcom_err -o build/lib.linux-x86_64-cpython-38/krb5/_context.cpython-38-x86_64-linux-gnu.so
18:10:18 2024/07/23 01:10:18 INFO    :       building 'krb5._context_mit' extension
18:10:18 2024/07/23 01:10:18 INFO    :       gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Isrc/krb5 -I/opt/workspace/workspace/sles12/SOURCES/hue/build/env/include -I/opt/tools/python3/Python-3.8.13/include/python3.8 -c src/krb5/_context_mit.c -o build/temp.linux-x86_64-cpython-38/src/krb5/_context_mit.o
18:10:18 2024/07/23 01:10:18 INFO    :       gcc -pthread -shared build/temp.linux-x86_64-cpython-38/src/krb5/_context_mit.o -L/opt/tools/python3/Python-3.8.13/lib -lkrb5 -lk5crypto -lcom_err -o build/lib.linux-x86_64-cpython-38/krb5/_context_mit.cpython-38-x86_64-linux-gnu.so
18:10:18 2024/07/23 01:10:18 INFO    :       building 'krb5._creds' extension
18:10:18 2024/07/23 01:10:18 INFO    :       gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Isrc/krb5 -I/opt/workspace/workspace/sles12/SOURCES/hue/build/env/include -I/opt/tools/python3/Python-3.8.13/include/python3.8 -c src/krb5/_creds.c -o build/temp.linux-x86_64-cpython-38/src/krb5/_creds.o
18:10:18 2024/07/23 01:10:18 INFO    :       src/krb5/_creds.c: In function ‘pykrb5_creds_get’:
18:10:18 2024/07/23 01:10:18 INFO    :       src/krb5/_creds.c:1314:13: error: ‘for’ loop initial declarations are only allowed in C99 mode
18:10:18 2024/07/23 01:10:18 INFO    :                    for (int i = 0; i < 32; i++) {
18:10:18 2024/07/23 01:10:18 INFO    :                    ^
18:10:18 2024/07/23 01:10:18 INFO    :       src/krb5/_creds.c:1314:13: note: use option -std=c99 or -std=gnu99 to compile your code
18:10:18 2024/07/23 01:10:18 INFO    :       error: command '/usr/bin/gcc' failed with exit code 1
18:10:18 2024/07/23 01:10:18 INFO    :       [end of output]
18:10:18 2024/07/23 01:10:18 INFO    : 
18:10:18 2024/07/23 01:10:18 INFO    :   note: This error originates from a subprocess, and is likely not a problem with pip.
18:10:18 2024/07/23 01:10:18 INFO    :   ERROR: Failed building wheel for krb5 
```

## How was this patch tested?

buid test

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
