### PR TITLE
[computes] fixed impala impersonation flag

### DIFF
--- a/desktop/core/src/desktop/management/commands/sync_warehouses.py
+++ b/desktop/core/src/desktop/management/commands/sync_warehouses.py
@@ -220,7 +220,7 @@ def update_impala_configs(namespace, impala, host):
     {"name": "transport_mode", "value": 'http'},
     {"name": "http_url", "value": 'http://%s:%s/cliservice' % (host, impala['server_port'])},
     {"name": "api_url", "value": 'http://%s:%s' % (host, impala['api_port'])},
-    {"name": "impersonation_enabled", "value": False},
+    {"name": "impersonation_enabled", "value": True},
     {"name": "use_sasl", "value": False},
     {"name": "hive_metastore_uris", "value": hive_metastore_uris},
   ]


### PR DESCRIPTION
This commit fixes a bug where impala queries were not going with the doas param resulting in all queries running with system user credentials.

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
