### PR TITLE
[conf][oozie] Add configuration option to enable or disable workflow creation in Hue documents

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -240,6 +240,9 @@ http_500_debug_mode=false
 # Note that this does not affect currently shared documents.
 ## enable_sharing=true
 
+# Global setting to enable or disable new workflow creation in Hue documents.
+## enable_workflow_creation_action=true
+
 # Choose whether to enable SQL syntax check or not
 ## enable_sql_syntax_check=true
 

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -246,6 +246,9 @@
   # Note that this does not affect currently shared documents.
   ## enable_sharing=true
 
+  # Global setting to enable or disable new workflow creation in Hue documents.
+  ## enable_workflow_creation_action=true
+
   # Choose whether to enable the new SQL syntax checker or not
   ## enable_sql_syntax_check=true
 

--- a/desktop/core/src/desktop/api2.py
+++ b/desktop/core/src/desktop/api2.py
@@ -47,6 +47,7 @@ from desktop.conf import (
   ENABLE_GIST_PREVIEW,
   ENABLE_NEW_STORAGE_BROWSER,
   ENABLE_SHARING,
+  ENABLE_WORKFLOW_CREATION_ACTION,
   TASK_SERVER_V2,
   get_clusters,
 )
@@ -136,6 +137,7 @@ def get_config(request):
   config['hue_config']['is_admin'] = is_admin(request.user)
   config['hue_config']['is_yarn_enabled'] = is_yarn()
   config['hue_config']['enable_task_server'] = TASK_SERVER_V2.ENABLED.get()
+  config['hue_config']['enable_workflow_creation_action'] = ENABLE_WORKFLOW_CREATION_ACTION.get()
   config['storage_browser']['enable_chunked_file_upload'] = ENABLE_CHUNKED_FILE_UPLOADER.get()
   config['storage_browser']['enable_new_storage_browser'] = ENABLE_NEW_STORAGE_BROWSER.get()
   config['storage_browser']['restrict_file_extensions'] = RESTRICT_FILE_EXTENSIONS.get()
@@ -145,9 +147,7 @@ def get_config(request):
   config['storage_browser']['max_file_editor_size'] = MAX_FILEEDITOR_SIZE
   config['storage_browser']['enable_extract_uploaded_archive'] = ENABLE_EXTRACT_UPLOADED_ARCHIVE.get()
   config['clusters'] = list(get_clusters(request.user).values())
-  config['documents'] = {
-    'types': list(Document2.objects.documents(user=request.user).order_by().values_list('type', flat=True).distinct())
-  }
+  config['documents'] = {'types': list(Document2.objects.documents(user=request.user).order_by().values_list('type', flat=True).distinct())}
   config['status'] = 0
 
   return JsonResponse(config)

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -1926,6 +1926,13 @@ ENABLE_SHARING = Config(
   type=coerce_bool,
   default=True)
 
+ENABLE_WORKFLOW_CREATION_ACTION = Config(
+  key="enable_workflow_creation_action",
+  help=_('Global setting to enable or disable new workflow creation in Hue documents.'),
+  type=coerce_bool,
+  default=True,
+)
+
 USE_NEW_ASSIST_PANEL = Config(
   key='use_new_assist_panel',
   default=False,


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add new config for enabling/disabling the New Workflow dropdown in Hue documents page. This is required for scenarios where blanket restriction is done on users for creating new workflows. Users should only have read access for the current workflows.

## How was this patch tested?

- Manually