### PR TITLE
[api] Add /get_trash_path public API

### DIFF
--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -212,6 +212,25 @@ def rmtree(request):
 
 
 @error_handler
+def get_trash_path(request):
+  path = _normalize_path(request.GET.get('path'))
+  response = {}
+
+  trash_path = request.fs.trash_path(path)
+  user_home_trash_path = request.fs.join(request.fs.current_trash_path(trash_path), request.user.get_home_directory().lstrip())
+
+  if request.fs.isdir(user_home_trash_path):
+    response['trash_path'] = user_home_trash_path
+  elif request.fs.isdir(trash_path):
+    response['trash_path'] = trash_path
+  else:
+    response['message'] = _('Trash path not found: The requested trash path for user does not exist.')
+    return JsonResponse(response, status=404)
+
+  return JsonResponse(response)
+
+
+@error_handler
 def trash_restore(request):
   path = request.POST.get('path')
   request.fs.restore(path)

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -217,7 +217,7 @@ def get_trash_path(request):
   response = {}
 
   trash_path = request.fs.trash_path(path)
-  user_home_trash_path = request.fs.join(request.fs.current_trash_path(trash_path), request.user.get_home_directory().lstrip())
+  user_home_trash_path = request.fs.join(request.fs.current_trash_path(trash_path), request.user.get_home_directory().lstrip('/'))
 
   if request.fs.isdir(user_home_trash_path):
     response['trash_path'] = user_home_trash_path

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -281,6 +281,12 @@ def storage_rmtree(request):
   return filebrowser_api.rmtree(django_request)
 
 
+@api_view(["GET"])
+def storage_get_trash_path(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.get_trash_path(django_request)
+
+
 @api_view(["POST"])
 def storage_trash_restore(request):
   django_request = get_django_request(request)

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -106,6 +106,7 @@ urlpatterns += [
   re_path(r'^storage/copy$', api_public.storage_copy, name='storage_copy'),
   re_path(r'^storage/set_replication$', api_public.storage_set_replication, name='storage_set_replication'),
   re_path(r'^storage/rmtree$', api_public.storage_rmtree, name='storage_rmtree'),
+  re_path(r'^storage/trash/get_trash_path$', api_public.storage_get_trash_path, name='storage_get_trash_path'),
   re_path(r'^storage/trash/restore$', api_public.storage_trash_restore, name='storage_trash_restore'),
   re_path(r'^storage/trash/purge$', api_public.storage_trash_purge, name='storage_trash_purge'),
 ]

--- a/desktop/core/src/desktop/lib/fs/proxyfs.py
+++ b/desktop/core/src/desktop/lib/fs/proxyfs.py
@@ -200,6 +200,9 @@ class ProxyFS(object):
   def get_content_summary(self, path):
     return self._get_fs(path).get_content_summary(path)
 
+  def trash_path(self, path):
+    return self._get_fs(path).trash_path(path)
+
   def create_home_dir(self, home_path=None):
     """
     Initially home_path will have path value for HDFS, try creating the user home dir for it first.


### PR DESCRIPTION
## What changes were proposed in this pull request?

- There was no API for getting trash path per user.
- Earlier, we were depending on a redirect from backend to the trash path but now having a dedicated API for trash path makes sense for revamping the filebrowser UX.
- This API is mainly for HDFS for now because other supported filesystems dont have a clear trash use-case concept in Hue.

## How was this patch tested?

- Manually