### PR TITLE
[conf] Add new coerce_list configuration type

### DIFF
--- a/desktop/core/src/desktop/lib/conf.py
+++ b/desktop/core/src/desktop/lib/conf.py
@@ -63,6 +63,7 @@ variables.
 
 import os
 import re
+import ast
 import sys
 import json
 import logging
@@ -229,6 +230,10 @@ class Config(object):
     if type is bool:
       LOG.warning("%s is of type bool. Resetting it as type 'coerce_bool'." " Please fix it permanently" % (key,))
       type = coerce_bool
+
+    if type is list:
+      LOG.warning("%s is of type list. Resetting it as type 'coerce_list'." " Please fix it permanently" % (key,))
+      type = coerce_list
 
     self.key = key
     self.default_value = default
@@ -659,6 +664,19 @@ def coerce_csv(value):
   elif isinstance(value, list):
     return value
   raise Exception("Could not coerce %r to csv array." % value)
+
+
+def coerce_list(value) -> list:
+  if isinstance(value, str):
+    try:
+      result = ast.literal_eval(value)
+      if isinstance(result, list):
+        return result
+    except (SyntaxError, ValueError):
+      return [value]
+  elif isinstance(value, list):
+    return value
+  raise Exception("Could not coerce %r to list." % value)
 
 
 def coerce_json_dict(value):

--- a/desktop/core/src/desktop/lib/conf_test.py
+++ b/desktop/core/src/desktop/lib/conf_test.py
@@ -24,6 +24,7 @@ import pytest
 import configobj
 
 from desktop.lib.conf import *
+from desktop.lib.conf import coerce_bool, coerce_list
 
 
 def my_dynamic_default():
@@ -186,6 +187,22 @@ class TestConfig(object):
     assert coerce_bool(True)
     with pytest.raises(Exception):
       coerce_bool(tuple("foo"))
+
+  def test_coerce_list(self):
+    assert coerce_list("[]") == []
+    assert coerce_list("Test val") == ["Test val"]
+    assert coerce_list("['Test val 1', 'Test val 2']") == ["Test val 1", "Test val 2"]
+    assert coerce_list("['Test val 1', 'Test val 2, 3']") == ["Test val 1", "Test val 2, 3"]
+    assert coerce_list("['Test val 1', 'Test val \\'2\\'']") == ["Test val 1", "Test val '2'"]
+
+    assert coerce_list(['Test val 1', 'Test val 2']) == ["Test val 1", "Test val 2"]
+
+    with pytest.raises(Exception):
+      coerce_list(tuple("foo"))
+    with pytest.raises(Exception):
+      coerce_list(1)
+    with pytest.raises(Exception):
+      coerce_list("{1:1, 2:2}")
 
   def test_print_help(self):
     out = string_io()


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Added a new configs datatype coerce_list
- It could be used in Hue ini as follows
```
[section]
key="val 1", "val 2,3"
```

Note:
- Safety: literal_eval() is generally safer than eval(), and current usage just accept list type. So it's safe.
- coerce_csv breaks when we have coma (,) in the value. coerce_list provides a more robust way to configure.

## How was this patch tested?

- Manual test
- UTs were added
