### PR TITLE
[compute] fixes for session close and recreate

### DIFF
--- a/apps/beeswax/src/beeswax/common.py
+++ b/apps/beeswax/src/beeswax/common.py
@@ -125,7 +125,7 @@ def find_compute(cluster=None, user=None, dialect=None, namespace_id=None):
     # Pick the most probable compute object
     selected_compute = (cluster if compute_check(cluster)
                         else compute if compute_check(compute)
-                        else connector if compute_check(connector) else None)
+                        else connector if compute_check(connector) else cluster)
 
     # If found, we will attempt to reload it, first by id then by name
     if selected_compute:
@@ -134,8 +134,11 @@ def find_compute(cluster=None, user=None, dialect=None, namespace_id=None):
         if c:
           return c.to_dict()
 
-      if selected_compute.get('name'):
-        c = Compute.objects.filter(name=selected_compute['name']).first()
+      # Compute name is sometimes passed in the type and dialect fields.
+      # So, we will attempt to load compute using name, type and dialect as name.
+      compute_name = selected_compute.get('name', selected_compute.get('type', selected_compute.get('dialect')))
+      if compute_name:
+        c = Compute.objects.filter(name=compute_name).first()
         if c:
           return c.to_dict()
 

--- a/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py
+++ b/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py
@@ -260,10 +260,11 @@ class HS2Api(Api):
 
     if not session_id:
       session = Session.objects.get_session(self.user, application=app_name)
-      decoded_guid = session.get_handle().sessionId.guid
-      session_decoded_id = unpack_guid(decoded_guid)
-      if source_method == "dt_logout":
-        LOG.debug("Closing Impala session id %s on logout for user %s" % (session_decoded_id, self.user.username))
+      if session:
+        decoded_guid = session.get_handle().sessionId.guid
+        session_decoded_id = unpack_guid(decoded_guid)
+        if source_method == "dt_logout":
+          LOG.debug("Closing Impala session id %s on logout for user %s" % (session_decoded_id, self.user.username))
 
     query_server = get_query_server_config(name=app_name)
 


### PR DESCRIPTION
A null check for session that are already gone.

While creating new sessions, the compute name and id information comes in different ways in different api's. This change attempts to load compute object if a type or dialect is also available.

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
