### PR TITLE
[security] SAML login issues with csp enabled

### DIFF
--- a/desktop/core/ext-py3/djangosaml2-0.18.0/djangosaml2/views.py
+++ b/desktop/core/ext-py3/djangosaml2-0.18.0/djangosaml2/views.py
@@ -232,6 +232,7 @@ def login(request,
                     saml_request = base64.b64encode(binary_type(request_xml))
 
                 http_response = render(request, post_binding_form_template, {
+                    'request': request,
                     'target_url': location,
                     'params': {
                         'SAMLRequest': saml_request,

--- a/desktop/core/src/desktop/templates/djangosaml2/post_binding_form.html
+++ b/desktop/core/src/desktop/templates/djangosaml2/post_binding_form.html
@@ -1,5 +1,5 @@
-<script type="text/javascript">
-	window.onload = function(){
+<script type="text/javascript"{% if request.csp_nonce %} nonce="{{ request.csp_nonce }}"{% endif %}>
+	window.onload = function() {
 		document.SSO_Login.submit();
 	};
 </script>
@@ -9,7 +9,7 @@ Please click the button below if you're not redirected automatically within a fe
 </p>
 <form method="post" action="{{ target_url }}" name="SSO_Login">
 	{% for key, value in params.items %}
-	    <input type="hidden" name="{{ key|safe }}" value="{{ value|safe }}" />
+	    <input type="hidden" name="{{ key }}" value="{{ value }}" />
 	{% endfor %}
     <input type="submit" value="Log in" />
 </form>


### PR DESCRIPTION
## What changes were proposed in this pull request?


* pysaml by default gives a template which has unsafe inline code. django saml bypasses that if we use a custom template. i have defined that custom template and added a request object.

* Uses the post binding form to add nonce, if the nonce is available in the request. if csp_nonce is disabled in the setting it won't be added here. 

## How was this patch tested?

- created a image replaced it in mow-dev to test the image. it was working with both csp enabled and disabled


- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
