### PR TITLE
[api] Ensure skip_trash is a boolean value in the /delete API

### DIFF
--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -679,7 +679,7 @@ def set_replication(request):
 def rmtree(request):
   # TODO: Check if this needs to be a DELETE request
   path = request.POST.get('path')
-  skip_trash = request.POST.get('skip_trash', False)
+  skip_trash = coerce_bool(request.POST.get('skip_trash', False))
 
   request.fs.rmtree(path, skip_trash)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Make sure the skip_trash value is explicitly converted to bool type.

## How was this patch tested?

- Manually