### PR TITLE
[ci] Update PR comments workflow to use pull_request_target event and adjust permissions

### DIFF
--- a/.github/workflows/pr-comments.yml
+++ b/.github/workflows/pr-comments.yml
@@ -1,13 +1,11 @@
 name: PR Comments
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
 
 permissions:
-  contents: write
-  checks: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/pr-comments.yml
+++ b/.github/workflows/pr-comments.yml
@@ -65,7 +65,7 @@ jobs:
           remove-link-from-badge: true
           default-branch: master
   
-  ut-files-comment:
+  python-ut-files-comment:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Change pull request event so that PRs from forks can also trigger the action comments on Hue PRs

## How was this patch tested?

- Running checks on PR Github Actions