### PR TITLE
[ui-storagebrowser] fix the translation strings

### DIFF
--- a/desktop/core/src/desktop/static/desktop/js/listdir-inline.js
+++ b/desktop/core/src/desktop/static/desktop/js/listdir-inline.js
@@ -1382,7 +1382,7 @@ var FileBrowserModel = function (files, page, breadcrumbs, currentDirPath) {
             $('.free-space-info').text('- Max file size upload limit: ' + formatBytes(freeSpace));
         },
         error: function(xhr, status, error) {
-            huePubSub.publish('hue.global.error', { message: '${ _("Error checking available space: ") }' + error});
+            huePubSub.publish('hue.global.error', { message: window.I18n('Error checking available space: ') + error});
             $('.free-space-info').text('Error checking available space');
         }
     });
@@ -1459,7 +1459,7 @@ var FileBrowserModel = function (files, page, breadcrumbs, currentDirPath) {
                   self.listItems.push(listItem);
                     if (scheduleUpload && self.pendingUploads() === 0) {
                       $('#uploadFileModal').modal('hide');
-                      huePubSub.publish('hue.global.info', { message: '${ _("File upload scheduled. Please check the task server page for progress.") }'});
+                      huePubSub.publish('hue.global.info', { message: window.I18n('File upload scheduled. Please check the task server page for progress.') });
                     }
                     // Add a delay of 2 seconds before calling pollForTaskProgress, to ensure the upload task is received by the task_server before checking its status. 
                     setTimeout(function() {
@@ -1489,10 +1489,10 @@ var FileBrowserModel = function (files, page, breadcrumbs, currentDirPath) {
                       // Update the free space display
                       $('.free-space-info').text('- Max file size upload limit: ' + formatBytes(freeSpace));
                       if ((file.size > freeSpace) || (file.size > window.MAX_FILE_SIZE_UPLOAD_LIMIT)) {
-                        huePubSub.publish('hue.global.error', { message: '${ _("Not enough space available to upload this file.") }'});
+                        huePubSub.publish('hue.global.error', { message: window.I18n('Not enough space available to upload this file.') });
                         deferred.failure(); // Reject the promise to cancel the upload
                       } else if (file.size > window.MAX_FILE_SIZE_UPLOAD_LIMIT) {
-                        huePubSub.publish('hue.global.error', { message: '${ _("File size is bigger than MAX_FILE_SIZE_UPLOAD_LIMIT.") }'});
+                        huePubSub.publish('hue.global.error', { message: window.I18n('File size is bigger than MAX_FILE_SIZE_UPLOAD_LIMIT.') });
                         deferred.failure(); // Reject the promise to cancel the upload
                       } else {
                         var newPath = "/filebrowser/upload/chunks/file?dest=" + encodeURIComponent(self.currentPath().normalize('NFC'));
@@ -1502,7 +1502,7 @@ var FileBrowserModel = function (files, page, breadcrumbs, currentDirPath) {
                       }
                     },
                     error: function(xhr, status, error) {
-                      huePubSub.publish('hue.global.error', { message: '${ _("Error checking available space: ") }' + error});
+                      huePubSub.publish('hue.global.error', { message: window.I18n('Error checking available space: ') + error});
                       deferred.failure(); // Reject the promise to cancel the upload
                     }
                   });


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Fixing the toaster message display on the old storage browser.

## How was this patch tested?

- manually tested

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
