### PR TITLE
Hue SAML logout not Post CDP logout URL

### DIFF
--- a/desktop/core/src/desktop/auth/views.py
+++ b/desktop/core/src/desktop/auth/views.py
@@ -34,6 +34,7 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.encoding import smart_str
 from django.utils.translation import gettext as _
+from django.contrib.auth.models import AnonymousUser
 
 from desktop.auth import forms as auth_forms
 from desktop.auth.backend import OIDCBackend
@@ -202,8 +203,9 @@ def dt_login(request, from_modal=False):
     request.session.set_test_cookie()
 
   if 'SAML2Backend' in backend_names:
-    request.session['samlgroup_permitted_flag'] = samlgroup_check(request)
-    saml_login_headers(request)
+    if not isinstance(request.user, AnonymousUser) and request.user.is_authenticated:
+        request.session['samlgroup_permitted_flag'] = samlgroup_check(request)
+        saml_login_headers(request)
 
   renderable_path = 'login.mako'
   if from_modal:


### PR DESCRIPTION

## What changes were proposed in this pull request?

* this seems an existing issue when logout happens from saml, there seems to be user session not being present, so it ends up with internal server errror

```
hue File "/opt/hive/build/env/lib/python3.9/site-packages/django/contrib/auth/models.py", line 420, in __int__
hue raise TypeError('Cannot cast AnonymousUser to int. Are you trying to use it in place of User?')
hue TypeError: Cannot cast AnonymousUser to int. Are you trying to use it in place of User?
```


I have made small change to check if user exists before performing that action.


## How was this patch tested?
- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
