### PR TITLE
Middleware to switch the upload handler and use HDFSfileUploadHandler for document upload

### DIFF
--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -162,6 +162,7 @@ MIDDLEWARE = [
     'desktop.middleware.ExceptionMiddleware',
     'desktop.middleware.ClusterMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'desktop.middleware.CustomUploadHandlerMiddleware',
     'desktop.middleware.CacheControlMiddleware',
     'django.middleware.http.ConditionalGetMiddleware',
     # 'axes.middleware.FailedLoginMiddleware',
@@ -682,7 +683,7 @@ else:
   if is_ofs_enabled():
     file_upload_handlers.insert(0, 'desktop.lib.fs.ozone.upload.OFSFileUploadHandler')
 
-FILE_UPLOAD_HANDLERS = tuple(file_upload_handlers)
+FILE_UPLOAD_HANDLERS = file_upload_handlers
 
 ############################################################
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Middleware to switch the upload handler and use HDFSfileUploadHandler for document upload. When the `chunked_file_uploader` and `task_server` config is enabled, the document uploads tries to use `FineUploaderChunkedUploadHandler`. Since user's don't upload large files in document upload's page (small json files with saved queries are uploaded), the chunked_file_upload implementation isn't needed. So adding a middleware to switch the upload handler in Documents upload page to `HDFSfileUploadHandler` even when the HDFS, S3, Azure FS might use the `FineUploaderChunkedUploadHandler`. 

## How was this patch tested?

Tested on mac, docker based system. Tested uploading a document concurrently during HDFS, S3, Azure file uploads. 

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
