### PR TITLE
[auth] Display login form when OIDC auth is enabled along with other auth backends

### DIFF
--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -593,6 +593,7 @@ for middleware in desktop.conf.MIDDLEWARE.get():
 def is_oidc_configured():
   return 'desktop.auth.backend.OIDCBackend' in AUTHENTICATION_BACKENDS
 
+
 def only_oidc_configured():
     """
     Check if only the OIDC Auth Backend is enabled.
@@ -602,6 +603,7 @@ def only_oidc_configured():
     return all(
         backend in ('desktop.auth.backend.OIDCBackend', 'axes.backends.AxesBackend')
         for backend in AUTHENTICATION_BACKENDS)
+
 
 if is_oidc_configured():
   INSTALLED_APPS.append('mozilla_django_oidc')

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -594,7 +594,11 @@ def is_oidc_configured():
   return 'desktop.auth.backend.OIDCBackend' in AUTHENTICATION_BACKENDS
 
 def only_oidc_configured():
-    """Check if only the OIDC Auth Backend is enabled"""
+    """
+    Check if only the OIDC Auth Backend is enabled.
+
+    Also, ignore Axes Backend which is always added implicitly.
+    """
     return all(
         backend in ('desktop.auth.backend.OIDCBackend', 'axes.backends.AxesBackend')
         for backend in AUTHENTICATION_BACKENDS)

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -594,7 +594,10 @@ def is_oidc_configured():
   return 'desktop.auth.backend.OIDCBackend' in AUTHENTICATION_BACKENDS
 
 def only_oidc_configured():
-  return not [b for b in AUTHENTICATION_BACKENDS if b != 'desktop.auth.backend.OIDCBackend']
+    """Check if only the OIDC Auth Backend is enabled"""
+    return all(
+        backend in ('desktop.auth.backend.OIDCBackend', 'axes.backends.AxesBackend')
+        for backend in AUTHENTICATION_BACKENDS)
 
 if is_oidc_configured():
   INSTALLED_APPS.append('mozilla_django_oidc')

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -593,10 +593,12 @@ for middleware in desktop.conf.MIDDLEWARE.get():
 def is_oidc_configured():
   return 'desktop.auth.backend.OIDCBackend' in AUTHENTICATION_BACKENDS
 
+def only_oidc_configured():
+  return not [b for b in AUTHENTICATION_BACKENDS if b != 'desktop.auth.backend.OIDCBackend']
 
 if is_oidc_configured():
   INSTALLED_APPS.append('mozilla_django_oidc')
-  if 'desktop.auth.backend.AllowFirstUserDjangoBackend' not in AUTHENTICATION_BACKENDS:
+  if only_oidc_configured():
     # when multi-backend auth, standard login URL '/hue/accounts/login' is used.
     LOGIN_URL = '/oidc/authenticate/'
   SESSION_EXPIRE_AT_BROWSER_CLOSE = True


### PR DESCRIPTION
## What changes were proposed in this pull request?

Without this fix Hue skips login form when `desktop.auth.backend` set to `desktop.auth.backend.OIDCBackend` (and does not include `desktop.auth.backend.AllowFirstUserDjangoBackend`).

But this does not cover a lot of cases, e.g.:
```ini
[desktop]
[[auth]]
backend=desktop.auth.backend.LdapBackend,desktop.auth.backend.OIDCBackend
```

or:
```ini
[desktop]
[[auth]]
backend=desktop.auth.backend.AllowFirstUserDjangoBackend,desktop.auth.backend.PamBackend,desktop.auth.backend.OIDCBackend
```

So in my opinion it's better to skip that form only when only `OIDCBackend` is used (pretty much exactly like the comment on the first line of that `if` statement says).


## How was this patch tested?

Manual