### PR TITLE
[cve] Migrate jquery.cookie to js.cookie for CVE-2022-23395

### DIFF
--- a/desktop/core/src/desktop/js/apps/editor/components/resultGrid/ko.resultDownloadModal.js
+++ b/desktop/core/src/desktop/js/apps/editor/components/resultGrid/ko.resultDownloadModal.js
@@ -22,6 +22,7 @@ import huePubSub from 'utils/huePubSub';
 import I18n from 'utils/i18n';
 import UUID from 'utils/string/UUID';
 import hueAnalytics from 'utils/hueAnalytics';
+import Cookies from 'js-cookie';
 
 export const NAME = 'download-result-modal';
 
@@ -72,7 +73,7 @@ class DownloadResultModal {
 
     params.executable.toContext(id).then(jsonContext => {
       this.cookieId = 'download-' + id;
-      $.cookie(this.cookieId, null, { expires: -1, path: '/' });
+      Cookies.set(this.cookieId, null, { expires: -1, path: '/' });
 
       this.addAndSubmitDownloadForm(jsonContext, params.format);
 
@@ -84,14 +85,14 @@ class DownloadResultModal {
   trackCookie() {
     let timesChecked = 0;
     this.checkDownloadInterval = window.setInterval(() => {
-      if (!$.cookie(this.cookieId)) {
+      if (!Cookies.get(this.cookieId)) {
         if (timesChecked > 9) {
           this.$downloadProgressModal.show();
         }
       } else {
         window.clearInterval(this.checkDownloadInterval);
         try {
-          const cookieContent = $.cookie(this.cookieId);
+          const cookieContent = Cookies.get(this.cookieId);
           const result = JSON.parse(
             cookieContent
               .substr(1, cookieContent.length - 2)

--- a/desktop/core/src/desktop/js/hue.js
+++ b/desktop/core/src/desktop/js/hue.js
@@ -31,6 +31,7 @@ import page from 'page';
 import qq from 'ext/fileuploader.custom.new';
 import fileuploader from 'ext/fileuploader.custom';
 import sprintf from 'sprintf-js';
+import Cookies from 'js-cookie';
 
 import ko from 'ko/ko.all';
 
@@ -117,6 +118,7 @@ window.sqlStatementsParser = sqlStatementsParser;
 window.hplsqlStatementsParser = hplsqlStatementsParser;
 window.sqlUtils = sqlUtils;
 window.createReactComponents = createReactComponents;
+window.Cookies = Cookies;
 
 $(document).ready(async () => {
   await refreshConfig(); // Make sure we have config up front

--- a/desktop/core/src/desktop/js/jest/jquery.setup.js
+++ b/desktop/core/src/desktop/js/jest/jquery.setup.js
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 import $ from 'jquery';
-import 'jquery.cookie';
 
 global.$ = $;
 global.jQuery = $;

--- a/desktop/core/src/desktop/js/jquery/jquery.common.js
+++ b/desktop/core/src/desktop/js/jquery/jquery.common.js
@@ -18,7 +18,6 @@ import $ from 'jquery';
 import 'jquery/jquery.migration';
 
 import 'jquery-contextmenu'; // TODO: Remove, it's only used for "old" query builder
-import 'jquery.cookie';
 import 'jquery-form';
 import 'jquery/plugins/jquery.selectize';
 import 'selectize-plugin-clear';

--- a/desktop/core/src/desktop/static/desktop/js/admin-wizard-inline.js
+++ b/desktop/core/src/desktop/static/desktop/js/admin-wizard-inline.js
@@ -168,10 +168,10 @@ $(document).ready(function () {
     });
   });
 
-  $("#updateSkipWizard").prop('checked', $.cookie("hueLandingPage", { path: "/" }) == "home");
+  $("#updateSkipWizard").prop('checked', Cookies.set("hueLandingPage", { path: "/" }) == "home");
 
   $("#updateSkipWizard").change(function () {
-    $.cookie("hueLandingPage", this.checked ? "home" : "wizard", {
+    Cookies.set("hueLandingPage", this.checked ? "home" : "wizard", {
       path: "/",
       secure: window.location.protocol.indexOf('https') > -1
     });

--- a/desktop/core/src/desktop/templates/common_notebook_ko_components.mako
+++ b/desktop/core/src/desktop/templates/common_notebook_ko_components.mako
@@ -491,7 +491,7 @@ from desktop.lib.django_util import nonce_attribute
         window.hueAnalytics.log('notebook', 'download' + format);
 
         var self = this;
-        $.cookie('download-' + self.snippet.id(), null, { expires: -1, path: '/' })
+        window.Cookies.set('download-' + self.snippet.id(), null, { expires: -1, path: '/' })
         self.$downloadForm.find('input[name=\'format\']').val(format);
         self.$downloadForm.find('input[name=\'notebook\']').val(ko.mapping.toJSON(self.notebook.getContext()));
         self.$downloadForm.find('input[name=\'snippet\']').val(ko.mapping.toJSON(self.snippet.getContext()));
@@ -502,7 +502,7 @@ from desktop.lib.django_util import nonce_attribute
 
         var timesChecked = 0;
         self.checkDownloadInterval = window.setInterval(function () {
-          if ($.cookie('download-' + self.snippet.id()) === null || typeof $.cookie('download-' + self.snippet.id()) === 'undefined') {
+          if (window.Cookies.get('download-' + self.snippet.id()) === null || typeof window.Cookies.get('download-' + self.snippet.id()) === 'undefined') {
             if (timesChecked == 10) {
               $(self.downloadProgressModalId).modal('show');
             }
@@ -510,7 +510,7 @@ from desktop.lib.django_util import nonce_attribute
           else {
             window.clearInterval(self.checkDownloadInterval);
             try {
-              var cookieContent = $.cookie('download-' + self.snippet.id());
+              var cookieContent = window.Cookies.get('download-' + self.snippet.id());
               var result = JSON.parse(cookieContent.substr(1, cookieContent.length - 2).replace(/\\"/g, '"').replace(/\\054/g, ','));
               self.downloadTruncated(result.truncated);
               self.downloadCounter(result.row_counter);

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "jquery-form": "4.3.0",
         "jquery-mousewheel": "3.1.13",
         "jquery-ui": "1.13.2",
-        "jquery.cookie": "1.4.1",
+        "js-cookie": "3.0.5",
         "knockout": "3.5.1",
         "knockout-sortable": "1.2.0",
         "knockout-switch-case": "2.1.0",
@@ -6771,6 +6771,12 @@
         "node": ">=5.5"
       }
     },
+    "node_modules/cuix/node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
+      "license": "MIT"
+    },
     "node_modules/d3v3": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/d3v3/-/d3v3-1.0.3.tgz",
@@ -12626,11 +12632,6 @@
         "jquery": ">=1.8.0 <4.0.0"
       }
     },
-    "node_modules/jquery.cookie": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jquery.cookie/-/jquery.cookie-1.4.1.tgz",
-      "integrity": "sha1-1j3OIJ6raR/mMxbbCMqeR+D5OFs="
-    },
     "node_modules/js-beautify": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.1.tgz",
@@ -12693,15 +12694,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/js-beautify/node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/js-beautify/node_modules/minimatch": {
       "version": "9.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
@@ -12742,9 +12734,13 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "jquery-form": "4.3.0",
     "jquery-mousewheel": "3.1.13",
     "jquery-ui": "1.13.2",
-    "jquery.cookie": "1.4.1",
     "knockout": "3.5.1",
     "knockout-sortable": "1.2.0",
     "knockout-switch-case": "2.1.0",
@@ -83,7 +82,8 @@
     "styled-components": "5.3.10",
     "vue": "3.2.0",
     "vue-custom-element": "3.2.14",
-    "vue3-datepicker": "0.2.5"
+    "vue3-datepicker": "0.2.5",
+    "js-cookie": "3.0.5"
   },
   "devDependencies": {
     "@babel/cli": "7.24.8",


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Migrates jquery.cookie to js.cookie for removing [CVE-2022-23395](https://nvd.nist.gov/vuln/detail/cve-2022-23395)
- [js.cookie migrating from jquery.cookie](https://github.com/js-cookie/js-cookie/tree/v1.5.1)
- The jquery.cookie has been moved to devDependencies for migration test code.


## How was this patch tested?

- Added unit test (desktop/core/src/desktop/js/jest/jsCookieMigration.test.js)
- Also manually checked js.cookie.js  is loaded and works
<img width="958" alt="스크린샷 2025-03-14 오후 12 33 37" src="https://github.com/user-attachments/assets/69fd96e6-d7da-48e9-bf22-a90319b67594" />
 
Please Remove https://github.com/cloudera/hue/pull/4053 PR as it duplicates this PR.


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
