### PR TITLE
[ui-importer] adds compute selection in importer destination

### DIFF
--- a/desktop/libs/indexer/src/indexer/templates/importer.mako
+++ b/desktop/libs/indexer/src/indexer/templates/importer.mako
@@ -1714,9 +1714,9 @@ ${ commonheader(_("Importer"), "indexer", user, request, "60px") | n,unicode }
       self.compute = wizard.compute;
       self.selectedComputeId = ko.observable();
 
-      self.selectedComputeId.subscribe(function (abc) {
+      self.selectedComputeId.subscribe(function (computeId) {
         var selectedCompute = self.namespace().computes.find(function (currCompute) {
-          return currCompute.name == self.selectedComputeId();
+          return currCompute.name == computeId;
         })
         self.compute(selectedCompute);
       });

--- a/desktop/libs/indexer/src/indexer/templates/importer.mako
+++ b/desktop/libs/indexer/src/indexer/templates/importer.mako
@@ -626,6 +626,14 @@ ${ commonheader(_("Importer"), "indexer", user, request, "60px") | n,unicode }
               <i class="fa fa-warning" style="color: #c09853"></i> ${ _('Does not exist') } <span data-bind="text: outputFormat"></span>
             </span>
           </div>
+
+          <!-- ko if: namespace().computes.length > 1 -->
+          <div class="control-group">
+            <label for="computeName" class="control-label"><div>${ _('Compute') }</div>
+              <select id="computeName" data-bind="selectize: namespace().computes, value: $parent.createWizard.source.selectedComputeId, optionsValue: 'name', optionsText: 'name'"></select>
+            </label>
+          </div>
+          <!-- /ko -->
         </div>
       </div>
 
@@ -1704,6 +1712,14 @@ ${ commonheader(_("Importer"), "indexer", user, request, "60px") | n,unicode }
       self.sampleCols = ko.observableArray();
       self.namespace = wizard.namespace;
       self.compute = wizard.compute;
+      self.selectedComputeId = ko.observable();
+
+      self.selectedComputeId.subscribe(function (abc) {
+        var selectedCompute = self.namespace().computes.find(function (currCompute) {
+          return currCompute.name == self.selectedComputeId();
+        })
+        self.compute(selectedCompute);
+      });
 
       var refreshThrottle = -1;
       var sampleColSubDisposals = [];


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Adding a compute selection in the import destination step so that user can selected the compute from available compute to import the data

## How was this patch tested?

- Tested manually for the .mako code

## Screenshot

<img width="796" alt="image" src="https://github.com/user-attachments/assets/6f29352f-4444-4e83-9f69-82e9c3109cc5">

