### PR TITLE
[ui-storagebrowser] fixes the navigation when sidebar icon is clicked

### DIFF
--- a/desktop/core/src/desktop/js/onePageViewModel.js
+++ b/desktop/core/src/desktop/js/onePageViewModel.js
@@ -376,6 +376,10 @@ class OnePageViewModel {
         self.embeddable_cache['editor'] = undefined;
       }
 
+      if (pageMapping.find(page => page.isReactApp && page.app === app)) {
+        self.embeddable_cache[app] = undefined;
+      }
+
       self.currentApp(app);
       if (!app.startsWith('security')) {
         self.lastContext = null;
@@ -706,7 +710,7 @@ class OnePageViewModel {
         }
       },
       { url: '/filebrowser/view=*', app: 'filebrowser' },
-      { url: '/filebrowser/new', app: 'newfilebrowser' },
+      { url: '/filebrowser/new', app: 'newfilebrowser', isReactApp: true },
       {
         url: '/filebrowser/*',
         app: function () {


### PR DESCRIPTION
## What changes were proposed in this pull request?

- When the sidebar icon of the new storage browser is clicked, due to caching, the page does not unmounts and re-mounts, resulting user seeing the last opened directory or file.

## How was this patch tested?

- Manually tested

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
