### PR TITLE
[api] Change RESTRICT_FILE_EXTENSIONS config's default value and fix restricted types handling in /rename API

### DIFF
--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -620,7 +620,7 @@ def rename(request):
   _, source_path_ext = os.path.splitext(source_path)
   _, dest_path_ext = os.path.splitext(destination_path)
 
-  restricted_file_types = [ext.lower() for ext in RESTRICT_FILE_EXTENSIONS.get()]
+  restricted_file_types = [ext.lower() for ext in RESTRICT_FILE_EXTENSIONS.get()] if RESTRICT_FILE_EXTENSIONS.get() else []
   # Check if destination path has a restricted file type and it doesn't match the source file type
   if dest_path_ext.lower() in restricted_file_types and (source_path_ext.lower() != dest_path_ext.lower()):
     return HttpResponse(f'Cannot rename file to a restricted file type: "{dest_path_ext}"', status=403)

--- a/apps/filebrowser/src/filebrowser/api_test.py
+++ b/apps/filebrowser/src/filebrowser/api_test.py
@@ -412,14 +412,13 @@ class TestRenameAPI:
     request = Mock(
       method='POST',
       POST={'source_path': 's3a://test-bucket/test-user/source.txt', 'destination_path': 'new_name.txt'},
-      body=Mock(),
       fs=Mock(
         exists=Mock(return_value=False),
         join=Mock(return_value='s3a://test-bucket/test-user/new_name.txt'),
         rename=Mock(),
       ),
     )
-    reset = RESTRICT_FILE_EXTENSIONS.set_for_testing('')
+    reset = RESTRICT_FILE_EXTENSIONS.set_for_testing(None)
     try:
       response = rename(request)
 
@@ -432,7 +431,6 @@ class TestRenameAPI:
     request = Mock(
       method='POST',
       POST={'source_path': 's3a://test-bucket/test-user/source.txt', 'destination_path': 'new_name.exe'},
-      body=Mock(),
       fs=Mock(
         rename=Mock(),
       ),
@@ -450,12 +448,11 @@ class TestRenameAPI:
     request = Mock(
       method='POST',
       POST={'source_path': 's3a://test-bucket/test-user/source.txt', 'destination_path': 'new#name.txt'},
-      body=Mock(),
       fs=Mock(
         rename=Mock(),
       ),
     )
-    reset = RESTRICT_FILE_EXTENSIONS.set_for_testing('')
+    reset = RESTRICT_FILE_EXTENSIONS.set_for_testing(None)
     try:
       response = rename(request)
 
@@ -468,14 +465,13 @@ class TestRenameAPI:
     request = Mock(
       method='POST',
       POST={'source_path': 's3a://test-bucket/test-user/source.txt', 'destination_path': 'new_name.txt'},
-      body=Mock(),
       fs=Mock(
         rename=Mock(),
         exists=Mock(return_value=True),
         join=Mock(return_value='s3a://test-bucket/test-user/new_name.txt'),
       ),
     )
-    reset = RESTRICT_FILE_EXTENSIONS.set_for_testing('')
+    reset = RESTRICT_FILE_EXTENSIONS.set_for_testing(None)
     try:
       response = rename(request)
 
@@ -488,12 +484,11 @@ class TestRenameAPI:
     request = Mock(
       method='POST',
       POST={'destination_path': 'new_name.txt'},
-      body=Mock(),
       fs=Mock(
         rename=Mock(),
       ),
     )
-    reset = RESTRICT_FILE_EXTENSIONS.set_for_testing('')
+    reset = RESTRICT_FILE_EXTENSIONS.set_for_testing(None)
     try:
       response = rename(request)
 
@@ -506,12 +501,11 @@ class TestRenameAPI:
     request = Mock(
       method='POST',
       POST={'source_path': 's3a://test-bucket/test-user/source.txt'},
-      body=Mock(),
       fs=Mock(
         rename=Mock(),
       ),
     )
-    reset = RESTRICT_FILE_EXTENSIONS.set_for_testing('')
+    reset = RESTRICT_FILE_EXTENSIONS.set_for_testing(None)
     try:
       response = rename(request)
 

--- a/apps/filebrowser/src/filebrowser/conf.py
+++ b/apps/filebrowser/src/filebrowser/conf.py
@@ -105,7 +105,7 @@ FILE_DOWNLOAD_CACHE_CONTROL = Config(
 
 RESTRICT_FILE_EXTENSIONS = Config(
   key='restrict_file_extensions',
-  default='',
+  default=None,
   type=coerce_csv,
   help=_(
     'Specify file extensions that are not allowed, separated by commas. For example: .exe, .zip, .rar, .tar, .gz'


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Fixes the issue where rename fails when the config is not set and files with no extensions were not allowed to rename in **new storage browser**.
- It also fixes upload operation for **both new storage browser and old filebrowser** where uploads of file with no extensions were failing when the config was not set.

## How was this patch tested?

- Manually
- Unit tests