### PR TITLE
[ui-core] remove urlPrefix option from useLoadData hook

### DIFF
--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage/StorageBrowserTabContents/StorageBrowserTabContent.tsx
@@ -60,8 +60,7 @@ const StorageBrowserTabContent = ({
     data: filesData,
     loading,
     reloadData
-  } = useLoadData<PathAndFileData>(filePath, {
-    urlPrefix: VIEWFILES_API_URl,
+  } = useLoadData<PathAndFileData>(`${VIEWFILES_API_URl}${filePath}`, {
     params: {
       pagesize: pageSize.toString(),
       pagenum: pageNumber.toString(),

--- a/desktop/core/src/desktop/js/reactComponents/FileChooser/FileChooserModal/FileChooserModal.tsx
+++ b/desktop/core/src/desktop/js/reactComponents/FileChooser/FileChooserModal/FileChooserModal.tsx
@@ -72,10 +72,12 @@ const FileChooserModal: React.FC<FileProps> = ({ show, onCancel, title, okText }
     }
   }, [fileSystemsData]);
 
-  const { data: filesData, loading: loadingFiles } = useLoadData<PathAndFileData>(filePath, {
-    urlPrefix: VIEWFILES_API_URl,
-    skip: !!filePath
-  });
+  const { data: filesData, loading: loadingFiles } = useLoadData<PathAndFileData>(
+    `${VIEWFILES_API_URl}${filePath}`,
+    {
+      skip: !!filePath
+    }
+  );
 
   return (
     <Modal

--- a/desktop/core/src/desktop/js/utils/hooks/useLoadData.test.tsx
+++ b/desktop/core/src/desktop/js/utils/hooks/useLoadData.test.tsx
@@ -130,21 +130,6 @@ describe('useLoadData', () => {
     });
   });
 
-  it('should handle URL prefix correctly', async () => {
-    const { result } = renderHook(() => useLoadData(mockEndpoint, { urlPrefix: mockUrlPrefix }));
-
-    expect(result.current.data).toBeUndefined();
-    expect(result.current.error).toBeUndefined();
-    expect(result.current.loading).toBe(true);
-
-    await waitFor(() => {
-      expect(mockGet).toHaveBeenCalledWith(mockUrl, undefined, expect.any(Object));
-      expect(result.current.data).toEqual(mockData);
-      expect(result.current.error).toBeUndefined();
-      expect(result.current.loading).toBe(false);
-    });
-  });
-
   it('should update options correctly', async () => {
     const { result, rerender } = renderHook(
       (props: { url: string; options }) => useLoadData(props.url, props.options),

--- a/desktop/core/src/desktop/js/utils/hooks/useLoadData.ts
+++ b/desktop/core/src/desktop/js/utils/hooks/useLoadData.ts
@@ -18,7 +18,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ApiFetchOptions, get } from '../../api/utils';
 
 export interface Options<T, U> {
-  urlPrefix?: string;
   params?: U;
   fetchOptions?: ApiFetchOptions<T>;
   skip?: boolean;
@@ -63,8 +62,7 @@ const useLoadData = <T, U = unknown>(
       setError(undefined);
 
       try {
-        const fetchUrl = localOptions?.urlPrefix ? `${localOptions.urlPrefix}${url}` : url;
-        const response = await get<T, U>(fetchUrl, localOptions?.params, fetchOptions);
+        const response = await get<T, U>(url, localOptions?.params, fetchOptions);
         setData(response);
         if (localOptions?.onSuccess) {
           localOptions.onSuccess(response);


### PR DESCRIPTION
## What changes were proposed in this pull request?

- This PR removes the urlPrefix option from useLoad Data hook

## How was this patch tested?

- Updated the unit test