### PR TITLE
[cve] Migrate jquery jquery.cookie to js.cookie for CVE-2022-23395

### DIFF
--- a/desktop/core/src/desktop/js/apps/editor/components/resultGrid/ko.resultDownloadModal.js
+++ b/desktop/core/src/desktop/js/apps/editor/components/resultGrid/ko.resultDownloadModal.js
@@ -72,7 +72,7 @@ class DownloadResultModal {
 
     params.executable.toContext(id).then(jsonContext => {
       this.cookieId = 'download-' + id;
-      $.cookie(this.cookieId, null, { expires: -1, path: '/' });
+      Cookies.set(this.cookieId, null, { expires: -1, path: '/' });
 
       this.addAndSubmitDownloadForm(jsonContext, params.format);
 
@@ -84,14 +84,14 @@ class DownloadResultModal {
   trackCookie() {
     let timesChecked = 0;
     this.checkDownloadInterval = window.setInterval(() => {
-      if (!$.cookie(this.cookieId)) {
+      if (!Cookies.get(this.cookieId)) {
         if (timesChecked > 9) {
           this.$downloadProgressModal.show();
         }
       } else {
         window.clearInterval(this.checkDownloadInterval);
         try {
-          const cookieContent = $.cookie(this.cookieId);
+          const cookieContent = Cookies.get(this.cookieId);
           const result = JSON.parse(
             cookieContent
               .substr(1, cookieContent.length - 2)

--- a/desktop/core/src/desktop/js/jest/jquery.setup.js
+++ b/desktop/core/src/desktop/js/jest/jquery.setup.js
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 import $ from 'jquery';
-import 'jquery.cookie';
 
 global.$ = $;
 global.jQuery = $;

--- a/desktop/core/src/desktop/js/jest/jsCookieMigration.test.js
+++ b/desktop/core/src/desktop/js/jest/jsCookieMigration.test.js
@@ -1,0 +1,34 @@
+import $ from 'jquery';
+import 'jquery.cookie';
+import Cookies from 'js-cookie';
+
+describe('Cookie Migration from jquery-cookie to js-cookie', () => {
+    afterEach(() => {
+        $.removeCookie('test');
+        Cookies.remove('test');
+    });
+
+    test('migrating from jqeury-cookie to js-cookie should works in getting and setting a cookie api', () => {
+        const value = 'value';
+
+        $.cookie('test', value);
+        const jqueryCookieValue = $.cookie('test');
+
+        Cookies.set('test', value);
+        const jsCookieValue = Cookies.get('test');
+
+        expect(jqueryCookieValue).toEqual(jsCookieValue);
+    });
+
+    test('migrating from jqeury-cookie to js-cookie should works in setting the options api', () => {
+        const value = 'value';
+
+        $.cookie('test', value, { path: '/', expires: 10 });
+        const jqueryCookieValue = $.cookie('test');
+
+        Cookies.set('test', value, { path: '/', expires: 10 });
+        const jsCookieValue = Cookies.get('test');
+
+        expect(jqueryCookieValue).toEqual(jsCookieValue);
+    });
+});

--- a/desktop/core/src/desktop/js/jquery/jquery.common.js
+++ b/desktop/core/src/desktop/js/jquery/jquery.common.js
@@ -18,7 +18,6 @@ import $ from 'jquery';
 import 'jquery/jquery.migration';
 
 import 'jquery-contextmenu'; // TODO: Remove, it's only used for "old" query builder
-import 'jquery.cookie';
 import 'jquery-form';
 import 'jquery/plugins/jquery.selectize';
 import 'selectize-plugin-clear';

--- a/desktop/core/src/desktop/static/desktop/js/admin-wizard-inline.js
+++ b/desktop/core/src/desktop/static/desktop/js/admin-wizard-inline.js
@@ -168,10 +168,10 @@ $(document).ready(function () {
     });
   });
 
-  $("#updateSkipWizard").prop('checked', $.cookie("hueLandingPage", { path: "/" }) == "home");
+  $("#updateSkipWizard").prop('checked', Cookies.set("hueLandingPage", { path: "/" }) == "home");
 
   $("#updateSkipWizard").change(function () {
-    $.cookie("hueLandingPage", this.checked ? "home" : "wizard", {
+    Cookies.set("hueLandingPage", this.checked ? "home" : "wizard", {
       path: "/",
       secure: window.location.protocol.indexOf('https') > -1
     });

--- a/desktop/core/src/desktop/static/desktop/js/js.cookie.js
+++ b/desktop/core/src/desktop/static/desktop/js/js.cookie.js
@@ -1,0 +1,147 @@
+/*!
+ * Javascript Cookie v1.5.1
+ * https://github.com/js-cookie/js-cookie
+ *
+ * Copyright 2006, 2014 Klaus Hartl
+ * Released under the MIT license
+ */
+(function (factory) {
+	var jQuery;
+	if (typeof define === 'function' && define.amd) {
+		// AMD (Register as an anonymous module)
+		define(['jquery'], factory);
+	} else if (typeof exports === 'object') {
+		// Node/CommonJS
+		try {
+			jQuery = require('jquery');
+		} catch(e) {}
+		module.exports = factory(jQuery);
+	} else {
+		// Browser globals
+		var _OldCookies = window.Cookies;
+		var api = window.Cookies = factory(window.jQuery);
+		api.noConflict = function() {
+			window.Cookies = _OldCookies;
+			return api;
+		};
+	}
+}(function ($) {
+
+	var pluses = /\+/g;
+
+	function encode(s) {
+		return api.raw ? s : encodeURIComponent(s);
+	}
+
+	function decode(s) {
+		return api.raw ? s : decodeURIComponent(s);
+	}
+
+	function stringifyCookieValue(value) {
+		return encode(api.json ? JSON.stringify(value) : String(value));
+	}
+
+	function parseCookieValue(s) {
+		if (s.indexOf('"') === 0) {
+			// This is a quoted cookie as according to RFC2068, unescape...
+			s = s.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+		}
+
+		try {
+			// Replace server-side written pluses with spaces.
+			// If we can't decode the cookie, ignore it, it's unusable.
+			// If we can't parse the cookie, ignore it, it's unusable.
+			s = decodeURIComponent(s.replace(pluses, ' '));
+			return api.json ? JSON.parse(s) : s;
+		} catch(e) {}
+	}
+
+	function read(s, converter) {
+		var value = api.raw ? s : parseCookieValue(s);
+		return isFunction(converter) ? converter(value) : value;
+	}
+
+	function extend() {
+		var key, options;
+		var i = 0;
+		var result = {};
+		for (; i < arguments.length; i++) {
+			options = arguments[ i ];
+			for (key in options) {
+				result[key] = options[key];
+			}
+		}
+		return result;
+	}
+
+	function isFunction(obj) {
+		return Object.prototype.toString.call(obj) === '[object Function]';
+	}
+
+	var api = function (key, value, options) {
+
+		// Write
+
+		if (arguments.length > 1 && !isFunction(value)) {
+			options = extend(api.defaults, options);
+
+			if (typeof options.expires === 'number') {
+				var days = options.expires, t = options.expires = new Date();
+				t.setMilliseconds(t.getMilliseconds() + days * 864e+5);
+			}
+
+			return (document.cookie = [
+				encode(key), '=', stringifyCookieValue(value),
+				options.expires ? '; expires=' + options.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE
+				options.path    ? '; path=' + options.path : '',
+				options.domain  ? '; domain=' + options.domain : '',
+				options.secure  ? '; secure' : ''
+			].join(''));
+		}
+
+		// Read
+
+		var result = key ? undefined : {},
+			// To prevent the for loop in the first place assign an empty array
+			// in case there are no cookies at all. Also prevents odd result when
+			// calling "get()".
+			cookies = document.cookie ? document.cookie.split('; ') : [],
+			i = 0,
+			l = cookies.length;
+
+		for (; i < l; i++) {
+			var parts = cookies[i].split('='),
+				name = decode(parts.shift()),
+				cookie = parts.join('=');
+
+			if (key === name) {
+				// If second argument (value) is a function it's a converter...
+				result = read(cookie, value);
+				break;
+			}
+
+			// Prevent storing a cookie that we couldn't decode.
+			if (!key && (cookie = read(cookie)) !== undefined) {
+				result[name] = cookie;
+			}
+		}
+
+		return result;
+	};
+
+	api.get = api.set = api;
+	api.defaults = {};
+
+	api.remove = function (key, options) {
+		// Must not alter options, thus extending a fresh object...
+		api(key, '', extend(options, { expires: -1 }));
+		return !api(key);
+	};
+
+	if ( $ ) {
+		$.cookie = api;
+		$.removeCookie = api.remove;
+	}
+
+	return api;
+}));

--- a/desktop/core/src/desktop/templates/common_notebook_ko_components.mako
+++ b/desktop/core/src/desktop/templates/common_notebook_ko_components.mako
@@ -491,7 +491,7 @@ from desktop.lib.django_util import nonce_attribute
         window.hueAnalytics.log('notebook', 'download' + format);
 
         var self = this;
-        $.cookie('download-' + self.snippet.id(), null, { expires: -1, path: '/' })
+        Cookies.set('download-' + self.snippet.id(), null, { expires: -1, path: '/' })
         self.$downloadForm.find('input[name=\'format\']').val(format);
         self.$downloadForm.find('input[name=\'notebook\']').val(ko.mapping.toJSON(self.notebook.getContext()));
         self.$downloadForm.find('input[name=\'snippet\']').val(ko.mapping.toJSON(self.snippet.getContext()));
@@ -502,7 +502,7 @@ from desktop.lib.django_util import nonce_attribute
 
         var timesChecked = 0;
         self.checkDownloadInterval = window.setInterval(function () {
-          if ($.cookie('download-' + self.snippet.id()) === null || typeof $.cookie('download-' + self.snippet.id()) === 'undefined') {
+          if (Cookies.get('download-' + self.snippet.id()) === null || typeof Cookies.get('download-' + self.snippet.id()) === 'undefined') {
             if (timesChecked == 10) {
               $(self.downloadProgressModalId).modal('show');
             }
@@ -510,7 +510,7 @@ from desktop.lib.django_util import nonce_attribute
           else {
             window.clearInterval(self.checkDownloadInterval);
             try {
-              var cookieContent = $.cookie('download-' + self.snippet.id());
+              var cookieContent = Cookies.get('download-' + self.snippet.id());
               var result = JSON.parse(cookieContent.substr(1, cookieContent.length - 2).replace(/\\"/g, '"').replace(/\\054/g, ','));
               self.downloadTruncated(result.truncated);
               self.downloadCounter(result.row_counter);

--- a/desktop/core/src/desktop/templates/hue.mako
+++ b/desktop/core/src/desktop/templates/hue.mako
@@ -98,6 +98,7 @@
 
   % if not conf.DEV.get():
   <script src="${ static('desktop/js/hue.errorcatcher.js') }"></script>
+  <script src="${ static('desktop/js/js.cookie.js') }"></script>
   % endif
 </head>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "jquery-form": "4.3.0",
         "jquery-mousewheel": "3.1.13",
         "jquery-ui": "1.13.2",
-        "jquery.cookie": "1.4.1",
         "knockout": "3.5.1",
         "knockout-sortable": "1.2.0",
         "knockout-switch-case": "2.1.0",
@@ -113,6 +112,8 @@
         "identity-obj-proxy": "3.0.0",
         "jest": "29.7.0",
         "jest-environment-jsdom": "29.7.0",
+        "jquery.cookie": "1.4.1",
+        "js-cookie": "1.5.1",
         "jsdom": "16.6.0",
         "less": "4.2.0",
         "less-loader": "12.2.0",
@@ -6771,6 +6772,12 @@
         "node": ">=5.5"
       }
     },
+    "node_modules/cuix/node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
+      "license": "MIT"
+    },
     "node_modules/d3v3": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/d3v3/-/d3v3-1.0.3.tgz",
@@ -12629,7 +12636,9 @@
     "node_modules/jquery.cookie": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jquery.cookie/-/jquery.cookie-1.4.1.tgz",
-      "integrity": "sha1-1j3OIJ6raR/mMxbbCMqeR+D5OFs="
+      "integrity": "sha512-c/hZOOL+8VSw/FkTVH637gS1/6YzMSCROpTZ2qBYwJ7s7sHajU7uBkSSiE5+GXWwrfCCyO+jsYjUQ7Hs2rIxAA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-beautify": {
       "version": "1.15.1",
@@ -12742,9 +12751,11 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-1.5.1.tgz",
+      "integrity": "sha512-pE43x+pKwBVgIByenRXiEcpXHUy/DoUe0yc4pktYR3227oM5YHiPfm8zAquLQcNAnC4vPYacHhYihOek1Caqwg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "jquery-form": "4.3.0",
     "jquery-mousewheel": "3.1.13",
     "jquery-ui": "1.13.2",
-    "jquery.cookie": "1.4.1",
     "knockout": "3.5.1",
     "knockout-sortable": "1.2.0",
     "knockout-switch-case": "2.1.0",
@@ -162,7 +161,9 @@
     "webpack": "5.94.0",
     "webpack-bundle-analyzer": "4.10.2",
     "webpack-bundle-tracker": "3.1.0",
-    "webpack-cli": "5.1.4"
+    "js-cookie": "1.5.1",
+    "webpack-cli": "5.1.4",
+    "jquery.cookie": "1.4.1"
   },
   "scripts": {
     "devinstall": "npm cache clean && npm install && npm prune",


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Migrates jquery.cookie to js.cookie for removing [CVE-2022-23395](https://nvd.nist.gov/vuln/detail/cve-2022-23395)
- [js.cookie migrating from js.cookie](https://github.com/js-cookie/js-cookie/tree/v1.5.1)
- The jquery.cookie has been moved to devDependencies for migration test code.


## How was this patch tested?

- Added unit test (desktop/core/src/desktop/js/jest/jsCookieMigration.test.js)
- Also manually checked js.cookie.js  is loaded and works
<img width="958" alt="스크린샷 2025-03-14 오후 12 33 37" src="https://github.com/user-attachments/assets/69fd96e6-d7da-48e9-bf22-a90319b67594" />
 
Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
