### PR TITLE
[ci] Add code coverage report generation to CI workflow

### DIFF
--- a/.github/workflows/commitflow-py3.yml
+++ b/.github/workflows/commitflow-py3.yml
@@ -62,13 +62,20 @@ jobs:
     - name: run tests
       run: |
         mkdir -p test-reports  # Ensure the directory exists
-        PYTHONWARNINGS=always ./build/env/bin/pytest --html=test-reports/report_${{ matrix.python-version }}.html --self-contained-html
+        mkdir -p code-coverage-reports  # Ensure the directory exists
+        PYTHONWARNINGS=always ./build/env/bin/pytest --cov=about,beeswax,filebrowser,hbase,help,hive,impala,jobbrowser,jobsub,metastore,oozie,pig,proxy,rdbms,search,security,spark,sqoop,useradmin,zookeeper,desktop,aws,azure,dashboard,hadoop,indexer,kafka,libanalyze,liboauth,liboozie,librdbms,libsaml,libsentry,libsolr,libzookeeper,metadata,notebook --no-cov-on-fail --cov-report=html:code-coverage-report --html=test-reports/report_${{ matrix.python-version }}.html --self-contained-html
  
     - name: upload pytest report
       uses: actions/upload-artifact@v4
       with:
         name: test-reports-${{ matrix.python-version }}
         path: test-reports
+    
+    - name: upload code coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: code-coverage-reports-${{ matrix.python-version }}
+        path: code-coverage-reports
 
     - name: Check and comment if no unit test files are modified
       if: matrix.python-version == '3.11'

--- a/.github/workflows/commitflow-py3.yml
+++ b/.github/workflows/commitflow-py3.yml
@@ -63,7 +63,7 @@ jobs:
       run: |
         mkdir -p test-reports  # Ensure the directory exists
         mkdir -p code-coverage-reports  # Ensure the directory exists
-        PYTHONWARNINGS=always ./build/env/bin/pytest --cov=about,beeswax,filebrowser,hbase,help,hive,impala,jobbrowser,jobsub,metastore,oozie,pig,proxy,rdbms,search,security,spark,sqoop,useradmin,zookeeper,desktop,aws,azure,dashboard,hadoop,indexer,kafka,libanalyze,liboauth,liboozie,librdbms,libsaml,libsentry,libsolr,libzookeeper,metadata,notebook --no-cov-on-fail --cov-report=html:code-coverage-report --html=test-reports/report_${{ matrix.python-version }}.html --self-contained-html
+        ./build/env/bin/pytest --cov=about --cov=beeswax --cov=filebrowser --cov=hbase --cov=help --cov=hive --cov=impala --cov=jobbrowser --cov=jobsub --cov=metastore --cov=oozie --cov=pig --cov=proxy --cov=rdbms --cov=search --cov=security --cov=spark --cov=sqoop --cov=useradmin --cov=zookeeper --cov=desktop --cov=aws --cov=azure --cov=dashboard --cov=hadoop --cov=indexer --cov=kafka --cov=libanalyze --cov=liboauth --cov=liboozie --cov=librdbms --cov=libsaml --cov=libsentry --cov=libsolr --cov=libzookeeper --cov=metadata --cov=notebook --cov-report=html:code-coverage-report --html=test-reports/report_${{ matrix.python-version }}.html --self-contained-html
  
     - name: upload pytest report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/commitflow-py3.yml
+++ b/.github/workflows/commitflow-py3.yml
@@ -74,8 +74,8 @@ jobs:
     - name: upload code coverage report
       uses: actions/upload-artifact@v4
       with:
-        name: code-coverage-reports-${{ matrix.python-version }}
-        path: code-coverage-reports
+        name: code-coverage-report-${{ matrix.python-version }}
+        path: code-coverage-report
 
     - name: Check and comment if no unit test files are modified
       if: matrix.python-version == '3.11'

--- a/desktop/core/test_requirements.txt
+++ b/desktop/core/test_requirements.txt
@@ -1,3 +1,5 @@
 pytest==8.1.1
 pytest-django==4.8.0
 pytest-html==4.1.1
+coverage==7.5.4
+pytest-cov==5.0.0


### PR DESCRIPTION
## What changes were proposed in this pull request?

- To get an idea of initial unfiltered (meaning nothing excluded) numbers and see the flow for coverage and pytest and what format it supports both on local setup and Github Action.
-  Then we can plan the next steps to refine the numbers and improve code coverage reporting in Hue.

## How was this patch tested?

- Github Actions CI check
- Manually