### PR TITLE
[raz][fips] Fix S3 WRITE operations from regressing in non-raz setup

### DIFF
--- a/desktop/core/ext-py3/boto-2.49.0/boto/utils.py
+++ b/desktop/core/ext-py3/boto-2.49.0/boto/utils.py
@@ -61,7 +61,7 @@ from boto.compat import six, StringIO, urllib, encodebytes
 
 from contextlib import contextmanager
 
-from hashlib import md5, sha512
+from hashlib import md5, sha512, new as hashlib_new
 _hashfn = sha512
 
 from boto.compat import json
@@ -1030,7 +1030,7 @@ def compute_md5(fp, buf_size=8192, size=None):
 
 
 def compute_hash(fp, buf_size=8192, size=None, hash_algorithm=md5):
-    hash_obj = hash_algorithm(usedforsecurity=False) if hash_algorithm == md5 else hash_algorithm()
+    hash_obj = hashlib_new('md5', usedforsecurity=False) if hash_algorithm == md5 else hash_algorithm()
     spos = fp.tell()
     if size and size < buf_size:
         s = fp.read(size)


### PR DESCRIPTION
## What changes were proposed in this pull request?

- When trying to upload or create file/directory in AWS S3 configured with access key and secret, it was regressing with the following error:

```
S3 check_access encountered error verifying WRITE permission at path "s3a://hue-bucket/user/csso_hue_user": 'usedforsecurity' is an invalid keyword argument for openssl_md5() 
```
- This change fixes this regression for non-raz setup.

## How was this patch tested?

- Manually in live RAZ setup (both FIPS and non-FIPS) and non-RAZ setup.