### PR TITLE
[importer] Change error logging from exception to warning for python-magic package import

### DIFF
--- a/desktop/core/src/desktop/lib/importer/operations.py
+++ b/desktop/core/src/desktop/lib/importer/operations.py
@@ -35,7 +35,7 @@ try:
 
   is_magic_lib_available = True
 except ImportError as e:
-  LOG.exception(f"Failed to import python-magic: {str(e)}")
+  LOG.warning(f"Failed to import python-magic: {e}")
   is_magic_lib_available = False
 
 


### PR DESCRIPTION
This pull request includes a minor update to the logging level in `desktop/lib/importer/operations.py`, changing an exception log to a warning to better reflect the severity of the issue.

* [`desktop/core/src/desktop/lib/importer/operations.py`](diffhunk://#diff-de3428bd573ff885faf6d14a8a3477b38df24b4587493591f3cc0627e4b693afL38-R38): Updated the logging level from `LOG.exception` to `LOG.warning` for cases where `python-magic` fails to import, ensuring the message aligns with the reduced severity of the situation.