### PR TITLE
[api] Add endpoint to fetch available apps for example installation

### DIFF
--- a/desktop/core/src/desktop/api2.py
+++ b/desktop/core/src/desktop/api2.py
@@ -1419,6 +1419,21 @@ def _paginate(request, queryset):
 
 
 @api_error_handler
+def available_app_examples(request):
+  """Returns a dictionary of available apps whose examples can be installed by the admin user."""
+
+  if not is_admin(request.user):
+    return JsonResponse({'message': "You must be a Hue admin to access this endpoint."}, status=403)
+
+  supported_app_examples = {'hive', 'impala', 'hbase', 'pig', 'oozie', 'notebook', 'search', 'spark', 'jobsub'}
+
+  # Filter apps based on supported list
+  available_examples = {app.name: app.nice_name for app in appmanager.get_apps(request.user) if app.name in supported_app_examples}
+
+  return JsonResponse({'apps': available_examples})
+
+
+@api_error_handler
 def install_app_examples(request):
   app_name = request.POST.get('app_name')
   if not app_name:

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -82,10 +82,12 @@ def install_app_examples(request):
   django_request = get_django_request(request)
   return desktop_api.install_app_examples(django_request)
 
+
 @api_view(["GET"])
 def available_app_examples(request):
   django_request = get_django_request(request)
   return desktop_api.available_app_examples(django_request)
+
 
 # Editor
 

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -82,6 +82,11 @@ def install_app_examples(request):
   django_request = get_django_request(request)
   return desktop_api.install_app_examples(django_request)
 
+@api_view(["GET"])
+def available_app_examples(request):
+  django_request = get_django_request(request)
+  return desktop_api.available_app_examples(django_request)
+
 # Editor
 
 

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -34,6 +34,7 @@ urlpatterns += [
   re_path(r'^logs/?$', api_public.get_hue_logs, name='core_get_hue_logs'),
   re_path(r'^logs/download/?$', api_public.download_hue_logs, name='core_download_hue_logs'),
   re_path(r'^install_app_examples/?$', api_public.install_app_examples, name='core_install_app_examples'),
+  re_path(r'^available_app_examples/?$', api_public.available_app_examples, name='core_available_app_examples'),
   re_path(r'^get_config/?$', api_public.get_config),
   re_path(r'^check_config/?$', api_public.check_config, name='core_check_config'),
   re_path(r'^get_namespaces/(?P<interface>[\w\-]+)/?$', api_public.get_context_namespaces),  # To remove


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Return all available apps per admin users for example installation.

## How was this patch tested?

- Manually
- Unit tests