### PR TITLE
[api] Refactor usage analytics API to DRF APIView and update tests

### DIFF
--- a/apps/about/src/about/api.py
+++ b/apps/about/src/about/api.py
@@ -30,7 +30,7 @@ from desktop.models import Settings
 LOG = logging.getLogger()
 
 
-class UsageAnalyticsSettingsView(APIView):
+class UsageAnalyticsAPI(APIView):
   """
   Provides GET and PUT handlers for the usage analytics setting.
 

--- a/apps/about/src/about/api.py
+++ b/apps/about/src/about/api.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 import logging
-from typing import Any, List, Type
+from typing import Any
 
 from rest_framework import status
 from rest_framework.request import Request
@@ -38,7 +38,7 @@ class UsageAnalyticsSettingsView(APIView):
   the `collect_usage` setting and update it.
   """
 
-  permission_classes: List[Type[IsAdminUser]] = [IsAdminUser]
+  permission_classes = [IsAdminUser]
 
   def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
     """Handles GET requests to retrieve the current analytics setting."""
@@ -58,7 +58,7 @@ class UsageAnalyticsSettingsView(APIView):
       if not serializer.is_valid():
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-      is_enabled: bool = serializer.validated_data["analytics_enabled"]
+      is_enabled = serializer.validated_data["analytics_enabled"]
 
       settings = Settings.get_settings()
       settings.collect_usage = is_enabled

--- a/apps/about/src/about/api.py
+++ b/apps/about/src/about/api.py
@@ -23,7 +23,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from about.serializer import AnalyticsSettingsSerializer
+from about.serializer import UsageAnalyticsSerializer
 from desktop.auth.api_permissions import IsAdminUser
 from desktop.models import Settings
 
@@ -44,21 +44,23 @@ class UsageAnalyticsAPI(APIView):
     """Handles GET requests to retrieve the current analytics setting."""
     try:
       settings = Settings.get_settings()
-      data = {"analytics_enabled": settings.collect_usage}
+      data = {"collect_usage": settings.collect_usage}
 
       return Response(data, status=status.HTTP_200_OK)
     except Exception as e:
       LOG.error("Error retrieving usage analytics: %s", e)
-      return Response({"error": "A server error occurred while retrieving settings."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+      return Response(
+        {"error": "A server error occurred while retrieving usage analytics settings."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+      )
 
   def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
     """Handles PUT requests to update the analytics setting."""
     try:
-      serializer = AnalyticsSettingsSerializer(data=request.data)
+      serializer = UsageAnalyticsSerializer(data=request.data)
       if not serializer.is_valid():
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-      is_enabled = serializer.validated_data["analytics_enabled"]
+      is_enabled = serializer.validated_data["collect_usage"]
 
       settings = Settings.get_settings()
       settings.collect_usage = is_enabled
@@ -67,4 +69,6 @@ class UsageAnalyticsAPI(APIView):
       return Response(serializer.data, status=status.HTTP_200_OK)
     except Exception as e:
       LOG.error("Error updating usage analytics: %s", e)
-      return Response({"error": "A server error occurred while saving the settings."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+      return Response(
+        {"error": "A server error occurred while saving the usage analytics settings."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+      )

--- a/apps/about/src/about/api.py
+++ b/apps/about/src/about/api.py
@@ -16,75 +16,55 @@
 # limitations under the License.
 
 import logging
+from typing import Any, List, Type
 
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
-from desktop.auth.backend import is_admin
-from desktop.lib.conf import coerce_bool
+from about.serializer import AnalyticsSettingsSerializer
+from desktop.auth.api_permissions import IsAdminUser
 from desktop.models import Settings
 
 LOG = logging.getLogger()
 
 
-def get_usage_analytics(request) -> Response:
+class UsageAnalyticsSettingsView(APIView):
   """
-  Retrieve the user preference for analytics settings.
+  Provides GET and PUT handlers for the usage analytics setting.
 
-  Args:
-    request (Request): The HTTP request object.
-
-  Returns:
-    Response: JSON response containing the analytics_enabled preference or an error message.
-
-  Raises:
-    403: If the user is not a Hue admin.
-    500: If there is an error retrieving preference.
+  This view allows authorized admin users to retrieve the current state of
+  the `collect_usage` setting and update it.
   """
-  if not is_admin(request.user):
-    return Response({'message': "You must be a Hue admin to access this endpoint."}, status=status.HTTP_403_FORBIDDEN)
 
-  try:
-    settings = Settings.get_settings()
-    return Response({'analytics_enabled': settings.collect_usage}, status=status.HTTP_200_OK)
+  permission_classes: List[Type[IsAdminUser]] = [IsAdminUser]
 
-  except Exception as e:
-    message = f"Error retrieving usage analytics: {e}"
-    LOG.error(message)
-    return Response({'message': message}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+  def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+    """Handles GET requests to retrieve the current analytics setting."""
+    try:
+      settings = Settings.get_settings()
+      data = {"analytics_enabled": settings.collect_usage}
 
+      return Response(data, status=status.HTTP_200_OK)
+    except Exception as e:
+      LOG.error("Error retrieving usage analytics: %s", e)
+      return Response({"error": "A server error occurred while retrieving settings."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-def update_usage_analytics(request) -> Response:
-  """
-  Update the user preference for analytics settings.
+  def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+    """Handles PUT requests to update the analytics setting."""
+    try:
+      serializer = AnalyticsSettingsSerializer(data=request.data)
+      if not serializer.is_valid():
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-  Args:
-    request (Request): The HTTP request object containing 'analytics_enabled' parameter.
+      is_enabled: bool = serializer.validated_data["analytics_enabled"]
 
-  Returns:
-    Response: JSON response with the updated analytics_enabled preference or an error message.
+      settings = Settings.get_settings()
+      settings.collect_usage = is_enabled
+      settings.save()
 
-  Raises:
-    403: If the user is not a Hue admin.
-    400: If 'analytics_enabled' parameter is missing or invalid.
-    500: If there is an error updating preference.
-  """
-  if not is_admin(request.user):
-    return Response({'message': "You must be a Hue admin to access this endpoint."}, status=status.HTTP_403_FORBIDDEN)
-
-  try:
-    analytics_enabled = request.POST.get('analytics_enabled')
-
-    if analytics_enabled is None:
-      return Response({'message': 'Missing parameter: analytics_enabled is required.'}, status=status.HTTP_400_BAD_REQUEST)
-
-    settings = Settings.get_settings()
-    settings.collect_usage = coerce_bool(analytics_enabled)
-    settings.save()
-
-    return Response({'analytics_enabled': settings.collect_usage}, status=status.HTTP_200_OK)
-
-  except Exception as e:
-    message = f"Error updating usage analytics: {e}"
-    LOG.error(message)
-    return Response({'message': message}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+      return Response(serializer.data, status=status.HTTP_200_OK)
+    except Exception as e:
+      LOG.error("Error updating usage analytics: %s", e)
+      return Response({"error": "A server error occurred while saving the settings."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/apps/about/src/about/api_tests.py
+++ b/apps/about/src/about/api_tests.py
@@ -52,7 +52,7 @@ class TestUsageAnalyticsSettingsAPI:
     response = api_client.get(analytics_settings_url)
 
     assert response.status_code == status.HTTP_200_OK
-    assert response.data == {"analytics_enabled": True}
+    assert response.data == {"collect_usage": True}
 
   @patch("desktop.auth.api_permissions.is_admin", return_value=False)
   def test_get_settings_as_non_admin_forbidden(self, mock_is_admin, api_client, regular_user, analytics_settings_url):
@@ -72,7 +72,7 @@ class TestUsageAnalyticsSettingsAPI:
     response = api_client.get(analytics_settings_url)
 
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-    assert response.data == {"error": "A server error occurred while retrieving settings."}
+    assert response.data == {"error": "A server error occurred while retrieving usage analytics settings."}
 
   @patch("desktop.auth.api_permissions.is_admin", return_value=True)
   @patch("about.api.Settings.get_settings")
@@ -80,7 +80,7 @@ class TestUsageAnalyticsSettingsAPI:
     mock_settings = MagicMock()
     mock_get_settings.return_value = mock_settings
     api_client.force_authenticate(user=admin_user)
-    payload = {"analytics_enabled": False}
+    payload = {"collect_usage": False}
 
     response = api_client.put(analytics_settings_url, data=payload, format="json")
 
@@ -103,12 +103,12 @@ class TestUsageAnalyticsSettingsAPI:
   def test_put_settings_as_admin_error(self, mock_get_settings, mock_is_admin, api_client, admin_user, analytics_settings_url):
     mock_get_settings.side_effect = ObjectDoesNotExist("Settings not found")
     api_client.force_authenticate(user=admin_user)
-    payload = {"analytics_enabled": False}
+    payload = {"collect_usage": False}
 
     response = api_client.put(analytics_settings_url, data=payload, format="json")
 
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-    assert response.data == {"error": "A server error occurred while saving the settings."}
+    assert response.data == {"error": "A server error occurred while saving the usage analytics settings."}
 
   @patch("desktop.auth.api_permissions.is_admin", return_value=True)
   @patch("about.api.Settings.get_settings")
@@ -120,4 +120,4 @@ class TestUsageAnalyticsSettingsAPI:
     response = api_client.put(analytics_settings_url, data=payload, format="json")
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.data == {"analytics_enabled": ["This field is required."]}
+    assert response.data == {"collect_usage": ["This field is required."]}

--- a/apps/about/src/about/serializer.py
+++ b/apps/about/src/about/serializer.py
@@ -17,7 +17,7 @@
 from rest_framework import serializers
 
 
-class AnalyticsSettingsSerializer(serializers.Serializer):
-  """Serializes and validates the analytics settings data."""
+class UsageAnalyticsSerializer(serializers.Serializer):
+  """Serializes and validates the usage analytics settings data."""
 
-  analytics_enabled = serializers.BooleanField(required=True, help_text="Indicates whether usage analytics collection is enabled.")
+  collect_usage = serializers.BooleanField(required=True, help_text="Indicates whether usage analytics collection is enabled.")

--- a/apps/about/src/about/serializer.py
+++ b/apps/about/src/about/serializer.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from rest_framework import serializers
+
+
+class AnalyticsSettingsSerializer(serializers.Serializer):
+  """Serializes and validates the analytics settings data."""
+
+  analytics_enabled = serializers.BooleanField(required=True, help_text="Indicates whether usage analytics collection is enabled.")

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -90,18 +90,6 @@ def available_app_examples(request):
   return desktop_api.available_app_examples(django_request)
 
 
-@api_view(["GET"])
-def get_usage_analytics(request):
-  django_request = get_django_request(request)
-  return about_api.get_usage_analytics(django_request)
-
-
-@api_view(["POST"])
-def update_usage_analytics(request):
-  django_request = get_django_request(request)
-  return about_api.update_usage_analytics(django_request)
-
-
 # Editor
 
 

--- a/desktop/core/src/desktop/api_public.py
+++ b/desktop/core/src/desktop/api_public.py
@@ -19,10 +19,9 @@ import json
 import logging
 
 from django.http import HttpResponse, QueryDict
-from rest_framework.decorators import api_view, authentication_classes, permission_classes
+from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 
-from about import api as about_api
 from beeswax import api as beeswax_api
 from desktop import api2 as desktop_api
 from desktop.auth.backend import rewrite_user

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -40,7 +40,7 @@ urlpatterns += [
   re_path(r'^get_config/?$', api_public.get_config),
   re_path(r'^check_config/?$', api_public.check_config, name='core_check_config'),
   re_path(r'^get_namespaces/(?P<interface>[\w\-]+)/?$', api_public.get_context_namespaces),  # To remove
-  re_path(r'^usage_analytics/?$', about_api.UsageAnalyticsSettingsView.as_view(), name='core_usage_analytics'),
+  re_path(r'^usage_analytics/?$', about_api.UsageAnalyticsAPI.as_view(), name='core_usage_analytics'),
 ]
 
 urlpatterns += [

--- a/desktop/core/src/desktop/api_public_urls_v1.py
+++ b/desktop/core/src/desktop/api_public_urls_v1.py
@@ -17,6 +17,7 @@
 
 from django.urls import re_path
 
+from about import api as about_api
 from desktop import api_public
 from desktop.lib.botserver import api as botserver_api
 from desktop.lib.importer import api as importer_api
@@ -36,11 +37,10 @@ urlpatterns += [
   re_path(r'^logs/download/?$', api_public.download_hue_logs, name='core_download_hue_logs'),
   re_path(r'^install_app_examples/?$', api_public.install_app_examples, name='core_install_app_examples'),
   re_path(r'^available_app_examples/?$', api_public.available_app_examples, name='core_available_app_examples'),
-  re_path(r'^usage_analytics/?$', api_public.get_usage_analytics, name='core_get_usage_analytics'),
-  re_path(r'^usage_analytics/update/?$', api_public.update_usage_analytics, name='core_update_usage_analytics'),
   re_path(r'^get_config/?$', api_public.get_config),
   re_path(r'^check_config/?$', api_public.check_config, name='core_check_config'),
   re_path(r'^get_namespaces/(?P<interface>[\w\-]+)/?$', api_public.get_context_namespaces),  # To remove
+  re_path(r'^usage_analytics/?$', about_api.UsageAnalyticsSettingsView.as_view(), name='core_usage_analytics'),
 ]
 
 urlpatterns += [

--- a/desktop/core/src/desktop/auth/api_permissions.py
+++ b/desktop/core/src/desktop/auth/api_permissions.py
@@ -32,7 +32,7 @@ LOG = logging.getLogger()
 class IsAdminUser(permissions.BasePermission):
   """A DRF permission class that only allows access to admin users."""
 
-  message: str = "You must be a Hue admin to perform this action."
+  message = "You must be a Hue admin to perform this action."
 
   def has_permission(self, request: Request, view: "APIView") -> bool:
     """Checks if the request's user is authenticated and is an admin."""

--- a/desktop/core/src/desktop/auth/api_permissions.py
+++ b/desktop/core/src/desktop/auth/api_permissions.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from typing import TYPE_CHECKING
+
+from rest_framework import permissions
+from rest_framework.request import Request
+
+from desktop.auth.backend import is_admin
+
+# TYPE_CHECKING is True only during static type checking, avoids circular imports.
+if TYPE_CHECKING:
+  from rest_framework.views import APIView
+
+LOG = logging.getLogger()
+
+
+class IsAdminUser(permissions.BasePermission):
+  """A DRF permission class that only allows access to admin users."""
+
+  message: str = "You must be a Hue admin to perform this action."
+
+  def has_permission(self, request: Request, view: "APIView") -> bool:
+    """Checks if the request's user is authenticated and is an admin."""
+
+    if not request.user or not request.user.is_authenticated:
+      return False
+
+    try:
+      return is_admin(request.user)
+    except Exception:
+      LOG.exception("Permission check failed: Could not validate user %s.", request.user)
+      return False


### PR DESCRIPTION
This pull request refactors the usage analytics API by introducing a class-based view, improving serializers, and updating permissions. It also replaces outdated function-based endpoints with a more modern structure and enhances test coverage for the API. 

### API Refactoring and Improvements:
* Replaced the function-based `get_usage_analytics` and `update_usage_analytics` endpoints with a class-based `UsageAnalyticsAPI` view in `apps/about/src/about/api.py`. The new view handles `GET` and `PUT` requests, uses `IsAdminUser` for permission checks, and integrates the `UsageAnalyticsSerializer` for data validation.
* Added `UsageAnalyticsSerializer` in `apps/about/src/about/serializer.py` to validate and serialize the `collect_usage` field, ensuring proper data handling for the API.
* Introduced `IsAdminUser` permission class in `desktop/core/src/desktop/auth/api_permissions.py` to enforce admin-only access to the usage analytics API.

### Test Enhancements:
* Replaced legacy tests with new pytest-based test cases in `apps/about/src/about/api_tests.py`. These tests validate API behavior for both admin and non-admin users, including scenarios for success, missing fields, and server errors.

### Routing and Cleanup:
* Updated URL routing in `desktop/core/src/desktop/api_public_urls_v1.py` to use the new `UsageAnalyticsAPI` class for the `usage_analytics` endpoint. Removed references to the old function-based endpoints.
* Removed outdated `get_usage_analytics` and `update_usage_analytics` methods from `desktop/core/src/desktop/api_public.py`.