### PR TITLE
[django] fixed was_modified_since by removing size param

### DIFF
--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -198,7 +198,7 @@ def download(request):
 
   content_type = mimetypes.guess_type(path)[0] or 'application/octet-stream'
   stats = request.fs.stats(path)
-  if not was_modified_since(request.META.get('HTTP_IF_MODIFIED_SINCE'), stats['mtime'], stats['size']):
+  if not was_modified_since(request.META.get('HTTP_IF_MODIFIED_SINCE'), stats['mtime']):
     return HttpResponseNotModified()
 
   fh = request.fs.open(path)

--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -220,7 +220,7 @@ def download(request, path):
   stats = request.fs.stats(path)
   mtime = stats['mtime']
   size = stats['size']
-  if not was_modified_since(request.META.get('HTTP_IF_MODIFIED_SINCE'), mtime, size):
+  if not was_modified_since(request.META.get('HTTP_IF_MODIFIED_SINCE'), mtime):
     return HttpResponseNotModified()
     # TODO(philip): Ideally a with statement would protect from leaks, but tricky to do here.
   fh = request.fs.open(path)


### PR DESCRIPTION
In django4.1 the size param has been removed. Justification from django looks good.

Removed outdated handling of length parameter to If-Modified-Since header The length parameter is not described in RFC-7232 and it's against HTTP/1.0 and HTTP/1.1 specifications. It was an old and unofficial extension set by some ancient versions of IE.

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
