### PR TITLE
[ui-editor] fixes loading computes in saved query page

### DIFF
--- a/desktop/core/src/desktop/js/apps/notebook/snippet.js
+++ b/desktop/core/src/desktop/js/apps/notebook/snippet.js
@@ -200,7 +200,10 @@ class Snippet {
 
     const updateConnector = id => {
       if (id) {
-        self.connector(findEditorConnector(connector => connector.id === id));
+        // when computes are enabled, hive becomes hive-compute.
+        self.connector(
+          findEditorConnector(connector => id === connector.id || id === `${connector.id}-compute`)
+        );
       }
     };
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- when computes are enabled, hive becomes hive-compute. Due to this findEditorConnector was not able to find the appropriate compute.

## How was this patch tested?

-  Tested manually

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
