### PR TITLE
[backend] Remove lockfile python package due to EOL

### DIFF
--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -37,7 +37,6 @@ jdcal==1.0.1
 kazoo==2.8.0
 kerberos==1.3.0
 kubernetes==26.1.0
-lockfile==0.12.2
 Mako==1.2.3
 Markdown==3.7
 openpyxl==3.0.9


### PR DESCRIPTION
(cherry picked from commit 5781f39d313cf7391f49dc59b91d87d91b94e2c1)

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
