### PR TITLE
[api] Improve filename handling in Content-Disposition header for /download API

### DIFF
--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -22,6 +22,7 @@ import operator
 import mimetypes
 import posixpath
 from io import BytesIO as string_io
+from urllib.parse import quote
 
 from django.core.files.uploadhandler import StopUpload
 from django.core.paginator import EmptyPage, Paginator
@@ -224,7 +225,14 @@ def download(request):
       request.GET.get('disposition') if request.GET.get('disposition') == 'inline' and _can_inline_display(path) else 'attachment'
     )
 
-    response['Content-Disposition'] = f'{content_disposition}; filename="{stats["name"]}"'
+    # Extract filename for HDFS and OFS for now because the path stats object has a bug in fetching name field
+    # TODO: Fix this super old bug when refactoring the underlying HDFS filesystem code
+    filename = os.path.basename(path) if request.fs._get_scheme(path).lower() in ('hdfs', 'ofs') else stats['name']
+
+    # Set the filename in the Content-Disposition header with proper encoding for special characters
+    encoded_filename = quote(filename)
+    response['Content-Disposition'] = f"{content_disposition}; filename*=UTF-8\'\'{encoded_filename}"
+
     response["Last-Modified"] = http_date(stats['mtime'])
     response["Content-Length"] = stats['size']
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This fixes 2 issues:
- Fix file download with names having spacial chars, whitespace, percentage for all filesystems.
- Fix file download for all filenames for HDFS and OFS filesystems as the stats object is buggy from very long time and does not correct set the name field for current path.

## How was this patch tested?

- Manually
- Add unit tests for /download API