### PR TITLE
Fix JB Oozie Log Icon

### DIFF
--- a/desktop/core/src/desktop/templates/job_browser_common.mako
+++ b/desktop/core/src/desktop/templates/job_browser_common.mako
@@ -2401,7 +2401,7 @@
             <tbody data-bind="foreach: properties['actions']">
             <tr>
               <td>
-                <a data-bind="hueLink: '/jobbrowser/jobs/' + ko.unwrap(externalId), clickBubble: false">
+                <a data-bind="hueLink: '/jobbrowser/jobs/#!id=' + ko.unwrap(externalId), clickBubble: false">
                   <i class="fa fa-tasks"></i>
                 </a>
               </td>


### PR DESCRIPTION
Stacktrace seen:

[07/Jan/2025 09:31:26 -0800] access       ERROR     admin - "POST /desktop/log_js_error HTTP/1.1" --- JS ERROR: {"msg":"Uncaught TypeError: lodash__WEBPACK_IMPORTED_MODULE_1___default.a.trimRight is not a function","url":"https://ccycloud-1.ni-717x-yq.root.comops.site:8889/static/desktop/js/bundles/hue/hue-bundle-651ca10da11cbc8f75e8.2537e7eff7ba.js","line":74060,"column":139,"stack":"TypeError: lodash__WEBPACK_IMPORTED_MODULE_1___default.a.trimRight is not a function\n    at app (https://ccycloud-1.ni-717x-yq.root.comops.site:8889/static/desktop/js/bundles/hue/hue-bundle-651ca10da11cbc8f75e8.2537e7eff7ba.js:74060:139)\n    at https://ccycloud-1.ni-717x-yq.root.comops.site:8889/static/desktop/js/bundles/hue/vendors~hue-chunk-651ca10da11cbc8f75e8.04f0b70fc23d.js:83803:52\n    at nextEnter (https://ccycloud-1.ni-717x-yq.root.comops.site:8889/static/desktop/js/bundles/hue/vendors~hue-chunk-651ca10da11cbc8f75e8.04f0b70fc23d.js:83627:7)\n    at https://ccycloud-1.ni-717x-yq.root.comops.site:8889/static/desktop/js/bundles/hue/vendors~hue-chunk-651ca10da11cbc8f75e8.04f0b70fc23d.js:83804:7\n    at nextEnter (https://ccycloud-1.ni-717x-yq.root.comops.site:8889/static/desktop/js/bundles/hue/vendors~hue-chunk-651ca10da11cbc8f75e8.04f0b70fc23d.js:83627:7)\n    at https://ccycloud-1.ni-717x-yq.root.comops.site:8889/static/desktop/js/bundles/hue/vendors~hue-chunk-651ca10da11cbc8f75e8.04f0b70fc23d.js:83804:7\n    at nextEnter (https://ccycloud-1.ni-717x-yq.root.comops.site:8889/static/desktop/js/bundles/hue/vendors~hue-chunk-651ca10da11cbc8f75e8.04f0b70fc23d.js:83627:7)\n    at https://ccycloud-1.ni-717x-yq.root.comops.site:8889/static/desktop/js/bundles/hue/vendors~hue-chunk-651ca10da11cbc8f75e8.04f0b70fc23d.js:83804:7\n    at nextEnter (https://ccycloud-1.ni-717x-yq.root.comops.site:8889/static/desktop/js/bundles/hue/vendors~hue-chunk-651ca10da11cbc8f75e8.04f0b70fc23d.js:83627:7)\n    at https://ccycloud-1.ni-717x-yq.root.comops.site:8889/static/desktop/js/bundles/hue/vendors~hue-chunk-651ca10da11cbc8f75e8.04f0b70fc23d.js:83804:7"}

Tested internally and works as expected without the above mentioned error