### PR TITLE
[compute][ui] old saved queries failing to load

### DIFF
--- a/desktop/core/src/desktop/js/apps/notebook/snippet.js
+++ b/desktop/core/src/desktop/js/apps/notebook/snippet.js
@@ -217,7 +217,7 @@ class Snippet {
       return vm.getSnippetViewSettings(self.dialect()).sqlDialect;
     });
 
-    self.dialect = ko.pureComputed(() => this.connector().dialect);
+    self.dialect = ko.pureComputed(() => this.connector() && this.connector().dialect);
 
     self.isBatchable = ko.computed(() => {
       return (

--- a/desktop/core/src/desktop/js/parse/utils.ts
+++ b/desktop/core/src/desktop/js/parse/utils.ts
@@ -20,7 +20,7 @@ import sqlStatementsParser from 'parse/sqlStatementsParser';
 import { SqlStatementsParser } from './types';
 
 export const getStatementsParser = (connector: Connector): SqlStatementsParser => {
-  if (connector.dialect === 'hplsql') {
+  if (connector && connector.dialect === 'hplsql') {
     return hplsqlStatementsParser as unknown as SqlStatementsParser;
   } else {
     return sqlStatementsParser;


### PR DESCRIPTION
This fix adds a check to avoid
`Uncaught TypeError: Cannot read properties of undefined (reading 'dialect')`

This unchecked attr access in js blocks saved queries from loading.

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
