### PR TITLE
[security] Fix AJAX Loading of Inline Scripts in editFile

### DIFF
--- a/desktop/core/src/desktop/static/desktop/js/file-display-inline.js
+++ b/desktop/core/src/desktop/static/desktop/js/file-display-inline.js
@@ -202,17 +202,30 @@
     self.editFile = function() {
       self.isViewing(false);
       self.isLoading(true);
-
+    
       const encodedPath = encodeURIComponent(FileViewOptions['path']);
       $.ajax({
         url: '/filebrowser/edit=' + encodedPath + '?is_embeddable=true',
-        beforeSend:function (xhr) {
+        beforeSend: function(xhr) {
           xhr.setRequestHeader('X-Requested-With', 'Hue');
         },
-        dataType:'html',
-        success:function (response) {
-          $('#fileeditor').html(response);
-          self.isLoading(false);
+        dataType: 'html',
+        success: function(response) {
+          const $response = $('<div>').html(response);
+          const scripts = $response.find('script').remove().toArray();
+          $('#fileeditor').html($response.html());
+          scripts.forEach(function(scriptTag) {
+            var script = document.createElement('script');
+            script.type = 'text/javascript';
+            script.src = scriptTag.src;
+            document.head.appendChild(script);
+          });
+        },
+        error: function(xhr, status, error) {
+          console.error("Error loading file editor:", error);
+        },
+        complete: function() {
+          self.isLoading(false); // Set loading to false after the request is complete
         }
       });
     }

--- a/desktop/core/src/desktop/static/desktop/js/file-display-inline.js
+++ b/desktop/core/src/desktop/static/desktop/js/file-display-inline.js
@@ -202,7 +202,6 @@
     self.editFile = function() {
       self.isViewing(false);
       self.isLoading(true);
-    
       const encodedPath = encodeURIComponent(FileViewOptions['path']);
       $.ajax({
         url: '/filebrowser/edit=' + encodedPath + '?is_embeddable=true',
@@ -225,7 +224,7 @@
           console.error("Error loading file editor:", error);
         },
         complete: function() {
-          self.isLoading(false); // Set loading to false after the request is complete
+          self.isLoading(false); 
         }
       });
     }

--- a/desktop/core/src/desktop/static/desktop/js/task-browser-inline.js
+++ b/desktop/core/src/desktop/static/desktop/js/task-browser-inline.js
@@ -1,0 +1,3 @@
+(function () {
+  window.createReactComponents('#taskbrowser-container');
+})();

--- a/desktop/core/src/desktop/templates/taskserver_list_tasks.mako
+++ b/desktop/core/src/desktop/templates/taskserver_list_tasks.mako
@@ -22,11 +22,7 @@ ${ layout.menubar(section='task_server') }
 <div class="container-fluid">
   <div class="card card-small">
 
-    <script type="text/javascript">
-      (function () {
-        window.createReactComponents('#taskbrowser-container');
-      })();
-    </script>
+    <script src="${ static('desktop/js/task-browser-inline.js') }" type="text/javascript"></script>
 
     <div id="taskbrowser-container">
       <MyComponent data-reactcomponent='TaskBrowser' data-props='{"myObj": {"id": 1}, "children": "mako template only", "version" : "${sys.version_info[0]}"}' ></MyComponent>


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Issue**: Inline scripts from AJAX responses aren't executed due to CSP restrictions when unsafe-inline is removed.
**Fix**: Manually process and append scripts from AJAX responses to ensure execution.

## How was this patch tested?

- tested in local

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
