### PR TITLE
[ui-admin] Improve server log formatting

### DIFF
--- a/desktop/core/src/desktop/js/apps/admin/ServerLogs/ServerLogsTab.scss
+++ b/desktop/core/src/desktop/js/apps/admin/ServerLogs/ServerLogsTab.scss
@@ -32,11 +32,16 @@
         background-color: $fluidx-white;
         margin: 0;
         padding: 2px;
-      }
-    }
+        white-space: nowrap;
+        font-family: 'Roboto Mono', monospace;
+        font-size: 12px;
 
-    .server_wrap {
-      white-space: nowrap;
+        &--wrap {
+          word-break: break-all;
+          word-wrap: break-word;
+          white-space: pre-wrap;
+        }
+      }
     }
 
     .server__no-logs-found {

--- a/desktop/core/src/desktop/js/apps/admin/ServerLogs/ServerLogsTab.test.tsx
+++ b/desktop/core/src/desktop/js/apps/admin/ServerLogs/ServerLogsTab.test.tsx
@@ -94,10 +94,11 @@ describe('ServerLogs Component', () => {
 
     render(<ServerLogs />);
 
-    expect(screen.getByText('Log entry 1')).toHaveClass('server_wrap');
+    expect(screen.getByLabelText('Wrap logs')).toBeChecked();
+    expect(screen.getByText('Log entry 1')).toHaveClass('server__log-line--wrap');
 
     fireEvent.click(screen.getByLabelText('Wrap logs'));
-
-    expect(screen.getByText('Log entry 1')).not.toHaveClass('server_wrap');
+    expect(screen.getByLabelText('Wrap logs')).not.toBeChecked();
+    expect(screen.getByText('Log entry 1')).not.toHaveClass('server__log-line--wrap');
   });
 });

--- a/desktop/core/src/desktop/js/apps/admin/ServerLogs/ServerLogsTab.tsx
+++ b/desktop/core/src/desktop/js/apps/admin/ServerLogs/ServerLogsTab.tsx
@@ -72,7 +72,7 @@ const ServerLogs: React.FC = (): JSX.Element => {
               <div className="server__display-logs">
                 {logsData.logs.map((line, index) => (
                   <div
-                    className={`server__log-line ${wrapLogs ? 'server_wrap' : ''}`}
+                    className={`server__log-line ${wrapLogs ? 'server__log-line--wrap' : ''}`}
                     key={'logs_' + index}
                   >
                     <HighlightText text={line} searchValue={filter} />


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Improve formatting of admin server log to match old style and functionality

Wrapping (and white space preserve):
![image](https://github.com/user-attachments/assets/5c4c60e0-ceb5-4a67-b698-b6ab33e40997)

No wrapping (and repeated whitespace removed):
![image](https://github.com/user-attachments/assets/b5fa28ef-8f3a-496b-9faa-6c2273954909)


## How was this patch tested?

- manual testing
- updated unit test

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
