### PR TITLE
[test] Move pytest and its dependencies from `make apps` to `make test_prep`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
 
             export PYTHON_VER=python3.8
             export ROOT=$PWD
-            make apps
+            make test_prep
 
       - run:
           name: run documentation lints

--- a/.github/workflows/commitflow-py3.yml
+++ b/.github/workflows/commitflow-py3.yml
@@ -57,7 +57,7 @@ jobs:
 
         export PYTHON_VER=python${{ matrix.python-version }}
         export ROOT=$PWD
-        make apps
+        make test_prep
 
     - name: run tests
       run: |

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ default:
 	@echo '  clean       : Remove desktop build products'
 	@echo '  distclean   : Remove desktop and thirdparty build products'
 # <<<< DEV ONLY
-	@echo '  doc 	       : Build documentation'
+	@echo '  doc 	      : Build documentation'
 	@echo '  prod        : Generate a tar file for production distribution'
 	@echo '  locales     : Extract strings and update dictionary of each locale'
 	@echo '  ace         : Builds the Ace Editor tool'
@@ -107,6 +107,13 @@ all: default
 
 # <<<< DEV ONLY
 include Makefile.tarball
+
+###################################
+# Build docs (unused)
+###################################
+.PHONY: test_prep
+test_prep: apps
+	@$(ENV_PIP) install -r $(REQUIREMENT_TEST_FILE)
 
 ###################################
 # Build docs (unused)

--- a/Makefile.vars
+++ b/Makefile.vars
@@ -140,6 +140,7 @@ PYBABEL := $(ROOT)/build/env/bin/pybabel
 ##############################
 REQUIREMENT_FILE := $(ROOT)/desktop/core/requirements.txt
 REQUIREMENT_DOT_FILE := $(ROOT)/desktop/core/.requirements
+REQUIREMENT_TEST_FILE := $(ROOT)/desktop/core/test_requirements.txt
 NAVOPTAPI_WHL := $(ROOT)/desktop/core/wheels/navoptapi-1.0.0-py3-none-any.whl
 
 ##############################

--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -43,12 +43,8 @@ openpyxl==3.0.9
 phoenixdb==1.2.1
 prompt-toolkit==3.0.39
 protobuf==3.20.3
-py==1.11.0
 pyarrow==17.0.0
 pyformance==0.3.2
-pytest==8.1.1
-pytest-django==4.8.0
-pytest-html==4.1.1
 python-dateutil==2.8.2
 python-daemon==2.2.4
 python-ldap==3.4.3

--- a/desktop/core/test_requirements.txt
+++ b/desktop/core/test_requirements.txt
@@ -1,0 +1,3 @@
+pytest==8.1.1
+pytest-django==4.8.0
+pytest-html==4.1.1


### PR DESCRIPTION
…t_prep`

## What changes were proposed in this pull request?

Separate test required package in different build target

## How was this patch tested?

Manual

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
