### PR TITLE
[ui-admin] disabled log out button for Knox

### DIFF
--- a/desktop/core/src/desktop/js/components/sidebar/HueSidebar.vue
+++ b/desktop/core/src/desktop/js/components/sidebar/HueSidebar.vue
@@ -156,12 +156,14 @@
     });
   }
 
-  USER_DRAWER_CHILDREN.push({
-    type: 'navigation',
-    name: 'logOut',
-    displayName: I18n('Log Out'),
-    handler: (event: Event) => onHueLinkClick(event, '/accounts/logout')
-  });
+  if (window.ALLOW_HUE_LOGOUT) {
+    USER_DRAWER_CHILDREN.push({
+      type: 'navigation',
+      name: 'logOut',
+      displayName: I18n('Log Out'),
+      handler: (event: Event) => onHueLinkClick(event, '/accounts/logout')
+    });
+  }
 
   const HELP_DRAWER_CHILDREN: Omit<SidebarNavigationItem, 'iconHtml'>[] = [
     {

--- a/desktop/core/src/desktop/templates/global_js_constants.mako
+++ b/desktop/core/src/desktop/templates/global_js_constants.mako
@@ -148,6 +148,9 @@
 
   window.SAML_LOGOUT_URL = '${ CDP_LOGOUT_URL.get() }';
   window.SAML_REDIRECT_URL = '${ get_logout_redirect_url() }';
+
+  window.ALLOW_HUE_LOGOUT = window.KNOX_BASE_URL === '';
+
   window.SKIP_CACHE = [
     'home', 'oozie_workflow', 'oozie_coordinator', 'oozie_bundle', 'dashboard', 'metastore', 'filebrowser',
     'useradmin_users', 'useradmin_groups', 'useradmin_newgroup', 'useradmin_editgroup',


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Disable the log out button if the authentication is handled by Knox

I didn't find enough info in the config API so I had to rely on the URL variables. 

@amitsrivastava can you verify that it is safe to depend on the global js variables like this and that the condition is complete? 

## How was this patch tested?

- manual testing by accessing different deployments using Knox or none to establish the condition used to set the ALLOW_HUE_LOGOUT flag. 
- Manually setting ALLOW_HUE_LOGOUT to true or false to verify that the logout button shows/disappears in the left bar both for expanded and collapsed.

![image](https://github.com/user-attachments/assets/df3c1d71-7210-446f-864a-01618704504b)
![image](https://github.com/user-attachments/assets/5465903b-103b-409b-92c1-f84dd2520a21)
![image](https://github.com/user-attachments/assets/babb017b-3e4a-402e-a0cd-d7332570b909)
![image](https://github.com/user-attachments/assets/1e49001e-27af-45e3-a5f1-86b47d644ffd)


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
