### PR TITLE
[Python3.11] Upgrade libs to support python3.11 with backward compatibility

### DIFF
--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -63,7 +63,7 @@ krb5==0.5.1  # pinned for Sles12, dep of requests-kerberos 0.14.0
 rsa==4.7.2
 ruff==0.4.2
 sasl==0.3.1  # Move to https://pypi.org/project/sasl3/ ?
-slack-sdk==3.2.0
+slack-sdk==3.31.0
 SQLAlchemy==1.3.8
 sqlparse==0.5.0
 tablib==0.13.0

--- a/desktop/core/requirements.txt
+++ b/desktop/core/requirements.txt
@@ -1,6 +1,6 @@
 cryptography==42.0.8
-numpy==1.23.1
-pandas==1.4.2
+numpy==1.24.4
+pandas==2.0.3
 lxml==4.9.1
 -r ${ROOT}/desktop/core/base_requirements.txt
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Upgrading the libraries to support the python 3.11.
- slack-sdk 3.2.0 -> 3.31.0
- pandas 1.4.2 -> 2.0.3
- numpy 1.23.1 ->1.24.4


## How was this patch tested?

- Locally
- CI
