### PR TITLE
[security] fix arguments error for saml logout issue

### DIFF
--- a/desktop/libs/libsaml/src/libsaml/backend.py
+++ b/desktop/libs/libsaml/src/libsaml/backend.py
@@ -120,7 +120,7 @@ class SAML2Backend(_Saml2Backend):
 
       html = '<html><body>' \
             '<form action="%s" method="POST">' \
-            '<input name="logoutRedirect" type="hidden" value="%s">%s</form>' \
+            '<input name="logoutRedirect" type="hidden" value="%s"></form>' \
             '<script%s>document.addEventListener("DOMContentLoaded", function() { document.forms[0].submit(); });</script>' \
             '</body></html>' % (conf.CDP_LOGOUT_URL.get(), redirect_url, nonce_attribute(request))
       return HttpResponse(html)


### PR DESCRIPTION
* [security] fix arguments error for saml logout issue

## What changes were proposed in this pull request?

* Remove the extra arguments . `exception: not enough arguments for format string`

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
