### PR TITLE
[core] Bump up celery to 5.4.0 and django-celery-beat to 2.6.0

### DIFF
--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -3,7 +3,7 @@ requests-gssapi==1.2.3
 asn1crypto==0.24.0
 avro-python3==1.8.2
 Babel==2.9.1
-celery[redis]==5.2.7
+celery[redis]==5.4.0
 cffi==1.15.0
 channels==3.0.3
 channels-redis==3.2.0
@@ -13,7 +13,7 @@ django-auth-ldap==4.3.0
 Django==3.2.25
 daphne==3.0.2
 django-redis==5.4.0
-django-celery-beat==2.5.0
+django-celery-beat==2.6.0
 django-celery-results==2.5.1
 django-cors-headers==3.7.0
 django-crequest==2018.5.11


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade celery to 5.4.0 and django-celery-beat to 2.6.0

## How was this patch tested?

bug blitz

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
