### PR TITLE
[Pytest] Generate HTML report for test results and disable warnings

### DIFF
--- a/.github/workflows/commitflow-py3.yml
+++ b/.github/workflows/commitflow-py3.yml
@@ -61,7 +61,14 @@ jobs:
 
     - name: run tests
       run: |
-        PYTHONWARNINGS=always ./build/env/bin/pytest
+        mkdir -p test-reports  # Ensure the directory exists
+        PYTHONWARNINGS=always ./build/env/bin/pytest --html=test-reports/report_${{ matrix.python-version }}.html --self-contained-html
+ 
+    - name: upload pytest report
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-reports-${{ matrix.python-version }}
+        path: test-reports
 
     - name: run python lints
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ desktop/desktop-test.db
 ext/hadoop/
 ext/hive/
 ext/oozie/
-nosetests.xml
+report.html
 oozie.sql
 tools/jenkins/ext/
 tools/jenkins/oozie.sql

--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -48,6 +48,7 @@ py==1.11.0
 pyformance==0.3.2
 pytest==8.1.1
 pytest-django==4.8.0
+pytest-html==4.1.1
 python-dateutil==2.8.2
 python-daemon==2.2.4
 python-ldap==3.4.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "desktop.settings"
-addopts = "-v -m 'not integration' --strict-markers --durations=10"
+console_output_style = "count"
+addopts = "-v -m 'not integration' --strict-markers --disable-warnings --html=report.html --self-contained-html"
 norecursedirs = "desktop/core/ext-py3"
 python_files = "tests.py test_*.py *_tests.py tests_* *_test.py"
 markers = [


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Generate an HTML report for both GitHub Actions and local runs. 
    - GitHub Action: If any tests fail, users can download the artifact from the uploaded pytest report in GitHub Actions to view the test results in a more readable format.
    - Local Run: Users can simply open the report.html file in any browser to view the test results.
- Disable warning summary for better visibility of test results.
- Display test output using counts instead of percentages.

## How was this patch tested?

- Locally
- Github action
