### PR TITLE
[impala][beeswax] Store cookies for beeswax http transport

### DIFF
--- a/apps/impala/src/impala/server.py
+++ b/apps/impala/src/impala/server.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import json
 import logging
 import threading
@@ -52,7 +51,7 @@ def _get_impala_server_url(session):
     properties = session.get_properties()
     http_addr = properties.get('coordinator_host', properties.get('http_addr'))
 
-  http_addr = http_addr.replace('http://', '').replace('https://', '')
+  http_addr = http_addr.replace('http://', '').replace('https://', '').replace('coordinator-int.', '')
   return ('https://' if get_webserver_certificate_file() else 'http://') + http_addr
 
 
@@ -76,7 +75,7 @@ class ImpalaServerClient(HiveServerClient):
     # GetExecSummary() only works for closed queries
     try:
       self.close_operation(operation_handle)
-    except QueryServerException as e:
+    except QueryServerException:
       LOG.warning('Failed to close operation for query handle, query may be invalid or already closed.')
 
     resp = self.call(self._client.GetExecSummary, req)
@@ -93,7 +92,7 @@ class ImpalaServerClient(HiveServerClient):
     # TGetRuntimeProfileReq() only works for closed queries
     try:
       self.close_operation(operation_handle)
-    except QueryServerException as e:
+    except QueryServerException:
       LOG.warning('Failed to close operation for query handle, query may be invalid or already closed.')
 
     resp = self.call(self._client.GetRuntimeProfile, req)

--- a/apps/jobbrowser/src/jobbrowser/apis/query_api.py
+++ b/apps/jobbrowser/src/jobbrowser/apis/query_api.py
@@ -15,18 +15,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
+import logging
 import os
 import re
-import sys
 import time
-import logging
-import itertools
 from builtins import filter, range
 from datetime import datetime
 from urllib.parse import urlparse
 
 import pytz
-from babel import localtime
 from django.utils.translation import gettext as _
 
 from desktop.lib import export_csvxls
@@ -52,11 +50,13 @@ def _get_api(user, cluster=None):
       compute = Compute.objects.get(id=compute['id']).to_dict()  # Reload the full compute from db
     if compute.get('options') and compute['options'].get('api_url'):
       server_url = compute['options'].get('api_url')
+    application = compute.get('name')
   else:
     # TODO: multi computes if snippet.get('compute') or snippet['type'] has computes
     application = cluster['compute']['type'] if cluster.get('compute') else cluster.get('interface', 'impala')
-    session = Session.objects.get_session(user, application=application)
-    server_url = _get_impala_server_url(session)
+
+  session = Session.objects.get_session(user, application=application)
+  server_url = _get_impala_server_url(session)
   return get_impalad_api(user=user, url=server_url)
 
 


### PR DESCRIPTION
Impala uses cookies for maintaining sticky sessions in active-active setup.

With this commit,
1. we extract all the cookies from the response,
2. store the cookies in the properties (json) column of sessions
3. When making a call, we pull the cookies from session and set it in the client.
4. More changes were needed to make sure that session info is flowing all the way to the spot of making the call.

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
