### PR TITLE
[ui] Add json-sumary as one of the coveragereporter config in jest

### DIFF
--- a/.github/workflows/pr-comments.yml
+++ b/.github/workflows/pr-comments.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  tests-and-coverage:
+  backend-tests-and-coverage:
     runs-on: ubuntu-latest
 
     steps:
@@ -120,12 +120,10 @@ jobs:
       - name: Add jest coverage PR comment
         uses: MishaKav/jest-coverage-comment@v1
         with:
-          coverage-summary-path: ./reports/jest/coverage-final.json
-          title: UI Code Coverage
-          summary-title: Jest Coverage Report
+          coverage-summary-path: ./reports/jest/coverage-summary.json
+          summary-title: UI Coverage Report
           badge-title: Coverage
           hide-comment: false
           create-new-comment: false
           hide-summary: false
           coverage-title: Coverage Report
-

--- a/jest.config.js
+++ b/jest.config.js
@@ -28,6 +28,7 @@ module.exports = {
     '<rootDir>/desktop/core/src/desktop/js/parse/sql/calcite/test',
     '<rootDir>/desktop/core/src/desktop/js/parse/sql/flink/test'
   ],
+  coverageReporters: ["lcov", "text", "json-summary"],
   collectCoverageFrom: [
     '<rootDir>/desktop/core/src/desktop/js/**/*.{js,jsx,ts,tsx,vue}',
     '!<rootDir>/desktop/core/src/desktop/js/ext/**',


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/pr-comments.yml` file to improve workflow organization and modify the Jest coverage report settings.

Workflow organization:

* Renamed the job `tests-and-coverage` to `backend-tests-and-coverage` for better clarity and distinction in workflow naming. (`permissions:` section, [.github/workflows/pr-comments.ymlL12-R12](diffhunk://#diff-e2eeb2f61cd715cd003bcb2d9904a7ef75aceece2b54c5efcb0dfc99b6622f9fL12-R12))

Jest coverage report settings:

* Updated the `coverage-summary-path` from `./reports/jest/coverage-final.json` to `./reports/jest/coverage-summary.json` and changed the `summary-title` from "Jest Coverage Report" to "UI Coverage Report" to align with updated reporting conventions. (`jobs:` section, [.github/workflows/pr-comments.ymlL123-L131](diffhunk://#diff-e2eeb2f61cd715cd003bcb2d9904a7ef75aceece2b54c5efcb0dfc99b6622f9fL123-L131))