### PR TITLE
[ui-filechooser] Add error handling for file upload failures

### DIFF
--- a/desktop/core/src/desktop/js/jquery/plugins/jquery.filechooser.js
+++ b/desktop/core/src/desktop/js/jquery/plugins/jquery.filechooser.js
@@ -953,6 +953,9 @@ function initUploader(path, _parent, el, labels) {
       },
       onComplete: function (id, fileName, responseJSON) {
         num_of_pending_uploads--;
+        if (responseJSON.status === 500 && responseJSON.responseText) {
+          huePubSub.publish('hue.global.error', { message: responseJSON.responseText });
+        }
         if (responseJSON.status == -1) {
           huePubSub.publish('hue.global.error', { message: responseJSON.data });
         } else if (!num_of_pending_uploads) {

--- a/desktop/core/src/desktop/js/reactComponents/GlobalAlert/GlobalAlert.scss
+++ b/desktop/core/src/desktop/js/reactComponents/GlobalAlert/GlobalAlert.scss
@@ -19,7 +19,7 @@
 .hue-alert {
   position: fixed;
   width: 30%;
-  z-index: 9999;
+  z-index: 10001;
   top: 7px;
   right: 0;
   margin-right: 24px;


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a file is uploaded in the old file browser, the error message is not displayed properly.

## How was this patch tested?

- Manually tested

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
