### PR TITLE
[ui-editor] fixes compute selection in presentation mode

### DIFF
--- a/desktop/core/src/desktop/js/apps/notebook/NotebookViewModel.js
+++ b/desktop/core/src/desktop/js/apps/notebook/NotebookViewModel.js
@@ -109,6 +109,7 @@ export default class NotebookViewModel {
         // Split statements
         notebook.type('notebook');
         const database = sourceSnippet.database();
+        const compute = sourceSnippet.compute();
         sourceSnippet.statementsList().forEach(sql_statement => {
           let presentationSnippet;
           const statementKey = sql_statement.hashCode() + database;
@@ -131,6 +132,7 @@ export default class NotebookViewModel {
             presentationSnippet = new Snippet(self, notebook, {
               type: notebook.initialType,
               database: database,
+              compute: compute,
               statement_raw: statementLines.join('\n'),
               result: {},
               name: titleLines.join('\n'),


### PR DESCRIPTION
## What changes were proposed in this pull request?

- When presentation mode is enabled, the selected compute was not getting passed to the Snippet class.

## How was this patch tested?

- Manually tested

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
