### PR TITLE
[api] Add new check_config API endpoint to validate Hue configuration

### DIFF
--- a/desktop/core/src/desktop/api2.py
+++ b/desktop/core/src/desktop/api2.py
@@ -71,7 +71,7 @@ from desktop.models import (
   set_user_preferences,
   uuid_default,
 )
-from desktop.views import get_banner_message, serve_403_error
+from desktop.views import get_banner_message, serve_403_error, _get_config_errors
 from filebrowser.conf import (
   CONCURRENT_MAX_CONNECTIONS,
   ENABLE_EXTRACT_UPLOADED_ARCHIVE,
@@ -1478,3 +1478,14 @@ def _setup_search_examples(request):
 
   if data == 'log_analytics_demo':
     search_setup.Command().handle()
+
+
+@api_error_handler
+def check_config(request):
+  """Returns the configuration directory and the list of validation errors."""
+  response = {
+    'hue_config_dir': os.path.realpath(os.getenv("HUE_CONF_DIR", get_desktop_root("conf"))),
+    'config_error_list': _get_config_errors(request, cache=False),
+  }
+
+  return JsonResponse(response)

--- a/desktop/core/src/desktop/api2.py
+++ b/desktop/core/src/desktop/api2.py
@@ -71,7 +71,7 @@ from desktop.models import (
   set_user_preferences,
   uuid_default,
 )
-from desktop.views import get_banner_message, serve_403_error, _get_config_errors
+from desktop.views import _get_config_errors, get_banner_message, serve_403_error
 from filebrowser.conf import (
   CONCURRENT_MAX_CONNECTIONS,
   ENABLE_EXTRACT_UPLOADED_ARCHIVE,

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -72,6 +72,12 @@ def download_hue_logs(request):
 
 
 @api_view(["POST"])
+def check_config(request):
+  django_request = get_django_request(request)
+  return desktop_api.check_config(django_request)
+
+
+@api_view(["POST"])
 def install_app_examples(request):
   django_request = get_django_request(request)
   return desktop_api.install_app_examples(django_request)

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -35,6 +35,7 @@ urlpatterns += [
   re_path(r'^logs/download/?$', api_public.download_hue_logs, name='core_download_hue_logs'),
   re_path(r'^install_app_examples/?$', api_public.install_app_examples, name='core_install_app_examples'),
   re_path(r'^get_config/?$', api_public.get_config),
+  re_path(r'^check_config/?$', api_public.check_config, name='core_check_config'),
   re_path(r'^get_namespaces/(?P<interface>[\w\-]+)/?$', api_public.get_context_namespaces),  # To remove
 ]
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Port the old /check_config API to new public API and also remove all mako relate code.

## How was this patch tested?

- Manually
- Unit test