### PR TITLE
[ui-core] Add the copy action to the context menu on the documents page and left assist

### DIFF
--- a/desktop/core/src/desktop/js/ko/components/assist/ko.assistDocumentsPanel.js
+++ b/desktop/core/src/desktop/js/ko/components/assist/ko.assistDocumentsPanel.js
@@ -42,10 +42,13 @@ const TEMPLATE = `
       'Show details'
     )}</a></li>
     <li><a href="javascript: void(0);" data-bind="click: open"><i class="fa fa-fw fa-edit"></i> ${I18n(
-      'Open document'
+      'Open'
+    )}</a></li>
+    <li><a href="javascript: void(0);" data-bind="click: function() { $data.selected(true); $data.parent.copy() }"><i class="fa fa-fw fa-files-o"></i> ${I18n(
+  'Copy'
     )}</a></li>
     <li><a href="javascript: void(0);" data-bind="click: function() { $data.selected(true); huePubSub.publish('doc.show.delete.modal', $data.parent); }"><i class="fa fa-fw fa-trash-o"></i> ${I18n(
-      'Delete document'
+      'Delete'
     )}</a></li>
     <!-- /ko -->
     <!-- ko if: $containerContext.sharingEnabled -->

--- a/desktop/core/src/desktop/templates/document_browser.mako
+++ b/desktop/core/src/desktop/templates/document_browser.mako
@@ -297,6 +297,9 @@ else:
                 <li data-bind="css: { 'disabled': $parent.selectedEntries().length !== 1 }"><a href="javascript:void(0);" data-bind="click: showRenameDirectoryModal, css: { 'disabled': $parent.selectedEntries().length !== 1 }"><i class="fa fa-fw fa-edit"></i> ${ _('Rename') }</a></li>
                 <!-- /ko -->
                 <li data-bind="css: { 'disabled': $parent.selectedEntries().length !== 1 }"><a href="javascript:void(0);" data-bind="click: open, css: { 'disabled': $parent.selectedEntries().length !== 1 }"><i class="fa fa-fw fa-file-o"></i> ${ _('Open') }</a></li>
+                <li data-bind="css: { 'disabled': isDirectory() || isTrashed() }">
+                  <a href="javascript:void(0);" data-bind="click: function () { $parent.copy()  }, css: { 'disabled': isDirectory() || isTrashed() }"><i class="fa fa-fw fa-files-o"></i> ${_('Copy')} <span data-bind="visible: $parent.selectedEntries().length > 1, text: '(' + $parent.selectedEntries().length + ')'"></span></a>
+                </li>
                 <li><a href="javascript:void(0);" data-bind="click: contextMenuDownload"><i class="fa fa-fw fa-download"></i> ${ _('Download') } <span data-bind="visible: $parent.selectedEntries().length > 1, text: '(' + $parent.selectedEntries().length + ')'"></span></a></li>
                 <li data-bind="css: { 'disabled' : $parent.sharedWithMeSelected()  && ! $parent.superuser }"><a href="javascript:void(0);" data-bind="click: function () { huePubSub.publish('doc.show.delete.modal', $parent); }, css: { 'disabled' : $parent.sharedWithMeSelected() && ! $parent.superuser }">
                   <i class="fa fa-fw fa-times"></i> ${ _('Move to trash') } <span data-bind="visible: $parent.selectedEntries().length > 1, text: '(' + $parent.selectedEntries().length + ')'"></span></a>


### PR DESCRIPTION
This adds the copy action for Hue documents to the right-click context menu in the left assist panel and the documents page.

Manually tested