### PR TITLE
[ui-importer-modal] Bulk Edit column modal second iteration

### DIFF
--- a/desktop/core/src/desktop/js/apps/newimporter/ImporterFilePreview/EditColumns/EditColumnsModal.test.tsx
+++ b/desktop/core/src/desktop/js/apps/newimporter/ImporterFilePreview/EditColumns/EditColumnsModal.test.tsx
@@ -14,10 +14,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@use 'variables' as vars;
-
-.antd.cuix {
-  .hue-importer-edit-columns {
-    padding: vars.$fluidx-spacing-s;
-  }
-}
+//Will write tests after first review

--- a/desktop/core/src/desktop/js/apps/newimporter/ImporterFilePreview/EditColumns/EditColumnsModal.tsx
+++ b/desktop/core/src/desktop/js/apps/newimporter/ImporterFilePreview/EditColumns/EditColumnsModal.tsx
@@ -14,27 +14,147 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from 'react';
+import React, { useState, useEffect, ChangeEvent, useMemo } from 'react';
 import { i18nReact } from '../../../../utils/i18nReact';
 import Modal from 'cuix/dist/components/Modal';
-import './EditColumns.scss';
+import Table from 'cuix/dist/components/Table';
+import Input from 'cuix/dist/components/Input';
+import Select from 'cuix/dist/components/Select';
+
+interface Column {
+  title: string;
+  dataIndex: string;
+  type?: string;
+  comment?: string;
+}
+
+interface EditRow {
+  key: number;
+  name: string;
+  type: string;
+  sample: string;
+  comment: string;
+}
 
 interface EditColumnsModalProps {
   isOpen: boolean;
   closeModal: () => void;
+  columns: Column[];
+  setColumns: (cols: Column[]) => void;
+  sample?: Record<string, any>[];
 }
 
-const EditColumnsModal = ({ isOpen, closeModal }: EditColumnsModalProps): JSX.Element => {
+const EditColumnsModal = ({
+  isOpen,
+  closeModal,
+  columns,
+  setColumns,
+  sample
+}: EditColumnsModalProps): JSX.Element => {
   const { t } = i18nReact.useTranslation();
+  const [editRows, setEditRows] = useState<EditRow[]>([]);
+
+  useEffect(() => {
+    setEditRows(
+      columns.map((col, idx) => ({
+        key: idx,
+        name: col.title,
+        type: col.type || 'string',
+        sample: sample && sample.length > 0 ? (sample[0][col.dataIndex] ?? '') : '',
+        comment: col.comment || ''
+      }))
+    );
+  }, [columns, sample, isOpen]);
+
+  const handleChange = (idx: number, field: keyof EditRow, value: string) => {
+    setEditRows(rows => rows.map((row, i) => (i === idx ? { ...row, [field]: value } : row)));
+  };
+
+  const handleDone = () => {
+    setColumns(
+      editRows.map(row => ({
+        ...columns[row.key],
+        title: row.name,
+        type: row.type,
+        comment: row.comment
+      }))
+    );
+    closeModal();
+  };
+
+  const modalColumns = useMemo(
+    () => [
+      {
+        title: t('Column Name'),
+        dataIndex: 'name',
+        render: (text: string, _: EditRow, idx: number) => (
+          <Input
+            value={text}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              handleChange(idx, 'name', e.target.value)
+            }
+            placeholder={t('Column Name')}
+          />
+        )
+      },
+      {
+        title: t('Column Type'),
+        dataIndex: 'type',
+        render: (value: string, _: EditRow, idx: number) => (
+          <Select
+            value={value}
+            onChange={(val: string) => handleChange(idx, 'type', val)}
+            getPopupContainer={triggerNode => triggerNode.parentNode}
+            style={{ border: '1px solid #838b92', borderRadius: '3px', width: '150px' }}
+          >
+            <Select.Option value="string">{t('String')}</Select.Option>
+            <Select.Option value="int">{t('Integer')}</Select.Option>
+            <Select.Option value="float">{t('Float')}</Select.Option>
+            <Select.Option value="bool">{t('Boolean')}</Select.Option>
+          </Select>
+        )
+      },
+      {
+        title: t('Sample Value'),
+        dataIndex: 'sample',
+        render: (text: string, _: EditRow, idx: number) => (
+          <Input
+            value={text}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              handleChange(idx, 'sample', e.target.value)
+            }
+            style={{ border: 'none' }}
+          />
+        )
+      },
+      {
+        title: t('Comment'),
+        dataIndex: 'comment',
+        render: (text: string, _: EditRow, idx: number) => (
+          <Input
+            value={text}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              handleChange(idx, 'comment', e.target.value)
+            }
+          />
+        )
+      }
+    ],
+    [t]
+  );
 
   return (
     <Modal
-      cancelText={t('Cancel')}
-      okText={t('Done')}
-      title={t('Edit Columns')}
       open={isOpen}
       onCancel={closeModal}
-    />
+      title={t('Edit Columns')}
+      cancelText={t('cancel')}
+      okText={t('Done')}
+      onOk={handleDone}
+      width={800}
+    >
+      <Table columns={modalColumns} dataSource={editRows} pagination={false} />
+    </Modal>
   );
 };
 

--- a/desktop/core/src/desktop/js/apps/newimporter/ImporterFilePreview/ImporterFilePreview.scss
+++ b/desktop/core/src/desktop/js/apps/newimporter/ImporterFilePreview/ImporterFilePreview.scss
@@ -66,5 +66,9 @@
       display: flex;
       justify-content: space-between;
     }
+
+    &__edit-columns-button{
+      padding: vars.$fluidx-spacing-s;
+    }
   }
 }

--- a/desktop/core/src/desktop/js/apps/newimporter/ImporterFilePreview/ImporterFilePreview.tsx
+++ b/desktop/core/src/desktop/js/apps/newimporter/ImporterFilePreview/ImporterFilePreview.tsx
@@ -40,6 +40,7 @@ const ImporterFilePreview = ({ fileMetaData }: ImporterFilePreviewProps): JSX.El
   const { t } = i18nReact.useTranslation();
   const [fileFormat, setFileFormat] = useState<FileFormatResponse | undefined>();
   const [isEditColumnsOpen, setIsEditColumnsOpen] = useState(false);
+  const [columns, setColumns] = useState<any[]>([]);
   const defaultTableName = getDefaultTableName(fileMetaData.path, fileMetaData.source);
 
   const { save: guessFormat, loading: guessingFormat } = useSaveData<FileFormatResponse>(
@@ -86,6 +87,14 @@ const ImporterFilePreview = ({ fileMetaData }: ImporterFilePreviewProps): JSX.El
     guessFields(formData);
   }, [fileMetaData.path, fileFormat]);
 
+  // Update columns when previewData changes
+  useEffect(() => {
+    if (previewData?.columns) {
+      setColumns(convertToAntdColumns(previewData.columns));
+    }
+  }, [previewData]);
+
+  // Update previewData columns before finishing import
   const handleFinishImport = () => {
     // TODO: take the hardcoded values from the form once implemented
     const dialect = 'impala';
@@ -97,12 +106,17 @@ const ImporterFilePreview = ({ fileMetaData }: ImporterFilePreviewProps): JSX.El
       format: fileFormat,
       sourceType: dialect
     };
+    // Map columns back to original format for backend if needed
     const destination = {
       outputFormat: 'table',
       nonDefaultLocation: fileMetaData.path,
       name: `${database}.${defaultTableName}`,
       sourceType: dialect,
-      columns: previewData?.columns
+      columns: columns.map(col => ({
+        name: col.title,
+        type: col.type || 'string',
+        comment: col.comment || ''
+      }))
     };
 
     const formData = new FormData();
@@ -112,8 +126,16 @@ const ImporterFilePreview = ({ fileMetaData }: ImporterFilePreviewProps): JSX.El
     save(formData);
   };
 
-  const columns = convertToAntdColumns(previewData?.columns ?? []);
   const tableData = convertToDataSource(columns, previewData?.sample);
+
+  const sampleRows = Array.isArray(previewData?.sample?.[0])
+    ? previewData.sample.map(rowArr =>
+        columns.reduce((acc, col, idx) => {
+          acc[col.dataIndex] = rowArr[idx];
+          return acc;
+        }, {})
+      )
+    : previewData?.sample;
 
   return (
     <div className="hue-importer-preview-page">
@@ -132,7 +154,10 @@ const ImporterFilePreview = ({ fileMetaData }: ImporterFilePreviewProps): JSX.El
       <div className="hue-importer-preview-page__main-section">
         <div className="hue-importer-preview-page__header-section">
           <SourceConfiguration fileFormat={fileFormat} setFileFormat={setFileFormat} />
-          <BorderlessButton onClick={() => setIsEditColumnsOpen(true)}>
+          <BorderlessButton
+            onClick={() => setIsEditColumnsOpen(true)}
+            className="hue-importer-preview-page__edit-columns-button"
+          >
             {t('Edit Columns')}
           </BorderlessButton>
         </div>
@@ -145,7 +170,14 @@ const ImporterFilePreview = ({ fileMetaData }: ImporterFilePreviewProps): JSX.El
           locale={{ emptyText: t('No data found in the file!') }}
         />
       </div>
-      <EditColumnsModal isOpen={isEditColumnsOpen} closeModal={() => setIsEditColumnsOpen(false)} />
+
+      <EditColumnsModal
+        isOpen={isEditColumnsOpen}
+        closeModal={() => setIsEditColumnsOpen(false)}
+        columns={columns}
+        setColumns={setColumns}
+        sample={sampleRows}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adding edit columns button on the right and on clicking it, getting the modal with 4 different columns, a cancel and a done button, where the user will be able to edit the column header from the modal and on clicking Done button, he/she will be able to see the updated column header (name) in the preview. Also, getting pre-filled data from the file (say csv) into the modal.

## How was this patch tested?
Manual testing, will add unit tests soon.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
