### PR TITLE
[ui-build] add strip-sourcemap-loader to remove 3rd party hardcoded m…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -125,6 +125,7 @@
         "sass-loader": "11.1.1",
         "snarkdown": "2.0.0",
         "source-map-loader": "5.0.0",
+        "strip-sourcemap-loader": "0.0.1",
         "style-loader": "2.0.0",
         "styled-components": "6.0.8",
         "stylelint": "16.7.0",
@@ -17024,6 +17025,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-sourcemap-loader": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/strip-sourcemap-loader/-/strip-sourcemap-loader-0.0.1.tgz",
+      "integrity": "sha512-IrVeMZNYS//7jKzCVF4U6keLyOe/6JYLtjyvCNyteKxXwWQ+MrwNGT42eJQll+pChxgE3K34iLddz4rWG6e8Ow==",
+      "dev": true
     },
     "node_modules/style-loader": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "sass-loader": "11.1.1",
     "snarkdown": "2.0.0",
     "source-map-loader": "5.0.0",
+    "strip-sourcemap-loader": "0.0.1",
     "style-loader": "2.0.0",
     "styled-components": "6.0.8",
     "stylelint": "16.7.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,6 +64,14 @@ const config = {
         enforce: 'pre',
         use: ['source-map-loader']
       },
+      // Remove hardcoded references to source map files in third party mjs-files
+      // since those files will be missing in our builds.
+      {
+        test: /\.mjs$/,
+        include: /node_modules/,
+        enforce: 'post',
+        loader: 'strip-sourcemap-loader'
+      },
       {
         test: /\.scss$/,
         exclude: /node_modules/,


### PR DESCRIPTION
…ap references

## What changes were proposed in this pull request?

It seems that references to index.mjs.map (e.g. `//# sourceMappingURL=index.mjs.map`) are always added to the "defaultVendors~~~~~-chunk-xxx.js" and that index.mjs.map file never exists, not even in dev mode. 

After a lot of digging it seems to be that case that some third party mjs-files have these map-files references hardcoded in them. This PR provides a fix that targets the mjs files under node_modules to remove these references in our bundles using a small loader called strip-sourcemap-loader.

## How was this patch tested?

- Ran a webpack build to verify that all source map references to index.mjs.map are gone

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
