### PR TITLE
Improvement - Hue Atlas search for classification and tags

### DIFF
--- a/desktop/libs/metadata/src/metadata/catalog/atlas_client.py
+++ b/desktop/libs/metadata/src/metadata/catalog/atlas_client.py
@@ -285,13 +285,17 @@ class AtlasApi(Api):
         'criterion': [{
           'condition': 'OR',
           'criterion': [{
-            'attributeName': 'name',
-            'attributeValue': query_s,
-            'operator': 'contains'
+            'attributeName': '__typeName',
+            'operator': 'eq',
+            'attributeValue': 'hive_column'
           }, {
-            'attributeName': 'description',
-            'attributeValue': query_s,
-            'operator': 'contains'
+            'attributeName': '__typeName',
+            'operator': 'eq',
+            'attributeValue': 'hive_table'
+          }, {
+            'attributeName': '__typeName',
+            'operator': 'eq',
+            'attributeValue': 'hive_db'
           }]
         }]
       },


### PR DESCRIPTION
Based on a discussion with Atlas team, came to know that the query_s for searching classification or tags can be slow in Atlas and can lead to timeouts. Have made the needed changes based on Atlas team and this was tested in CU environment.
