### PR TITLE
[api] Refactor /filesystems API and include extra HDFS configs in its response

### DIFF
--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -128,6 +128,7 @@ def _get_extra_configs(fs, request):
     is_hdfs_superuser = _is_hdfs_superuser(request)
     extra_configs = {
       'is_trash_enabled': is_hdfs_trash_enabled(),
+      # TODO: Check if any of the below fields should be part of new Hue user and group management APIs
       'is_hdfs_superuser': is_hdfs_superuser,
       'groups': [str(x) for x in Group.objects.values_list('name', flat=True)] if is_hdfs_superuser else [],
       'users': [str(x) for x in User.objects.values_list('username', flat=True)] if is_hdfs_superuser else [],

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -122,6 +122,21 @@ def _get_hdfs_home_directory(user):
   return user.get_home_directory()
 
 
+def _get_extra_configs(fs, request):
+  extra_configs = {}
+  if fs == 'hdfs':
+    is_hdfs_superuser = _is_hdfs_superuser(request)
+    extra_configs = {
+      'is_trash_enabled': is_hdfs_trash_enabled(),
+      'is_hdfs_superuser': is_hdfs_superuser,
+      'groups': [str(x) for x in Group.objects.values_list('name', flat=True)] if is_hdfs_superuser else [],
+      'users': [str(x) for x in User.objects.values_list('username', flat=True)] if is_hdfs_superuser else [],
+      'superuser': request.fs.superuser,
+      'supergroup': request.fs.supergroup,
+    }
+  return extra_configs
+
+
 @api_error_handler
 def get_all_filesystems(request):
   """
@@ -136,7 +151,6 @@ def get_all_filesystems(request):
   Returns:
     JsonResponse: A JSON response containing a list of filesystems with their configurations.
   """
-  filesystems = []
   fs_home_dir_mapping = {
     'hdfs': _get_hdfs_home_directory,
     's3a': get_s3_home_directory,
@@ -145,20 +159,10 @@ def get_all_filesystems(request):
     'ofs': get_ofs_home_directory,
   }
 
+  filesystems = []
   for fs in fsmanager.get_filesystems(request.user):
-    extra_configs = {}
     user_home_dir = fs_home_dir_mapping[fs](request.user)
-
-    if fs == 'hdfs':
-      is_hdfs_superuser = _is_hdfs_superuser(request)
-      extra_configs = {
-        'is_trash_enabled': is_hdfs_trash_enabled(),
-        'is_hdfs_superuser': is_hdfs_superuser,
-        'groups': [str(x) for x in Group.objects.values_list('name', flat=True)] if is_hdfs_superuser else [],
-        'users': [str(x) for x in User.objects.values_list('username', flat=True)] if is_hdfs_superuser else [],
-        'superuser': request.fs.superuser,
-        'supergroup': request.fs.supergroup,
-      }
+    extra_configs = _get_extra_configs(fs, request)
 
     filesystems.append({'file_system': fs, 'user_home_directory': user_home_dir, 'extra_configs': extra_configs})
 

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -122,11 +122,11 @@ def _get_hdfs_home_directory(user):
   return user.get_home_directory()
 
 
-def _get_extra_configs(fs, request):
-  extra_configs = {}
+def _get_config(fs, request):
+  config = {}
   if fs == 'hdfs':
     is_hdfs_superuser = _is_hdfs_superuser(request)
-    extra_configs = {
+    config = {
       'is_trash_enabled': is_hdfs_trash_enabled(),
       # TODO: Check if any of the below fields should be part of new Hue user and group management APIs
       'is_hdfs_superuser': is_hdfs_superuser,
@@ -135,7 +135,7 @@ def _get_extra_configs(fs, request):
       'superuser': request.fs.superuser,
       'supergroup': request.fs.supergroup,
     }
-  return extra_configs
+  return config
 
 
 @api_error_handler
@@ -163,9 +163,9 @@ def get_all_filesystems(request):
   filesystems = []
   for fs in fsmanager.get_filesystems(request.user):
     user_home_dir = fs_home_dir_mapping[fs](request.user)
-    extra_configs = _get_extra_configs(fs, request)
+    config = _get_config(fs, request)
 
-    filesystems.append({'file_system': fs, 'user_home_directory': user_home_dir, 'extra_configs': extra_configs})
+    filesystems.append({'file_system': fs, 'user_home_directory': user_home_dir, 'config': config})
 
   return JsonResponse(filesystems, safe=False)
 

--- a/apps/filebrowser/src/filebrowser/api_test.py
+++ b/apps/filebrowser/src/filebrowser/api_test.py
@@ -462,8 +462,8 @@ class TestGetFilesystemsAPI:
 
           assert response.status_code == 200
           assert response_data == [
-            {'file_system': 's3a', 'user_home_directory': 's3a://test-bucket/test-user-home-dir/', 'extra_configs': {}},
-            {'file_system': 'ofs', 'user_home_directory': 'ofs://', 'extra_configs': {}},
+            {'file_system': 's3a', 'user_home_directory': 's3a://test-bucket/test-user-home-dir/', 'config': {}},
+            {'file_system': 'ofs', 'user_home_directory': 'ofs://', 'config': {}},
           ]
 
   def test_get_all_filesystems_success(self):
@@ -492,7 +492,7 @@ class TestGetFilesystemsAPI:
                 {
                   'file_system': 'hdfs',
                   'user_home_directory': '/user/test-user',
-                  'extra_configs': {
+                  'config': {
                     'is_trash_enabled': False,
                     'is_hdfs_superuser': False,
                     'groups': [],
@@ -501,6 +501,6 @@ class TestGetFilesystemsAPI:
                     'supergroup': 'test-supergroup',
                   },
                 },
-                {'file_system': 's3a', 'user_home_directory': 's3a://test-bucket/test-user-home-dir/', 'extra_configs': {}},
-                {'file_system': 'ofs', 'user_home_directory': 'ofs://', 'extra_configs': {}},
+                {'file_system': 's3a', 'user_home_directory': 's3a://test-bucket/test-user-home-dir/', 'config': {}},
+                {'file_system': 'ofs', 'user_home_directory': 'ofs://', 'config': {}},
               ]

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -401,6 +401,7 @@ def storage_bulk_chmod(request):
   django_request = get_django_request(request)
   return filebrowser_api.bulk_op(django_request, filebrowser_api.chmod)
 
+
 @api_view(["GET"])
 def storage_get_hdfs_config(request):
   django_request = get_django_request(request)

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -401,6 +401,11 @@ def storage_bulk_chmod(request):
   django_request = get_django_request(request)
   return filebrowser_api.bulk_op(django_request, filebrowser_api.chmod)
 
+@api_view(["GET"])
+def storage_get_hdfs_config(request):
+  django_request = get_django_request(request)
+  return filebrowser_api.get_hdfs_config(django_request)
+
 
 # Task Server
 

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -225,7 +225,7 @@ def analyze_table(request, dialect, database, table, columns=None):
 @api_view(["GET"])
 def storage_get_filesystems(request):
   django_request = get_django_request(request)
-  return filebrowser_api.get_filesystems_with_home_dirs(django_request)
+  return filebrowser_api.get_all_filesystems(django_request)
 
 
 @api_view(["GET"])
@@ -400,12 +400,6 @@ def storage_bulk_chown(request):
 def storage_bulk_chmod(request):
   django_request = get_django_request(request)
   return filebrowser_api.bulk_op(django_request, filebrowser_api.chmod)
-
-
-@api_view(["GET"])
-def storage_get_hdfs_config(request):
-  django_request = get_django_request(request)
-  return filebrowser_api.get_hdfs_config(django_request)
 
 
 # Task Server

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -132,6 +132,7 @@ urlpatterns += [
   re_path(r'^storage/trash/restore/bulk/?$', api_public.storage_trash_bulk_restore, name='storage_trash_bulk_restore'),
   re_path(r'^storage/chown/bulk/?$', api_public.storage_bulk_chown, name='storage_bulk_chown'),
   re_path(r'^storage/chmod/bulk/?$', api_public.storage_bulk_chmod, name='storage_bulk_chmod'),
+  re_path(r'^storage/config/hdfs/?$', api_public.storage_get_hdfs_config, name='storage_get_hdfs_config'),
 ]
 
 urlpatterns += [

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -132,7 +132,6 @@ urlpatterns += [
   re_path(r'^storage/trash/restore/bulk/?$', api_public.storage_trash_bulk_restore, name='storage_trash_bulk_restore'),
   re_path(r'^storage/chown/bulk/?$', api_public.storage_bulk_chown, name='storage_bulk_chown'),
   re_path(r'^storage/chmod/bulk/?$', api_public.storage_bulk_chmod, name='storage_bulk_chmod'),
-  re_path(r'^storage/config/hdfs/?$', api_public.storage_get_hdfs_config, name='storage_get_hdfs_config'),
 ]
 
 urlpatterns += [

--- a/desktop/core/src/desktop/lib/fs/ozone/ofs.py
+++ b/desktop/core/src/desktop/lib/fs/ozone/ofs.py
@@ -39,7 +39,8 @@ from hadoop.hdfs_site import get_umask_mode
 LOG = logging.getLogger()
 
 
-def get_ofs_home_directory():
+def get_ofs_home_directory(user=None):
+  # TODO: Check if Ozone bring the concept of home directory in the future
   return OFS_ROOT
 
 

--- a/desktop/libs/hadoop/src/hadoop/conf.py
+++ b/desktop/libs/hadoop/src/hadoop/conf.py
@@ -66,7 +66,9 @@ def get_hadoop_conf_dir_default():
 
 
 def is_hdfs_trash_enabled():
-  return any([hdfs_cluster.TRASH_INTERVAL.get() > 0 for hdfs_cluster in list(HDFS_CLUSTERS.values())])
+  return (
+    'default' in list(HDFS_CLUSTERS.keys()) and HDFS_CLUSTERS['default'].get_raw() and (HDFS_CLUSTERS['default'].TRASH_INTERVAL.get() > 0)
+  )
 
 
 HDFS_CLUSTERS = UnspecifiedConfigSection(


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Removed extra response fields from the /list API and included them in /filesystems API only for HDFS. This way we can use the configs only when HDFS is configured and it will not clutter the response for /list for all filesystems.

<br>

- Trash is also configurable now to make it easier to enable and test locally. Although it is recommended we read the values from `core-site.xml` in the prod deployments so be at better sync with the running HDFS service. Because of this reason, I've not added the config explicitly in the `.ini` files and also we are dynamically defaulting always to the `core-site.xml` value.

## How was this patch tested?

- Manually
- Unit tests