### PR TITLE
[ui-metrics-cuix] Updating metrics to sync with Cloudera design

### DIFF
--- a/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.scss
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.scss
@@ -22,10 +22,7 @@
 
   .metrics-heading {
     color: $fluidx-gray-700;
-    padding-left: $font-size-lg;
     font-size: $fluidx-heading-h4-size;
-    line-height: $fluidx-heading-h4-line-height;
-    font-weight: $fluidx-heading-h4-weight;
   }
 
   .metrics-filter {
@@ -38,8 +35,11 @@
     }
   }
 
-  .metrics-table th {
-    width: 30%;
+  .metrics-table {
+    th {
+      width: 30%;
+    }
+    margin-bottom: $font-size-base;
   }
 
   .metrics-select {

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.scss
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.scss
@@ -39,7 +39,6 @@
     th {
       width: 30%;
     }
-
     margin-bottom: $font-size-base;
   }
 

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.scss
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.scss
@@ -16,13 +16,14 @@
 
 @import '../../components/styles/variables';
 
-.metrics-component {
+.metrics-component.antd.cuix {
   background-color: $fluidx-gray-100;
   padding: 0 24px 24px 24px;
 
   .metrics-heading {
-    color: $fluidx-gray-700;
-    font-size: $fluidx-heading-h4-size;
+    font-size: $font-size-base;
+    font-weight: 500;
+    color: $fluidx-gray-900;
   }
 
   .metrics-filter {
@@ -38,7 +39,9 @@
   .metrics-table {
     th {
       width: 30%;
+      background-color: #fafbfc;
     }
+
     margin-bottom: $font-size-base;
   }
 

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.scss
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.scss
@@ -39,7 +39,7 @@
   .metrics-table {
     th {
       width: 30%;
-      background-color: $cdl-gray-040;
+      background-color: $fluidx-gray-040;
     }
 
     margin-bottom: $font-size-base;

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.scss
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.scss
@@ -39,6 +39,7 @@
     th {
       width: 30%;
     }
+
     margin-bottom: $font-size-base;
   }
 

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.scss
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.scss
@@ -39,7 +39,7 @@
   .metrics-table {
     th {
       width: 30%;
-      background-color: #fafbfc;
+      background-color: $cdl-gray-040;
     }
 
     margin-bottom: $font-size-base;

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.test.tsx
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.test.tsx
@@ -89,7 +89,10 @@ describe('Metrics', () => {
     if (secondOption) {
       fireEvent.click(secondOption);
       await waitFor(() => {
-        const headings = screen.queryAllByRole('heading', { level: 4 });
+        // const headings = screen.queryAllByRole('heading', { level: 4 });
+        const headings = screen.queryAllByText((_, element) => 
+          element?.tagName.toLowerCase() === 'span' && element?.className === 'metrics-heading'
+        );
         expect(headings).toHaveLength(1);
       });
     }

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.test.tsx
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.test.tsx
@@ -90,8 +90,9 @@ describe('Metrics', () => {
       fireEvent.click(secondOption);
       await waitFor(() => {
         // const headings = screen.queryAllByRole('heading', { level: 4 });
-        const headings = screen.queryAllByText((_, element) => 
-          element?.tagName.toLowerCase() === 'span' && element?.className === 'metrics-heading'
+        const headings = screen.queryAllByText(
+          (_, element) =>
+            element?.tagName.toLowerCase() === 'span' && element?.className === 'metrics-heading'
         );
         expect(headings).toHaveLength(1);
       });

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.tsx
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.tsx
@@ -111,7 +111,7 @@ const Metrics: React.FC = (): JSX.Element => {
 
             <Input
               className="metrics-filter"
-              placeholder={I18n("Filter metrics...")}
+              placeholder={I18n('Filter metrics...')}
               value={searchQuery}
               onChange={handleFilterInputChange}
               prefix={<SearchOutlined />}

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.tsx
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.tsx
@@ -19,6 +19,7 @@ import MetricsTable, { MetricsResponse } from './MetricsTable';
 import { Spin, Input, Select, Alert } from 'antd';
 import { get } from 'api/utils';
 import { SearchOutlined } from '@ant-design/icons';
+import I18n from 'utils/i18n';
 import './Metrics.scss';
 
 const { Option } = Select;
@@ -110,7 +111,7 @@ const Metrics: React.FC = (): JSX.Element => {
 
             <Input
               className="metrics-filter"
-              placeholder="Filter metrics..."
+              placeholder={I18n("Filter metrics...")}
               value={searchQuery}
               onChange={handleFilterInputChange}
               prefix={<SearchOutlined />}

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.tsx
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.tsx
@@ -19,7 +19,7 @@ import MetricsTable, { MetricsResponse } from './MetricsTable';
 import { Spin, Input, Select, Alert } from 'antd';
 import { get } from 'api/utils';
 import { SearchOutlined } from '@ant-design/icons';
-import { i18nReact } from 'utils/i18nReact';
+import { i18nReact } from '../../../utils/i18nReact';
 import './Metrics.scss';
 
 const { Option } = Select;

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.tsx
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.tsx
@@ -19,7 +19,7 @@ import MetricsTable, { MetricsResponse } from './MetricsTable';
 import { Spin, Input, Select, Alert } from 'antd';
 import { get } from 'api/utils';
 import { SearchOutlined } from '@ant-design/icons';
-import I18n from 'utils/i18n';
+import { i18nReact } from 'utils/i18nReact';
 import './Metrics.scss';
 
 const { Option } = Select;
@@ -87,6 +87,8 @@ const Metrics: React.FC = (): JSX.Element => {
     setSearchQuery(e.target.value);
   };
 
+  const { t } = i18nReact.useTranslation();
+
   return (
     <div className="cuix antd metrics-component">
       <Spin spinning={loading}>
@@ -111,7 +113,7 @@ const Metrics: React.FC = (): JSX.Element => {
 
             <Input
               className="metrics-filter"
-              placeholder={I18n('Filter metrics...')}
+              placeholder={t('Filter metrics...')}
               value={searchQuery}
               onChange={handleFilterInputChange}
               prefix={<SearchOutlined />}

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.tsx
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.tsx
@@ -15,9 +15,9 @@
 // limitations under the License.
 
 import React, { useState, useEffect, useRef } from 'react';
-import MetricsTable, { MetricsResponse } from './MetricsTable';
+import MetricsTable, { MetricsResponse, MetricsTableProps } from './MetricsTable';
 import { Spin, Input, Select, Alert } from 'antd';
-import { get } from 'api/utils';
+import { get } from '../../../api/utils';
 import { SearchOutlined } from '@ant-design/icons';
 import { i18nReact } from '../../../utils/i18nReact';
 import './Metrics.scss';
@@ -32,7 +32,7 @@ const Metrics: React.FC = (): JSX.Element => {
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [selectedMetric, setSelectedMetric] = useState<string>('');
   const [showAllTables, setShowAllTables] = useState(true);
-  const [filteredMetricsData, setFilteredMetricsData] = useState<MetricsData[]>([]);
+  const [filteredMetricsData, setFilteredMetricsData] = useState<MetricsTableProps[]>([]);
   const dropdownRef = useRef(null);
 
   useEffect(() => {

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.tsx
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.tsx
@@ -91,14 +91,6 @@ const Metrics: React.FC = (): JSX.Element => {
       <Spin spinning={loading}>
         {!error && (
           <>
-            <Input
-              className="metrics-filter"
-              placeholder="Filter metrics..."
-              value={searchQuery}
-              onChange={handleFilterInputChange}
-              prefix={<SearchOutlined />}
-            />
-
             <Select
               className="metrics-select"
               //to make sure antd class gets applied
@@ -115,6 +107,14 @@ const Metrics: React.FC = (): JSX.Element => {
                 </Option>
               ))}
             </Select>
+
+            <Input
+              className="metrics-filter"
+              placeholder="Filter metrics..."
+              value={searchQuery}
+              onChange={handleFilterInputChange}
+              prefix={<SearchOutlined />}
+            />
           </>
         )}
 

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/MetricsTable.tsx
@@ -14,13 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import Table from 'cuix/dist/components/Table/Table';
 import type { ColumnType } from 'antd/es/table';
 import './Metrics.scss';
 import { i18nReact } from '../../../utils/i18nReact';
-
-const { t } = i18nReact.useTranslation();
 
 interface MetricsValue {
   value: number;
@@ -80,52 +78,54 @@ interface MetricsTableProps {
   caption: string;
   dataSource: DataSourceItem[];
 }
+
 const metricLabels: { [key: string]: string } = {
-  'queries.number': t('Number of Queries'),
-  'requests.active': t('Active Requests'),
-  'requests.exceptions': t('Request Exceptions'),
-  'requests.response-time': t('Request Response Time'),
-  'threads.daemon': t('Daemon Threads'),
-  'threads.total': t('Total Threads'),
-  users: t('Users'),
-  'users.active': t('Active Users'),
-  'users.active.total': t('Total Active Users')
+  'queries.number': 'Number of Queries',
+  'requests.active': 'Active Requests',
+  'requests.exceptions': 'Request Exceptions',
+  'requests.response-time': 'Request Response Time',
+  'threads.daemon': 'Daemon Threads',
+  'threads.total': 'Total Threads',
+  users: 'Users',
+  'users.active': 'Active Users',
+  'users.active.total': 'Total Active Users'
 };
 
-const transformMetricNames = (dataSource: DataSourceItem[]): DataSourceItem[] =>
-  dataSource.map(item => ({
-    ...item,
-    name: metricLabels[item.name] || item.name
-  }));
+const metricsColumns: ColumnType<DataSourceItem>[] = [
+  {
+    title: 'Name',
+    dataIndex: 'name',
+    key: 'name'
+  },
+  {
+    title: 'Value',
+    dataIndex: 'value',
+    key: 'value',
+    render: value => (typeof value === 'number' ? value : JSON.stringify(value))
+  }
+];
 
 const MetricsTable: React.FC<MetricsTableProps> = ({ caption, dataSource }) => {
-  const transformedDataSource = transformMetricNames(dataSource);
+  const { t } = i18nReact.useTranslation();
 
-  const metricsColumns: ColumnType<DataSourceItem>[] = [
-    {
-      title: 'Name',
-      dataIndex: 'name',
-      key: 'name'
-    },
-    {
-      title: 'Value',
-      dataIndex: 'value',
-      key: 'value',
-      render: value => (typeof value === 'number' ? value : JSON.stringify(value))
-    }
-  ];
+  const transformedDataSource: DataSourceItem[] = useMemo(
+    () =>
+      dataSource.map(item => ({
+        ...item,
+        name: t(metricLabels[item.name]) || item.name
+      })),
+    [dataSource]
+  );
 
   return (
-    <>
-      <Table
-        className="metrics-table"
-        dataSource={transformedDataSource}
-        rowKey="name"
-        columns={metricsColumns}
-        pagination={false}
-        title={() => <span className="metrics-heading">{caption}</span>}
-      />
-    </>
+    <Table
+      className="metrics-table"
+      dataSource={transformedDataSource}
+      rowKey="name"
+      columns={metricsColumns}
+      pagination={false}
+      title={() => <span className="metrics-heading">{caption}</span>}
+    />
   );
 };
 

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/MetricsTable.tsx
@@ -74,7 +74,7 @@ interface DataSourceItem {
   value: number | MetricsTime;
 }
 
-interface MetricsTableProps {
+export interface MetricsTableProps {
   caption: string;
   dataSource: DataSourceItem[];
 }

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/MetricsTable.tsx
@@ -115,13 +115,14 @@ const MetricsTable: React.FC<MetricsTableProps> = ({ caption, dataSource }) => {
 
   return (
     <>
-      <h4 className="metrics-heading">{caption}</h4>
       <Table
         className="metrics-table"
         dataSource={transformedDataSource}
         rowKey="name"
         columns={metricsColumns}
         pagination={false}
+        title={() => <h4 className="metrics-heading">{caption}</h4>}
+        bordered
       />
     </>
   );

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/MetricsTable.tsx
@@ -121,7 +121,7 @@ const MetricsTable: React.FC<MetricsTableProps> = ({ caption, dataSource }) => {
         rowKey="name"
         columns={metricsColumns}
         pagination={false}
-        title={() => <h4 className="metrics-heading">{caption}</h4>}
+        title={() => <span className="metrics-heading">{caption}</span>}
       />
     </>
   );

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/MetricsTable.tsx
@@ -18,7 +18,9 @@ import React from 'react';
 import Table from 'cuix/dist/components/Table/Table';
 import type { ColumnType } from 'antd/es/table';
 import './Metrics.scss';
-import I18n from 'utils/i18n';
+import { i18nReact } from 'utils/i18nReact';
+
+const { t } = i18nReact.useTranslation();
 
 interface MetricsValue {
   value: number;
@@ -79,15 +81,15 @@ interface MetricsTableProps {
   dataSource: DataSourceItem[];
 }
 const metricLabels: { [key: string]: string } = {
-  'queries.number': I18n('Number of Queries'),
-  'requests.active': I18n('Active Requests'),
-  'requests.exceptions': I18n('Request Exceptions'),
-  'requests.response-time': I18n('Request Response Time'),
-  'threads.daemon': I18n('Daemon Threads'),
-  'threads.total': I18n('Total Threads'),
-  users: I18n('Users'),
-  'users.active': I18n('Active Users'),
-  'users.active.total': I18n('Total Active Users')
+  'queries.number': t('Number of Queries'),
+  'requests.active': t('Active Requests'),
+  'requests.exceptions': t('Request Exceptions'),
+  'requests.response-time': t('Request Response Time'),
+  'threads.daemon': t('Daemon Threads'),
+  'threads.total': t('Total Threads'),
+  users: t('Users'),
+  'users.active': t('Active Users'),
+  'users.active.total': t('Total Active Users')
 };
 
 const transformMetricNames = (dataSource: DataSourceItem[]): DataSourceItem[] =>

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/MetricsTable.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import Table from 'cuix/dist/components/Table/Table';
 import type { ColumnType } from 'antd/es/table';
 import './Metrics.scss';
-import { i18nReact } from 'utils/i18nReact';
+import { i18nReact } from '../../../utils/i18nReact';
 
 const { t } = i18nReact.useTranslation();
 

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/MetricsTable.tsx
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/MetricsTable.tsx
@@ -122,7 +122,6 @@ const MetricsTable: React.FC<MetricsTableProps> = ({ caption, dataSource }) => {
         columns={metricsColumns}
         pagination={false}
         title={() => <h4 className="metrics-heading">{caption}</h4>}
-        bordered
       />
     </>
   );


### PR DESCRIPTION
## What changes were proposed in this pull request?
Metrics page wasn't exactly synced with Cloudera design. This PR ensures consistency of the metrics page. Mainly exchanging the positions of dropDown and filter & getting the headings (captions) of each small table within the table (leading to make changes in the test as well) with some changed style of the headings.
The Metrics page is now with sync in Cloudera design. UseMemo has been introduced in the code to be able to cache the result of a function, so that it can be returned again without re-computation.
PR has some basic updations in the metrics code to make it more readable and trying to use the best coding practices.

Original PR of updating metrics: https://github.com/cloudera/hue/pull/3707
Additional metrics PR: https://github.com/cloudera/hue/pull/3761

## How was this patch tested?
Sanity check of the metrics page

Old metrics page:

<img width="1194" alt="Screenshot 2024-08-22 at 6 49 57 PM" src="https://github.com/user-attachments/assets/cb969706-6653-42ca-80f7-5ae07434b833">


Updated metrics page images:

<img width="1195" alt="Screenshot 2024-08-31 at 3 21 03 PM" src="https://github.com/user-attachments/assets/15cec6ab-8da5-4d10-a763-f96badbedb35">
<img width="1728" alt="Screenshot 2024-08-31 at 3 19 15 PM" src="https://github.com/user-attachments/assets/c0828a0e-cfc9-4dd5-a964-e3c3337f53c2">

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
