### PR TITLE
[api] Prevent renaming files to restricted file types

### DIFF
--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -496,6 +496,10 @@ def rename(request):
   source_path = request.POST.get('source_path', '')
   destination_path = request.POST.get('destination_path', '')
 
+  # Check if source and destination paths are provided
+  if not source_path or not destination_path:
+    return HttpResponse("Missing required parameters: source_path and destination_path", status=400)
+
   # Extract file extensions from paths
   _, source_path_ext = os.path.splitext(source_path)
   _, dest_path_ext = os.path.splitext(destination_path)
@@ -505,18 +509,18 @@ def rename(request):
   if dest_path_ext.lower() in restricted_file_types and (source_path_ext.lower() != dest_path_ext.lower()):
     return HttpResponse(f'Cannot rename file to a restricted file type: "{dest_path_ext}"', status=403)
 
+   # Check if destination path contains a hash character
   if "#" in destination_path:
-    return HttpResponse(
-      f"Error creating {os.path.basename(source_path)} to {destination_path}: Hashes are not allowed in file or directory names", status=400
-    )
+    return HttpResponse("Hashes are not allowed in file or directory names. Please choose a different name.", status=400)
 
-  # If dest_path doesn't have a directory specified, use same directory.
+  # If destination path doesn't have a directory specified, use the same directory as the source path
   if "/" not in destination_path:
     source_dir = os.path.dirname(source_path)
     destination_path = request.fs.join(source_dir, destination_path)
 
+  # Check if destination path already exists
   if request.fs.exists(destination_path):
-    return HttpResponse(f"The destination path {destination_path} already exists.", status=500)  # TODO: Status code?
+    return HttpResponse(f"The destination path {destination_path} already exists.", status=409)
 
   request.fs.rename(source_path, destination_path)
   return HttpResponse(status=200)

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -496,6 +496,15 @@ def rename(request):
   source_path = request.POST.get('source_path', '')
   destination_path = request.POST.get('destination_path', '')
 
+  # Extract file extensions from paths
+  _, source_path_ext = os.path.splitext(source_path)
+  _, dest_path_ext = os.path.splitext(destination_path)
+
+  restricted_file_types = [ext.lower() for ext in RESTRICT_FILE_EXTENSIONS.get()]
+  # Check if destination path has a restricted file type and it doesn't match the source file type
+  if dest_path_ext.lower() in restricted_file_types and (source_path_ext.lower() != dest_path_ext.lower()):
+    return HttpResponse(f'Cannot rename file to a restricted file type: "{dest_path_ext}"', status=403)
+
   if "#" in destination_path:
     return HttpResponse(
       f"Error creating {os.path.basename(source_path)} to {destination_path}: Hashes are not allowed in file or directory names", status=400


### PR DESCRIPTION
## What changes were proposed in this pull request?

- We need to prevent users to rename files to restricted file types. This is to counter the scenario where user uploads a file with different type then renames it to a different type for malicious intent. 
- Although we are not restricting when the source file type is already restricted and then user is renaming to same file type because we don't know how the file is present in the first place in the filesystem as Hue will not allow normal upload of restricted file type.

## How was this patch tested?

- Manually
- Adding new unit tests