### PR TITLE
Remove psycopg2-binary due to FIPS restrictions

### DIFF
--- a/tools/cloudera/build_hue_common.sh
+++ b/tools/cloudera/build_hue_common.sh
@@ -185,6 +185,8 @@ function sles12_install() {
       libpcap \
       ncurses-devel \
       nmap \
+      python3-devel \
+      postgresql-server-devel \
       xmlsec1 xmlsec1-devel  xmlsec1-openssl-devel'
     # MySQLdb install
     sudo -- sh -c 'zypper install -y libmysqlclient-devel libmysqlclient18 libmysqld18 libmysqld-devel'
@@ -216,6 +218,7 @@ function sles15_install() {
       libpcap1 \
       ncurses-devel \
       nmap \
+      postgresql-server-devel \
       xmlsec1 xmlsec1-devel  xmlsec1-openssl-devel'
     # MySQLdb install
     sudo -- sh -c 'zypper install -y libmariadb-devel mariadb-client python3-mysqlclient'
@@ -247,7 +250,9 @@ function centos7_install() {
       nmap-ncat \
       xmlsec1 \
       xmlsec1-openssl \
-      unzip'
+      unzip \
+      python3-devel \
+      postgresql-devel'
     # MySQLdb install
     sudo -- sh -c 'curl -sSLO https://dev.mysql.com/get/mysql80-community-release-el7-11.noarch.rpm && \
         rpm -ivh mysql80-community-release-el7-11.noarch.rpm && \
@@ -289,7 +294,9 @@ function redhat8_install() {
       xmlsec1 \
       xmlsec1-openssl \
       libss \
-      ncurses-c++-libs'
+      ncurses-c++-libs \
+      python3-devel \
+      postgresql-devel'
     # MySQLdb install
     sudo -- sh -c 'yum install -y python3-mysqlclient'
     # NODEJS 20 install
@@ -364,6 +371,8 @@ function ubuntu18_install() {
         python3-setuptools \
         python3-wheel \
         python3.8-venv \
+        python3-dev \
+        libpq-dev \
         zlibc'
     # MySQLdb install
     # It is pre-installed
@@ -399,6 +408,7 @@ function ubuntu20_install() {
         libpython3.8-stdlib \
         libxmlsec1 \
         libxmlsec1-openssl \
+        libpq-dev \
         netcat \
         nmap \
         python-asn1crypto \
@@ -447,6 +457,7 @@ function ubuntu22_install() {
         libpython3.10-stdlib \
         libxmlsec1 \
         libxmlsec1-openssl \
+        libpq-dev \
         netcat \
         nmap \
         python3-asn1crypto \
@@ -491,7 +502,8 @@ function redhat9_install() {
       xmlsec1 \
       xmlsec1-openssl \
       libss \
-      ncurses-c++-libs'
+      ncurses-c++-libs \
+      postgresql-devel'
     # MySQLdb install
     sudo -- sh -c 'yum install -y python3-mysqlclient'
     # NODEJS 20 install

--- a/tools/container/hue/Dockerfile
+++ b/tools/container/hue/Dockerfile
@@ -33,8 +33,15 @@ RUN yum install -y microdnf && \
 COPY --chown=${HUEUSER}:${HUEUSER} ${HUEUSER} ${HUE_HOME}
 COPY --chown=${HUEUSER}:${HUEUSER} hue.sh ${HUE_HOME}/hue.sh
 
-# Install psycopg2-binary
-RUN $HUE_BIN/python3.8 -m pip install --upgrade pip --force && $HUE_BIN/pip install psycopg2-binary
+# Install psycopg2
+RUN set -eux; \
+    apk --no-cache add \
+    gcc \
+    python3-dev \
+    build-base \
+    postgresql-dev && \
+    $HUE_BIN/python3.8 -m pip install --upgrade pip --force && \
+    $HUE_BIN/pip install psycopg2 --no-cache-dir
 
 # Setup directory structure
 RUN mkdir -p ${HUE_LOG_DIR} && chown -R ${HUEUSER}:${HUEUSER} ${HUE_LOG_DIR}


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Psycopg2-binary comes pre-packaged with a openssl version that is not compatible with the FIPS requirements. So, removing the psycopg2-binary package and installing psycopg2 & its necessary dependencies. 

## How was this patch tested?

- Manual tests on Rhel-8,9 , Centos, Ubuntu, Sles12,15

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
