### PR TITLE
[abfs] Fix isdir and isfile methods to handle exceptions better

### DIFF
--- a/desktop/libs/azure/src/azure/abfs/abfs.py
+++ b/desktop/libs/azure/src/azure/abfs/abfs.py
@@ -148,16 +148,21 @@ class ABFS(object):
       stats = self.stats(path)
       return stats.isDir
     except Exception as e:
-      # If checking stats for path here gives a 404 error, it means the path does not exist and therefore is not a directory.
+      # If checking stats for path here gives 404 error, it means the path does not exist and therefore is not a directory.
       if e.code == 404:
         return False
       raise e
 
   def isfile(self, path):
-    """
-    Checks if the path is a file
-    """
-    return not self.isdir(path)
+    """Check if the given path is a file or not."""
+    try:
+      stats = self.stats(path)
+      return not stats.isDir
+    except Exception as e:
+      # If checking stats for path here gives 404 error, it means the path does not exist and therefore is not a file.
+      if e.code == 404:
+        return False
+      raise e
 
   def exists(self, path):
     """

--- a/desktop/libs/azure/src/azure/abfs/abfs.py
+++ b/desktop/libs/azure/src/azure/abfs/abfs.py
@@ -143,11 +143,15 @@ class ABFS(object):
   # Parse info about filesystems, directories, and files
   # --------------------------------
   def isdir(self, path):
-    """
-    Checks if the path is a directory (note diabled because filebrowser/views is bugged)
-    """
-    resp = self.stats(path)
-    return resp.isDir
+    """Check if the given path is a directory or not."""
+    try:
+      stats = self.stats(path)
+      return stats.isDir
+    except Exception as e:
+      # If checking stats for path here gives a 404 error, it means the path does not exist and therefore is not a directory.
+      if e.code == 404:
+        return False
+      raise e
 
   def isfile(self, path):
     """


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add try/except block to correctly catch ABFS exceptions and then handle the 404 case explicitly to determine if the path exists or not.

## How was this patch tested?

- Manually