### PR TITLE
[core] Upgrade markdown package from 3.1 to 3.7

### DIFF
--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -39,7 +39,7 @@ kerberos==1.3.0
 kubernetes==26.1.0
 lockfile==0.12.2
 Mako==1.2.3
-Markdown==3.1
+Markdown==3.7
 openpyxl==3.0.9
 phoenixdb==1.2.1
 prompt-toolkit==3.0.39


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Markdown 3.1 to 3.7 (supporting Py3.8, Py3.9, Py3.10, Py3.11)
- https://pypi.org/project/Markdown/
## How was this patch tested?

- Locally
- Redhat8-Arm64
