### PR TITLE
Fix Metrics for Oracle DPI errors

### DIFF
--- a/apps/useradmin/src/useradmin/metrics.py
+++ b/apps/useradmin/src/useradmin/metrics.py
@@ -18,7 +18,7 @@ import logging
 from datetime import datetime, timedelta
 
 from django.db import connection
-from django.db.utils import OperationalError
+from django.db.utils import DatabaseError, OperationalError
 from prometheus_client import Gauge
 
 from desktop.lib.metrics import global_registry
@@ -35,7 +35,7 @@ def active_users():
         first_login=False,
         hostname__isnull=False
     ).count()
-  except OperationalError as oe:
+  except (OperationalError, DatabaseError) as oe:
     LOG.debug('active_users recovering from %s' % str(oe))
     connection.close()
     connection.connect()
@@ -67,7 +67,7 @@ def active_users_per_instance():
   try:
     count = UserProfile.objects.filter(last_activity__gt=datetime.now() - timedelta(hours=1),
                                        hostname=get_localhost_name()).count()
-  except OperationalError as oe:
+  except (OperationalError, DatabaseError) as oe:
     LOG.debug('active_users_per_instance recovering from %s' % str(oe))
     connection.close()
     connection.connect()

--- a/desktop/core/src/desktop/metrics.py
+++ b/desktop/core/src/desktop/metrics.py
@@ -24,7 +24,7 @@ from builtins import range
 from datetime import datetime, timedelta
 
 from django.db import connection
-from django.db.utils import OperationalError
+from django.db.utils import DatabaseError, OperationalError
 from future import standard_library
 from prometheus_client import REGISTRY, Gauge
 
@@ -149,7 +149,7 @@ def user_count():
   users = 0
   try:
     users = User.objects.count()
-  except OperationalError as oe:
+  except (OperationalError, DatabaseError) as oe:
     LOG.debug('user_count recovering from %s' % str(oe))
     connection.close()
     connection.connect()
@@ -207,7 +207,7 @@ def num_of_queries():
       is_history=True,
       last_modified__gt=datetime.now() - timedelta(minutes=10)
     ).count()
-  except OperationalError as oe:
+  except (OperationalError, DatabaseError) as oe:
     LOG.debug('num_of_queries recovering from %s' % str(oe))
     connection.close()
     connection.connect()


### PR DESCRIPTION
Stacktrace:
[20/Dec/2024 08:23:00 -0500] metrics      ERROR    Could not get active_users
Traceback (most recent call last):
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p1015.59425156/lib/hue/build/env/lib/python3.8/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p1015.59425156/lib/hue/build/env/lib/python3.8/site-packages/django/db/backends/oracle/base.py", line 521, in execute
    self._guess_input_sizes([params])
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p1015.59425156/lib/hue/build/env/lib/python3.8/site-packages/django/db/backends/oracle/base.py", line 467, in _guess_input_sizes
    self.setinputsizes(**sizes)
cx_Oracle.DatabaseError: DPI-1010: not connected

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p1015.59425156/lib/hue/apps/useradmin/src/useradmin/metrics.py", line 33, in active_users
    count = UserProfile.objects.filter(
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p1015.59425156/lib/hue/build/env/lib/python3.8/site-packages/django/db/models/query.py", line 412, in count
    return self.query.get_count(using=self.db)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p1015.59425156/lib/hue/build/env/lib/python3.8/site-packages/django/db/models/sql/query.py", line 528, in get_count
    number = obj.get_aggregation(using, ['__count'])['__count']
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p1015.59425156/lib/hue/build/env/lib/python3.8/site-packages/django/db/models/sql/query.py", line 513, in get_aggregation
    result = compiler.execute_sql(SINGLE)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p1015.59425156/lib/hue/build/env/lib/python3.8/site-packages/django/db/models/sql/compiler.py", line 1175, in execute_sql
    cursor.execute(sql, params)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p1015.59425156/lib/hue/build/env/lib/python3.8/site-packages/django/db/backends/utils.py", line 66, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p1015.59425156/lib/hue/build/env/lib/python3.8/site-packages/django/db/backends/utils.py", line 75, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p1015.59425156/lib/hue/build/env/lib/python3.8/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p1015.59425156/lib/hue/build/env/lib/python3.8/site-packages/django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p1015.59425156/lib/hue/build/env/lib/python3.8/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p1015.59425156/lib/hue/build/env/lib/python3.8/site-packages/django/db/backends/oracle/base.py", line 521, in execute
    self._guess_input_sizes([params])
  File "/opt/cloudera/parcels/CDH-7.1.9-1.cdh7.1.9.p1015.59425156/lib/hue/build/env/lib/python3.8/site-packages/django/db/backends/oracle/base.py", line 467, in _guess_input_sizes
    self.setinputsizes(**sizes)
django.db.utils.DatabaseError: DPI-1010: not connected. 

Testing:
Manually tested and was also tested at customer end.