### PR TITLE
[ui-storagebrowser] Adds silent polling for list_dir during file upload

### DIFF
--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageDirectoryPage/StorageDirectoryPage.scss
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageDirectoryPage/StorageDirectoryPage.scss
@@ -71,6 +71,10 @@ $icon-margin: 5px;
       height: $cell-height;
       @include mixins.nowrap-ellipsis;
     }
+
+    td.ant-table-cell:first-child {
+      text-overflow: initial;
+    }
   }
 
   .hue-storage-browser__table-cell-name {

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageDirectoryPage/StorageDirectoryPage.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageDirectoryPage/StorageDirectoryPage.tsx
@@ -45,7 +45,7 @@ import { formatTimestamp } from '../../../utils/dateTimeUtils';
 import useLoadData from '../../../utils/hooks/useLoadData';
 import {
   DEFAULT_PAGE_SIZE,
-  DEFAULT_POOLING_TIME,
+  DEFAULT_POLLING_TIME,
   FileUploadStatus
 } from '../../../utils/constants/storageBrowser';
 import CreateAndUploadAction from './CreateAndUploadAction/CreateAndUploadAction';
@@ -81,7 +81,7 @@ const StorageDirectoryPage = ({
   const [tableHeight, setTableHeight] = useState<number>(100);
   const [selectedFiles, setSelectedFiles] = useState<StorageDirectoryTableData[]>([]);
   const [filesToUpload, setFilesToUpload] = useState<UploadItem[]>([]);
-  const [pooling, setPooling] = useState<boolean>(false);
+  const [polling, setPolling] = useState<boolean>(false);
 
   const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE);
   const [pageNumber, setPageNumber] = useState<number>(1);
@@ -112,7 +112,7 @@ const StorageDirectoryPage = ({
     onSuccess: () => {
       setSelectedFiles([]);
     },
-    pollInterval: pooling ? DEFAULT_POOLING_TIME : undefined
+    pollInterval: polling ? DEFAULT_POLLING_TIME : undefined
   });
 
   const tableData: StorageDirectoryTableData[] = useMemo(() => {
@@ -240,7 +240,7 @@ const StorageDirectoryPage = ({
         status: FileUploadStatus.Pending
       };
     });
-    setPooling(true);
+    setPolling(true);
     setFilesToUpload(prevFiles => [...prevFiles, ...newUploadItems]);
   };
 
@@ -310,7 +310,7 @@ const StorageDirectoryPage = ({
 
       <DragAndDrop onDrop={onFilesDrop}>
         <LoadingErrorWrapper
-          loading={(loadingFiles || listDirectoryLoading) && !pooling}
+          loading={(loadingFiles || listDirectoryLoading) && !polling}
           errors={errorConfig}
         >
           <Table
@@ -351,7 +351,7 @@ const StorageDirectoryPage = ({
           onClose={() => setFilesToUpload([])}
           onComplete={() => {
             reloadData();
-            setPooling(false);
+            setPolling(false);
           }}
         />
       )}

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageDirectoryPage/StorageDirectoryPage.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageDirectoryPage/StorageDirectoryPage.tsx
@@ -43,7 +43,11 @@ import formatBytes from '../../../utils/formatBytes';
 import './StorageDirectoryPage.scss';
 import { formatTimestamp } from '../../../utils/dateTimeUtils';
 import useLoadData from '../../../utils/hooks/useLoadData';
-import { DEFAULT_PAGE_SIZE, FileUploadStatus } from '../../../utils/constants/storageBrowser';
+import {
+  DEFAULT_PAGE_SIZE,
+  DEFAULT_POOLING_TIME,
+  FileUploadStatus
+} from '../../../utils/constants/storageBrowser';
 import CreateAndUploadAction from './CreateAndUploadAction/CreateAndUploadAction';
 import DragAndDrop from '../../../reactComponents/DragAndDrop/DragAndDrop';
 import UUID from '../../../utils/string/UUID';
@@ -77,6 +81,7 @@ const StorageDirectoryPage = ({
   const [tableHeight, setTableHeight] = useState<number>(100);
   const [selectedFiles, setSelectedFiles] = useState<StorageDirectoryTableData[]>([]);
   const [filesToUpload, setFilesToUpload] = useState<UploadItem[]>([]);
+  const [pooling, setPooling] = useState<boolean>(false);
 
   const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE);
   const [pageNumber, setPageNumber] = useState<number>(1);
@@ -106,7 +111,8 @@ const StorageDirectoryPage = ({
       fileStats.type !== BrowserViewType.dir,
     onSuccess: () => {
       setSelectedFiles([]);
-    }
+    },
+    pollInterval: pooling ? DEFAULT_POOLING_TIME : undefined
   });
 
   const tableData: StorageDirectoryTableData[] = useMemo(() => {
@@ -234,6 +240,7 @@ const StorageDirectoryPage = ({
         status: FileUploadStatus.Pending
       };
     });
+    setPooling(true);
     setFilesToUpload(prevFiles => [...prevFiles, ...newUploadItems]);
   };
 
@@ -302,7 +309,10 @@ const StorageDirectoryPage = ({
       </div>
 
       <DragAndDrop onDrop={onFilesDrop}>
-        <LoadingErrorWrapper loading={loadingFiles || listDirectoryLoading} errors={errorConfig}>
+        <LoadingErrorWrapper
+          loading={(loadingFiles || listDirectoryLoading) && !pooling}
+          errors={errorConfig}
+        >
           <Table
             className={className}
             columns={getColumns(tableData[0] ?? {})}
@@ -312,11 +322,13 @@ const StorageDirectoryPage = ({
             rowClassName={rowClassName}
             rowKey={r => `${r.path}_${r.type}_${r.mtime}`}
             rowSelection={{
+              hideSelectAll: !tableData.length,
+              columnWidth: 36,
               type: 'checkbox',
               ...rowSelection
             }}
             scroll={{ y: tableHeight }}
-            data-testid={`${testId}`}
+            data-testid={testId}
             locale={locale}
             {...restProps}
           />
@@ -337,7 +349,10 @@ const StorageDirectoryPage = ({
         <FileUploadQueue
           filesQueue={filesToUpload}
           onClose={() => setFilesToUpload([])}
-          onComplete={reloadData}
+          onComplete={() => {
+            reloadData();
+            setPooling(false);
+          }}
         />
       )}
     </>

--- a/desktop/core/src/desktop/js/utils/constants/storageBrowser.ts
+++ b/desktop/core/src/desktop/js/utils/constants/storageBrowser.ts
@@ -18,7 +18,7 @@ export const DEFAULT_PAGE_SIZE = 50;
 export const DEFAULT_CHUNK_SIZE = 5 * 1024 * 1024; // 5 MiB
 export const DEFAULT_CONCURRENT_MAX_CONNECTIONS = 3;
 export const DEFAULT_ENABLE_CHUNK_UPLOAD = false;
-export const DEFAULT_POOLING_TIME = 10 * 1000; // 10 seconds
+export const DEFAULT_POLLING_TIME = 10 * 1000; // 10 seconds
 
 export enum SupportedFileTypes {
   IMAGE = 'image',

--- a/desktop/core/src/desktop/js/utils/constants/storageBrowser.ts
+++ b/desktop/core/src/desktop/js/utils/constants/storageBrowser.ts
@@ -18,6 +18,7 @@ export const DEFAULT_PAGE_SIZE = 50;
 export const DEFAULT_CHUNK_SIZE = 5 * 1024 * 1024; // 5 MiB
 export const DEFAULT_CONCURRENT_MAX_CONNECTIONS = 3;
 export const DEFAULT_ENABLE_CHUNK_UPLOAD = false;
+export const DEFAULT_POOLING_TIME = 10 * 1000; // 10 seconds
 
 export enum SupportedFileTypes {
   IMAGE = 'image',


### PR DESCRIPTION
## What changes were proposed in this pull request?

- When the files are queued for upload, currently we refresh the UI once all the files are uploaded, this becomes painful when the list of files that are queued is long.
- To Give user the sense of upload success (Similar to file upload in Google Drive and other file browser), The short silent pooling is introduced, this refetches the list of files and folders in the background and updates the list with new files that got uploaded successfully. 

## How was this patch tested?

- Manually tested