### PR TITLE
[raz][fips] Set usedforsecurity=False for MD5 hash to support FIPS mode

### DIFF
--- a/desktop/core/ext-py3/boto-2.49.0/boto/utils.py
+++ b/desktop/core/ext-py3/boto-2.49.0/boto/utils.py
@@ -1030,7 +1030,7 @@ def compute_md5(fp, buf_size=8192, size=None):
 
 
 def compute_hash(fp, buf_size=8192, size=None, hash_algorithm=md5):
-    hash_obj = hash_algorithm()
+    hash_obj = hash_algorithm(usedforsecurity=False) if hash_algorithm == md5 else hash_algorithm()
     spos = fp.tell()
     if size and size < buf_size:
         s = fp.read(size)


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Support WRITE operations for AWS S3 + RAZ in FIPS mode.

## How was this patch tested?

- E2E testing in live setup (both FIPS and non-FIPS)