### PR TITLE
documents uploads will use HDFSfileUploadHandler when task_server is on

### DIFF
--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -660,7 +660,7 @@ from desktop.conf import ENABLE_NEW_STORAGE_BROWSER  # noqa: E402
 file_upload_handlers = []
 if is_chunked_fileuploader_enabled():
   file_upload_handlers = [
-    'hadoop.fs.upload.FineUploaderChunkedUploadHandler',
+    'hadoop.fs.upload.CustomDocumentsUploadHandler',
     'django.core.files.uploadhandler.MemoryFileUploadHandler',
     'django.core.files.uploadhandler.TemporaryFileUploadHandler',
   ]

--- a/desktop/core/src/desktop/urls.py
+++ b/desktop/core/src/desktop/urls.py
@@ -165,7 +165,7 @@ dynamic_patterns += [
   re_path(r'^desktop/api2/user_preferences(?:/(?P<key>\w+))?/?$', desktop_api2.user_preferences, name="desktop.api2.user_preferences"),
 
   re_path(r'^desktop/api2/doc/export/?$', desktop_api2.export_documents),
-  re_path(r'^desktop/api2/doc/import/?$', desktop_api2.import_documents),
+  re_path(r'^desktop/api2/doc/import/?$', desktop_api2.import_documents, name='import_documents'),
 
   re_path(r'^desktop/api2/gist/create/?$', desktop_api2.gist_create),
   re_path(r'^desktop/api2/gist/open/?$', desktop_api2.gist_get),


### PR DESCRIPTION
## What changes were proposed in this pull request?

Import documents in documents tab are failing, when task server is enabled with error 
"  File "/opt/hive/desktop/core/src/desktop/api2.py", line 1027, in import_documents
    raise PopupException(_('Failed to import documents, the file does not contain valid JSON.'))".
    
This was because the document upload handler was using `FineUploaderChunkedUploadHandler` when the `is_chunked_fileuploader_enabled` flag is on. No supporting logic was added to `FineUploaderChunkedUploadHandler` to support document uploads as the main motive of `FineUploaderChunkedUploadHandler` was to support large file uploads. 

So adding a custom upload handler that will delegate the document upload tasks to the `HDFSfileUploadHandler` and rest of the file uploads to `FineUploaderChunkedUploadHandler` when `is_chunked_fileuploader_enabled` is on. 

## How was this patch tested?

-tested local setup and Kubernetes setup

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
