### PR TITLE
[api] Refactor old filebrowser methods to new public APIs

### DIFF
--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -826,7 +826,7 @@ def bulk_op(request, op):
   for p in path_list:
 
     tmp_dict = bulk_dict
-    if op in (copy, move):  # TODO: Check if chmod is also special case for permissions to calculate mode
+    if op in (copy, move):
       tmp_dict['source_path'] = p
     else:
       tmp_dict['path'] = p

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -808,12 +808,3 @@ def get_available_space_for_upload(request):
     return HttpResponse(message, status=500)  # TODO: status code?
   finally:
     redis_client.close()
-
-
-@api_error_handler
-def reserve_space_for_upload(request):
-  pass
-
-@api_error_handler
-def release_reserved_space_for_upload(request):
-  pass

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -291,14 +291,16 @@ def listdir_paged(request):
   # shown_stats.insert(0, current_stat)
 
   # Include parent dir always as second option, unless at filesystem root or when RAZ is enabled.
-  if not (request.fs.isroot(path) or RAZ.IS_ENABLED.get()):
-    parent_path = request.fs.parent_path(path)
-    parent_stat = request.fs.stats(parent_path)
-    # The 'path' field would be absolute, but we want its basename to be
-    # actually '..' for display purposes. Encode it since _massage_stats expects byte strings.
-    parent_stat['path'] = parent_path
-    parent_stat['name'] = ".."
-    shown_stats.insert(0, parent_stat)
+  # TODO: Do stats call from UI side if required
+
+  # if not (request.fs.isroot(path) or RAZ.IS_ENABLED.get()):
+  #   parent_path = request.fs.parent_path(path)
+  #   parent_stat = request.fs.stats(parent_path)
+  #   # The 'path' field would be absolute, but we want its basename to be
+  #   # actually '..' for display purposes. Encode it since _massage_stats expects byte strings.
+  #   parent_stat['path'] = parent_path
+  #   parent_stat['name'] = ".."
+  #   shown_stats.insert(0, parent_stat)
 
   if page:
     # TODO: Check if we need to clean response of _massage_stats

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -864,6 +864,7 @@ def bulk_op(request, op):
   path_list = request.POST.getlist('dest_path_list') if op in ('copy', 'move') else request.POST.getlist('path_list')
   bulk_dict = request.POST.copy()
 
+  error_dict = {}
   for p in path_list:
     tmp_dict = bulk_dict
     if op in ('copy', 'move'):  # TODO: Check if chmod is also special case for permissions to calculate mode
@@ -874,7 +875,6 @@ def bulk_op(request, op):
     request.POST = tmp_dict
     response = op(request)
 
-    error_dict = {}
     if response.status_code != 200:
       error_dict[p] = {'error': response.content}
       if op == 'copy' and p.startswith('ofs://'):

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -101,6 +101,7 @@ def api_error_handler(view_fn):
   """
   Decorator to handle exceptions and return a JSON response with an error message.
   """
+
   def decorator(*args, **kwargs):
     try:
       return view_fn(*args, **kwargs)
@@ -303,33 +304,31 @@ def listdir_paged(request):
   is_fs_superuser = is_hdfs and _is_hdfs_superuser(request)
 
   response = {
-      # 'path': path,
-      # 'breadcrumbs': breadcrumbs,
-      # 'current_request_path': '/filebrowser/view=' + urllib_quote(path.encode('utf-8'), safe=SAFE_CHARACTERS_URI_COMPONENTS),
-      'is_trash_enabled': is_trash_enabled,
-      'files': page.object_list if page else [],
-      'page': _massage_page(page, paginator) if page else {},  # TODO: Check if we need to clean response of _massage_page
-      'pagesize': pagesize,
-      # 'home_directory': home_dir_path if home_dir_path and request.fs.isdir(home_dir_path) else None,
-      # 'descending': descending_param,
-
-      # The following should probably be deprecated
-      # TODO: Check what to keep or what to remove? or move some fields to /get_config?
-
-      'cwd_set': True,
-      'file_filter': 'any',
-      # 'current_dir_path': path,
-      'is_fs_superuser': is_fs_superuser,
-      'groups': is_fs_superuser and [str(x) for x in Group.objects.values_list('name', flat=True)] or [],
-      'users': is_fs_superuser and [str(x) for x in User.objects.values_list('username', flat=True)] or [],
-      'superuser': request.fs.superuser,
-      'supergroup': request.fs.supergroup,
-      # 'is_sentry_managed': request.fs.is_sentry_managed(path),
-      # 'apps': list(appmanager.get_apps_dict(request.user).keys()),
-      'show_download_button': SHOW_DOWNLOAD_BUTTON.get(),
-      'show_upload_button': SHOW_UPLOAD_BUTTON.get(),
-      # 'is_embeddable': request.GET.get('is_embeddable', False),
-      # 's3_listing_not_allowed': s3_listing_not_allowed
+    # 'path': path,
+    # 'breadcrumbs': breadcrumbs,
+    # 'current_request_path': '/filebrowser/view=' + urllib_quote(path.encode('utf-8'), safe=SAFE_CHARACTERS_URI_COMPONENTS),
+    'is_trash_enabled': is_trash_enabled,
+    'files': page.object_list if page else [],
+    'page': _massage_page(page, paginator) if page else {},  # TODO: Check if we need to clean response of _massage_page
+    'pagesize': pagesize,
+    # 'home_directory': home_dir_path if home_dir_path and request.fs.isdir(home_dir_path) else None,
+    # 'descending': descending_param,
+    # The following should probably be deprecated
+    # TODO: Check what to keep or what to remove? or move some fields to /get_config?
+    'cwd_set': True,
+    'file_filter': 'any',
+    # 'current_dir_path': path,
+    'is_fs_superuser': is_fs_superuser,
+    'groups': is_fs_superuser and [str(x) for x in Group.objects.values_list('name', flat=True)] or [],
+    'users': is_fs_superuser and [str(x) for x in User.objects.values_list('username', flat=True)] or [],
+    'superuser': request.fs.superuser,
+    'supergroup': request.fs.supergroup,
+    # 'is_sentry_managed': request.fs.is_sentry_managed(path),
+    # 'apps': list(appmanager.get_apps_dict(request.user).keys()),
+    'show_download_button': SHOW_DOWNLOAD_BUTTON.get(),
+    'show_upload_button': SHOW_UPLOAD_BUTTON.get(),
+    # 'is_embeddable': request.GET.get('is_embeddable', False),
+    # 's3_listing_not_allowed': s3_listing_not_allowed
   }
 
   return JsonResponse(response)
@@ -439,14 +438,14 @@ def display(request):
   # And add a view structure:
   # data["success"] = True
   data["view"] = {
-      'offset': offset,
-      'length': length,
-      'end': offset + len(contents),
-      # 'dirname': dirname,
-      'mode': mode,
-      'compression': compression,
-      # 'size': stats.size,
-      'max_chunk_size': str(MAX_CHUNK_SIZE_BYTES)
+    'offset': offset,
+    'length': length,
+    'end': offset + len(contents),
+    # 'dirname': dirname,
+    'mode': mode,
+    'compression': compression,
+    # 'size': stats.size,
+    'max_chunk_size': str(MAX_CHUNK_SIZE_BYTES),
   }
   # data["filename"] = os.path.basename(path)
   data["editable"] = stats.size < MAX_FILEEDITOR_SIZE  # TODO: To improve this limit and sent it as /get_config? Needs discussion.
@@ -544,88 +543,90 @@ def _upload_file(request):
     return HttpResponse(messsage, status=500)  # TODO: Check error messages above and status code
 
   # TODO: Check response fields below
-  response.update({
+  response.update(
+    {
       'path': filepath,
       'result': _massage_stats(request, stat_absolute_path(filepath, request.fs.stats(filepath))),
       # 'next': request.GET.get("next")
-  })
+    }
+  )
 
   return JsonResponse(response)
 
 
 @api_error_handler
 def mkdir(request):
-  path = request.POST.get('path')
-  name = request.POST.get('name')
+  path = request.PUT.get('path')
+  name = request.PUT.get('name')
 
   if name and (posixpath.sep in name or "#" in name):
-    raise Exception(_("Error creating %s directory. Slashes or hashes are not allowed in directory name." % name))
+    return HttpResponse(f"Error creating {name} directory. Slashes or hashes are not allowed in directory name.", status=400)
 
   request.fs.mkdir(request.fs.join(path, name))
-  return HttpResponse(status=200)
+  return HttpResponse(status=201)
 
 
 @api_error_handler
 def touch(request):
-  path = request.POST.get('path')
-  name = request.POST.get('name')
+  path = request.PUT.get('path')
+  name = request.PUT.get('name')
 
   if name and (posixpath.sep in name):
-    raise Exception(_("Error creating %s file. Slashes are not allowed in filename." % name))
+    return HttpResponse(f"Error creating {name} file: Slashes are not allowed in filename.", status=400)
 
   request.fs.create(request.fs.join(path, name))
-  return HttpResponse(status=200)
+  return HttpResponse(status=201)
 
 
 @api_error_handler
 def rename(request):
-  src_path = request.POST.get('src_path')
-  dest_path = request.POST.get('dest_path')
+  source_path = request.POST.get('source_path')
+  destination_path = request.POST.get('destination_path')
 
-  if "#" in dest_path:
-    raise Exception(
-      _("Error renaming %s to %s. Hashes are not allowed in file or directory names." % (os.path.basename(src_path), dest_path))
+  if "#" in destination_path:
+    return HttpResponse(
+      f"Error creating {os.path.basename(source_path)} to {destination_path}: Hashes are not allowed in file or directory names", status=400
     )
 
   # If dest_path doesn't have a directory specified, use same directory.
-  if "/" not in dest_path:
-    src_dir = os.path.dirname(src_path)
-    dest_path = request.fs.join(src_dir, dest_path)
+  if "/" not in destination_path:
+    source_dir = os.path.dirname(source_path)
+    destination_path = request.fs.join(source_dir, destination_path)
 
-  if request.fs.exists(dest_path):
-    raise Exception(_('The destination path "%s" already exists.') % dest_path)
+  if request.fs.exists(destination_path):
+    return HttpResponse(f"The destination path {destination_path} already exists.", status=500)  # TODO: Status code?
 
-  request.fs.rename(src_path, dest_path)
+  request.fs.rename(source_path, destination_path)
   return HttpResponse(status=200)
 
 
 @api_error_handler
 def move(request):
-  src_path = request.POST.get('src_path')
-  dest_path = request.POST.get('dest_path')
+  source_path = request.POST.get('source_path')
+  destination_path = request.POST.get('destination_path')
 
-  if src_path == dest_path:
-    raise Exception(_('Source and destination path cannot be same.'))
+  if source_path == destination_path:
+    return HttpResponse('Source and destination path cannot be same.', status=400)
 
-  request.fs.rename(src_path, dest_path)
+  request.fs.rename(source_path, destination_path)
   return HttpResponse(status=200)
 
 
 @api_error_handler
 def copy(request):
-  src_path = request.POST.get('src_path')
-  dest_path = request.POST.get('dest_path')
+  source_path = request.POST.get('source_path')
+  destination_path = request.POST.get('destination_path')
 
-  if src_path == dest_path:
-    raise Exception(_('Source and destination path cannot be same.'))
+  if source_path == destination_path:
+    return HttpResponse('Source and destination path cannot be same.', status=400)
 
   # Copy method for Ozone FS returns a string of skipped files if their size is greater than configured chunk size.
-  if src_path.startswith('ofs://'):
-    ofs_skip_files = request.fs.copy(src_path, dest_path, recursive=True, owner=request.user)
+  if source_path.startswith('ofs://'):
+    ofs_skip_files = request.fs.copy(source_path, destination_path, recursive=True, owner=request.user)
     if ofs_skip_files:
-      return HttpResponse(ofs_skip_files, status=200)
+      return JsonResponse(ofs_skip_files, status=200)
   else:
-    request.fs.copy(src_path, dest_path, recursive=True, owner=request.user)
+    request.fs.copy(source_path, destination_path, recursive=True, owner=request.user)
 
   return HttpResponse(status=200)
 

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -63,6 +63,7 @@ from filebrowser.views import (
 )
 from hadoop.core_site import get_trash_interval
 from hadoop.fs.exceptions import WebHdfsException
+from hadoop.fs.fsutils import do_overwrite_save
 from useradmin.models import Group, User
 
 LOG = logging.getLogger()
@@ -520,7 +521,7 @@ def _upload_file(request):
     return HttpResponse(request.META.get('upload_failed'), status=500)  # TODO: Check error message and status code
 
   uploaded_file = request.FILES['file']
-  dest_path = request.GET['destination_path']
+  dest_path = request.GET.get('destination_path')
 
   filepath = request.fs.join(dest_path, uploaded_file.name)
 
@@ -576,6 +577,34 @@ def touch(request):
 
   request.fs.create(request.fs.join(path, name))
   return HttpResponse(status=201)
+
+
+@api_error_handler
+def save_file(request):
+  """
+  The POST endpoint to save a file in the file editor.
+
+  Does the save and then redirects back to the edit page.
+  """
+  path = request.POST.get('path')
+  path = _normalize_path(path)
+
+  encoding = request.POST.get('encoding')
+  data = request.POST.get('contents').encode(encoding)
+
+  if not path:
+    return HttpResponse("Path parameter is required for saving the file.", status=400)
+
+  try:
+    if request.fs.exists(path):
+      do_overwrite_save(request.fs, path, data)
+    else:
+      request.fs.create(path, overwrite=False, data=data)
+  except Exception as e:
+    return HttpResponse(f"The file could not be saved: {str(e)}", status=500)  # TODO: Status code?
+
+  # TODO: Any response field required?
+  return HttpResponse(status=200)
 
 
 @api_error_handler

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -581,8 +581,8 @@ def save_file(request):
 
 @api_error_handler
 def rename(request):
-  source_path = request.POST.get('source_path')
-  destination_path = request.POST.get('destination_path')
+  source_path = request.POST.get('source_path', '')
+  destination_path = request.POST.get('destination_path', '')
 
   if "#" in destination_path:
     return HttpResponse(
@@ -603,8 +603,8 @@ def rename(request):
 
 @api_error_handler
 def move(request):
-  source_path = request.POST.get('source_path')
-  destination_path = request.POST.get('destination_path')
+  source_path = request.POST.get('source_path', '')
+  destination_path = request.POST.get('destination_path', '')
 
   if source_path == destination_path:
     return HttpResponse('Source and destination path cannot be same.', status=400)
@@ -615,8 +615,8 @@ def move(request):
 
 @api_error_handler
 def copy(request):
-  source_path = request.POST.get('source_path')
-  destination_path = request.POST.get('destination_path')
+  source_path = request.POST.get('source_path', '')
+  destination_path = request.POST.get('destination_path', '')
 
   if source_path == destination_path:
     return HttpResponse('Source and destination path cannot be same.', status=400)

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -451,7 +451,7 @@ def display(request):
   # data["filename"] = os.path.basename(path)
   data["editable"] = stats.size < MAX_FILEEDITOR_SIZE  # TODO: To improve this limit and sent it as /get_config? Needs discussion.
 
-  # TODO: Understand the comment. Then check why are we logging file content? Then also check how is masked_binary_data used? Finally improve code.
+  # TODO: Understand the comment. Check why are we logging file content? Also check how is masked_binary_data used? Finally improve code.
   if mode == "binary":
     # This might be the wrong thing for ?format=json; doing the
     # xxd'ing in javascript might be more compact, or sending a less

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -17,20 +17,25 @@
 
 import os
 import logging
+import operator
 import mimetypes
 import posixpath
 
+from django.core.paginator import EmptyPage, InvalidPage, Page, Paginator
 from django.http import HttpResponse, HttpResponseNotModified, HttpResponseRedirect, StreamingHttpResponse
 from django.utils.http import http_date
 from django.utils.translation import gettext as _
 from django.views.static import was_modified_since
 
-from aws.s3.s3fs import get_s3_home_directory
+from aws.s3.s3fs import S3FileSystemException, S3ListAllBucketsException, get_s3_home_directory
 from azure.abfs.__init__ import get_abfs_home_directory
-from desktop.lib import fsmanager
+from desktop.auth.backend import is_admin
+from desktop.conf import ENABLE_NEW_STORAGE_BROWSER, RAZ, TASK_SERVER_V2
+from desktop.lib import fsmanager, i18n
+from desktop.lib.conf import coerce_bool
 from desktop.lib.django_util import JsonResponse
 from desktop.lib.export_csvxls import file_reader
-from desktop.lib.fs.gc.gs import get_gs_home_directory
+from desktop.lib.fs.gc.gs import GSListAllBucketsException, get_gs_home_directory
 from desktop.lib.fs.ozone.ofs import get_ofs_home_directory
 from filebrowser.conf import (
   ARCHIVE_UPLOAD_TEMPDIR,
@@ -41,10 +46,24 @@ from filebrowser.conf import (
   SHOW_DOWNLOAD_BUTTON,
   SHOW_UPLOAD_BUTTON,
 )
-from filebrowser.views import _can_inline_display, _normalize_path
+from filebrowser.lib import xxd
+from filebrowser.views import (
+  BYTES_PER_LINE,
+  BYTES_PER_SENTENCE,
+  DEFAULT_CHUNK_SIZE_BYTES,
+  MAX_CHUNK_SIZE_BYTES,
+  MAX_FILEEDITOR_SIZE,
+  _can_inline_display,
+  _is_hdfs_superuser,
+  _massage_page,
+  _massage_stats,
+  _normalize_path,
+  read_contents,
+  stat_absolute_path,
+)
+from hadoop.core_site import get_trash_interval
 from hadoop.fs.exceptions import WebHdfsException
-from desktop.lib.i18n import smart_str
-from filebrowser.views import _normalize_path
+from useradmin.models import Group, User
 
 LOG = logging.getLogger()
 
@@ -77,6 +96,7 @@ def get_filesystems(request):
   return JsonResponse(response)
 
 
+# TODO: Improve error response further with better context -- Error UX Phase 1 item
 def api_error_handler(view_fn):
   """
   Decorator to handle exceptions and return a JSON response with an error message.
@@ -86,7 +106,6 @@ def api_error_handler(view_fn):
       return view_fn(*args, **kwargs)
     except Exception as e:
       LOG.exception(f'Error running {view_fn.__name__}: {str(e)}')
-      # TODO: Improve error response with better context
       return JsonResponse({'error': str(e)}, status=500)
 
   return decorator
@@ -119,6 +138,7 @@ def get_filesystems_with_home_dirs(request):
   return JsonResponse(filesystems, safe=False)
 
 
+@api_error_handler
 def download(request):
   """
   Downloads a file.
@@ -186,7 +206,286 @@ def download(request):
     return HttpResponse(f'Failed to download file at path {path}: {str(e)}', status=500)  # TODO: status code?
 
 
-@error_handler
+@api_error_handler
+def listdir_paged(request):
+  """
+  A paginated version of listdir.
+
+  Query parameters:
+    pagenum           - The page number to show. Defaults to 1.
+    pagesize          - How many to show on a page. Defaults to 15.
+    sortby=?          - Specify attribute to sort by. Accepts: (type, name, atime, mtime, size, user, group). Defaults to name.
+    descending        - Specify a descending sort order. Default to false.
+    filter=?          - Specify a substring filter to search for in the filename field.
+  """
+  path = request.GET.get('path', '/')  # Set default path for index directory
+  path = _normalize_path(path)
+
+  if not request.fs.isdir(path):
+    return HttpResponse(f'{path} is not a directory.', status=400)
+
+  pagenum = int(request.GET.get('pagenum', 1))
+  pagesize = int(request.GET.get('pagesize', 30))
+
+  do_as = None
+  if is_admin(request.user) or request.user.has_hue_permission(action="impersonate", app="security"):
+    do_as = request.GET.get('doas', request.user.username)
+  if hasattr(request, 'doas'):
+    do_as = request.doas
+
+  # if request.fs._get_scheme(path) == 'hdfs':
+  #   home_dir_path = request.user.get_home_directory()
+  # else:
+  #   home_dir_path = None
+
+  # breadcrumbs = parse_breadcrumbs(path)
+
+  try:
+    if do_as:
+      all_stats = request.fs.do_as_user(do_as, request.fs.listdir_stats, path)
+    else:
+      all_stats = request.fs.listdir_stats(path)
+  except (S3ListAllBucketsException, GSListAllBucketsException) as e:
+    return HttpResponse(f'Bucket listing is not allowed: {str(e)}', status=403)
+
+  # Filter first
+  filter_string = request.GET.get('filter')
+  if filter_string:
+    filtered_stats = [sb for sb in all_stats if filter_string in sb['name']]
+    all_stats = filtered_stats
+
+  # Sort next
+  sortby = request.GET.get('sortby')
+  descending_param = request.GET.get('descending')
+  if sortby:
+    if sortby not in ('type', 'name', 'atime', 'mtime', 'user', 'group', 'size'):
+      LOG.info(f'Invalid sort attribute {sortby} for list directory operation. Skipping it.')
+    else:
+      all_stats = sorted(all_stats, key=operator.attrgetter(sortby), reverse=coerce_bool(descending_param))
+
+  # Do pagination
+  try:
+    paginator = Paginator(all_stats, pagesize, allow_empty_first_page=True)
+    page = paginator.page(pagenum)
+    shown_stats = page.object_list
+  except EmptyPage:
+    message = "No results found for the requested page."
+    LOG.warn(message)
+    return HttpResponse(message, status=404)  # TODO: status code?
+
+  # TODO: Current same dir stats below?
+
+  # # Include same dir always as first option to see stats of the current folder.
+  # current_stat = request.fs.stats(path)
+  # # The 'path' field would be absolute, but we want its basename to be
+  # # actually '.' for display purposes. Encode it since _massage_stats expects byte strings.
+  # current_stat.path = path
+  # current_stat.name = "."
+  # shown_stats.insert(0, current_stat)
+
+  # Include parent dir always as second option, unless at filesystem root or when RAZ is enabled.
+  if not (request.fs.isroot(path) or RAZ.IS_ENABLED.get()):
+    parent_path = request.fs.parent_path(path)
+    parent_stat = request.fs.stats(parent_path)
+    # The 'path' field would be absolute, but we want its basename to be
+    # actually '..' for display purposes. Encode it since _massage_stats expects byte strings.
+    parent_stat['path'] = parent_path
+    parent_stat['name'] = ".."
+    shown_stats.insert(0, parent_stat)
+
+  if page:
+    # TODO: Check if we need to clean response of _massage_stats
+    page.object_list = [_massage_stats(request, stat_absolute_path(path, s)) for s in shown_stats]
+
+  # TODO: Shift below fields to /get_config?
+  is_hdfs = request.fs._get_scheme(path) == 'hdfs'
+  is_trash_enabled = is_hdfs and int(get_trash_interval()) > 0
+  is_fs_superuser = is_hdfs and _is_hdfs_superuser(request)
+
+  response = {
+      # 'path': path,
+      # 'breadcrumbs': breadcrumbs,
+      # 'current_request_path': '/filebrowser/view=' + urllib_quote(path.encode('utf-8'), safe=SAFE_CHARACTERS_URI_COMPONENTS),
+      'is_trash_enabled': is_trash_enabled,
+      'files': page.object_list if page else [],
+      'page': _massage_page(page, paginator) if page else {},  # TODO: Check if we need to clean response of _massage_page
+      'pagesize': pagesize,
+      # 'home_directory': home_dir_path if home_dir_path and request.fs.isdir(home_dir_path) else None,
+      # 'descending': descending_param,
+
+      # The following should probably be deprecated
+      # TODO: Check what to keep or what to remove? or move some fields to /get_config?
+
+      'cwd_set': True,
+      'file_filter': 'any',
+      # 'current_dir_path': path,
+      'is_fs_superuser': is_fs_superuser,
+      'groups': is_fs_superuser and [str(x) for x in Group.objects.values_list('name', flat=True)] or [],
+      'users': is_fs_superuser and [str(x) for x in User.objects.values_list('username', flat=True)] or [],
+      'superuser': request.fs.superuser,
+      'supergroup': request.fs.supergroup,
+      # 'is_sentry_managed': request.fs.is_sentry_managed(path),
+      # 'apps': list(appmanager.get_apps_dict(request.user).keys()),
+      'show_download_button': SHOW_DOWNLOAD_BUTTON.get(),
+      'show_upload_button': SHOW_UPLOAD_BUTTON.get(),
+      # 'is_embeddable': request.GET.get('is_embeddable', False),
+      # 's3_listing_not_allowed': s3_listing_not_allowed
+  }
+
+  return JsonResponse(response)
+
+
+@api_error_handler
+def display(request):
+  """
+  Implements displaying part of a file.
+
+  GET arguments are length, offset, mode, compression and encoding
+  with reasonable defaults chosen.
+
+  Note that display by length and offset are on bytes, not on characters.
+  """
+  path = request.GET.get('path', '/')  # Set default path for index directory
+  path = _normalize_path(path)
+
+  if not request.fs.isfile(path):
+    return HttpResponse(f'{path} is not a file.', status=400)
+
+  # TODO: Check if we still need this or not
+  # # display inline files just if it's not an ajax request
+  # if not is_ajax(request):
+  #   if _can_inline_display(path):
+  #     return redirect(reverse('filebrowser:filebrowser_views_download', args=[path]) + '?disposition=inline')
+
+  stats = request.fs.stats(path)
+  encoding = request.GET.get('encoding') or i18n.get_site_encoding()
+
+  # I'm mixing URL-based parameters and traditional
+  # HTTP GET parameters, since URL-based parameters
+  # can't naturally be optional.
+
+  # Need to deal with possibility that length is not present
+  # because the offset came in via the toolbar manual byte entry.
+  end = request.GET.get("end")
+  if end:
+    end = int(end)
+
+  begin = request.GET.get("begin", 1)
+  if begin:
+    # Subtract one to zero index for file read
+    begin = int(begin) - 1
+
+  if end:
+    offset = begin
+    length = end - begin
+    if begin >= end:
+      return HttpResponse("First byte to display must be before last byte to display.", status=400)
+  else:
+    length = int(request.GET.get("length", DEFAULT_CHUNK_SIZE_BYTES))
+    # Display first block by default.
+    offset = int(request.GET.get("offset", 0))
+
+  mode = request.GET.get("mode")
+  compression = request.GET.get("compression")
+
+  if mode and mode not in ["binary", "text"]:
+    return HttpResponse("Mode must be one of 'binary' or 'text'.", status=400)
+  if offset < 0:
+    return HttpResponse("Offset may not be less than zero.", status=400)
+  if length < 0:
+    return HttpResponse("Length may not be less than zero.", status=400)
+  if length > MAX_CHUNK_SIZE_BYTES:
+    return HttpResponse(f'Cannot request chunks greater than {MAX_CHUNK_SIZE_BYTES} bytes.', status=400)
+
+  # Do not decompress in binary mode.
+  if mode == 'binary':
+    compression = 'none'
+
+  # Read out based on meta.
+  compression, offset, length, contents = read_contents(compression, path, request.fs, offset, length)
+
+  # Get contents as string for text mode, or at least try
+  file_contents = None
+  if mode is None or mode == 'text':
+    if isinstance(contents, str):
+      file_contents = contents
+      is_binary = False
+      mode = 'text'
+    else:
+      # TODO: Check if the content is used in OLD CODE, when is_binary was true and replacement character was found.
+      # TODO: Then finally check how is binary content sent, is old UI reading from uni_content or the below xxd_out??
+      try:
+        file_contents = contents.decode(encoding)
+        is_binary = False
+        mode = 'text'
+      except UnicodeDecodeError:
+        file_contents = contents
+        is_binary = True
+        mode = 'binary' if mode is None else mode
+
+  # Get contents as bytes
+  if mode == "binary":
+    xxd_out = list(xxd.xxd(offset, contents, BYTES_PER_LINE, BYTES_PER_SENTENCE))
+
+  # TODO: Check what all UI needs and clean the field below, currently commenting out few duplicates which needs to be verified.
+
+  # dirname = posixpath.dirname(path)
+  # Start with index-like data:
+
+  stats = request.fs.stats(path)
+  data = _massage_stats(request, stat_absolute_path(path, stats))  # TODO: Stats required again?
+  # data["is_embeddable"] = request.GET.get('is_embeddable', False)
+
+  # And add a view structure:
+  # data["success"] = True
+  data["view"] = {
+      'offset': offset,
+      'length': length,
+      'end': offset + len(contents),
+      # 'dirname': dirname,
+      'mode': mode,
+      'compression': compression,
+      # 'size': stats.size,
+      'max_chunk_size': str(MAX_CHUNK_SIZE_BYTES)
+  }
+  # data["filename"] = os.path.basename(path)
+  data["editable"] = stats.size < MAX_FILEEDITOR_SIZE  # TODO: To improve this limit and sent it as /get_config? Needs discussion.
+
+  # TODO: Understand the comment. Then check why are we logging file content? Then also check how is masked_binary_data used? Finally improve code.
+  if mode == "binary":
+    # This might be the wrong thing for ?format=json; doing the
+    # xxd'ing in javascript might be more compact, or sending a less
+    # intermediate representation...
+    LOG.debug("xxd: " + str(xxd_out))
+    data['view']['xxd'] = xxd_out
+    data['view']['masked_binary_data'] = False
+  else:
+    data['view']['contents'] = file_contents
+    data['view']['masked_binary_data'] = is_binary
+
+  # data['breadcrumbs'] = parse_breadcrumbs(path)
+  # data['show_download_button'] = SHOW_DOWNLOAD_BUTTON.get()  # TODO: Add as /get_config?
+
+  return JsonResponse(data)
+
+
+@api_error_handler
+def stat(request):
+  """
+  Returns the generic stats of FS object.
+  """
+  path = request.GET.get('path')
+  path = _normalize_path(path)
+
+  if not request.fs.exists(path):
+    return HttpResponse(f'Object does not exist: {path}', status=404)
+
+  stats = request.fs.stats(path)
+
+  return JsonResponse(_massage_stats(request, stat_absolute_path(path, stats)))
+
+
+@api_error_handler
 def mkdir(request):
   path = request.POST.get('path')
   name = request.POST.get('name')
@@ -198,7 +497,7 @@ def mkdir(request):
   return HttpResponse(status=200)
 
 
-@error_handler
+@api_error_handler
 def touch(request):
   path = request.POST.get('path')
   name = request.POST.get('name')
@@ -210,7 +509,7 @@ def touch(request):
   return HttpResponse(status=200)
 
 
-@error_handler
+@api_error_handler
 def rename(request):
   src_path = request.POST.get('src_path')
   dest_path = request.POST.get('dest_path')
@@ -232,7 +531,7 @@ def rename(request):
   return HttpResponse(status=200)
 
 
-@error_handler
+@api_error_handler
 def move(request):
   src_path = request.POST.get('src_path')
   dest_path = request.POST.get('dest_path')
@@ -244,7 +543,7 @@ def move(request):
   return HttpResponse(status=200)
 
 
-@error_handler
+@api_error_handler
 def copy(request):
   src_path = request.POST.get('src_path')
   dest_path = request.POST.get('dest_path')
@@ -263,54 +562,56 @@ def copy(request):
   return HttpResponse(status=200)
 
 
-@error_handler
-def content_summary(request, path):
+@api_error_handler
+def content_summary(request):
+  path = request.GET.get('path')
   path = _normalize_path(path)
-  response = {}
 
   if not path:
-    raise Exception(_('Path parameter is required to fetch content summary.'))
+    return HttpResponse("Path parameter is required to fetch content summary.", status=400)
 
   if not request.fs.exists(path):
-    return JsonResponse(response, status=404)
+    return HttpResponse(f'Path does not exist: {path}', status=404)
 
+  response = {}
   try:
     content_summary = request.fs.get_content_summary(path)
     replication_factor = request.fs.stats(path)['replication']
 
     content_summary.summary.update({'replication': replication_factor})
     response['summary'] = content_summary.summary
-  except Exception as e:
-    raise Exception(_('Failed to fetch content summary for "%s". ') % path)
+  except Exception:
+    return HttpResponse(f'Failed to fetch content summary for path: {path}', status=500)
 
   return JsonResponse(response)
 
 
-@error_handler
+@api_error_handler
 def set_replication(request):
-  src_path = request.POST.get('src_path')
-  replication_factor = request.POST.get('replication_factor')
+  path = request.PUT.get('path')
+  replication_factor = request.PUT.get('replication_factor')
 
-  result = request.fs.set_replication(src_path, replication_factor)
+  result = request.fs.set_replication(path, replication_factor)
   if not result:
-    raise Exception(_("Failed to set the replication factor."))
+    return HttpResponse("Failed to set the replication factor.", status=500)
 
   return HttpResponse(status=200)
 
 
-@error_handler
+@api_error_handler
 def rmtree(request):
-  path = request.POST.get('path')
-  skip_trash = request.POST.get('skip_trash', False)
+  path = request.DELETE.get('path')
+  skip_trash = request.DELETE.get('skip_trash', False)
 
   request.fs.rmtree(path, skip_trash)
 
   return HttpResponse(status=200)
 
 
-@error_handler
+@api_error_handler
 def get_trash_path(request):
-  path = _normalize_path(request.GET.get('path'))
+  path = request.GET.get('path')
+  path = _normalize_path(path)
   response = {}
 
   trash_path = request.fs.trash_path(path)
@@ -321,13 +622,12 @@ def get_trash_path(request):
   elif request.fs.isdir(trash_path):
     response['trash_path'] = trash_path
   else:
-    response['message'] = _('Trash path not found: The requested trash path for user does not exist.')
-    return JsonResponse(response, status=404)
+    response['trash_path'] = None
 
   return JsonResponse(response)
 
 
-@error_handler
+@api_error_handler
 def trash_restore(request):
   path = request.POST.get('path')
   request.fs.restore(path)
@@ -335,7 +635,7 @@ def trash_restore(request):
   return HttpResponse(status=200)
 
 
-@error_handler
+@api_error_handler
 def trash_purge(request):
   request.fs.purge_trash()
 

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -568,8 +568,9 @@ def _upload_file(request):
 
 @api_error_handler
 def mkdir(request):
-  path = request.PUT.get('path')
-  name = request.PUT.get('name')
+  # TODO: Check if this needs to be a PUT request
+  path = request.POST.get('path')
+  name = request.POST.get('name')
 
   if name and (posixpath.sep in name or "#" in name):
     return HttpResponse(f"Error creating {name} directory. Slashes or hashes are not allowed in directory name.", status=400)
@@ -580,8 +581,8 @@ def mkdir(request):
 
 @api_error_handler
 def touch(request):
-  path = request.PUT.get('path')
-  name = request.PUT.get('name')
+  path = request.POST.get('path')
+  name = request.POST.get('name')
 
   if name and (posixpath.sep in name):
     return HttpResponse(f"Error creating {name} file: Slashes are not allowed in filename.", status=400)
@@ -697,8 +698,9 @@ def content_summary(request):
 
 @api_error_handler
 def set_replication(request):
-  path = request.PUT.get('path')
-  replication_factor = request.PUT.get('replication_factor')
+  # TODO: Check if this needs to be a PUT request
+  path = request.POST.get('path')
+  replication_factor = request.POST.get('replication_factor')
 
   result = request.fs.set_replication(path, replication_factor)
   if not result:
@@ -749,6 +751,35 @@ def trash_purge(request):
   request.fs.purge_trash()
 
   return HttpResponse(status=200)
+
+
+@api_error_handler
+def chown(request):
+  # TODO: Check if this needs to be a PUT request
+  path = request.POST.get('path')
+  user = request.POST.get("user")
+  group = request.POST.get("group")
+  recursive = request.POST.get('recursive', False)
+
+  # TODO: Check if we need to explicitly handle encoding anywhere
+  request.fs.chown(path, user, group, recursive=recursive)
+
+  return HttpResponse(status=200)
+
+
+@api_error_handler
+def chmod(request):
+  pass
+  # # TODO: Check if this needs to be a PUT request
+  # path = request.POST.get('path')
+  # permission = request.POST.get("permission")
+  # group = request.POST.get("group")
+  # recursive = request.POST.get('recursive', False)
+
+  # # TODO: Check if we need to explicitly handle encoding anywhere
+  # request.fs.chmod(path, user, group, recursive=recursive)
+
+  # return HttpResponse(status=200)
 
 
 @api_error_handler

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -720,6 +720,7 @@ def chmod(request):
 
 @api_error_handler
 def extract_archive_using_batch_job(request):
+  # TODO: Check core logic with E2E tests -- dont use it until then
   if not ENABLE_EXTRACT_UPLOADED_ARCHIVE.get():
     return HttpResponse("Extract archive operation is disabled by configuration.", status=500)  # TODO: status code?
 
@@ -740,6 +741,7 @@ def extract_archive_using_batch_job(request):
 
 @api_error_handler
 def compress_files_using_batch_job(request):
+  # TODO: Check core logic with E2E tests -- dont use it until then
   if not ENABLE_EXTRACT_UPLOADED_ARCHIVE.get():
     return HttpResponse("Compress files operation is disabled by configuration.", status=500)  # TODO: status code?
 

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -37,6 +37,8 @@ from desktop.lib.django_util import JsonResponse
 from desktop.lib.export_csvxls import file_reader
 from desktop.lib.fs.gc.gs import GSListAllBucketsException, get_gs_home_directory
 from desktop.lib.fs.ozone.ofs import get_ofs_home_directory
+from desktop.lib.tasks.compress_files.compress_utils import compress_files_in_hdfs
+from desktop.lib.tasks.extract_archive.extract_utils import extract_archive_in_hdfs
 from filebrowser.conf import (
   ARCHIVE_UPLOAD_TEMPDIR,
   ENABLE_EXTRACT_UPLOADED_ARCHIVE,
@@ -738,3 +740,45 @@ def trash_purge(request):
   request.fs.purge_trash()
 
   return HttpResponse(status=200)
+
+
+@api_error_handler
+def extract_archive_using_batch_job(request):
+
+  if not ENABLE_EXTRACT_UPLOADED_ARCHIVE.get():
+    return HttpResponse("Extract archive operation is disabled by configuration.", status=500)  # TODO: status code?
+
+  upload_path = request.fs.netnormpath(request.POST.get('upload_path'))
+  archive_name = request.POST.get('archive_name')
+
+  if upload_path and archive_name:
+    try:
+      # TODO: Check is we really require urllib_unquote here? Maybe need to improve old oozie methods also?
+      # upload_path = urllib_unquote(upload_path)
+      # archive_name = urllib_unquote(archive_name)
+      response = extract_archive_in_hdfs(request, upload_path, archive_name)
+    except Exception as e:
+      return HttpResponse(f'Failed to extract archive: {str(e)}', status=500)  # TODO: status code?
+
+  return JsonResponse(response)
+
+
+@api_error_handler
+def compress_files_using_batch_job(request):
+
+  if not ENABLE_EXTRACT_UPLOADED_ARCHIVE.get():
+    return HttpResponse("Compress files operation is disabled by configuration.", status=500)  # TODO: status code?
+
+  upload_path = request.fs.netnormpath(request.POST.get('upload_path'))
+  archive_name = request.POST.get('archive_name')
+  file_names = request.POST.getlist('files[]')  # TODO: Check if this param is correct? Need to improve it?
+
+  if upload_path and file_names and archive_name:
+    try:
+      response = compress_files_in_hdfs(request, file_names, upload_path, archive_name)
+    except Exception as e:
+      return HttpResponse(f'Failed to compress files: {str(e)}', status=500)  # TODO: status code?
+  else:
+    return HttpResponse('Output directory is not set.', status=500)  # TODO: status code?
+
+  return JsonResponse(response)

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -313,7 +313,6 @@ def display(request):
   if not request.fs.isfile(path):
     return HttpResponse(f'{path} is not a file.', status=400)
 
-  stats = request.fs.stats(path)
   encoding = request.GET.get('encoding') or i18n.get_site_encoding()
 
   # Need to deal with possibility that length is not present

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -49,6 +49,7 @@ from filebrowser.conf import (
   SHOW_UPLOAD_BUTTON,
 )
 from filebrowser.lib import xxd
+from filebrowser.utils import parse_broker_url
 from filebrowser.views import (
   BYTES_PER_LINE,
   BYTES_PER_SENTENCE,
@@ -486,6 +487,14 @@ def stat(request):
 
   return JsonResponse(_massage_stats(request, stat_absolute_path(path, stats)))
 
+@api_error_handler
+def upload_chunks(request):
+  pass
+
+@api_error_handler
+def upload_complete(request):
+  pass
+
 
 @api_error_handler
 def upload_file(request):
@@ -782,3 +791,29 @@ def compress_files_using_batch_job(request):
     return HttpResponse('Output directory is not set.', status=500)  # TODO: status code?
 
   return JsonResponse(response)
+
+
+@api_error_handler
+def get_available_space_for_upload(request):
+  redis_client = parse_broker_url(TASK_SERVER_V2.BROKER_URL.get())
+  try:
+    upload_available_space = int(redis_client.get('upload_available_space'))
+    if upload_available_space is None:
+      return HttpResponse("upload_available_space key is not set in Redis.", status=500)  # TODO: status code?
+
+    return JsonResponse({'upload_available_space': upload_available_space})
+  except Exception as e:
+    message = f"Failed to get available space from Redis: {str(e)}"
+    LOG.exception(message)
+    return HttpResponse(message, status=500)  # TODO: status code?
+  finally:
+    redis_client.close()
+
+
+@api_error_handler
+def reserve_space_for_upload(request):
+  pass
+
+@api_error_handler
+def release_reserved_space_for_upload(request):
+  pass

--- a/apps/filebrowser/src/filebrowser/forms.py
+++ b/apps/filebrowser/src/filebrowser/forms.py
@@ -137,6 +137,9 @@ class UploadFileForm(forms.Form):
   dest = PathField(label=_("Destination Path"), help_text=_("Filename or directory to upload to."), required=False)  # Used actually?
   extract_archive = BooleanField(required=False)
 
+class UploadAPIFileForm(forms.Form):
+  op = "upload"
+  file = FileField(label=_("File to Upload"))
 
 class UploadLocalFileForm(forms.Form):
   op = "upload"

--- a/apps/filebrowser/src/filebrowser/forms.py
+++ b/apps/filebrowser/src/filebrowser/forms.py
@@ -137,9 +137,6 @@ class UploadFileForm(forms.Form):
   dest = PathField(label=_("Destination Path"), help_text=_("Filename or directory to upload to."), required=False)  # Used actually?
   extract_archive = BooleanField(required=False)
 
-# class UploadAPIFileForm(forms.Form):
-#   op = "upload"
-#   file = FileField(label=_("File to Upload"))
 
 class UploadLocalFileForm(forms.Form):
   op = "upload"

--- a/apps/filebrowser/src/filebrowser/forms.py
+++ b/apps/filebrowser/src/filebrowser/forms.py
@@ -137,9 +137,9 @@ class UploadFileForm(forms.Form):
   dest = PathField(label=_("Destination Path"), help_text=_("Filename or directory to upload to."), required=False)  # Used actually?
   extract_archive = BooleanField(required=False)
 
-class UploadAPIFileForm(forms.Form):
-  op = "upload"
-  file = FileField(label=_("File to Upload"))
+# class UploadAPIFileForm(forms.Form):
+#   op = "upload"
+#   file = FileField(label=_("File to Upload"))
 
 class UploadLocalFileForm(forms.Form):
   op = "upload"

--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -171,9 +171,13 @@ def _decode_slashes(path):
   # This is a fix for some installations where the path is still having the slash (/) encoded
   # as %2F while the rest of the path is actually decoded.
   encoded_slash = '%2F'
-  if path and (path.startswith(encoded_slash) or path.startswith('abfs:' + encoded_slash) or \
-    path.startswith('s3a:' + encoded_slash) or path.startswith('gs:' + encoded_slash) or \
-    path.startswith('ofs:' + encoded_slash)):
+  if path and (
+    path.startswith(encoded_slash)
+    or path.startswith('abfs:' + encoded_slash)
+    or path.startswith('s3a:' + encoded_slash)
+    or path.startswith('gs:' + encoded_slash)
+    or path.startswith('ofs:' + encoded_slash)
+  ):
     path = path.replace(encoded_slash, '/')
 
   return path

--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -171,9 +171,9 @@ def _decode_slashes(path):
   # This is a fix for some installations where the path is still having the slash (/) encoded
   # as %2F while the rest of the path is actually decoded.
   encoded_slash = '%2F'
-  if path and path.startswith(encoded_slash) or path.startswith('abfs:' + encoded_slash) or \
+  if path and (path.startswith(encoded_slash) or path.startswith('abfs:' + encoded_slash) or \
     path.startswith('s3a:' + encoded_slash) or path.startswith('gs:' + encoded_slash) or \
-    path.startswith('ofs:' + encoded_slash):
+    path.startswith('ofs:' + encoded_slash)):
     path = path.replace(encoded_slash, '/')
 
   return path

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -254,7 +254,7 @@ def storage_save_file(request):
 @api_view(["POST"])
 def storage_upload_file(request):
   django_request = get_django_request(request)
-  return filebrowser_api.upload_file(django_request)
+  return filebrowser_views.upload_file(django_request)  # TODO: Fix new api method and switch here
 
 
 @api_view(["POST"])

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -232,6 +232,7 @@ def storage_listdir_paged(request):
   django_request = get_django_request(request)
   return filebrowser_api.listdir_paged(django_request)
 
+
 @api_view(["GET"])
 def storage_display(request):
   django_request = get_django_request(request)

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -222,9 +222,9 @@ def storage_view(request, path):
 
 
 @api_view(["GET"])
-def storage_download(request, path):
+def storage_download(request):
   django_request = get_django_request(request)
-  return filebrowser_views.download(django_request, path)
+  return filebrowser_views.download(django_request)
 
 
 @api_view(["POST"])

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -296,7 +296,7 @@ def storage_content_summary(request):
 @api_view(["POST"])
 def storage_bulk_move(request):
   django_request = get_django_request(request)
-  return filebrowser_api.bulk_op(django_request, 'move')
+  return filebrowser_api.bulk_op(django_request, filebrowser_api.move)
 
 
 @api_view(["POST"])
@@ -308,7 +308,7 @@ def storage_move(request):
 @api_view(["POST"])
 def storage_bulk_copy(request):
   django_request = get_django_request(request)
-  return filebrowser_api.bulk_op(django_request, 'copy')
+  return filebrowser_api.bulk_op(django_request, filebrowser_api.copy)
 
 
 @api_view(["POST"])
@@ -332,7 +332,7 @@ def storage_rmtree(request):
 @api_view(["POST"])
 def storage_bulk_rmtree(request):
   django_request = get_django_request(request)
-  return filebrowser_api.bulk_op(django_request, 'rmtree')
+  return filebrowser_api.bulk_op(django_request, filebrowser_api.rmtree)
 
 
 @api_view(["GET"])
@@ -350,7 +350,7 @@ def storage_trash_restore(request):
 @api_view(["POST"])
 def storage_trash_bulk_restore(request):
   django_request = get_django_request(request)
-  return filebrowser_api.bulk_op(django_request, 'trash_restore')
+  return filebrowser_api.bulk_op(django_request, filebrowser_api.trash_restore)
 
 
 @api_view(["DELETE"])
@@ -386,13 +386,13 @@ def storage_chmod(request):
 @api_view(["POST"])
 def storage_bulk_chown(request):
   django_request = get_django_request(request)
-  return filebrowser_api.bulk_op(django_request, 'chown')
+  return filebrowser_api.bulk_op(django_request, filebrowser_api.chown)
 
 
 @api_view(["POST"])
 def storage_bulk_chmod(request):
   django_request = get_django_request(request)
-  return filebrowser_api.bulk_op(django_request, 'chmod')
+  return filebrowser_api.bulk_op(django_request, filebrowser_api.chmod)
 
 
 # Task Server

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -322,6 +322,16 @@ def storage_trash_purge(request):
   django_request = get_django_request(request)
   return filebrowser_api.trash_purge(django_request)
 
+@api_view(["POST"])
+def storage_compress_files_using_batch_job(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.compress_files_using_batch_job(django_request)
+
+@api_view(["POST"])
+def storage_extract_archive_using_batch_job(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.extract_archive_using_batch_job(django_request)
+
 
 # Importer
 

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -347,20 +347,12 @@ def storage_extract_archive_using_batch_job(request):
 
 # Task Server
 
+
 @api_view(["GET"])
 def taskserver_get_available_space_for_upload(request):
   django_request = get_django_request(request)
   return filebrowser_api.get_available_space_for_upload(django_request)
 
-@api_view(["POST"])
-def taskserver_reserve_space_for_upload(request):
-  django_request = get_django_request(request)
-  return filebrowser_api.reserve_space_for_upload(django_request)
-
-@api_view(["POST"])
-def taskserver_release_reserved_space_for_upload(request):
-  django_request = get_django_request(request)
-  return filebrowser_api.release_reserved_space_for_upload(django_request)
 
 # Importer
 

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -216,15 +216,32 @@ def storage_get_filesystems(request):
 
 
 @api_view(["GET"])
-def storage_view(request, path):
+def storage_view(request):
   django_request = get_django_request(request)
-  return filebrowser_views.view(django_request, path)
+  return filebrowser_views.view(django_request)
+
+
+@api_view(["GET"])
+def storage_stat(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.stat(django_request)
+
+
+@api_view(["GET"])
+def storage_listdir_paged(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.listdir_paged(django_request)
+
+@api_view(["GET"])
+def storage_display(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.display(django_request)
 
 
 @api_view(["GET"])
 def storage_download(request):
   django_request = get_django_request(request)
-  return filebrowser_views.download(django_request)
+  return filebrowser_api.download(django_request)
 
 
 @api_view(["POST"])
@@ -252,9 +269,9 @@ def storage_rename(request):
 
 
 @api_view(["GET"])
-def storage_content_summary(request, path):
+def storage_content_summary(request):
   django_request = get_django_request(request)
-  return filebrowser_api.content_summary(django_request, path)
+  return filebrowser_api.content_summary(django_request)
 
 
 @api_view(["POST"])
@@ -269,13 +286,13 @@ def storage_copy(request):
   return filebrowser_api.copy(django_request)
 
 
-@api_view(["POST"])
+@api_view(["PUT"])
 def storage_set_replication(request):
   django_request = get_django_request(request)
   return filebrowser_api.set_replication(django_request)
 
 
-@api_view(["POST"])
+@api_view(["DELETE"])
 def storage_rmtree(request):
   django_request = get_django_request(request)
   return filebrowser_api.rmtree(django_request)
@@ -293,7 +310,7 @@ def storage_trash_restore(request):
   return filebrowser_api.trash_restore(django_request)
 
 
-@api_view(["POST"])
+@api_view(["DELETE"])
 def storage_trash_purge(request):
   django_request = get_django_request(request)
   return filebrowser_api.trash_purge(django_request)

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -267,13 +267,13 @@ def storage_upload_complete(request):
   return filebrowser_api.upload_complete(django_request)
 
 
-@api_view(["PUT"])
+@api_view(["POST"])
 def storage_mkdir(request):
   django_request = get_django_request(request)
   return filebrowser_api.mkdir(django_request)
 
 
-@api_view(["PUT"])
+@api_view(["POST"])
 def storage_touch(request):
   django_request = get_django_request(request)
   return filebrowser_api.touch(django_request)
@@ -315,7 +315,7 @@ def storage_copy(request):
   return filebrowser_api.copy(django_request)
 
 
-@api_view(["PUT"])
+@api_view(["POST"])
 def storage_set_replication(request):
   django_request = get_django_request(request)
   return filebrowser_api.set_replication(django_request)
@@ -367,6 +367,18 @@ def storage_compress_files_using_batch_job(request):
 def storage_extract_archive_using_batch_job(request):
   django_request = get_django_request(request)
   return filebrowser_api.extract_archive_using_batch_job(django_request)
+
+
+@api_view(["POST"])
+def storage_chown(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.chown(django_request)
+
+
+@api_view(["POST"])
+def storage_chmod(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.chmod(django_request)
 
 
 # Task Server

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -256,6 +256,16 @@ def storage_upload_file(request):
   django_request = get_django_request(request)
   return filebrowser_api.upload_file(django_request)
 
+@api_view(["POST"])
+def storage_upload_chunks(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.upload_chunks(django_request)
+
+@api_view(["POST"])
+def storage_upload_complete(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.upload_complete(django_request)
+
 
 @api_view(["PUT"])
 def storage_mkdir(request):
@@ -322,16 +332,35 @@ def storage_trash_purge(request):
   django_request = get_django_request(request)
   return filebrowser_api.trash_purge(django_request)
 
+
 @api_view(["POST"])
 def storage_compress_files_using_batch_job(request):
   django_request = get_django_request(request)
   return filebrowser_api.compress_files_using_batch_job(django_request)
+
 
 @api_view(["POST"])
 def storage_extract_archive_using_batch_job(request):
   django_request = get_django_request(request)
   return filebrowser_api.extract_archive_using_batch_job(django_request)
 
+
+# Task Server
+
+@api_view(["GET"])
+def taskserver_get_available_space_for_upload(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.get_available_space_for_upload(django_request)
+
+@api_view(["POST"])
+def taskserver_reserve_space_for_upload(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.reserve_space_for_upload(django_request)
+
+@api_view(["POST"])
+def taskserver_release_reserved_space_for_upload(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.release_reserved_space_for_upload(django_request)
 
 # Importer
 

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -292,9 +292,21 @@ def storage_content_summary(request):
 
 
 @api_view(["POST"])
+def storage_bulk_move(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.move(django_request)
+
+
+@api_view(["POST"])
 def storage_move(request):
   django_request = get_django_request(request)
   return filebrowser_api.move(django_request)
+
+
+@api_view(["POST"])
+def storage_bulk_copy(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.copy(django_request)
 
 
 @api_view(["POST"])
@@ -315,6 +327,12 @@ def storage_rmtree(request):
   return filebrowser_api.rmtree(django_request)
 
 
+@api_view(["DELETE"])
+def storage_bulk_rmtree(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.rmtree(django_request)
+
+
 @api_view(["GET"])
 def storage_get_trash_path(request):
   django_request = get_django_request(request)
@@ -323,6 +341,12 @@ def storage_get_trash_path(request):
 
 @api_view(["POST"])
 def storage_trash_restore(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.trash_restore(django_request)
+
+
+@api_view(["POST"])
+def storage_trash_bulk_restore(request):
   django_request = get_django_request(request)
   return filebrowser_api.trash_restore(django_request)
 

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -256,10 +256,12 @@ def storage_upload_file(request):
   django_request = get_django_request(request)
   return filebrowser_api.upload_file(django_request)
 
+
 @api_view(["POST"])
 def storage_upload_chunks(request):
   django_request = get_django_request(request)
   return filebrowser_api.upload_chunks(django_request)
+
 
 @api_view(["POST"])
 def storage_upload_complete(request):

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -246,9 +246,15 @@ def storage_download(request):
 
 
 @api_view(["POST"])
+def storage_save_file(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.save_file(django_request)
+
+
+@api_view(["POST"])
 def storage_upload_file(request):
   django_request = get_django_request(request)
-  return filebrowser_views.upload_file(django_request)
+  return filebrowser_api.upload_file(django_request)
 
 
 @api_view(["PUT"])

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -216,9 +216,9 @@ def storage_get_filesystems(request):
 
 
 @api_view(["GET"])
-def storage_view(request):
+def storage_view(request, path):
   django_request = get_django_request(request)
-  return filebrowser_views.view(django_request)
+  return filebrowser_views.view(django_request, path)
 
 
 @api_view(["GET"])

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -296,7 +296,7 @@ def storage_content_summary(request):
 @api_view(["POST"])
 def storage_bulk_move(request):
   django_request = get_django_request(request)
-  return filebrowser_api.move(django_request)
+  return filebrowser_api.bulk_op(django_request, 'move')
 
 
 @api_view(["POST"])
@@ -308,7 +308,7 @@ def storage_move(request):
 @api_view(["POST"])
 def storage_bulk_copy(request):
   django_request = get_django_request(request)
-  return filebrowser_api.copy(django_request)
+  return filebrowser_api.bulk_op(django_request, 'copy')
 
 
 @api_view(["POST"])
@@ -323,16 +323,16 @@ def storage_set_replication(request):
   return filebrowser_api.set_replication(django_request)
 
 
-@api_view(["DELETE"])
+@api_view(["POST"])
 def storage_rmtree(request):
   django_request = get_django_request(request)
   return filebrowser_api.rmtree(django_request)
 
 
-@api_view(["DELETE"])
+@api_view(["POST"])
 def storage_bulk_rmtree(request):
   django_request = get_django_request(request)
-  return filebrowser_api.rmtree(django_request)
+  return filebrowser_api.bulk_op(django_request, 'rmtree')
 
 
 @api_view(["GET"])
@@ -350,7 +350,7 @@ def storage_trash_restore(request):
 @api_view(["POST"])
 def storage_trash_bulk_restore(request):
   django_request = get_django_request(request)
-  return filebrowser_api.trash_restore(django_request)
+  return filebrowser_api.bulk_op(django_request, 'trash_restore')
 
 
 @api_view(["DELETE"])
@@ -381,6 +381,18 @@ def storage_chown(request):
 def storage_chmod(request):
   django_request = get_django_request(request)
   return filebrowser_api.chmod(django_request)
+
+
+@api_view(["POST"])
+def storage_bulk_chown(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.bulk_op(django_request, 'chown')
+
+
+@api_view(["POST"])
+def storage_bulk_chmod(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.bulk_op(django_request, 'chmod')
 
 
 # Task Server

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -251,13 +251,13 @@ def storage_upload_file(request):
   return filebrowser_views.upload_file(django_request)
 
 
-@api_view(["POST"])
+@api_view(["PUT"])
 def storage_mkdir(request):
   django_request = get_django_request(request)
   return filebrowser_api.mkdir(django_request)
 
 
-@api_view(["POST"])
+@api_view(["PUT"])
 def storage_touch(request):
   django_request = get_django_request(request)
   return filebrowser_api.touch(django_request)

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -96,14 +96,6 @@ urlpatterns += [
     api_public.taskserver_get_available_space_for_upload,
     name='taskserver_get_available_space_for_upload',
   ),
-  re_path(
-    r'^taskserver/upload/reserve_space/?$', api_public.taskserver_reserve_space_for_upload, name='taskserver_reserve_space_for_upload'
-  ),
-  re_path(
-    r'^taskserver/upload/release_reserved_space/?$',
-    api_public.taskserver_release_reserved_space_for_upload,
-    name='taskserver_release_reserved_space_for_upload',
-  ),
 ]
 
 urlpatterns += [

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -97,19 +97,22 @@ urlpatterns += [
   re_path(r'^storage/mkdir$', api_public.storage_mkdir, name='storage_mkdir'),
   re_path(r'^storage/touch$', api_public.storage_touch, name='storage_touch'),
   re_path(r'^storage/rename$', api_public.storage_rename, name='storage_rename'),
-  re_path(r'^storage/content_summary=(?P<path>.*)$', api_public.storage_content_summary, name='storage_content_summary'),
   re_path(r'^storage/move$', api_public.storage_move, name='storage_move'),
   re_path(r'^storage/copy$', api_public.storage_copy, name='storage_copy'),
-  re_path(r'^storage/set_replication$', api_public.storage_set_replication, name='storage_set_replication'),
-  re_path(r'^storage/rmtree$', api_public.storage_rmtree, name='storage_rmtree'),
-  re_path(r'^storage/trash/get_trash_path$', api_public.storage_get_trash_path, name='storage_get_trash_path'),
-  re_path(r'^storage/trash/restore$', api_public.storage_trash_restore, name='storage_trash_restore'),
-  re_path(r'^storage/trash/purge$', api_public.storage_trash_purge, name='storage_trash_purge'),
 ]
 
 urlpatterns += [
   re_path(r'^storage/filesystems/?$', api_public.storage_get_filesystems, name='storage_get_filesystems'),
+  re_path(r'^storage/list/?$', api_public.storage_listdir_paged, name='storage_listdir_paged'),
+  re_path(r'^storage/stat/?$', api_public.storage_stat, name='storage_stat'),
+  re_path(r'^storage/display/?$', api_public.storage_display, name='storage_display'),
   re_path(r'^storage/download/?$', api_public.storage_download, name='storage_download'),
+  re_path(r'^storage/delete/?$', api_public.storage_rmtree, name='storage_rmtree'),
+  re_path(r'^storage/content_summary/?$', api_public.storage_content_summary, name='storage_content_summary'),
+  re_path(r'^storage/replication/?$', api_public.storage_set_replication, name='storage_set_replication'),
+  re_path(r'^storage/trash/path/?$', api_public.storage_get_trash_path, name='storage_get_trash_path'),
+  re_path(r'^storage/trash/restore/?$', api_public.storage_trash_restore, name='storage_trash_restore'),
+  re_path(r'^storage/trash/purge/?$', api_public.storage_trash_purge, name='storage_trash_purge'),
 ]
 
 urlpatterns += [

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -92,9 +92,7 @@ urlpatterns += [
 ]
 
 urlpatterns += [
-  re_path(r'^storage/filesystems/?$', api_public.storage_get_filesystems, name='storage_get_filesystems'),
   re_path(r'^storage/view=(?P<path>.*)$', api_public.storage_view, name='storage_view'),
-  re_path(r'^storage/download=(?P<path>.*)$', api_public.storage_download, name='storage_download'),
   re_path(r'^storage/upload/file/?$', api_public.storage_upload_file, name='storage_upload_file'),
   re_path(r'^storage/mkdir$', api_public.storage_mkdir, name='storage_mkdir'),
   re_path(r'^storage/touch$', api_public.storage_touch, name='storage_touch'),
@@ -107,6 +105,11 @@ urlpatterns += [
   re_path(r'^storage/trash/get_trash_path$', api_public.storage_get_trash_path, name='storage_get_trash_path'),
   re_path(r'^storage/trash/restore$', api_public.storage_trash_restore, name='storage_trash_restore'),
   re_path(r'^storage/trash/purge$', api_public.storage_trash_purge, name='storage_trash_purge'),
+]
+
+urlpatterns += [
+  re_path(r'^storage/filesystems/?$', api_public.storage_get_filesystems, name='storage_get_filesystems'),
+  re_path(r'^storage/download/?$', api_public.storage_download, name='storage_download'),
 ]
 
 urlpatterns += [

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -115,6 +115,8 @@ urlpatterns += [
   re_path(r'^storage/trash/path/?$', api_public.storage_get_trash_path, name='storage_get_trash_path'),
   re_path(r'^storage/trash/restore/?$', api_public.storage_trash_restore, name='storage_trash_restore'),
   re_path(r'^storage/trash/purge/?$', api_public.storage_trash_purge, name='storage_trash_purge'),
+  re_path(r'^storage/extract_archive/?', api_public.storage_extract_archive_using_batch_job, name='storage_extract_archive_using_batch_job'),
+  re_path(r'^storage/compress_files/?', api_public.storage_compress_files_using_batch_job, name='storage_compress_files_using_batch_job'),
 ]
 
 urlpatterns += [

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -100,6 +100,7 @@ urlpatterns += [
   re_path(r'^storage/list/?$', api_public.storage_listdir_paged, name='storage_listdir_paged'),
   re_path(r'^storage/create/file/?$', api_public.storage_touch, name='storage_touch'),
   re_path(r'^storage/create/directory/?$', api_public.storage_mkdir, name='storage_mkdir'),
+  re_path(r'^storage/save/?$', api_public.storage_save_file, name="storage_save_file"),
   re_path(r'^storage/rename/?$', api_public.storage_rename, name='storage_rename'),
   re_path(r'^storage/move/?$', api_public.storage_move, name='storage_move'),
   re_path(r'^storage/copy/?$', api_public.storage_copy, name='storage_copy'),

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -94,7 +94,6 @@ urlpatterns += [
 urlpatterns += [
   re_path(r'^storage/view=(?P<path>.*)$', api_public.storage_view, name='storage_view'),
 
-  re_path(r'^storage/upload/file/?$', api_public.storage_upload_file, name='storage_upload_file'),
   re_path(r'^storage/mkdir$', api_public.storage_mkdir, name='storage_mkdir'),
   re_path(r'^storage/touch$', api_public.storage_touch, name='storage_touch'),
   re_path(r'^storage/rename$', api_public.storage_rename, name='storage_rename'),
@@ -105,6 +104,8 @@ urlpatterns += [
 urlpatterns += [
   re_path(r'^storage/filesystems/?$', api_public.storage_get_filesystems, name='storage_get_filesystems'),
   re_path(r'^storage/list/?$', api_public.storage_listdir_paged, name='storage_listdir_paged'),
+  re_path(r'^storage/upload/file/?$', api_public.storage_upload_file, name='storage_upload_file'),
+
   re_path(r'^storage/stat/?$', api_public.storage_stat, name='storage_stat'),
   re_path(r'^storage/display/?$', api_public.storage_display, name='storage_display'),
   re_path(r'^storage/download/?$', api_public.storage_download, name='storage_download'),

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -93,6 +93,7 @@ urlpatterns += [
 
 urlpatterns += [
   re_path(r'^storage/view=(?P<path>.*)$', api_public.storage_view, name='storage_view'),
+
   re_path(r'^storage/upload/file/?$', api_public.storage_upload_file, name='storage_upload_file'),
   re_path(r'^storage/mkdir$', api_public.storage_mkdir, name='storage_mkdir'),
   re_path(r'^storage/touch$', api_public.storage_touch, name='storage_touch'),

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-
 from django.urls import re_path
 
 from desktop import api_public
@@ -93,6 +91,19 @@ urlpatterns += [
 
 urlpatterns += [
   re_path(r'^storage/view=(?P<path>.*)$', api_public.storage_view, name='storage_view'),
+  re_path(
+    r'^taskserver/upload/available_space/?$',
+    api_public.taskserver_get_available_space_for_upload,
+    name='taskserver_get_available_space_for_upload',
+  ),
+  re_path(
+    r'^taskserver/upload/reserve_space/?$', api_public.taskserver_reserve_space_for_upload, name='taskserver_reserve_space_for_upload'
+  ),
+  re_path(
+    r'^taskserver/upload/release_reserved_space/?$',
+    api_public.taskserver_release_reserved_space_for_upload,
+    name='taskserver_release_reserved_space_for_upload',
+  ),
 ]
 
 urlpatterns += [
@@ -105,7 +116,8 @@ urlpatterns += [
   re_path(r'^storage/move/?$', api_public.storage_move, name='storage_move'),
   re_path(r'^storage/copy/?$', api_public.storage_copy, name='storage_copy'),
   re_path(r'^storage/upload/file/?$', api_public.storage_upload_file, name='storage_upload_file'),
-
+  re_path(r'^storage/upload/chunks/?$', api_public.storage_upload_chunks, name='storage_upload_chunks'),
+  re_path(r'^storage/upload/complete/?$', api_public.storage_upload_complete, name='storage_upload_complete'),
   re_path(r'^storage/stat/?$', api_public.storage_stat, name='storage_stat'),
   re_path(r'^storage/display/?$', api_public.storage_display, name='storage_display'),
   re_path(r'^storage/download/?$', api_public.storage_download, name='storage_download'),
@@ -115,8 +127,10 @@ urlpatterns += [
   re_path(r'^storage/trash/path/?$', api_public.storage_get_trash_path, name='storage_get_trash_path'),
   re_path(r'^storage/trash/restore/?$', api_public.storage_trash_restore, name='storage_trash_restore'),
   re_path(r'^storage/trash/purge/?$', api_public.storage_trash_purge, name='storage_trash_purge'),
-  re_path(r'^storage/extract_archive/?', api_public.storage_extract_archive_using_batch_job, name='storage_extract_archive_using_batch_job'),
-  re_path(r'^storage/compress_files/?', api_public.storage_compress_files_using_batch_job, name='storage_compress_files_using_batch_job'),
+  re_path(
+    r'^storage/extract_archive/?$', api_public.storage_extract_archive_using_batch_job, name='storage_extract_archive_using_batch_job'
+  ),
+  re_path(r'^storage/compress_files/?$', api_public.storage_compress_files_using_batch_job, name='storage_compress_files_using_batch_job'),
 ]
 
 urlpatterns += [

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -123,6 +123,10 @@ urlpatterns += [
     r'^storage/extract_archive/?$', api_public.storage_extract_archive_using_batch_job, name='storage_extract_archive_using_batch_job'
   ),
   re_path(r'^storage/compress_files/?$', api_public.storage_compress_files_using_batch_job, name='storage_compress_files_using_batch_job'),
+  re_path(r'^storage/move/bulk/?$', api_public.storage_bulk_move, name='storage_bulk_move'),
+  re_path(r'^storage/copy/bulk/?$', api_public.storage_bulk_copy, name='storage_bulk_copy'),
+  re_path(r'^storage/delete/bulk/?$', api_public.storage_bulk_rmtree, name='storage_bulk_rmtree'),
+  re_path(r'^storage/trash/restore/bulk/?$', api_public.storage_trash_bulk_restore, name='storage_trash_bulk_restore'),
 ]
 
 urlpatterns += [

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -129,6 +129,8 @@ urlpatterns += [
   re_path(r'^storage/copy/bulk/?$', api_public.storage_bulk_copy, name='storage_bulk_copy'),
   re_path(r'^storage/delete/bulk/?$', api_public.storage_bulk_rmtree, name='storage_bulk_rmtree'),
   re_path(r'^storage/trash/restore/bulk/?$', api_public.storage_trash_bulk_restore, name='storage_trash_bulk_restore'),
+  re_path(r'^storage/chown/bulk/?$', api_public.storage_bulk_chown, name='storage_bulk_chown'),
+  re_path(r'^storage/chmod/bulk/?$', api_public.storage_bulk_chmod, name='storage_bulk_chmod'),
 ]
 
 urlpatterns += [

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -119,6 +119,8 @@ urlpatterns += [
   re_path(r'^storage/trash/path/?$', api_public.storage_get_trash_path, name='storage_get_trash_path'),
   re_path(r'^storage/trash/restore/?$', api_public.storage_trash_restore, name='storage_trash_restore'),
   re_path(r'^storage/trash/purge/?$', api_public.storage_trash_purge, name='storage_trash_purge'),
+  re_path(r'^storage/chown/?$', api_public.storage_chown, name='storage_chown'),
+  re_path(r'^storage/chmod/?$', api_public.storage_chmod, name='storage_chmod'),
   re_path(
     r'^storage/extract_archive/?$', api_public.storage_extract_archive_using_batch_job, name='storage_extract_archive_using_batch_job'
   ),

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -93,17 +93,16 @@ urlpatterns += [
 
 urlpatterns += [
   re_path(r'^storage/view=(?P<path>.*)$', api_public.storage_view, name='storage_view'),
-
-  re_path(r'^storage/mkdir$', api_public.storage_mkdir, name='storage_mkdir'),
-  re_path(r'^storage/touch$', api_public.storage_touch, name='storage_touch'),
-  re_path(r'^storage/rename$', api_public.storage_rename, name='storage_rename'),
-  re_path(r'^storage/move$', api_public.storage_move, name='storage_move'),
-  re_path(r'^storage/copy$', api_public.storage_copy, name='storage_copy'),
 ]
 
 urlpatterns += [
   re_path(r'^storage/filesystems/?$', api_public.storage_get_filesystems, name='storage_get_filesystems'),
   re_path(r'^storage/list/?$', api_public.storage_listdir_paged, name='storage_listdir_paged'),
+  re_path(r'^storage/create/file/?$', api_public.storage_touch, name='storage_touch'),
+  re_path(r'^storage/create/directory/?$', api_public.storage_mkdir, name='storage_mkdir'),
+  re_path(r'^storage/rename/?$', api_public.storage_rename, name='storage_rename'),
+  re_path(r'^storage/move/?$', api_public.storage_move, name='storage_move'),
+  re_path(r'^storage/copy/?$', api_public.storage_copy, name='storage_copy'),
   re_path(r'^storage/upload/file/?$', api_public.storage_upload_file, name='storage_upload_file'),
 
   re_path(r'^storage/stat/?$', api_public.storage_stat, name='storage_stat'),

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -671,9 +671,6 @@ else:
   if is_ofs_enabled():
     file_upload_handlers.insert(0, 'desktop.lib.fs.ozone.upload.OFSFileUploadHandler')
 
-  if is_ofs_enabled():
-    file_upload_handlers.insert(0, 'desktop.lib.fs.ozone.upload.OFSFileUploadHandler')
-
 FILE_UPLOAD_HANDLERS = tuple(file_upload_handlers)
 
 ############################################################

--- a/desktop/core/src/desktop/templates/global_js_constants.mako
+++ b/desktop/core/src/desktop/templates/global_js_constants.mako
@@ -32,6 +32,7 @@
   from jobbrowser.conf import ENABLE_HISTORY_V2, ENABLE_QUERY_BROWSER, ENABLE_HIVE_QUERY_BROWSER, MAX_JOB_FETCH, \
       QUERY_STORE
   from filebrowser.conf import SHOW_UPLOAD_BUTTON, REMOTE_STORAGE_HOME, MAX_FILE_SIZE_UPLOAD_LIMIT, SHOW_DOWNLOAD_BUTTON
+  from filebrowser.views import MAX_FILEEDITOR_SIZE
   from indexer.conf import ENABLE_NEW_INDEXER
   from libsaml.conf import get_logout_redirect_url, CDP_LOGOUT_URL
   from metadata.conf import has_catalog, has_readonly_catalog, has_optimizer, has_workload_analytics, OPTIMIZER, get_optimizer_url, \
@@ -211,6 +212,7 @@
   window.SHOW_NOTEBOOKS = '${ SHOW_NOTEBOOKS.get() }' === 'True'
   window.SHOW_UPLOAD_BUTTON = '${ hasattr(SHOW_UPLOAD_BUTTON, 'get') and SHOW_UPLOAD_BUTTON.get() }' === 'True'
   window.SHOW_DOWNLOAD_BUTTON = '${ hasattr(SHOW_DOWNLOAD_BUTTON, 'get') and SHOW_DOWNLOAD_BUTTON.get() }' === 'True'
+  window.MAX_FILEEDITOR_SIZE = '${ MAX_FILEEDITOR_SIZE }';
 
   window.UPLOAD_CHUNK_SIZE = ${ UPLOAD_CHUNK_SIZE.get() };
   window.MAX_FILE_SIZE_UPLOAD_LIMIT = ${ MAX_FILE_SIZE_UPLOAD_LIMIT.get() if hasattr(MAX_FILE_SIZE_UPLOAD_LIMIT, 'get') and MAX_FILE_SIZE_UPLOAD_LIMIT.get() >= 0 else 'undefined' };

--- a/desktop/core/src/desktop/templates/global_js_constants.mako
+++ b/desktop/core/src/desktop/templates/global_js_constants.mako
@@ -31,7 +31,7 @@
   from indexer.conf import ENABLE_NEW_INDEXER
   from jobbrowser.conf import ENABLE_HISTORY_V2, ENABLE_QUERY_BROWSER, ENABLE_HIVE_QUERY_BROWSER, MAX_JOB_FETCH, \
       QUERY_STORE
-  from filebrowser.conf import SHOW_UPLOAD_BUTTON, REMOTE_STORAGE_HOME, MAX_FILE_SIZE_UPLOAD_LIMIT
+  from filebrowser.conf import SHOW_UPLOAD_BUTTON, REMOTE_STORAGE_HOME, MAX_FILE_SIZE_UPLOAD_LIMIT, SHOW_DOWNLOAD_BUTTON
   from indexer.conf import ENABLE_NEW_INDEXER
   from libsaml.conf import get_logout_redirect_url, CDP_LOGOUT_URL
   from metadata.conf import has_catalog, has_readonly_catalog, has_optimizer, has_workload_analytics, OPTIMIZER, get_optimizer_url, \
@@ -210,6 +210,7 @@
 
   window.SHOW_NOTEBOOKS = '${ SHOW_NOTEBOOKS.get() }' === 'True'
   window.SHOW_UPLOAD_BUTTON = '${ hasattr(SHOW_UPLOAD_BUTTON, 'get') and SHOW_UPLOAD_BUTTON.get() }' === 'True'
+  window.SHOW_DOWNLOAD_BUTTON = '${ hasattr(SHOW_DOWNLOAD_BUTTON, 'get') and SHOW_DOWNLOAD_BUTTON.get() }' === 'True'
 
   window.UPLOAD_CHUNK_SIZE = ${ UPLOAD_CHUNK_SIZE.get() };
   window.MAX_FILE_SIZE_UPLOAD_LIMIT = ${ MAX_FILE_SIZE_UPLOAD_LIMIT.get() if hasattr(MAX_FILE_SIZE_UPLOAD_LIMIT, 'get') and MAX_FILE_SIZE_UPLOAD_LIMIT.get() >= 0 else 'undefined' };

--- a/desktop/libs/aws/src/aws/s3/s3fs.py
+++ b/desktop/libs/aws/src/aws/s3/s3fs.py
@@ -353,7 +353,7 @@ class S3FileSystem(object):
   @auth_error_handler
   def rmtree(self, path, skipTrash=True):
     if not skipTrash:
-      raise NotImplementedError(_('Moving to trash is not implemented for S3'))
+      raise NotImplementedError('Moving to trash is not implemented for S3')
 
     bucket_name, key_name = s3.parse_uri(path)[:2]
     if bucket_name and not key_name:

--- a/desktop/libs/aws/src/aws/s3/s3fs.py
+++ b/desktop/libs/aws/src/aws/s3/s3fs.py
@@ -29,6 +29,7 @@ from boto.exception import BotoClientError, S3ResponseError
 from boto.s3.connection import Location
 from boto.s3.key import Key
 from boto.s3.prefix import Prefix
+from django.http.multipartparser import MultiPartParser
 from django.utils.translation import gettext as _
 
 from aws import s3
@@ -572,6 +573,8 @@ class S3FileSystem(object):
 
   @translate_s3_error
   def upload(self, file, path, *args, **kwargs):
+    # parser = MultiPartParser(META, post_data, self.upload_handlers, self.encoding)
+    # return parser.parse()
     pass  # upload is handled by S3FileUploadHandler
 
   @translate_s3_error


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Clean all filebrowser APIs with improved logic as separate methods serving public APIs
- Currently /upload, /extract, /compress APIs are not refactored -- that will be done in future PR.
- Will add unit tests in future PR.

## How was this patch tested?

- Manually