### PR TITLE
[api] Fix error handling in bulk operations

### DIFF
--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -882,7 +882,7 @@ def bulk_op(request, op):
 
       # Also store the skipped files for each path in case OzoneFS copy operation fails
       if op == copy and p.startswith('ofs://'):
-        error_dict[p].update({'ofs_skip_files': res_content})
+        error_dict[p].update({'skipped_files': res_content})
 
   if error_dict:
     return JsonResponse(error_dict, status=500)  # TODO: Check if we need diff status code or diff json structure?

--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -882,7 +882,7 @@ def bulk_op(request, op):
 
       # Also store the skipped files for each path in case OzoneFS copy operation fails
       if op == copy and p.startswith('ofs://'):
-        error_dict[p] = {'ofs_skip_files': res_content}
+        error_dict[p].update({'ofs_skip_files': res_content})
 
   if error_dict:
     return JsonResponse(error_dict, status=500)  # TODO: Check if we need diff status code or diff json structure?


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Error handling was broken for 500 code JsonResponse objects for the bulk operations. This PR fixes it and improves the error response structure a bit.
- More improvement will be part of Error UX roadmap item.

## How was this patch tested?

- Manually