### PR TITLE
[ci] Setup node v20 correctly for py3 checks

### DIFF
--- a/.github/workflows/commitflow-py3.yml
+++ b/.github/workflows/commitflow-py3.yml
@@ -32,7 +32,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache pip
-      uses: actions/cache@v4 
+      uses: actions/cache@v4
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
@@ -41,11 +41,16 @@ jobs:
           ${{ runner.os }}-pip-
           ${{ runner.os }}-
 
+    - name: Setup node 20 and cache npm
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'npm'
+
     - name: compile
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc g++ build-essential python${{ matrix.python-version }}-dev python${{ matrix.python-version }}-venv python${{ matrix.python-version }}-distutils asciidoc rsync curl sudo libkrb5-dev libldap2-dev libsasl2-dev libxml2-dev libxslt-dev  libsasl2-modules-gssapi-mit libsnappy-dev libffi-dev # This should not be needed as some point
-        sudo curl -sL https://deb.nodesource.com/setup_20.x | sudo bash - && sudo apt-get install -y nodejs
         sudo curl -sL https://bootstrap.pypa.io/get-pip.py | sudo python${{ matrix.python-version }}
         sudo apt-get install -y python3-setuptools
         sudo apt-get install -y libncursesw5-dev libgdbm-dev libc6-dev libssl-dev openssl


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Earlier, the node version in ubuntu was defaulting to v18 even after explicitly installing node v20.
- Using the dedication action simplifies it and makes sure node v20 is correctly installed.

## How was this patch tested?

- By validating all checks are passing and checking node version in py3 CI logs