### PR TITLE
upgrade setuptools package due to CVE-2024-6345

### DIFF
--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -1,3 +1,4 @@
+setuptools==70.0.0
 apache-ranger==0.0.3
 requests-gssapi==1.2.3
 asn1crypto==0.24.0


### PR DESCRIPTION
## What changes were proposed in this pull request?

upgrading setuptools package to 70.0.0 version due to https://nvd.nist.gov/vuln/detail/cve-2024-6345 

## How was this patch tested?
Created a build and tested the docker image on CDW. Hue works fine. 

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
