### PR TITLE
[api] Improve error handling for non-decodable files in /display filebrowser API

### DIFF
--- a/apps/filebrowser/src/filebrowser/api.py
+++ b/apps/filebrowser/src/filebrowser/api.py
@@ -410,7 +410,8 @@ def display(request):
       file_contents = contents.decode(encoding)
       mode = 'text'
     except UnicodeDecodeError:
-      file_contents = contents
+      LOG.error("Cannot decode file contents with encoding: %s." % encoding)
+      return HttpResponse("Cannot display file content. Please download the file instead.", status=422)
 
   data = {
     'contents': file_contents,


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Instead of displaying raw binary content when file decoding fails, returns a user-friendly error message suggesting file download as an alternative.

- Adds error logging to help diagnose encoding issues in server logs.

## How was this patch tested?

- Manually