### PR TITLE
replace the hardcoded filename with correct filename

### DIFF
--- a/desktop/core/src/desktop/static/desktop/js/file-display-inline.js
+++ b/desktop/core/src/desktop/static/desktop/js/file-display-inline.js
@@ -64,7 +64,8 @@
     // In this case we don't want to sanitize the path for XSS as we want exact match on the actual file name,
     // so to prevent breaking the page on substitution we enforce a js compatible string by only encoding the backtick
     // char (`) with a js decode to restore it in case file actually has backtick in the name.
-    const decodedPath = `/user/admin/ai_case.txt`.replaceAll('&#96;', '`');
+    
+    const decodedPath = FileViewOptions.path.replaceAll('`', '&#96;');
     const encodedPath = encodeURIComponent(decodedPath);
     const pathPrefix = "/filebrowser/view=";
     const contentPath = pathPrefix+encodedPath;


### PR DESCRIPTION
## What changes were proposed in this pull request?

As part of removing csp with inline javascript, a filename was hardcoded by mistake, this has been fixed

[file-display-inline.js#67](https://github.com/cloudera/hue/pull/3923/files#diff-f7ca5d7f137c38ed478b2912804d5dd191ada020a4962280b07922a974238d7dR67) instead has an hardcoded /user/admin/ai_case.txt path used

Fixes: https://github.com/cloudera/hue/issues/3956

## How was this patch tested?
- This has been tested manually


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
