### PR TITLE
[django] Fix for removal of django.conf.urls.url in Django4

### DIFF
--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -18,12 +18,10 @@ django-celery-beat==2.6.0
 django-celery-results==2.5.1
 django-cors-headers==3.13.0
 django-crequest==2018.5.11
-django-debug-panel==0.8.3
-django-debug-toolbar==3.6.0
 django-extensions==3.2.1
 django-ipware==3.0.2
 django_opentracing==1.1.0
-django_prometheus==1.0.15
+django_prometheus==2.3.1
 django-webpack-loader==1.0.0
 djangomako==1.3.2
 djangorestframework-simplejwt==5.2.1

--- a/desktop/core/ext-py3/djangosaml2-0.18.0/djangosaml2/urls.py
+++ b/desktop/core/ext-py3/djangosaml2-0.18.0/djangosaml2/urls.py
@@ -13,15 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
-from djangosaml2 import views
+from django.urls import path
 
+from . import views
 
 urlpatterns = [
-    url(r'^login/$', views.login, name='saml2_login'),
-    url(r'^acs/$', views.assertion_consumer_service, name='saml2_acs'),
-    url(r'^logout/$', views.logout, name='saml2_logout'),
-    url(r'^ls/$', views.logout_service, name='saml2_ls'),
-    url(r'^ls/post/$', views.logout_service_post, name='saml2_ls_post'),
-    url(r'^metadata/$', views.metadata, name='saml2_metadata'),
+    path('login/', views.login, name='saml2_login'),
+    path('acs/', views.assertion_consumer_service, name='saml2_acs'),
+    path('logout/', views.logout, name='saml2_logout'),
+    path('ls/', views.logout_service, name='saml2_ls'),
+    path('ls/post/', views.logout_service_post, name='saml2_ls_post'),
+    path('metadata/', views.metadata, name='saml2_metadata'),
 ]


### PR DESCRIPTION
`django-debug-panel` is dropped as it is no longer supported for django4. If we want something we will need to bring in some other more modern debug panel.

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
