### PR TITLE
[api] Creating api for Server Logs page

### DIFF
--- a/desktop/core/src/desktop/urls.py
+++ b/desktop/core/src/desktop/urls.py
@@ -74,6 +74,7 @@ else:
 
 dynamic_patterns += [
   re_path(r'^logs$', desktop_views.log_view, name="desktop.views.log_view"),
+  re_path(r'^logs\.json$', desktop_views.log_json_view, name="desktop.views.log_json_view"),
   re_path(r'^task_server$', desktop_views.task_server_view, name='desktop.views.task_server_view'),
   re_path(r'^desktop/log_analytics$', desktop_views.log_analytics),
   re_path(r'^desktop/log_js_error$', desktop_views.log_js_error),


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently there is no API endpoint to be able to fetch the data and render it on Server Logs page. The data displayed currently is via Server Side Rendering via the call `/logs?&is_embeddable=true` as seen in the Network tab.

## How was this patch tested?
The new api is created via the name logs.json. Able to see `logs.json` call in the Network tab wherein json response from `logs.json` can be seen.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
