### PR TITLE
[fb] Stop file uploads with restrictive file types for old upload handlers

### DIFF
--- a/desktop/core/src/desktop/lib/fs/gc/upload.py
+++ b/desktop/core/src/desktop/lib/fs/gc/upload.py
@@ -74,15 +74,16 @@ class GSFileUploadHandler(FileUploadHandler):
     This method is called when a new file is encountered during the upload process.
     """
     if self._is_gs_upload():
+      LOG.info('Using GSFileUploadHandler to handle file upload.')
+
       _, file_type = os.path.splitext(file_name)
       if RESTRICT_FILE_EXTENSIONS.get() and file_type.lower() in [ext.lower() for ext in RESTRICT_FILE_EXTENSIONS.get()]:
-        err_message = f'GS upload error: File type "{file_type}" is not allowed. Please choose a file with a different type.'
+        err_message = f'Uploading files with type "{file_type}" is not allowed. Hue is configured to restrict this type.'
         LOG.error(err_message)
         raise Exception(err_message)
 
       super().new_file(field_name, file_name, *args, **kwargs)
 
-      LOG.info('Using GSFileUploadHandler to handle file upload.')
       self.target_path = self._fs.join(self.key_name, file_name)
 
       try:

--- a/desktop/core/src/desktop/lib/fs/gc/upload.py
+++ b/desktop/core/src/desktop/lib/fs/gc/upload.py
@@ -21,6 +21,7 @@ Classes for a custom upload handler to stream into GS.
 See http://docs.djangoproject.com/en/1.9/topics/http/file-uploads/
 """
 
+import os
 import logging
 from io import BytesIO as stream_io
 
@@ -30,6 +31,7 @@ from django.core.files.uploadhandler import FileUploadHandler, StopFutureHandler
 from desktop.lib.fs.gc import parse_uri
 from desktop.lib.fs.gc.gs import GSFileSystemException
 from desktop.lib.fsmanager import get_client
+from filebrowser.conf import RESTRICT_FILE_EXTENSIONS
 
 LOG = logging.getLogger()
 
@@ -72,6 +74,12 @@ class GSFileUploadHandler(FileUploadHandler):
     This method is called when a new file is encountered during the upload process.
     """
     if self._is_gs_upload():
+      _, file_type = os.path.splitext(file_name)
+      if RESTRICT_FILE_EXTENSIONS.get() and file_type.lower() in [ext.lower() for ext in RESTRICT_FILE_EXTENSIONS.get()]:
+        err_message = f'GS upload error: File type "{file_type}" is not allowed. Please choose a file with a different type.'
+        LOG.error(err_message)
+        raise Exception(err_message)
+
       super().new_file(field_name, file_name, *args, **kwargs)
 
       LOG.info('Using GSFileUploadHandler to handle file upload.')

--- a/desktop/core/src/desktop/lib/fs/ozone/upload.py
+++ b/desktop/core/src/desktop/lib/fs/ozone/upload.py
@@ -203,15 +203,16 @@ class OFSFileUploadHandler(FileUploadHandler):
 
   def new_file(self, field_name, file_name, *args, **kwargs):
     if self._is_ofs_upload():
+      LOG.info('Using OFSFileUploadHandler to handle file upload.')
+
       _, file_type = os.path.splitext(file_name)
       if RESTRICT_FILE_EXTENSIONS.get() and file_type.lower() in [ext.lower() for ext in RESTRICT_FILE_EXTENSIONS.get()]:
-        err_message = f'OFS upload error: File type "{file_type}" is not allowed. Please choose a file with a different type.'
+        err_message = f'Uploading files with type "{file_type}" is not allowed. Hue is configured to restrict this type.'
         LOG.error(err_message)
         raise Exception(err_message)
 
       super(OFSFileUploadHandler, self).new_file(field_name, file_name, *args, **kwargs)
 
-      LOG.info('Using OFSFileUploadHandler to handle file upload.')
       self.target_path = self._fs.join(self.destination, file_name)
 
       try:

--- a/desktop/libs/aws/src/aws/s3/upload.py
+++ b/desktop/libs/aws/src/aws/s3/upload.py
@@ -21,6 +21,7 @@ Classes for a custom upload handler to stream into S3.
 See http://docs.djangoproject.com/en/1.9/topics/http/file-uploads/
 """
 
+import os
 import logging
 import unicodedata
 from io import BytesIO as stream_io
@@ -34,6 +35,7 @@ from aws.s3.s3fs import S3FileSystemException
 from desktop.conf import TASK_SERVER_V2
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.fsmanager import get_client
+from filebrowser.conf import RESTRICT_FILE_EXTENSIONS
 from filebrowser.utils import calculate_total_size, generate_chunks
 
 DEFAULT_WRITE_SIZE = 1024 * 1024 * 128  # TODO: set in configuration (currently 128 MiB)
@@ -156,6 +158,12 @@ class S3FileUploadHandler(FileUploadHandler):
 
   def new_file(self, field_name, file_name, *args, **kwargs):
     if self._is_s3_upload():
+      _, file_type = os.path.splitext(file_name)
+      if RESTRICT_FILE_EXTENSIONS.get() and file_type.lower() in [ext.lower() for ext in RESTRICT_FILE_EXTENSIONS.get()]:
+        err_message = f'S3 upload error: File type "{file_type}" is not allowed. Please choose a file with a different type.'
+        LOG.error(err_message)
+        raise Exception(err_message)
+
       super(S3FileUploadHandler, self).new_file(field_name, file_name, *args, **kwargs)
 
       LOG.info('Using S3FileUploadHandler to handle file upload.')

--- a/desktop/libs/aws/src/aws/s3/upload.py
+++ b/desktop/libs/aws/src/aws/s3/upload.py
@@ -158,15 +158,16 @@ class S3FileUploadHandler(FileUploadHandler):
 
   def new_file(self, field_name, file_name, *args, **kwargs):
     if self._is_s3_upload():
+      LOG.info('Using S3FileUploadHandler to handle file upload.')
+
       _, file_type = os.path.splitext(file_name)
       if RESTRICT_FILE_EXTENSIONS.get() and file_type.lower() in [ext.lower() for ext in RESTRICT_FILE_EXTENSIONS.get()]:
-        err_message = f'S3 upload error: File type "{file_type}" is not allowed. Please choose a file with a different type.'
+        err_message = f'Uploading files with type "{file_type}" is not allowed. Hue is configured to restrict this type.'
         LOG.error(err_message)
         raise Exception(err_message)
 
       super(S3FileUploadHandler, self).new_file(field_name, file_name, *args, **kwargs)
 
-      LOG.info('Using S3FileUploadHandler to handle file upload.')
       self.target_path = self._fs.join(self.key_name, file_name)
 
       try:

--- a/desktop/libs/azure/src/azure/abfs/upload.py
+++ b/desktop/libs/azure/src/azure/abfs/upload.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import logging
 import unicodedata
 from io import BytesIO
@@ -27,6 +28,7 @@ from azure.abfs.abfs import ABFSFileSystemException
 from desktop.conf import TASK_SERVER_V2
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.fsmanager import get_client
+from filebrowser.conf import RESTRICT_FILE_EXTENSIONS
 from filebrowser.utils import calculate_total_size, generate_chunks
 
 DEFAULT_WRITE_SIZE = 100 * 1024 * 1024  # As per Azure doc, maximum blob size is 100MB
@@ -171,6 +173,12 @@ class ABFSFileUploadHandler(FileUploadHandler):
 
   def new_file(self, field_name, file_name, *args, **kwargs):
     if self._is_abfs_upload():
+      _, file_type = os.path.splitext(file_name)
+      if RESTRICT_FILE_EXTENSIONS.get() and file_type.lower() in [ext.lower() for ext in RESTRICT_FILE_EXTENSIONS.get()]:
+        err_message = f'ABFS upload error: File type "{file_type}" is not allowed. Please choose a file with a different type.'
+        LOG.error(err_message)
+        raise Exception(err_message)
+
       super(ABFSFileUploadHandler, self).new_file(field_name, file_name, *args, **kwargs)
 
       LOG.info('Using ABFSFileUploadHandler to handle file upload wit temp file%s.' % file_name)

--- a/desktop/libs/azure/src/azure/abfs/upload.py
+++ b/desktop/libs/azure/src/azure/abfs/upload.py
@@ -173,15 +173,16 @@ class ABFSFileUploadHandler(FileUploadHandler):
 
   def new_file(self, field_name, file_name, *args, **kwargs):
     if self._is_abfs_upload():
+      LOG.info('Using ABFSFileUploadHandler to handle file upload wit temp file%s.' % file_name)
+
       _, file_type = os.path.splitext(file_name)
       if RESTRICT_FILE_EXTENSIONS.get() and file_type.lower() in [ext.lower() for ext in RESTRICT_FILE_EXTENSIONS.get()]:
-        err_message = f'ABFS upload error: File type "{file_type}" is not allowed. Please choose a file with a different type.'
+        err_message = f'Uploading files with type "{file_type}" is not allowed. Hue is configured to restrict this type.'
         LOG.error(err_message)
         raise Exception(err_message)
 
       super(ABFSFileUploadHandler, self).new_file(field_name, file_name, *args, **kwargs)
 
-      LOG.info('Using ABFSFileUploadHandler to handle file upload wit temp file%s.' % file_name)
       self.target_path = self._fs.join(self.destination, file_name)
 
       try:

--- a/desktop/libs/hadoop/src/hadoop/fs/upload.py
+++ b/desktop/libs/hadoop/src/hadoop/fs/upload.py
@@ -34,7 +34,7 @@ import hadoop.cluster
 from desktop.lib import fsmanager
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.fsmanager import get_client
-from filebrowser.conf import ARCHIVE_UPLOAD_TEMPDIR
+from filebrowser.conf import ARCHIVE_UPLOAD_TEMPDIR, RESTRICT_FILE_EXTENSIONS
 from filebrowser.utils import calculate_total_size, generate_chunks
 from hadoop.conf import UPLOAD_CHUNK_SIZE
 from hadoop.fs.exceptions import WebHdfsException
@@ -302,6 +302,13 @@ class HDFSfileUploadHandler(FileUploadHandler):
     # Detect "HDFS" in the field name.
     if field_name.upper().startswith('HDFS'):
       LOG.info('Using HDFSfileUploadHandler to handle file upload.')
+
+      _, file_type = os.path.splitext(file_name)
+      if RESTRICT_FILE_EXTENSIONS.get() and file_type.lower() in [ext.lower() for ext in RESTRICT_FILE_EXTENSIONS.get()]:
+        err_message = f'HDFS upload error: File type "{file_type}" is not allowed. Please choose a file with a different type.'
+        LOG.error(err_message)
+        raise Exception(err_message)
+
       try:
         fs_ref = self.request.GET.get('fs', 'default')
         self.request.fs = fsmanager.get_filesystem(fs_ref)

--- a/desktop/libs/hadoop/src/hadoop/fs/upload.py
+++ b/desktop/libs/hadoop/src/hadoop/fs/upload.py
@@ -305,7 +305,7 @@ class HDFSfileUploadHandler(FileUploadHandler):
 
       _, file_type = os.path.splitext(file_name)
       if RESTRICT_FILE_EXTENSIONS.get() and file_type.lower() in [ext.lower() for ext in RESTRICT_FILE_EXTENSIONS.get()]:
-        err_message = f'HDFS upload error: File type "{file_type}" is not allowed. Please choose a file with a different type.'
+        err_message = f'Uploading files with type "{file_type}" is not allowed. Hue is configured to restrict this type.'
         LOG.error(err_message)
         raise Exception(err_message)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add check for preventing upload operation for files having restrictive file extensions in old upload handlers also.

## How was this patch tested?

- Manually