### PR TITLE
[lint] Reorder imports, fix exception usage and remove unused imports for fix linting

### DIFF
--- a/desktop/core/src/desktop/auth/backend.py
+++ b/desktop/core/src/desktop/auth/backend.py
@@ -28,14 +28,13 @@ Because Django's models are sometimes unfriendly, you'll want
 User to remain a django.contrib.auth.models.User object.
 """
 
-import sys
 import logging
 from builtins import object
 from importlib import import_module
 from pwd import getpwnam
 
-import requests
 import django.contrib.auth.backends
+import requests
 from django.contrib import auth
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.forms import ValidationError
@@ -47,7 +46,7 @@ from desktop.conf import AUTH, ENABLE_ORGANIZATIONS, LDAP, OIDC
 from desktop.settings import LOAD_BALANCER_COOKIE
 from liboauth.metrics import oauth_authentication_time
 from useradmin import ldap_access
-from useradmin.models import User, UserProfile, get_default_user_group, get_profile, install_sample_user
+from useradmin.models import get_default_user_group, get_profile, install_sample_user, User, UserProfile
 from useradmin.organization import get_organization
 
 LOG = logging.getLogger()
@@ -69,11 +68,11 @@ except ImportError:
   LOG.warning('django_auth_ldap module not found')
   class LDAPSearch:
     pass
-  class LDAPSearch:
+  class LDAPBackend:
     pass
 
 try:
-  from mozilla_django_oidc.auth import OIDCAuthenticationBackend, default_username_algo
+  from mozilla_django_oidc.auth import default_username_algo, OIDCAuthenticationBackend
   from mozilla_django_oidc.utils import absolutify, import_from_settings
 except ImportError:
   LOG.warning('mozilla_django_oidc module not found')
@@ -288,7 +287,7 @@ class DesktopBackendBase(object):
     Implementors should return a boolean value which determines
     whether the given username and password pair is valid.
     """
-    raise NotImplemented("Abstract class - must implement check_auth")
+    raise NotImplementedError("Abstract class - must implement check_auth")
 
 
 class AllowFirstUserDjangoBackend(django.contrib.auth.backends.ModelBackend):
@@ -496,7 +495,7 @@ class LdapBackend(object):
               return User.objects.get_or_create(username=username)
           else:
             return User.objects.get_or_create(username=username)
-        except ValidationError as e:
+        except ValidationError:
           LOG.exception("LDAP username is invalid: %s" % username)
 
     self._backend = _LDAPBackend()

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -20,13 +20,13 @@
 # Local customizations are done by symlinking a file
 # as local_settings.py.
 
+import datetime
 import gc
+import json
+import logging
 import os
 import sys
-import json
 import uuid
-import logging
-import datetime
 from builtins import map, zip
 
 import pkg_resources
@@ -36,9 +36,9 @@ import desktop.redaction
 from aws.conf import is_enabled as is_s3_enabled
 from azure.conf import is_abfs_enabled
 from desktop import appmanager
-from desktop.conf import TASK_SERVER_V2, is_chunked_fileuploader_enabled, is_gs_enabled, is_ofs_enabled
+from desktop.conf import is_chunked_fileuploader_enabled, is_gs_enabled, is_ofs_enabled
 from desktop.lib import conf
-from desktop.lib.paths import get_desktop_root, get_run_root
+from desktop.lib.paths import get_desktop_root
 from desktop.lib.python_util import force_dict_to_strings
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -579,7 +579,7 @@ LOGIN_URL = '/hue/accounts/login'
 # SAML
 SAML_AUTHENTICATION = 'libsaml.backend.SAML2Backend' in AUTHENTICATION_BACKENDS
 if SAML_AUTHENTICATION:
-  from libsaml.saml_settings import *
+  from libsaml.saml_settings import *  # noqa: F403
   INSTALLED_APPS.append('libsaml')
   LOGIN_URL = '/saml2/login/'
   SESSION_EXPIRE_AT_BROWSER_CLOSE = True


### PR DESCRIPTION
This pull request focuses on improving code readability and correctness in the `desktop/core/src/desktop/auth/backend.py` and `desktop/core/src/desktop/settings.py` files. The changes include fixing errors, reordering imports for consistency, and removing unused imports.

### Code correctness improvements:

* [`desktop/core/src/desktop/auth/backend.py`](diffhunk://#diff-951aaa602e227f5660ef03f69ebbd6433ccfcb1a425b32c92d62552fd23f9302L291-R290): Fixed the incorrect exception raised in the `check_auth` method by replacing `NotImplemented` with `NotImplementedError`.
* [`desktop/core/src/desktop/auth/backend.py`](diffhunk://#diff-951aaa602e227f5660ef03f69ebbd6433ccfcb1a425b32c92d62552fd23f9302L499-R498): Updated the `get_or_create_user` method to remove the unused exception variable `e` in the `except ValidationError` block.

### Code readability improvements:

* [`desktop/core/src/desktop/auth/backend.py`](diffhunk://#diff-951aaa602e227f5660ef03f69ebbd6433ccfcb1a425b32c92d62552fd23f9302L31-R37): Reordered imports to follow Python's standard practice of grouping and ordering imports (e.g., built-in modules, third-party libraries, and local modules). [[1]](diffhunk://#diff-951aaa602e227f5660ef03f69ebbd6433ccfcb1a425b32c92d62552fd23f9302L31-R37) [[2]](diffhunk://#diff-951aaa602e227f5660ef03f69ebbd6433ccfcb1a425b32c92d62552fd23f9302L50-R49) [[3]](diffhunk://#diff-951aaa602e227f5660ef03f69ebbd6433ccfcb1a425b32c92d62552fd23f9302L72-R75)
* [`desktop/core/src/desktop/settings.py`](diffhunk://#diff-596f63f423dd7766a77d4ac934f3e1b73220354f8c6d5dcd4bbefcaf10776da4R23-L29): Reordered imports for consistency and removed unused imports such as `TASK_SERVER_V2` and `get_run_root`. [[1]](diffhunk://#diff-596f63f423dd7766a77d4ac934f3e1b73220354f8c6d5dcd4bbefcaf10776da4R23-L29) [[2]](diffhunk://#diff-596f63f423dd7766a77d4ac934f3e1b73220354f8c6d5dcd4bbefcaf10776da4L39-R41)

### Minor adjustments:

* [`desktop/core/src/desktop/settings.py`](diffhunk://#diff-596f63f423dd7766a77d4ac934f3e1b73220354f8c6d5dcd4bbefcaf10776da4L582-R582): Added `# noqa: F403` to suppress linter warnings for wildcard imports from `libsaml.saml_settings`.