### PR TITLE
[api] Rename 'config_error_list' to 'config_errors' in check_config API response

### DIFF
--- a/desktop/core/src/desktop/api2.py
+++ b/desktop/core/src/desktop/api2.py
@@ -1485,7 +1485,7 @@ def check_config(request):
   """Returns the configuration directory and the list of validation errors."""
   response = {
     'hue_config_dir': os.path.realpath(os.getenv("HUE_CONF_DIR", get_desktop_root("conf"))),
-    'config_error_list': _get_config_errors(request, cache=False),
+    'config_errors': _get_config_errors(request, cache=False),
   }
 
   return JsonResponse(response)

--- a/desktop/core/src/desktop/api2_tests.py
+++ b/desktop/core/src/desktop/api2_tests.py
@@ -868,7 +868,7 @@ class TestCheckConfigAPI:
         assert response.status_code == 200
         assert response_data == {
           "hue_config_dir": "/test/hue/conf",
-          "config_error_list": [
+          "config_errors": [
             {"name": "Hive", "message": "The application won't work without a running HiveServer2."},
             {"name": "Impala", "message": "No available Impalad to send queries to."},
             {"name": "Spark", "message": "The app won't work without a running Livy Spark Server"},


### PR DESCRIPTION

## What changes were proposed in this pull request?

- Change field name as per this PR comment: https://github.com/cloudera/hue/pull/4018#discussion_r1973621488

## How was this patch tested?

- Manually
- Unit tests