### PR TITLE
[importer] Integrate Pydantic schemas for file operations and enhance validation

### DIFF
--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -45,6 +45,7 @@ polars[calamine]==1.8.2  # Python >= 3.8
 prompt-toolkit==3.0.39
 protobuf==3.20.3
 pyarrow==17.0.0
+pydantic==2.10.6
 pyformance==0.3.2
 python-dateutil==2.8.2
 python-daemon==2.2.4

--- a/desktop/core/generate_requirements.py
+++ b/desktop/core/generate_requirements.py
@@ -92,6 +92,7 @@ class RequirementsGenerator:
       "protobuf==3.20.3",
       "psutil==5.8.0",
       "pyarrow==17.0.0",
+      "pydantic==2.10.6",
       "pyformance==0.3.2",
       "PyJWT==2.4.0",
       "python-daemon==2.2.4",

--- a/desktop/core/src/desktop/lib/importer/api.py
+++ b/desktop/core/src/desktop/lib/importer/api.py
@@ -25,6 +25,13 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from desktop.lib.importer import operations
+from desktop.lib.importer.schemas import (
+  GuessFileHeaderSchema,
+  GuessFileMetadataSchema,
+  LocalFileUploadSchema,
+  PreviewFileSchema,
+  SqlTypeMapperSchema,
+)
 from desktop.lib.importer.serializers import (
   GuessFileHeaderSerializer,
   GuessFileMetadataSerializer,
@@ -79,10 +86,10 @@ def local_file_upload(request: Request) -> Response:
   if not serializer.is_valid():
     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-  uploaded_file = serializer.validated_data["file"]
+  upload_data = serializer.validated_data
 
-  LOG.info(f"User {request.user.username} is uploading a local file: {uploaded_file.name}")
-  result = operations.local_file_upload(uploaded_file, request.user.username)
+  LOG.info(f"User {request.user.username} is uploading a local file: {upload_data.filename}")
+  result = operations.local_file_upload(upload_data, request.user.username)
 
   return Response(result, status=status.HTTP_201_CREATED)
 
@@ -114,15 +121,10 @@ def guess_file_metadata(request: Request) -> Response:
   if not serializer.is_valid():
     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-  validated_data = serializer.validated_data
-  file_path = validated_data["file_path"]
-  import_type = validated_data["import_type"]
+  metadata_params = serializer.validated_data
 
   try:
-    metadata = operations.guess_file_metadata(
-      file_path=file_path, import_type=import_type, fs=request.fs if import_type == "remote" else None
-    )
-
+    metadata = operations.guess_file_metadata(data=metadata_params, fs=request.fs if metadata_params.import_type == "remote" else None)
     return Response(metadata, status=status.HTTP_200_OK)
 
   except ValueError as e:
@@ -152,44 +154,10 @@ def preview_file(request: Request) -> Response:
   if not serializer.is_valid():
     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-  # Get validated data
-  validated_data = serializer.validated_data
-  file_path = validated_data["file_path"]
-  file_type = validated_data["file_type"]
-  import_type = validated_data["import_type"]
-  sql_dialect = validated_data["sql_dialect"]
-  has_header = validated_data.get("has_header")
+  preview_params = serializer.validated_data
 
   try:
-    if file_type == "excel":
-      sheet_name = validated_data.get("sheet_name")
-
-      preview = operations.preview_file(
-        file_path=file_path,
-        file_type=file_type,
-        import_type=import_type,
-        sql_dialect=sql_dialect,
-        has_header=has_header,
-        sheet_name=sheet_name,
-        fs=request.fs if import_type == "remote" else None,
-      )
-    else:  # Delimited file types
-      field_separator = validated_data.get("field_separator")
-      quote_char = validated_data.get("quote_char")
-      record_separator = validated_data.get("record_separator")
-
-      preview = operations.preview_file(
-        file_path=file_path,
-        file_type=file_type,
-        import_type=import_type,
-        sql_dialect=sql_dialect,
-        has_header=has_header,
-        field_separator=field_separator,
-        quote_char=quote_char,
-        record_separator=record_separator,
-        fs=request.fs if import_type == "remote" else None,
-      )
-
+    preview = operations.preview_file(data=preview_params, fs=request.fs if preview_params.import_type == "remote" else None)
     return Response(preview, status=status.HTTP_200_OK)
 
   except ValueError as e:
@@ -224,17 +192,10 @@ def guess_file_header(request: Request) -> Response:
   if not serializer.is_valid():
     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-  validated_data = serializer.validated_data
+  header_params = serializer.validated_data
 
   try:
-    has_header = operations.guess_file_header(
-      file_path=validated_data["file_path"],
-      file_type=validated_data["file_type"],
-      import_type=validated_data["import_type"],
-      sheet_name=validated_data.get("sheet_name"),
-      fs=request.fs if validated_data["import_type"] == "remote" else None,
-    )
-
+    has_header = operations.guess_file_header(data=header_params, fs=request.fs if header_params.import_type == "remote" else None)
     return Response({"has_header": has_header}, status=status.HTTP_200_OK)
 
   except ValueError as e:
@@ -267,13 +228,11 @@ def get_sql_type_mapping(request: Request) -> Response:
   if not serializer.is_valid():
     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-  validated_data = serializer.validated_data
-  sql_dialect = validated_data["sql_dialect"]
+  type_mapping_params = serializer.validated_data
 
   try:
-    type_mapping = operations.get_sql_type_mapping(sql_dialect)
+    type_mapping = operations.get_sql_type_mapping(type_mapping_params)
     return Response(type_mapping, status=status.HTTP_200_OK)
-
   except ValueError as e:
     return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
   except Exception as e:

--- a/desktop/core/src/desktop/lib/importer/api.py
+++ b/desktop/core/src/desktop/lib/importer/api.py
@@ -25,13 +25,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from desktop.lib.importer import operations
-from desktop.lib.importer.schemas import (
-  GuessFileHeaderSchema,
-  GuessFileMetadataSchema,
-  LocalFileUploadSchema,
-  PreviewFileSchema,
-  SqlTypeMapperSchema,
-)
 from desktop.lib.importer.serializers import (
   GuessFileHeaderSerializer,
   GuessFileMetadataSerializer,

--- a/desktop/core/src/desktop/lib/importer/api_tests.py
+++ b/desktop/core/src/desktop/lib/importer/api_tests.py
@@ -28,7 +28,14 @@ class TestLocalFileUploadAPI:
   @patch("desktop.lib.importer.api.LocalFileUploadSerializer")
   @patch("desktop.lib.importer.api.operations.local_file_upload")
   def test_local_file_upload_success(self, mock_local_file_upload, mock_serializer_class):
-    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data={"file": SimpleUploadedFile("test.csv", b"content")})
+    # Create a mock schema object that will be returned by the serializer
+    mock_file = SimpleUploadedFile("test.csv", b"content")
+    mock_schema = MagicMock()
+    mock_schema.file = mock_file
+    mock_schema.filename = "test.csv"
+    mock_schema.filesize = 7
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_local_file_upload.return_value = {"file_path": "/tmp/user_12345_test.csv"}
@@ -40,7 +47,7 @@ class TestLocalFileUploadAPI:
 
     assert response.status_code == status.HTTP_201_CREATED
     assert response.data == {"file_path": "/tmp/user_12345_test.csv"}
-    mock_local_file_upload.assert_called_once_with(mock_serializer.validated_data["file"], "test_user")
+    mock_local_file_upload.assert_called_once_with(mock_schema, "test_user")
 
   @patch("desktop.lib.importer.api.LocalFileUploadSerializer")
   def test_local_file_upload_invalid_data(self, mock_serializer_class):
@@ -58,7 +65,14 @@ class TestLocalFileUploadAPI:
   @patch("desktop.lib.importer.api.LocalFileUploadSerializer")
   @patch("desktop.lib.importer.api.operations.local_file_upload")
   def test_local_file_upload_operation_error(self, mock_local_file_upload, mock_serializer_class):
-    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data={"file": SimpleUploadedFile("test.csv", b"content")})
+    # Create a mock schema object that will be returned by the serializer
+    mock_file = SimpleUploadedFile("test.csv", b"content")
+    mock_schema = MagicMock()
+    mock_schema.file = mock_file
+    mock_schema.filename = "test.csv"
+    mock_schema.filesize = 7
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_local_file_upload.side_effect = IOError("Operation error")
@@ -76,9 +90,12 @@ class TestGuessFileMetadataAPI:
   @patch("desktop.lib.importer.api.GuessFileMetadataSerializer")
   @patch("desktop.lib.importer.api.operations.guess_file_metadata")
   def test_guess_csv_file_metadata_success(self, mock_guess_file_metadata, mock_serializer_class):
-    mock_serializer = MagicMock(
-      is_valid=MagicMock(return_value=True), validated_data={"file_path": "/path/to/test.csv", "import_type": "local"}
-    )
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.file_path = "/path/to/test.csv"
+    mock_schema.import_type = "local"
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_guess_file_metadata.return_value = {"type": "csv", "field_separator": ",", "quote_char": '"', "record_separator": "\n"}
@@ -92,14 +109,17 @@ class TestGuessFileMetadataAPI:
 
     assert response.status_code == status.HTTP_200_OK
     assert response.data == {"type": "csv", "field_separator": ",", "quote_char": '"', "record_separator": "\n"}
-    mock_guess_file_metadata.assert_called_once_with(file_path="/path/to/test.csv", import_type="local", fs=None)
+    mock_guess_file_metadata.assert_called_once_with(data=mock_schema, fs=None)
 
   @patch("desktop.lib.importer.api.GuessFileMetadataSerializer")
   @patch("desktop.lib.importer.api.operations.guess_file_metadata")
   def test_guess_excel_file_metadata_success(self, mock_guess_file_metadata, mock_serializer_class):
-    mock_serializer = MagicMock(
-      is_valid=MagicMock(return_value=True), validated_data={"file_path": "/path/to/test.xlsx", "import_type": "local"}
-    )
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.file_path = "/path/to/test.xlsx"
+    mock_schema.import_type = "local"
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_guess_file_metadata.return_value = {"type": "excel", "sheet_names": ["Sheet1", "Sheet2"]}
@@ -113,14 +133,17 @@ class TestGuessFileMetadataAPI:
 
     assert response.status_code == status.HTTP_200_OK
     assert response.data == {"type": "excel", "sheet_names": ["Sheet1", "Sheet2"]}
-    mock_guess_file_metadata.assert_called_once_with(file_path="/path/to/test.xlsx", import_type="local", fs=None)
+    mock_guess_file_metadata.assert_called_once_with(data=mock_schema, fs=None)
 
   @patch("desktop.lib.importer.api.GuessFileMetadataSerializer")
   @patch("desktop.lib.importer.api.operations.guess_file_metadata")
   def test_guess_file_metadata_remote_csv_file(self, mock_guess_file_metadata, mock_serializer_class):
-    mock_serializer = MagicMock(
-      is_valid=MagicMock(return_value=True), validated_data={"file_path": "s3a://bucket/user/test_user/test.csv", "import_type": "remote"}
-    )
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.file_path = "s3a://bucket/user/test_user/test.csv"
+    mock_schema.import_type = "remote"
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_guess_file_metadata.return_value = {"type": "csv", "field_separator": ",", "quote_char": '"', "record_separator": "\n"}
@@ -135,7 +158,7 @@ class TestGuessFileMetadataAPI:
 
     assert response.status_code == status.HTTP_200_OK
     assert response.data == {"type": "csv", "field_separator": ",", "quote_char": '"', "record_separator": "\n"}
-    mock_guess_file_metadata.assert_called_once_with(file_path="s3a://bucket/user/test_user/test.csv", import_type="remote", fs=mock_fs)
+    mock_guess_file_metadata.assert_called_once_with(data=mock_schema, fs=mock_fs)
 
   @patch("desktop.lib.importer.api.GuessFileMetadataSerializer")
   def test_guess_file_metadata_invalid_data(self, mock_serializer_class):
@@ -154,9 +177,12 @@ class TestGuessFileMetadataAPI:
   @patch("desktop.lib.importer.api.GuessFileMetadataSerializer")
   @patch("desktop.lib.importer.api.operations.guess_file_metadata")
   def test_guess_file_metadata_value_error(self, mock_guess_file_metadata, mock_serializer_class):
-    mock_serializer = MagicMock(
-      is_valid=MagicMock(return_value=True), validated_data={"file_path": "/path/to/test.csv", "import_type": "local"}
-    )
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.file_path = "/path/to/test.csv"
+    mock_schema.import_type = "local"
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_guess_file_metadata.side_effect = ValueError("File does not exist")
@@ -174,9 +200,12 @@ class TestGuessFileMetadataAPI:
   @patch("desktop.lib.importer.api.GuessFileMetadataSerializer")
   @patch("desktop.lib.importer.api.operations.guess_file_metadata")
   def test_guess_file_metadata_operation_error(self, mock_guess_file_metadata, mock_serializer_class):
-    mock_serializer = MagicMock(
-      is_valid=MagicMock(return_value=True), validated_data={"file_path": "/path/to/test.csv", "import_type": "local"}
-    )
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.file_path = "/path/to/test.csv"
+    mock_schema.import_type = "local"
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_guess_file_metadata.side_effect = RuntimeError("Operation error")
@@ -196,19 +225,18 @@ class TestPreviewFileAPI:
   @patch("desktop.lib.importer.api.PreviewFileSerializer")
   @patch("desktop.lib.importer.api.operations.preview_file")
   def test_preview_csv_file_success(self, mock_preview_file, mock_serializer_class):
-    mock_serializer = MagicMock(
-      is_valid=MagicMock(return_value=True),
-      validated_data={
-        "file_path": "/path/to/test.csv",
-        "file_type": "csv",
-        "import_type": "local",
-        "sql_dialect": "hive",
-        "has_header": True,
-        "field_separator": ",",
-        "quote_char": '"',
-        "record_separator": "\n",
-      },
-    )
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.file_path = "/path/to/test.csv"
+    mock_schema.file_type = "csv"
+    mock_schema.import_type = "local"
+    mock_schema.sql_dialect = "hive"
+    mock_schema.has_header = True
+    mock_schema.field_separator = ","
+    mock_schema.quote_char = '"'
+    mock_schema.record_separator = "\n"
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_preview_result = {
@@ -227,32 +255,21 @@ class TestPreviewFileAPI:
 
     assert response.status_code == status.HTTP_200_OK
     assert response.data == mock_preview_result
-    mock_preview_file.assert_called_once_with(
-      file_path="/path/to/test.csv",
-      file_type="csv",
-      import_type="local",
-      sql_dialect="hive",
-      has_header=True,
-      field_separator=",",
-      quote_char='"',
-      record_separator="\n",
-      fs=None,
-    )
+    mock_preview_file.assert_called_once_with(data=mock_schema, fs=None)
 
   @patch("desktop.lib.importer.api.PreviewFileSerializer")
   @patch("desktop.lib.importer.api.operations.preview_file")
   def test_preview_excel_file_success(self, mock_preview_file, mock_serializer_class):
-    mock_serializer = MagicMock(
-      is_valid=MagicMock(return_value=True),
-      validated_data={
-        "file_path": "/path/to/test.xlsx",
-        "file_type": "excel",
-        "import_type": "local",
-        "sql_dialect": "hive",
-        "has_header": True,
-        "sheet_name": "Sheet1",
-      },
-    )
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.file_path = "/path/to/test.xlsx"
+    mock_schema.file_type = "excel"
+    mock_schema.import_type = "local"
+    mock_schema.sql_dialect = "hive"
+    mock_schema.has_header = True
+    mock_schema.sheet_name = "Sheet1"
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_preview_result = {
@@ -271,32 +288,23 @@ class TestPreviewFileAPI:
 
     assert response.status_code == status.HTTP_200_OK
     assert response.data == mock_preview_result
-    mock_preview_file.assert_called_once_with(
-      file_path="/path/to/test.xlsx",
-      file_type="excel",
-      import_type="local",
-      sql_dialect="hive",
-      has_header=True,
-      sheet_name="Sheet1",
-      fs=None,
-    )
+    mock_preview_file.assert_called_once_with(data=mock_schema, fs=None)
 
   @patch("desktop.lib.importer.api.PreviewFileSerializer")
   @patch("desktop.lib.importer.api.operations.preview_file")
   def test_preview_tsv_file_success(self, mock_preview_file, mock_serializer_class):
-    mock_serializer = MagicMock(
-      is_valid=MagicMock(return_value=True),
-      validated_data={
-        "file_path": "/path/to/test.tsv",
-        "file_type": "tsv",
-        "import_type": "local",
-        "sql_dialect": "impala",
-        "has_header": True,
-        "field_separator": "\t",
-        "quote_char": '"',
-        "record_separator": "\n",
-      },
-    )
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.file_path = "/path/to/test.tsv"
+    mock_schema.file_type = "tsv"
+    mock_schema.import_type = "local"
+    mock_schema.sql_dialect = "impala"
+    mock_schema.has_header = True
+    mock_schema.field_separator = "\t"
+    mock_schema.quote_char = '"'
+    mock_schema.record_separator = "\n"
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_preview_result = {
@@ -315,34 +323,23 @@ class TestPreviewFileAPI:
 
     assert response.status_code == status.HTTP_200_OK
     assert response.data == mock_preview_result
-    mock_preview_file.assert_called_once_with(
-      file_path="/path/to/test.tsv",
-      file_type="tsv",
-      import_type="local",
-      sql_dialect="impala",
-      has_header=True,
-      field_separator="\t",
-      quote_char='"',
-      record_separator="\n",
-      fs=None,
-    )
+    mock_preview_file.assert_called_once_with(data=mock_schema, fs=None)
 
   @patch("desktop.lib.importer.api.PreviewFileSerializer")
   @patch("desktop.lib.importer.api.operations.preview_file")
   def test_preview_remote_csv_file_success(self, mock_preview_file, mock_serializer_class):
-    mock_serializer = MagicMock(
-      is_valid=MagicMock(return_value=True),
-      validated_data={
-        "file_path": "s3a://bucket/user/test_user/test.csv",
-        "file_type": "csv",
-        "import_type": "remote",
-        "sql_dialect": "hive",
-        "has_header": True,
-        "field_separator": ",",
-        "quote_char": '"',
-        "record_separator": "\n",
-      },
-    )
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.file_path = "s3a://bucket/user/test_user/test.csv"
+    mock_schema.file_type = "csv"
+    mock_schema.import_type = "remote"
+    mock_schema.sql_dialect = "hive"
+    mock_schema.has_header = True
+    mock_schema.field_separator = ","
+    mock_schema.quote_char = '"'
+    mock_schema.record_separator = "\n"
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_preview_result = {
@@ -363,17 +360,7 @@ class TestPreviewFileAPI:
 
     assert response.status_code == status.HTTP_200_OK
     assert response.data == mock_preview_result
-    mock_preview_file.assert_called_once_with(
-      file_path="s3a://bucket/user/test_user/test.csv",
-      file_type="csv",
-      import_type="remote",
-      sql_dialect="hive",
-      has_header=True,
-      field_separator=",",
-      quote_char='"',
-      record_separator="\n",
-      fs=mock_fs,
-    )
+    mock_preview_file.assert_called_once_with(data=mock_schema, fs=mock_fs)
 
   @patch("desktop.lib.importer.api.PreviewFileSerializer")
   def test_preview_file_invalid_data(self, mock_serializer_class):
@@ -406,19 +393,18 @@ class TestPreviewFileAPI:
   @patch("desktop.lib.importer.api.PreviewFileSerializer")
   @patch("desktop.lib.importer.api.operations.preview_file")
   def test_preview_file_value_error(self, mock_preview_file, mock_serializer_class):
-    mock_serializer = MagicMock(
-      is_valid=MagicMock(return_value=True),
-      validated_data={
-        "file_path": "/path/to/test.csv",
-        "file_type": "csv",
-        "import_type": "local",
-        "sql_dialect": "hive",
-        "has_header": True,
-        "field_separator": ",",
-        "quote_char": '"',
-        "record_separator": "\n",
-      },
-    )
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.file_path = "/path/to/test.csv"
+    mock_schema.file_type = "csv"
+    mock_schema.import_type = "local"
+    mock_schema.sql_dialect = "hive"
+    mock_schema.has_header = True
+    mock_schema.field_separator = ","
+    mock_schema.quote_char = '"'
+    mock_schema.record_separator = "\n"
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_preview_file.side_effect = ValueError("File does not exist")
@@ -436,19 +422,18 @@ class TestPreviewFileAPI:
   @patch("desktop.lib.importer.api.PreviewFileSerializer")
   @patch("desktop.lib.importer.api.operations.preview_file")
   def test_preview_file_operation_error(self, mock_preview_file, mock_serializer_class):
-    mock_serializer = MagicMock(
-      is_valid=MagicMock(return_value=True),
-      validated_data={
-        "file_path": "/path/to/test.csv",
-        "file_type": "csv",
-        "import_type": "local",
-        "sql_dialect": "hive",
-        "has_header": True,
-        "field_separator": ",",
-        "quote_char": '"',
-        "record_separator": "\n",
-      },
-    )
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.file_path = "/path/to/test.csv"
+    mock_schema.file_type = "csv"
+    mock_schema.import_type = "local"
+    mock_schema.sql_dialect = "hive"
+    mock_schema.has_header = True
+    mock_schema.field_separator = ","
+    mock_schema.quote_char = '"'
+    mock_schema.record_separator = "\n"
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_preview_file.side_effect = RuntimeError("Operation error")
@@ -468,9 +453,14 @@ class TestGuessFileHeaderAPI:
   @patch("desktop.lib.importer.api.GuessFileHeaderSerializer")
   @patch("desktop.lib.importer.api.operations.guess_file_header")
   def test_guess_csv_file_header_success(self, mock_guess_file_header, mock_serializer_class):
-    mock_serializer = MagicMock(
-      is_valid=MagicMock(return_value=True), validated_data={"file_path": "/path/to/test.csv", "file_type": "csv", "import_type": "local"}
-    )
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.file_path = "/path/to/test.csv"
+    mock_schema.file_type = "csv"
+    mock_schema.import_type = "local"
+    mock_schema.sheet_name = None
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_guess_file_header.return_value = True
@@ -484,17 +474,19 @@ class TestGuessFileHeaderAPI:
 
     assert response.status_code == status.HTTP_200_OK
     assert response.data == {"has_header": True}
-    mock_guess_file_header.assert_called_once_with(
-      file_path="/path/to/test.csv", file_type="csv", import_type="local", sheet_name=None, fs=None
-    )
+    mock_guess_file_header.assert_called_once_with(data=mock_schema, fs=None)
 
   @patch("desktop.lib.importer.api.GuessFileHeaderSerializer")
   @patch("desktop.lib.importer.api.operations.guess_file_header")
   def test_guess_excel_file_header_success(self, mock_guess_file_header, mock_serializer_class):
-    mock_serializer = MagicMock(
-      is_valid=MagicMock(return_value=True),
-      validated_data={"file_path": "/path/to/test.xlsx", "file_type": "excel", "import_type": "local", "sheet_name": "Sheet1"},
-    )
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.file_path = "/path/to/test.xlsx"
+    mock_schema.file_type = "excel"
+    mock_schema.import_type = "local"
+    mock_schema.sheet_name = "Sheet1"
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_guess_file_header.return_value = True
@@ -508,17 +500,19 @@ class TestGuessFileHeaderAPI:
 
     assert response.status_code == status.HTTP_200_OK
     assert response.data == {"has_header": True}
-    mock_guess_file_header.assert_called_once_with(
-      file_path="/path/to/test.xlsx", file_type="excel", import_type="local", sheet_name="Sheet1", fs=None
-    )
+    mock_guess_file_header.assert_called_once_with(data=mock_schema, fs=None)
 
   @patch("desktop.lib.importer.api.GuessFileHeaderSerializer")
   @patch("desktop.lib.importer.api.operations.guess_file_header")
   def test_guess_remote_csv_file_header_success(self, mock_guess_file_header, mock_serializer_class):
-    mock_serializer = MagicMock(
-      is_valid=MagicMock(return_value=True),
-      validated_data={"file_path": "s3a://bucket/user/test_user/test.csv", "file_type": "csv", "import_type": "remote"},
-    )
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.file_path = "s3a://bucket/user/test_user/test.csv"
+    mock_schema.file_type = "csv"
+    mock_schema.import_type = "remote"
+    mock_schema.sheet_name = None
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_guess_file_header.return_value = True
@@ -533,17 +527,19 @@ class TestGuessFileHeaderAPI:
 
     assert response.status_code == status.HTTP_200_OK
     assert response.data == {"has_header": True}
-    mock_guess_file_header.assert_called_once_with(
-      file_path="s3a://bucket/user/test_user/test.csv", file_type="csv", import_type="remote", sheet_name=None, fs=mock_fs
-    )
+    mock_guess_file_header.assert_called_once_with(data=mock_schema, fs=mock_fs)
 
   @patch("desktop.lib.importer.api.GuessFileHeaderSerializer")
   @patch("desktop.lib.importer.api.operations.guess_file_header")
   def test_guess_remote_csv_file_header_success_false_value(self, mock_guess_file_header, mock_serializer_class):
-    mock_serializer = MagicMock(
-      is_valid=MagicMock(return_value=True),
-      validated_data={"file_path": "s3a://bucket/user/test_user/test.csv", "file_type": "csv", "import_type": "remote"},
-    )
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.file_path = "s3a://bucket/user/test_user/test.csv"
+    mock_schema.file_type = "csv"
+    mock_schema.import_type = "remote"
+    mock_schema.sheet_name = None
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_guess_file_header.return_value = False
@@ -558,9 +554,7 @@ class TestGuessFileHeaderAPI:
 
     assert response.status_code == status.HTTP_200_OK
     assert response.data == {"has_header": False}
-    mock_guess_file_header.assert_called_once_with(
-      file_path="s3a://bucket/user/test_user/test.csv", file_type="csv", import_type="remote", sheet_name=None, fs=mock_fs
-    )
+    mock_guess_file_header.assert_called_once_with(data=mock_schema, fs=mock_fs)
 
   @patch("desktop.lib.importer.api.GuessFileHeaderSerializer")
   def test_guess_file_header_invalid_data(self, mock_serializer_class):
@@ -579,9 +573,14 @@ class TestGuessFileHeaderAPI:
   @patch("desktop.lib.importer.api.GuessFileHeaderSerializer")
   @patch("desktop.lib.importer.api.operations.guess_file_header")
   def test_guess_file_header_value_error(self, mock_guess_file_header, mock_serializer_class):
-    mock_serializer = MagicMock(
-      is_valid=MagicMock(return_value=True), validated_data={"file_path": "/path/to/test.csv", "file_type": "csv", "import_type": "local"}
-    )
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.file_path = "/path/to/test.csv"
+    mock_schema.file_type = "csv"
+    mock_schema.import_type = "local"
+    mock_schema.sheet_name = None
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_guess_file_header.side_effect = ValueError("File does not exist")
@@ -599,9 +598,14 @@ class TestGuessFileHeaderAPI:
   @patch("desktop.lib.importer.api.GuessFileHeaderSerializer")
   @patch("desktop.lib.importer.api.operations.guess_file_header")
   def test_guess_file_header_operation_error(self, mock_guess_file_header, mock_serializer_class):
-    mock_serializer = MagicMock(
-      is_valid=MagicMock(return_value=True), validated_data={"file_path": "/path/to/test.csv", "file_type": "csv", "import_type": "local"}
-    )
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.file_path = "/path/to/test.csv"
+    mock_schema.file_type = "csv"
+    mock_schema.import_type = "local"
+    mock_schema.sheet_name = None
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_guess_file_header.side_effect = RuntimeError("Operation error")
@@ -621,7 +625,11 @@ class TestSqlTypeMappingAPI:
   @patch("desktop.lib.importer.api.SqlTypeMapperSerializer")
   @patch("desktop.lib.importer.api.operations.get_sql_type_mapping")
   def test_get_sql_type_mapping_success(self, mock_get_sql_type_mapping, mock_serializer_class):
-    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data={"sql_dialect": "hive"})
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.sql_dialect = "hive"
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_get_sql_type_mapping.return_value = {"Int32": "INT", "Utf8": "STRING", "Float64": "DOUBLE", "Boolean": "BOOLEAN"}
@@ -634,7 +642,7 @@ class TestSqlTypeMappingAPI:
 
     assert response.status_code == status.HTTP_200_OK
     assert response.data == {"Int32": "INT", "Utf8": "STRING", "Float64": "DOUBLE", "Boolean": "BOOLEAN"}
-    mock_get_sql_type_mapping.assert_called_once_with("hive")
+    mock_get_sql_type_mapping.assert_called_once_with(mock_schema)
 
   @patch("desktop.lib.importer.api.SqlTypeMapperSerializer")
   def test_get_sql_type_mapping_invalid_dialect(self, mock_serializer_class):
@@ -653,7 +661,11 @@ class TestSqlTypeMappingAPI:
   @patch("desktop.lib.importer.api.SqlTypeMapperSerializer")
   @patch("desktop.lib.importer.api.operations.get_sql_type_mapping")
   def test_get_sql_type_mapping_value_error(self, mock_get_sql_type_mapping, mock_serializer_class):
-    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data={"sql_dialect": "hive"})
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.sql_dialect = "hive"
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_get_sql_type_mapping.side_effect = ValueError("Unsupported dialect")
@@ -670,7 +682,11 @@ class TestSqlTypeMappingAPI:
   @patch("desktop.lib.importer.api.SqlTypeMapperSerializer")
   @patch("desktop.lib.importer.api.operations.get_sql_type_mapping")
   def test_get_sql_type_mapping_operation_error(self, mock_get_sql_type_mapping, mock_serializer_class):
-    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data={"sql_dialect": "hive"})
+    # Create a mock schema object that will be returned by the serializer
+    mock_schema = MagicMock()
+    mock_schema.sql_dialect = "hive"
+
+    mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
     mock_get_sql_type_mapping.side_effect = RuntimeError("Operation error")

--- a/desktop/core/src/desktop/lib/importer/operations.py
+++ b/desktop/core/src/desktop/lib/importer/operations.py
@@ -194,7 +194,7 @@ def guess_file_metadata(data: GuessFileMetadataSchema, fs=None) -> Dict[str, Any
   elif data.import_type == "remote" and fs and not fs.exists(data.file_path):
     raise ValueError(f"Remote file does not exist: {data.file_path}")
 
-  error_occurred = False
+  should_cleanup = False
   fh = open(data.file_path, "rb") if data.import_type == "local" else fs.open(data.file_path, "rb")
 
   try:
@@ -217,13 +217,13 @@ def guess_file_metadata(data: GuessFileMetadataSchema, fs=None) -> Dict[str, Any
     return metadata
 
   except Exception as e:
-    error_occurred = True
+    should_cleanup = True
     LOG.exception(f"Error guessing file metadata: {e}", exc_info=True)
     raise e
 
   finally:
     fh.close()
-    if data.import_type == "local" and error_occurred and os.path.exists(data.file_path):
+    if data.import_type == "local" and should_cleanup and os.path.exists(data.file_path):
       LOG.debug(f"Due to error in guess_file_metadata, cleaning up uploaded local file: {data.file_path}")
       os.remove(data.file_path)
 
@@ -258,7 +258,7 @@ def preview_file(data: PreviewFileSchema, fs=None, preview_rows: int = 50) -> Di
   elif data.import_type == "remote" and fs and not fs.exists(data.file_path):
     raise ValueError(f"Remote file does not exist: {data.file_path}")
 
-  error_occurred = False
+  should_cleanup = False
   fh = open(data.file_path, "rb") if data.import_type == "local" else fs.open(data.file_path, "rb")
 
   try:
@@ -271,13 +271,13 @@ def preview_file(data: PreviewFileSchema, fs=None, preview_rows: int = 50) -> Di
 
     return preview
   except Exception as e:
-    error_occurred = True
+    should_cleanup = True
     LOG.exception(f"Error previewing file: {e}", exc_info=True)
     raise e
 
   finally:
     fh.close()
-    if data.import_type == "local" and error_occurred and os.path.exists(data.file_path):
+    if data.import_type == "local" and should_cleanup and os.path.exists(data.file_path):
       LOG.debug(f"Due to error in preview_file, cleaning up uploaded local file: {data.file_path}")
       os.remove(data.file_path)
 

--- a/desktop/core/src/desktop/lib/importer/operations.py
+++ b/desktop/core/src/desktop/lib/importer/operations.py
@@ -14,7 +14,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import codecs
 import csv
 import logging
 import os
@@ -428,9 +427,7 @@ def _get_delimited_metadata(file_sample: Union[bytes, str], file_type: str) -> D
   }
 
 
-def _preview_excel_file(
-  fh: BinaryIO, data: PreviewFileSchema, preview_rows: int = 50
-) -> Dict[str, Any]:
+def _preview_excel_file(fh: BinaryIO, data: PreviewFileSchema, preview_rows: int = 50) -> Dict[str, Any]:
   """Preview an Excel file (.xlsx, .xls)
 
   Args:
@@ -451,7 +448,11 @@ def _preview_excel_file(
     fh.seek(0)
 
     df = pl.read_excel(
-      BytesIO(fh.read()), sheet_name=data.sheet_name, has_header=data.has_header, read_options={"n_rows": preview_rows}, infer_schema_length=10000
+      BytesIO(fh.read()),
+      sheet_name=data.sheet_name,
+      has_header=data.has_header,
+      read_options={"n_rows": preview_rows},
+      infer_schema_length=10000,
     )
 
     # Return empty result if the df is empty

--- a/desktop/core/src/desktop/lib/importer/operations_tests.py
+++ b/desktop/core/src/desktop/lib/importer/operations_tests.py
@@ -18,65 +18,139 @@
 import os
 import tempfile
 import zipfile
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 
+from desktop.conf import IMPORTER
 from desktop.lib.importer import operations
+from desktop.lib.importer.schemas import (
+  GuessFileHeaderSchema,
+  GuessFileMetadataSchema,
+  LocalFileUploadSchema,
+  PreviewFileSchema,
+  SqlTypeMapperSchema,
+)
 
 
 class TestLocalFileUpload:
-  @patch("uuid.uuid4")
-  def test_local_file_upload_success(self, mock_uuid):
-    # Mock uuid to get a predictable filename
-    mock_uuid.return_value.hex = "12345678"
-
-    test_file = SimpleUploadedFile(name="test_file.csv", content=b"header1,header2\nvalue1,value2", content_type="text/csv")
-
-    result = operations.local_file_upload(test_file, "test_user")
-
-    # Get the expected file path
-    temp_dir = tempfile.gettempdir()
-    expected_path = os.path.join(temp_dir, "test_user_12345678_test_file.csv")
+  def test_local_file_upload_success(self):
+    resets = [
+      IMPORTER.RESTRICT_LOCAL_FILE_EXTENSIONS.set_for_testing([".exe", ".bat"]),
+      IMPORTER.MAX_LOCAL_FILE_SIZE_UPLOAD_LIMIT.set_for_testing(10 * 1024 * 1024),  # 10 MiB limit
+    ]
 
     try:
+      test_file = SimpleUploadedFile(name="test_file.csv", content=b"header1,header2\nvalue1,value2", content_type="text/csv")
+
+      # Create schema object
+      schema = LocalFileUploadSchema(file=test_file, filename="test_file.csv", filesize=test_file.size)
+
+      result = operations.local_file_upload(schema, "test_user")
+
       assert "file_path" in result
-      assert result["file_path"] == expected_path
+      file_path = result["file_path"]
+
+      # Verify the file path contains expected components
+      assert "test_user_" in file_path
+      assert "_test_file.csv" in file_path
+      assert file_path.startswith(tempfile.gettempdir())
 
       # Verify the file was created and has the right content
-      assert os.path.exists(expected_path)
-      with open(expected_path, "rb") as f:
+      assert os.path.exists(file_path)
+      with open(file_path, "rb") as f:
         assert f.read() == b"header1,header2\nvalue1,value2"
 
     finally:
-      # Clean up the file
-      if os.path.exists(expected_path):
-        os.remove(expected_path)
+      # Clean up in case assertion fails
+      if os.path.exists(result["file_path"]):
+        os.remove(result["file_path"])
 
-      assert not os.path.exists(expected_path), "Temporary file was not cleaned up properly"
+      for reset in resets:
+        reset()
 
-  def test_local_file_upload_none_file(self):
-    with pytest.raises(ValueError, match="Upload file cannot be None or empty."):
-      operations.local_file_upload(None, "test_user")
-
-  def test_local_file_upload_none_username(self):
+  def test_local_file_upload_empty_username(self):
     test_file = SimpleUploadedFile(name="test_file.csv", content=b"header1,header2\nvalue1,value2", content_type="text/csv")
+
+    # Create schema object
+    schema = LocalFileUploadSchema(file=test_file, filename="test_file.csv", filesize=test_file.size)
 
     with pytest.raises(ValueError, match="Username cannot be None or empty."):
-      operations.local_file_upload(test_file, None)
+      operations.local_file_upload(schema, "")
 
-  @patch("os.path.join")
-  @patch("builtins.open", new_callable=mock_open)
-  def test_local_file_upload_exception_handling(self, mock_file_open, mock_join):
-    # Setup mocks to raise an exception when opening the file
-    mock_file_open.side_effect = IOError("Test IO Error")
-    mock_join.return_value = "/tmp/test_user_12345678_test_file.csv"
+  @patch("tempfile.NamedTemporaryFile")
+  @patch("shutil.copyfileobj")
+  def test_local_file_upload_exception_handling_with_cleanup(self, mock_copyfileobj, mock_tempfile):
+    resets = [
+      IMPORTER.RESTRICT_LOCAL_FILE_EXTENSIONS.set_for_testing([".exe", ".bat"]),
+      IMPORTER.MAX_LOCAL_FILE_SIZE_UPLOAD_LIMIT.set_for_testing(10 * 1024 * 1024),  # 10 MiB limit
+    ]
+
+    # Mock the temporary file
+    mock_file = MagicMock()
+    mock_file.name = "/tmp/test_user_12345678_test_file.csv"
+    mock_tempfile.return_value = mock_file
+    mock_file.__enter__.return_value = mock_file
+
+    # Make copyfileobj raise an exception
+    mock_copyfileobj.side_effect = IOError("Test IO Error")
 
     test_file = SimpleUploadedFile(name="test_file.csv", content=b"header1,header2\nvalue1,value2", content_type="text/csv")
 
-    with pytest.raises(Exception, match="Test IO Error"):
-      operations.local_file_upload(test_file, "test_user")
+    # Create schema object
+    schema = LocalFileUploadSchema(file=test_file, filename="test_file.csv", filesize=test_file.size)
+
+    # Create the temp file for testing cleanup
+    with open(mock_file.name, "w") as f:
+      f.write("temp")
+
+    try:
+      with pytest.raises(IOError, match="Test IO Error"):
+        operations.local_file_upload(schema, "test_user")
+
+      # Verify the file was cleaned up after the exception
+      assert not os.path.exists(mock_file.name), "Temporary file was not cleaned up after exception"
+
+    finally:
+      # Clean up in case assertion fails
+      if os.path.exists(mock_file.name):
+        os.remove(mock_file.name)
+
+      for reset in resets:
+        reset()
+
+  def test_local_file_upload_special_characters_in_filename(self):
+    resets = [
+      IMPORTER.RESTRICT_LOCAL_FILE_EXTENSIONS.set_for_testing([".exe", ".bat"]),
+      IMPORTER.MAX_LOCAL_FILE_SIZE_UPLOAD_LIMIT.set_for_testing(10 * 1024 * 1024),  # 10 MiB limit
+    ]
+
+    # Test with special characters in filename
+    test_file = SimpleUploadedFile(name="test file (with) [special] {chars} & symbols!.csv", content=b"data", content_type="text/csv")
+
+    # Create schema object
+    schema = LocalFileUploadSchema(file=test_file, filename="test file (with) [special] {chars} & symbols!.csv", filesize=test_file.size)
+
+    result = operations.local_file_upload(schema, "test_user")
+
+    try:
+      assert "file_path" in result
+      file_path = result["file_path"]
+
+      # Verify the file was created
+      assert os.path.exists(file_path)
+
+      # Verify filename is sanitized properly
+      assert "_test file (with) [special] {chars} & symbols!.csv" in file_path
+
+    finally:
+      # Clean up the file
+      if os.path.exists(result["file_path"]):
+        os.remove(result["file_path"])
+
+      for reset in resets:
+        reset()
 
 
 @pytest.mark.usefixtures("cleanup_temp_files")
@@ -107,7 +181,10 @@ class TestGuessFileMetadata:
     # Mock magic.from_buffer to return text/csv MIME type
     mock_magic.from_buffer.return_value = "text/plain"
 
-    result = operations.guess_file_metadata(temp_file.name, "local")
+    # Create schema object
+    schema = GuessFileMetadataSchema(file_path=temp_file.name, import_type="local")
+
+    result = operations.guess_file_metadata(data=schema)
 
     assert result == {
       "type": "csv",
@@ -130,7 +207,10 @@ class TestGuessFileMetadata:
     # Mock magic.from_buffer to return text/plain MIME type
     mock_magic.from_buffer.return_value = "text/plain"
 
-    result = operations.guess_file_metadata(temp_file.name, "local")
+    # Create schema object
+    schema = GuessFileMetadataSchema(file_path=temp_file.name, import_type="local")
+
+    result = operations.guess_file_metadata(data=schema)
 
     assert result == {
       "type": "tsv",
@@ -165,7 +245,10 @@ class TestGuessFileMetadata:
     # Mock _get_sheet_names_xlsx to return sheet names
     mock_get_sheet_names.return_value = ["Sheet1", "Sheet2", "Sheet3"]
 
-    result = operations.guess_file_metadata(temp_file.name, "local")
+    # Create schema object
+    schema = GuessFileMetadataSchema(file_path=temp_file.name, import_type="local")
+
+    result = operations.guess_file_metadata(data=schema)
 
     assert result == {
       "type": "excel",
@@ -184,21 +267,25 @@ class TestGuessFileMetadata:
     # Mock magic.from_buffer to return an unsupported MIME type
     mock_magic.from_buffer.return_value = "application/octet-stream"
 
+    # Create schema object
+    schema = GuessFileMetadataSchema(file_path=temp_file.name, import_type="local")
+
     with pytest.raises(ValueError, match="Unable to detect file format."):
-      operations.guess_file_metadata(temp_file.name, "local")
+      operations.guess_file_metadata(data=schema)
 
   def test_guess_file_metadata_nonexistent_file(self):
-    file_path = "/path/to/nonexistent/file.csv"
+    # Create schema object
+    schema = GuessFileMetadataSchema(file_path="/path/to/nonexistent/file.csv", import_type="local")
 
     with pytest.raises(ValueError, match="Local file does not exist."):
-      operations.guess_file_metadata(file_path, "local")
+      operations.guess_file_metadata(data=schema)
 
   def test_guess_remote_file_metadata_no_fs(self):
+    # Create schema object
+    schema = GuessFileMetadataSchema(file_path="s3a://bucket/user/test_user/test.csv", import_type="remote")
+
     with pytest.raises(ValueError, match="File system object is required for remote import type"):
-      operations.guess_file_metadata(
-        file_path="s3a://bucket/user/test_user/test.csv",  # Remote file path
-        import_type="remote",  # Remote file but no fs provided
-      )
+      operations.guess_file_metadata(data=schema, fs=None)
 
   def test_guess_file_metadata_empty_file(self, cleanup_temp_files):
     temp_file = tempfile.NamedTemporaryFile(delete=False)
@@ -206,8 +293,11 @@ class TestGuessFileMetadata:
 
     cleanup_temp_files.append(temp_file.name)
 
+    # Create schema object
+    schema = GuessFileMetadataSchema(file_path=temp_file.name, import_type="local")
+
     with pytest.raises(ValueError, match="File is empty, cannot detect file format."):
-      operations.guess_file_metadata(temp_file.name, "local")
+      operations.guess_file_metadata(data=schema)
 
   @patch("desktop.lib.importer.operations.is_magic_lib_available", False)
   def test_guess_file_metadata_no_magic_lib(self, cleanup_temp_files):
@@ -217,8 +307,11 @@ class TestGuessFileMetadata:
 
     cleanup_temp_files.append(temp_file.name)
 
+    # Create schema object
+    schema = GuessFileMetadataSchema(file_path=temp_file.name, import_type="local")
+
     with pytest.raises(RuntimeError, match="Unable to guess file type. python-magic or its dependency libmagic is not installed."):
-      operations.guess_file_metadata(temp_file.name, "local")
+      operations.guess_file_metadata(data=schema)
 
 
 @pytest.mark.usefixtures("cleanup_temp_files")
@@ -260,9 +353,12 @@ class TestPreviewFile:
 
     mock_pl.read_excel.return_value = mock_df
 
-    result = operations.preview_file(
+    # Create schema object
+    schema = PreviewFileSchema(
       file_path=temp_file.name, file_type="excel", import_type="local", sql_dialect="hive", has_header=True, sheet_name="Sheet1"
     )
+
+    result = operations.preview_file(data=schema)
 
     assert result == {
       "type": "excel",
@@ -282,7 +378,8 @@ class TestPreviewFile:
 
     cleanup_temp_files.append(temp_file.name)
 
-    result = operations.preview_file(
+    # Create schema object
+    schema = PreviewFileSchema(
       file_path=temp_file.name,
       file_type="csv",
       import_type="local",
@@ -292,6 +389,8 @@ class TestPreviewFile:
       quote_char='"',
       record_separator="\n",
     )
+
+    result = operations.preview_file(data=schema)
 
     assert result == {
       "type": "csv",
@@ -311,7 +410,8 @@ class TestPreviewFile:
 
     cleanup_temp_files.append(temp_file.name)
 
-    result = operations.preview_file(
+    # Create schema object
+    schema = PreviewFileSchema(
       file_path=temp_file.name,
       file_type="csv",
       import_type="local",
@@ -321,6 +421,8 @@ class TestPreviewFile:
       quote_char='"',
       record_separator="\n",
     )
+
+    result = operations.preview_file(data=schema)
 
     assert result == {
       "type": "csv",
@@ -336,7 +438,8 @@ class TestPreviewFile:
 
     cleanup_temp_files.append(temp_file.name)
 
-    result = operations.preview_file(
+    # Create schema object
+    schema = PreviewFileSchema(
       file_path=temp_file.name,
       file_type="csv",
       import_type="local",
@@ -347,54 +450,34 @@ class TestPreviewFile:
       record_separator="\n",
     )
 
+    result = operations.preview_file(data=schema)
+
     assert result == {
       "type": "csv",
       "columns": [],
       "preview_data": {},
     }
 
-  def test_preview_invalid_file_path(self):
-    with pytest.raises(ValueError, match="File path cannot be empty"):
-      operations.preview_file(file_path="", file_type="csv", import_type="local", sql_dialect="hive", has_header=True)
-
-  def test_preview_unsupported_file_type(self):
-    with pytest.raises(ValueError, match="Unsupported file type: json"):
-      operations.preview_file(
-        file_path="/path/to/test.json",
-        file_type="json",  # Unsupported type
-        import_type="local",
-        sql_dialect="hive",
-        has_header=True,
-      )
-
-  def test_preview_unsupported_sql_dialect(self):
-    with pytest.raises(ValueError, match="Unsupported SQL dialect: mysql"):
-      operations.preview_file(
-        file_path="/path/to/test.csv",
-        file_type="csv",
-        import_type="local",
-        sql_dialect="mysql",  # Unsupported dialect
-        has_header=True,
-      )
-
   def test_preview_remote_file_no_fs(self):
+    # Create schema object
+    schema = PreviewFileSchema(
+      file_path="s3a://bucket/user/test_user/test.csv", file_type="csv", import_type="remote", sql_dialect="hive", has_header=True
+    )
+
     with pytest.raises(ValueError, match="File system object is required for remote import type"):
-      operations.preview_file(
-        file_path="s3a://bucket/user/test_user/test.csv",  # Remote file path
-        file_type="csv",
-        import_type="remote",  # Remote file but no fs provided
-        sql_dialect="hive",
-        has_header=True,
-      )
+      operations.preview_file(data=schema, fs=None)
 
   @patch("os.path.exists")
   def test_preview_nonexistent_local_file(self, mock_exists):
     mock_exists.return_value = False
 
+    # Create schema object
+    schema = PreviewFileSchema(
+      file_path="/path/to/nonexistent.csv", file_type="csv", import_type="local", sql_dialect="hive", has_header=True
+    )
+
     with pytest.raises(ValueError, match="Local file does not exist: /path/to/nonexistent.csv"):
-      operations.preview_file(
-        file_path="/path/to/nonexistent.csv", file_type="csv", import_type="local", sql_dialect="hive", has_header=True
-      )
+      operations.preview_file(data=schema)
 
   def test_preview_trino_dialect_type_mapping(self, cleanup_temp_files):
     test_content = "string_col\nfoo\nbar"
@@ -404,7 +487,8 @@ class TestPreviewFile:
 
     cleanup_temp_files.append(temp_file.name)
 
-    result = operations.preview_file(
+    # Create schema object
+    schema = PreviewFileSchema(
       file_path=temp_file.name,
       file_type="csv",
       import_type="local",
@@ -412,6 +496,8 @@ class TestPreviewFile:
       has_header=True,
       field_separator=",",
     )
+
+    result = operations.preview_file(data=schema)
 
     # Check the result for Trino-specific type mapping
     assert result["columns"][0]["type"] == "VARCHAR"  # Not STRING
@@ -439,7 +525,10 @@ class TestGuessFileHeader:
 
     cleanup_temp_files.append(temp_file.name)
 
-    result = operations.guess_file_header(file_path=temp_file.name, file_type="csv", import_type="local")
+    # Create schema object
+    schema = GuessFileHeaderSchema(file_path=temp_file.name, file_type="csv", import_type="local")
+
+    result = operations.guess_file_header(data=schema)
 
     assert result
 
@@ -467,120 +556,270 @@ class TestGuessFileHeader:
     mock_sniffer_instance.has_header.return_value = True
     mock_sniffer.return_value = mock_sniffer_instance
 
-    result = operations.guess_file_header(file_path=temp_file.name, file_type="excel", import_type="local", sheet_name="Sheet1")
+    # Create schema object
+    schema = GuessFileHeaderSchema(file_path=temp_file.name, file_type="excel", import_type="local", sheet_name="Sheet1")
+
+    result = operations.guess_file_header(data=schema)
 
     assert result
 
-  def test_guess_header_excel_no_sheet_name(self, cleanup_temp_files):
-    test_content = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-    <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
-    </workbook>"""
-
-    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx")
-    temp_file.write(test_content.encode("utf-8"))
-    temp_file.close()
-
-    cleanup_temp_files.append(temp_file.name)
-
-    with pytest.raises(ValueError, match="Sheet name is required for Excel files"):
-      operations.guess_file_header(
-        file_path=temp_file.name,
-        file_type="excel",
-        import_type="local",
-        # Missing sheet_name
-      )
-
-  def test_guess_header_invalid_path(self):
-    with pytest.raises(ValueError, match="File path cannot be empty"):
-      operations.guess_file_header(file_path="", file_type="csv", import_type="local")
-
-  def test_guess_header_unsupported_file_type(self):
-    with pytest.raises(ValueError, match="Unsupported file type: json"):
-      operations.guess_file_header(
-        file_path="/path/to/test.json",
-        file_type="json",  # Unsupported type
-        import_type="local",
-      )
-
   def test_guess_header_nonexistent_local_file(self):
+    # Create schema object
+    schema = GuessFileHeaderSchema(file_path="/path/to/nonexistent/file.csv", file_type="csv", import_type="local")
+
     with pytest.raises(ValueError, match="Local file does not exist"):
-      operations.guess_file_header(file_path="/path/to/nonexistent.csv", file_type="csv", import_type="local")
+      operations.guess_file_header(data=schema)
 
   def test_guess_header_remote_file_no_fs(self):
+    # Create schema object
+    schema = GuessFileHeaderSchema(file_path="s3a://bucket/user/test_user/test.csv", file_type="csv", import_type="remote")
+
     with pytest.raises(ValueError, match="File system object is required for remote import type"):
-      operations.guess_file_header(
-        file_path="hdfs:///path/to/test.csv",
-        file_type="csv",
-        import_type="remote",  # Remote but no fs provided
-      )
+      operations.guess_file_header(data=schema, fs=None)
 
 
 class TestSqlTypeMapping:
   def test_get_sql_type_mapping_hive(self):
-    mappings = operations.get_sql_type_mapping("hive")
+    # Create schema object
+    schema = SqlTypeMapperSchema(sql_dialect="hive")
 
-    # Check some key mappings for Hive
-    assert mappings["Int32"] == "INT"
-    assert mappings["Utf8"] == "STRING"
-    assert mappings["Float64"] == "DOUBLE"
-    assert mappings["Boolean"] == "BOOLEAN"
-    assert mappings["Decimal"] == "DECIMAL"
+    result = operations.get_sql_type_mapping(schema)
+
+    # Test all integer types (signed and unsigned)
+    assert result["Int8"] == "TINYINT"
+    assert result["Int16"] == "SMALLINT"
+    assert result["Int32"] == "INT"
+    assert result["Int64"] == "BIGINT"
+    assert result["UInt8"] == "TINYINT"  # Unsigned mapped to signed in Hive
+    assert result["UInt16"] == "SMALLINT"
+    assert result["UInt32"] == "INT"
+    assert result["UInt64"] == "BIGINT"
+
+    # Test floating point and decimal types
+    assert result["Float32"] == "FLOAT"
+    assert result["Float64"] == "DOUBLE"
+    assert result["Decimal"] == "DECIMAL"
+
+    # Test boolean, string, and binary types
+    assert result["Boolean"] == "BOOLEAN"
+    assert result["Utf8"] == "STRING"
+    assert result["String"] == "STRING"
+    assert result["Categorical"] == "STRING"
+    assert result["Enum"] == "STRING"
+    assert result["Binary"] == "BINARY"
+
+    # Test temporal types
+    assert result["Date"] == "DATE"
+    assert result["Time"] == "TIMESTAMP"  # No pure TIME type in Hive
+    assert result["Datetime"] == "TIMESTAMP"
+    assert result["Duration"] == "INTERVAL DAY TO SECOND"
+
+    # Test nested and other types
+    assert result["Array"] == "ARRAY"
+    assert result["List"] == "ARRAY"
+    assert result["Struct"] == "STRUCT"
+    assert result["Object"] == "STRING"
+    assert result["Null"] == "STRING"
+    assert result["Unknown"] == "STRING"
 
   def test_get_sql_type_mapping_trino(self):
-    mappings = operations.get_sql_type_mapping("trino")
+    # Create schema object
+    schema = SqlTypeMapperSchema(sql_dialect="trino")
 
-    # Check some key mappings for Trino that differ from Hive
-    assert mappings["Int32"] == "INTEGER"
-    assert mappings["Utf8"] == "VARCHAR"
-    assert mappings["Binary"] == "VARBINARY"
-    assert mappings["Float32"] == "REAL"
-    assert mappings["Struct"] == "ROW"
-    assert mappings["Object"] == "JSON"
+    result = operations.get_sql_type_mapping(schema)
+
+    # Test Trino-specific overrides
+    assert result["Int32"] == "INTEGER"  # Not INT
+    assert result["UInt32"] == "INTEGER"  # Not INT
+    assert result["Float32"] == "REAL"  # Not FLOAT
+    assert result["Utf8"] == "VARCHAR"  # Not STRING
+    assert result["String"] == "VARCHAR"  # Not STRING
+    assert result["Binary"] == "VARBINARY"  # Not BINARY
+    assert result["Struct"] == "ROW"  # Not STRUCT
+    assert result["Object"] == "JSON"  # Not STRING
+    assert result["Duration"] == "INTERVAL DAY TO SECOND"
+
+    # Test types that remain the same as base mapping
+    assert result["Int8"] == "TINYINT"
+    assert result["Int16"] == "SMALLINT"
+    assert result["Int64"] == "BIGINT"
+    assert result["Float64"] == "DOUBLE"
+    assert result["Boolean"] == "BOOLEAN"
+    assert result["Date"] == "DATE"
+    assert result["Time"] == "TIMESTAMP"
+    assert result["Datetime"] == "TIMESTAMP"
 
   def test_get_sql_type_mapping_phoenix(self):
-    mappings = operations.get_sql_type_mapping("phoenix")
+    # Create schema object
+    schema = SqlTypeMapperSchema(sql_dialect="phoenix")
 
-    # Check some key mappings for Phoenix
-    assert mappings["UInt32"] == "UNSIGNED_INT"
-    assert mappings["Utf8"] == "VARCHAR"
-    assert mappings["Time"] == "TIME"
-    assert mappings["Struct"] == "STRING"  # Phoenix treats structs as strings
-    assert mappings["Duration"] == "STRING"  # Phoenix treats durations as strings
+    result = operations.get_sql_type_mapping(schema)
+
+    # Test Phoenix-specific unsigned integer mappings
+    assert result["UInt8"] == "UNSIGNED_TINYINT"
+    assert result["UInt16"] == "UNSIGNED_SMALLINT"
+    assert result["UInt32"] == "UNSIGNED_INT"
+    assert result["UInt64"] == "UNSIGNED_LONG"
+
+    # Test other Phoenix-specific overrides
+    assert result["Utf8"] == "VARCHAR"  # Not STRING
+    assert result["String"] == "VARCHAR"  # Not STRING
+    assert result["Binary"] == "VARBINARY"  # Not BINARY
+    assert result["Duration"] == "STRING"  # Phoenix treats durations as strings
+    assert result["Struct"] == "STRING"  # No native STRUCT type
+    assert result["Object"] == "VARCHAR"  # Not STRING
+    assert result["Time"] == "TIME"  # Phoenix has its own TIME type
+    assert result["Decimal"] == "DECIMAL"
+
+    # Test signed integers (use base mapping)
+    assert result["Int8"] == "TINYINT"
+    assert result["Int16"] == "SMALLINT"
+    assert result["Int32"] == "INT"
+    assert result["Int64"] == "BIGINT"
+
+    # Test other types that remain the same
+    assert result["Float32"] == "FLOAT"
+    assert result["Float64"] == "DOUBLE"
+    assert result["Boolean"] == "BOOLEAN"
+    assert result["Date"] == "DATE"
+    assert result["Datetime"] == "TIMESTAMP"
 
   def test_get_sql_type_mapping_impala(self):
-    result = operations.get_sql_type_mapping("impala")
+    # Create schema object
+    schema = SqlTypeMapperSchema(sql_dialect="impala")
 
-    # Impala uses the base mappings, so check those
+    result = operations.get_sql_type_mapping(schema)
+
+    # Impala uses all base mappings (no overrides)
+    # Test a comprehensive set to ensure no overrides are applied
+    assert result["Int8"] == "TINYINT"
+    assert result["Int16"] == "SMALLINT"
     assert result["Int32"] == "INT"
     assert result["Int64"] == "BIGINT"
+    assert result["UInt8"] == "TINYINT"
+    assert result["UInt16"] == "SMALLINT"
+    assert result["UInt32"] == "INT"
+    assert result["UInt64"] == "BIGINT"
+    assert result["Float32"] == "FLOAT"
     assert result["Float64"] == "DOUBLE"
+    assert result["Decimal"] == "DECIMAL"
+    assert result["Boolean"] == "BOOLEAN"
     assert result["Utf8"] == "STRING"
+    assert result["String"] == "STRING"
+    assert result["Binary"] == "BINARY"
+    assert result["Date"] == "DATE"
+    assert result["Time"] == "TIMESTAMP"
+    assert result["Datetime"] == "TIMESTAMP"
+    assert result["Duration"] == "INTERVAL DAY TO SECOND"
+    assert result["Array"] == "ARRAY"
+    assert result["Struct"] == "STRUCT"
+    assert result["Object"] == "STRING"
 
   def test_get_sql_type_mapping_sparksql(self):
-    result = operations.get_sql_type_mapping("sparksql")
+    # Create schema object
+    schema = SqlTypeMapperSchema(sql_dialect="sparksql")
 
-    # SparkSQL uses the base mappings, so check those
+    result = operations.get_sql_type_mapping(schema)
+
+    # SparkSQL uses all base mappings (no overrides)
+    # Test a comprehensive set to ensure no overrides are applied
+    assert result["Int8"] == "TINYINT"
+    assert result["Int16"] == "SMALLINT"
     assert result["Int32"] == "INT"
     assert result["Int64"] == "BIGINT"
+    assert result["UInt8"] == "TINYINT"
+    assert result["UInt16"] == "SMALLINT"
+    assert result["UInt32"] == "INT"
+    assert result["UInt64"] == "BIGINT"
+    assert result["Float32"] == "FLOAT"
     assert result["Float64"] == "DOUBLE"
+    assert result["Decimal"] == "DECIMAL"
+    assert result["Boolean"] == "BOOLEAN"
     assert result["Utf8"] == "STRING"
+    assert result["String"] == "STRING"
+    assert result["Binary"] == "BINARY"
+    assert result["Date"] == "DATE"
+    assert result["Time"] == "TIMESTAMP"
+    assert result["Datetime"] == "TIMESTAMP"
+    assert result["Duration"] == "INTERVAL DAY TO SECOND"
+    assert result["Array"] == "ARRAY"
+    assert result["Struct"] == "STRUCT"
+    assert result["Object"] == "STRING"
 
-  def test_get_sql_type_mapping_unsupported_dialect(self):
-    with pytest.raises(ValueError, match="Unsupported dialect: mysql"):
-      operations.get_sql_type_mapping("mysql")
+  def test_get_sql_type_mapping_all_dialects_consistency(self):
+    # Test that all dialects return mappings for all base types
+    dialects = ["hive", "impala", "sparksql", "trino", "phoenix"]
+    base_types = [
+      "Int8",
+      "Int16",
+      "Int32",
+      "Int64",
+      "UInt8",
+      "UInt16",
+      "UInt32",
+      "UInt64",
+      "Float32",
+      "Float64",
+      "Decimal",
+      "Boolean",
+      "Utf8",
+      "String",
+      "Categorical",
+      "Enum",
+      "Binary",
+      "Date",
+      "Time",
+      "Datetime",
+      "Duration",
+      "Array",
+      "List",
+      "Struct",
+      "Object",
+      "Null",
+      "Unknown",
+    ]
+
+    for dialect in dialects:
+      schema = SqlTypeMapperSchema(sql_dialect=dialect)
+      result = operations.get_sql_type_mapping(schema)
+
+      # Ensure all base types have mappings
+      for base_type in base_types:
+        assert base_type in result, f"Missing mapping for {base_type} in {dialect} dialect"
+        assert isinstance(result[base_type], str), f"Invalid mapping type for {base_type} in {dialect} dialect"
+        assert len(result[base_type]) > 0, f"Empty mapping for {base_type} in {dialect} dialect"
 
   def test_map_polars_dtype_to_sql_type(self):
-    # Test with Hive dialect
-    assert operations._map_polars_dtype_to_sql_type("hive", "Int64") == "BIGINT"
-    assert operations._map_polars_dtype_to_sql_type("hive", "Float32") == "FLOAT"
+    # Test comprehensive type mapping for each dialect
 
-    # Test with Trino dialect
-    assert operations._map_polars_dtype_to_sql_type("trino", "Int64") == "BIGINT"
+    # Hive dialect tests
+    assert operations._map_polars_dtype_to_sql_type("hive", "Int8") == "TINYINT"
+    assert operations._map_polars_dtype_to_sql_type("hive", "Int32") == "INT"
+    assert operations._map_polars_dtype_to_sql_type("hive", "Float64") == "DOUBLE"
+    assert operations._map_polars_dtype_to_sql_type("hive", "Utf8") == "STRING"
+    assert operations._map_polars_dtype_to_sql_type("hive", "Boolean") == "BOOLEAN"
+    assert operations._map_polars_dtype_to_sql_type("hive", "Date") == "DATE"
+    assert operations._map_polars_dtype_to_sql_type("hive", "Array") == "ARRAY"
+
+    # Trino dialect tests (with overrides)
+    assert operations._map_polars_dtype_to_sql_type("trino", "Int32") == "INTEGER"
     assert operations._map_polars_dtype_to_sql_type("trino", "Float32") == "REAL"
+    assert operations._map_polars_dtype_to_sql_type("trino", "Utf8") == "VARCHAR"
+    assert operations._map_polars_dtype_to_sql_type("trino", "Binary") == "VARBINARY"
+    assert operations._map_polars_dtype_to_sql_type("trino", "Struct") == "ROW"
+    assert operations._map_polars_dtype_to_sql_type("trino", "Object") == "JSON"
 
-    # Test unsupported type
+    # Phoenix dialect tests (with unsigned types)
+    assert operations._map_polars_dtype_to_sql_type("phoenix", "UInt8") == "UNSIGNED_TINYINT"
+    assert operations._map_polars_dtype_to_sql_type("phoenix", "UInt32") == "UNSIGNED_INT"
+    assert operations._map_polars_dtype_to_sql_type("phoenix", "UInt64") == "UNSIGNED_LONG"
+    assert operations._map_polars_dtype_to_sql_type("phoenix", "Time") == "TIME"
+    assert operations._map_polars_dtype_to_sql_type("phoenix", "Duration") == "STRING"
+    assert operations._map_polars_dtype_to_sql_type("phoenix", "Struct") == "STRING"
+
+    # Test error for unknown type
     with pytest.raises(ValueError, match="No mapping for Polars dtype"):
-      operations._map_polars_dtype_to_sql_type("hive", "NonExistentType")
+      operations._map_polars_dtype_to_sql_type("hive", "UnknownType")
 
 
 @pytest.mark.usefixtures("cleanup_temp_files")

--- a/desktop/core/src/desktop/lib/importer/schemas.py
+++ b/desktop/core/src/desktop/lib/importer/schemas.py
@@ -19,7 +19,7 @@ import codecs
 import os
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, FilePath, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from desktop.conf import IMPORTER
 
@@ -53,12 +53,19 @@ class LocalFileUploadSchema(BaseModel):
 
 
 class GuessFileMetadataSchema(BaseModel):
-  file_path: FilePath = Field(..., description="Full path to the file to analyze")
+  file_path: str = Field(..., description="Full path to the file to analyze")
   import_type: Literal["local", "remote"] = Field(..., description="Whether the file is local or on a remote filesystem")
+
+  @field_validator("file_path")
+  @classmethod
+  def file_path_not_blank(cls, v: str) -> str:
+    if not v or v.strip() == "":
+      raise ValueError("File path cannot be empty or whitespace.")
+    return v
 
 
 class PreviewFileSchema(BaseModel):
-  file_path: FilePath = Field(..., description="Full path to the file to preview")
+  file_path: str = Field(..., description="Full path to the file to preview")
   file_type: Literal["csv", "tsv", "excel", "delimiter_format"] = Field(..., description="Type of file (csv, tsv, excel, delimiter_format)")
   import_type: Literal["local", "remote"] = Field(..., description="Whether the file is local or on a remote filesystem")
   sql_dialect: Literal["hive", "impala", "trino", "phoenix", "sparksql"] = Field(..., description="SQL dialect for mapping column types")
@@ -67,6 +74,13 @@ class PreviewFileSchema(BaseModel):
   field_separator: Optional[str] = Field(None, description="Field separator character")
   quote_char: Optional[str] = Field(None, description="Quote character")
   record_separator: Optional[str] = Field(None, description="Record separator character")
+
+  @field_validator("file_path")
+  @classmethod
+  def file_path_not_blank(cls, v: str) -> str:
+    if not v or v.strip() == "":
+      raise ValueError("File path cannot be empty or whitespace.")
+    return v
 
   @field_validator("field_separator", "quote_char", "record_separator", mode="before")
   @classmethod
@@ -109,10 +123,17 @@ class SqlTypeMapperSchema(BaseModel):
 
 
 class GuessFileHeaderSchema(BaseModel):
-  file_path: FilePath = Field(..., description="Full path to the file to analyze")
+  file_path: str = Field(..., description="Full path to the file to analyze")
   file_type: Literal["csv", "tsv", "excel", "delimiter_format"] = Field(..., description="Type of file (csv, tsv, excel, delimiter_format)")
   import_type: Literal["local", "remote"] = Field(..., description="Whether the file is local or on a remote filesystem")
   sheet_name: Optional[str] = Field(None, description="Sheet name for Excel files")
+
+  @field_validator("file_path")
+  @classmethod
+  def file_path_not_blank(cls, v: str) -> str:
+    if not v or v.strip() == "":
+      raise ValueError("File path cannot be empty or whitespace.")
+    return v
 
   @model_validator(mode="after")
   def sheet_name_required_for_excel(self) -> "GuessFileHeaderSchema":

--- a/desktop/core/src/desktop/lib/importer/schemas.py
+++ b/desktop/core/src/desktop/lib/importer/schemas.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, FilePath, model_validator
+
+from desktop.conf import IMPORTER
+
+
+class LocalFileUploadSchema(BaseModel):
+  model_config = ConfigDict(arbitrary_types_allowed=True)
+
+  file: Any = Field(..., description="CSV or Excel file to upload and process")
+  filename: str = Field(..., description="The name of the file")
+  filesize: int = Field(..., description="The size of the file in bytes")
+
+  @field_validator("filename")
+  @classmethod
+  def validate_filename(cls, v: str) -> str:
+    # Check if the file type is restricted
+    _, file_type = os.path.splitext(v)
+    restricted_extensions = IMPORTER.RESTRICT_LOCAL_FILE_EXTENSIONS.get()
+    if restricted_extensions and file_type.lower() in [ext.lower() for ext in restricted_extensions]:
+      raise ValueError(f'Uploading files with type "{file_type}" is not allowed. Hue is configured to restrict this type.')
+    return v
+
+  @field_validator("filesize")
+  @classmethod
+  def validate_filesize(cls, v: int) -> int:
+    # Check file size
+    max_size = IMPORTER.MAX_LOCAL_FILE_SIZE_UPLOAD_LIMIT.get()
+    if v > max_size:
+      max_size_mib = max_size / (1024 * 1024)
+      raise ValueError(f"File too large. Maximum file size is {max_size_mib:.0f} MiB.")
+    return v
+
+
+class GuessFileMetadataSchema(BaseModel):
+  file_path: FilePath = Field(..., description="Full path to the file to analyze")
+  import_type: Literal["local", "remote"] = Field(..., description="Whether the file is local or on a remote filesystem")
+
+
+class PreviewFileSchema(BaseModel):
+  file_path: FilePath = Field(..., description="Full path to the file to preview")
+  file_type: Literal["csv", "tsv", "excel", "delimiter_format"] = Field(..., description="Type of file (csv, tsv, excel, delimiter_format)")
+  import_type: Literal["local", "remote"] = Field(..., description="Whether the file is local or on a remote filesystem")
+  sql_dialect: Literal["hive", "impala", "trino", "phoenix", "sparksql"] = Field(..., description="SQL dialect for mapping column types")
+  has_header: bool = Field(False, description="Whether the file has a header row or not")
+  sheet_name: Optional[str] = Field(None, description="Sheet name for Excel files")
+  field_separator: Optional[str] = Field(None, description="Field separator character")
+  quote_char: Optional[str] = Field(None, description="Quote character")
+  record_separator: Optional[str] = Field(None, description="Record separator character")
+
+  @model_validator(mode="after")
+  def set_defaults_and_validate_dependencies(self) -> "PreviewFileSchema":
+    # Validate sheet_name dependency for excel files
+    if self.file_type == "excel" and not self.sheet_name:
+      raise ValueError("Sheet name is required for Excel files.")
+
+    # Set defaults for delimited files
+    if self.file_type in ["csv", "tsv", "delimiter_format"]:
+      if self.field_separator is None:
+        if self.file_type == "csv":
+          self.field_separator = ","
+        elif self.file_type == "tsv":
+          self.field_separator = "\t"
+        else:
+          raise ValueError("Field separator is required for delimited files")
+
+      if self.quote_char is None:
+        self.quote_char = '"'
+
+      if self.record_separator is None:
+        self.record_separator = "\n"
+
+    return self
+
+
+class SqlTypeMapperSchema(BaseModel):
+  sql_dialect: Literal["hive", "impala", "trino", "phoenix", "sparksql"] = Field(..., description="SQL dialect for mapping column types")
+
+
+class GuessFileHeaderSchema(BaseModel):
+  file_path: FilePath = Field(..., description="Full path to the file to analyze")
+  file_type: Literal["csv", "tsv", "excel", "delimiter_format"] = Field(..., description="Type of file (csv, tsv, excel, delimiter_format)")
+  import_type: Literal["local", "remote"] = Field(..., description="Whether the file is local or on a remote filesystem")
+  sheet_name: Optional[str] = Field(None, description="Sheet name for Excel files")
+
+  @model_validator(mode="after")
+  def sheet_name_required_for_excel(self) -> "GuessFileHeaderSchema":
+    if self.file_type == "excel" and not self.sheet_name:
+      raise ValueError("Sheet name is required for Excel files.")
+    return self

--- a/desktop/core/src/desktop/lib/importer/schemas_tests.py
+++ b/desktop/core/src/desktop/lib/importer/schemas_tests.py
@@ -1,0 +1,540 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from desktop.conf import IMPORTER
+from desktop.lib.importer.schemas import (
+  GuessFileHeaderSchema,
+  GuessFileMetadataSchema,
+  LocalFileUploadSchema,
+  PreviewFileSchema,
+  SqlTypeMapperSchema,
+)
+
+
+class TestLocalFileUploadSchema:
+  def test_valid_file_upload(self):
+    resets = [
+      IMPORTER.RESTRICT_LOCAL_FILE_EXTENSIONS.set_for_testing([".exe", ".bat"]),
+      IMPORTER.MAX_LOCAL_FILE_SIZE_UPLOAD_LIMIT.set_for_testing(10 * 1024 * 1024),  # 10 MiB limit
+    ]
+    try:
+      mock_file = MagicMock()
+      schema = LocalFileUploadSchema(file=mock_file, filename="test.csv", filesize=1024)
+
+      assert schema.file == mock_file
+      assert schema.filename == "test.csv"
+      assert schema.filesize == 1024
+    finally:
+      for reset in resets:
+        reset()
+
+  def test_restricted_file_extension(self):
+    resets = [IMPORTER.RESTRICT_LOCAL_FILE_EXTENSIONS.set_for_testing([".exe", ".bat", ".csv"])]
+    try:
+      mock_file = MagicMock()
+
+      with pytest.raises(ValidationError) as exc_info:
+        LocalFileUploadSchema(file=mock_file, filename="test.csv", filesize=1024)
+
+      errors = exc_info.value.errors()
+      assert len(errors) == 1
+      assert "filename" in str(errors[0]["loc"])
+      assert "not allowed" in str(errors[0]["msg"])
+    finally:
+      for reset in resets:
+        reset()
+
+  def test_file_too_large(self):
+    resets = [IMPORTER.MAX_LOCAL_FILE_SIZE_UPLOAD_LIMIT.set_for_testing(1024 * 1024)]  # 1 MiB
+    try:
+      mock_file = MagicMock()
+
+      with pytest.raises(ValidationError) as exc_info:
+        LocalFileUploadSchema(file=mock_file, filename="test.csv", filesize=1024 * 1024 * 2)  # 2 MiB
+
+      errors = exc_info.value.errors()
+      assert len(errors) == 1
+      assert "filesize" in str(errors[0]["loc"])
+      assert "too large" in str(errors[0]["msg"])
+    finally:
+      for reset in resets:
+        reset()
+
+  def test_case_insensitive_extension_check(self):
+    resets = [
+      IMPORTER.RESTRICT_LOCAL_FILE_EXTENSIONS.set_for_testing([".EXE", ".BAT"]),
+      IMPORTER.MAX_LOCAL_FILE_SIZE_UPLOAD_LIMIT.set_for_testing(1024 * 1024 * 10),  # 10 MiB limit
+    ]
+    try:
+      mock_file = MagicMock()
+
+      with pytest.raises(ValidationError) as exc_info:
+        LocalFileUploadSchema(file=mock_file, filename="test.exe", filesize=1024)
+
+      errors = exc_info.value.errors()
+      assert len(errors) == 1
+      assert "filename" in str(errors[0]["loc"])
+      assert "not allowed" in str(errors[0]["msg"])
+    finally:
+      for reset in resets:
+        reset()
+
+  def test_missing_file(self):
+    with pytest.raises(ValidationError) as exc_info:
+      LocalFileUploadSchema()
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 3
+    assert "file" in str(errors[0]["loc"])
+    assert "filename" in str(errors[1]["loc"])
+    assert "filesize" in str(errors[2]["loc"])
+
+
+class TestGuessFileMetadataSchema:
+  def test_valid_local_file_metadata(self):
+    schema = GuessFileMetadataSchema(file_path="/path/to/test.csv", import_type="local")
+
+    assert schema.file_path == "/path/to/test.csv"
+    assert schema.import_type == "local"
+
+  def test_valid_remote_file_metadata(self):
+    schema = GuessFileMetadataSchema(file_path="s3a://bucket/test.csv", import_type="remote")
+
+    assert schema.file_path == "s3a://bucket/test.csv"
+    assert schema.import_type == "remote"
+
+  def test_invalid_import_type(self):
+    with pytest.raises(ValidationError) as exc_info:
+      GuessFileMetadataSchema(file_path="/path/to/test.csv", import_type="invalid")
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert "import_type" in str(errors[0]["loc"])
+
+  def test_missing_required_fields(self):
+    with pytest.raises(ValidationError) as exc_info:
+      GuessFileMetadataSchema()
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 2  # file_path and import_type are required
+
+  def test_invalid_file_path(self):
+    with pytest.raises(ValidationError) as exc_info:
+      GuessFileMetadataSchema(file_path="", import_type="local")
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert "file_path" in str(errors[0]["loc"])
+
+
+class TestPreviewFileSchema:
+  def test_valid_csv_preview(self):
+    schema = PreviewFileSchema(
+      file_path="/path/to/test.csv",
+      file_type="csv",
+      import_type="local",
+      sql_dialect="hive",
+      has_header=True,
+      field_separator=",",
+      quote_char='"',
+      record_separator="\n",
+    )
+
+    assert schema.file_path == "/path/to/test.csv"
+    assert schema.file_type == "csv"
+    assert schema.import_type == "local"
+    assert schema.sql_dialect == "hive"
+    assert schema.has_header is True
+    assert schema.field_separator == ","
+    assert schema.quote_char == '"'
+    assert schema.record_separator == "\n"
+
+  def test_csv_default_values(self):
+    schema = PreviewFileSchema(file_path="/path/to/test.csv", file_type="csv", import_type="local", sql_dialect="hive", has_header=False)
+
+    assert schema.field_separator == ","
+    assert schema.quote_char == '"'
+    assert schema.record_separator == "\n"
+
+  def test_tsv_default_values(self):
+    schema = PreviewFileSchema(file_path="/path/to/test.tsv", file_type="tsv", import_type="local", sql_dialect="hive", has_header=False)
+
+    assert schema.field_separator == "\t"
+    assert schema.quote_char == '"'
+    assert schema.record_separator == "\n"
+
+  def test_excel_requires_sheet_name(self):
+    with pytest.raises(ValidationError) as exc_info:
+      PreviewFileSchema(file_path="/path/to/test.xlsx", file_type="excel", import_type="local", sql_dialect="hive", has_header=False)
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert "Sheet name is required for Excel files" in str(errors[0]["msg"])
+
+  def test_valid_excel_preview(self):
+    schema = PreviewFileSchema(
+      file_path="/path/to/test.xlsx",
+      file_type="excel",
+      import_type="local",
+      sql_dialect="hive",
+      has_header=True,
+      sheet_name="Sheet1",
+    )
+
+    assert schema.file_type == "excel"
+    assert schema.sheet_name == "Sheet1"
+
+  def test_delimiter_format_requires_field_separator(self):
+    with pytest.raises(ValidationError) as exc_info:
+      PreviewFileSchema(
+        file_path="/path/to/test.txt", file_type="delimiter_format", import_type="local", sql_dialect="hive", has_header=False
+      )
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert "Field separator is required for delimited files" in str(errors[0]["msg"])
+
+  def test_valid_delimiter_format(self):
+    schema = PreviewFileSchema(
+      file_path="/path/to/test.txt",
+      file_type="delimiter_format",
+      import_type="local",
+      sql_dialect="hive",
+      has_header=False,
+      field_separator="|",
+    )
+
+    assert schema.field_separator == "|"
+    assert schema.quote_char == '"'
+    assert schema.record_separator == "\n"
+
+  def test_invalid_file_type(self):
+    with pytest.raises(ValidationError) as exc_info:
+      PreviewFileSchema(file_path="/path/to/test.pdf", file_type="pdf", import_type="local", sql_dialect="hive", has_header=False)
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert "file_type" in str(errors[0]["loc"])
+
+  def test_invalid_file_path(self):
+    with pytest.raises(ValidationError) as exc_info:
+      PreviewFileSchema(file_path="", file_type="csv", import_type="local", sql_dialect="hive", has_header=False)
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert "file_path" in str(errors[0]["loc"])
+
+  def test_invalid_sql_dialect(self):
+    with pytest.raises(ValidationError) as exc_info:
+      PreviewFileSchema(file_path="/path/to/test.csv", file_type="csv", import_type="local", sql_dialect="mysql", has_header=False)
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert "sql_dialect" in str(errors[0]["loc"])
+
+  def test_decode_escape_sequences_field_separator(self):
+    # Test tab escape sequence
+    schema = PreviewFileSchema(
+      file_path="/path/to/test.txt",
+      file_type="delimiter_format",
+      import_type="local",
+      sql_dialect="hive",
+      has_header=True,
+      field_separator="\\t",  # Tab character as escape sequence
+    )
+
+    assert schema.field_separator == "\t"  # Should be decoded to actual tab
+
+    # Test newline escape sequence
+    schema = PreviewFileSchema(
+      file_path="/path/to/test.txt",
+      file_type="delimiter_format",
+      import_type="local",
+      sql_dialect="hive",
+      has_header=True,
+      field_separator="\\n",
+    )
+    assert schema.field_separator == "\n"
+
+    # Test backslash escape sequence
+    schema = PreviewFileSchema(
+      file_path="/path/to/test.txt",
+      file_type="delimiter_format",
+      import_type="local",
+      sql_dialect="hive",
+      has_header=True,
+      field_separator="\\\\",
+    )
+    assert schema.field_separator == "\\"
+
+  def test_decode_escape_sequences_quote_char(self):
+    # Test double quote escape sequence
+    schema = PreviewFileSchema(
+      file_path="/path/to/test.csv",
+      file_type="csv",
+      import_type="local",
+      sql_dialect="hive",
+      has_header=True,
+      quote_char='\\"',  # Escaped double quote
+    )
+
+    assert schema.quote_char == '"'
+
+    # Test single quote escape sequence
+    schema = PreviewFileSchema(
+      file_path="/path/to/test.csv",
+      file_type="csv",
+      import_type="local",
+      sql_dialect="hive",
+      has_header=True,
+      quote_char="\\'",
+    )
+    assert schema.quote_char == "'"
+
+    # Test Unicode escape sequence
+    schema = PreviewFileSchema(
+      file_path="/path/to/test.csv",
+      file_type="csv",
+      import_type="local",
+      sql_dialect="hive",
+      has_header=True,
+      quote_char="\\u0022",  # Unicode for double quote
+    )
+    assert schema.quote_char == '"'
+
+  def test_decode_escape_sequences_record_separator(self):
+    # Test newline escape sequence
+    schema = PreviewFileSchema(
+      file_path="/path/to/test.csv",
+      file_type="csv",
+      import_type="local",
+      sql_dialect="hive",
+      has_header=True,
+      record_separator="\\n",
+    )
+
+    assert schema.record_separator == "\n"
+
+    # Test carriage return + newline (should be normalized to just newline)
+    schema = PreviewFileSchema(
+      file_path="/path/to/test.csv",
+      file_type="csv",
+      import_type="local",
+      sql_dialect="hive",
+      has_header=True,
+      record_separator="\\r\\n",
+    )
+    assert schema.record_separator == "\n"  # Should be normalized
+
+    # Test just carriage return
+    schema = PreviewFileSchema(
+      file_path="/path/to/test.csv",
+      file_type="csv",
+      import_type="local",
+      sql_dialect="hive",
+      has_header=True,
+      record_separator="\\r",
+    )
+    assert schema.record_separator == "\r"
+
+  def test_decode_escape_sequences_with_none_values(self):
+    # Test that None values are handled properly and defaults are set
+    schema = PreviewFileSchema(
+      file_path="/path/to/test.csv",
+      file_type="csv",
+      import_type="local",
+      sql_dialect="hive",
+      has_header=True,
+      field_separator=None,
+      quote_char=None,
+      record_separator=None,
+    )
+
+    # CSV defaults should be applied
+    assert schema.field_separator == ","
+    assert schema.quote_char == '"'
+    assert schema.record_separator == "\n"
+
+  def test_decode_escape_sequences_with_complex_patterns(self):
+    # Test multiple escape sequences in a single value
+    schema = PreviewFileSchema(
+      file_path="/path/to/test.txt",
+      file_type="delimiter_format",
+      import_type="local",
+      sql_dialect="hive",
+      has_header=True,
+      field_separator="\\t\\t",  # Double tab
+      quote_char="\\x22",  # Hex escape for double quote
+      record_separator="\\x0A",  # Hex escape for newline
+    )
+
+    assert schema.field_separator == "\t\t"
+    assert schema.quote_char == '"'
+    assert schema.record_separator == "\n"
+
+  def test_decode_escape_sequences_preserves_regular_strings(self):
+    # Test that regular strings without escape sequences are preserved
+    schema = PreviewFileSchema(
+      file_path="/path/to/test.txt",
+      file_type="delimiter_format",
+      import_type="local",
+      sql_dialect="hive",
+      has_header=True,
+      field_separator="|",
+      quote_char="'",
+      record_separator="###",
+    )
+
+    assert schema.field_separator == "|"
+    assert schema.quote_char == "'"
+    assert schema.record_separator == "###"
+
+  def test_decode_escape_sequences_mixed_scenarios(self):
+    # Test various escape sequence patterns
+    test_cases = [
+      ("\\x09", "\t"),  # Hex escape for tab
+      ("\\u0009", "\t"),  # Unicode escape for tab
+      ("\\a", "\a"),  # Bell/alert character
+      ("\\b", "\b"),  # Backspace
+      ("\\f", "\f"),  # Form feed
+      ("\\v", "\v"),  # Vertical tab
+      ("\\0", "\0"),  # Null character
+    ]
+
+    for input_val, expected_val in test_cases:
+      schema = PreviewFileSchema(
+        file_path="/path/to/test.txt",
+        file_type="delimiter_format",
+        import_type="local",
+        sql_dialect="hive",
+        has_header=True,
+        field_separator=input_val,
+      )
+      assert schema.field_separator == expected_val, f"Failed for input: {repr(input_val)}"
+
+  def test_record_separator_normalization(self):
+    # Test that \r\n is normalized to \n
+    schema = PreviewFileSchema(
+      file_path="/path/to/test.csv",
+      file_type="csv",
+      import_type="local",
+      sql_dialect="hive",
+      has_header=True,
+      record_separator="\r\n",  # Already decoded value
+    )
+    assert schema.record_separator == "\n"  # Should be normalized
+
+    # But \r alone should remain as \r
+    schema = PreviewFileSchema(
+      file_path="/path/to/test.csv",
+      file_type="csv",
+      import_type="local",
+      sql_dialect="hive",
+      has_header=True,
+      record_separator="\r",
+    )
+    assert schema.record_separator == "\r"  # Should NOT be normalized
+
+
+class TestSqlTypeMapperSchema:
+  def test_valid_sql_dialects(self):
+    valid_dialects = ["hive", "impala", "trino", "phoenix", "sparksql"]
+
+    for dialect in valid_dialects:
+      schema = SqlTypeMapperSchema(sql_dialect=dialect)
+      assert schema.sql_dialect == dialect
+
+  def test_invalid_sql_dialect(self):
+    with pytest.raises(ValidationError) as exc_info:
+      SqlTypeMapperSchema(sql_dialect="mysql")
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert "sql_dialect" in str(errors[0]["loc"])
+
+  def test_missing_sql_dialect(self):
+    with pytest.raises(ValidationError) as exc_info:
+      SqlTypeMapperSchema()
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert "sql_dialect" in str(errors[0]["loc"])
+
+
+class TestGuessFileHeaderSchema:
+  def test_valid_csv_header_guess(self):
+    schema = GuessFileHeaderSchema(file_path="/path/to/test.csv", file_type="csv", import_type="local")
+
+    assert schema.file_path == "/path/to/test.csv"
+    assert schema.file_type == "csv"
+    assert schema.import_type == "local"
+    assert schema.sheet_name is None
+
+  def test_excel_requires_sheet_name(self):
+    with pytest.raises(ValidationError) as exc_info:
+      GuessFileHeaderSchema(file_path="/path/to/test.xlsx", file_type="excel", import_type="local")
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert "Sheet name is required for Excel files" in str(errors[0]["msg"])
+
+  def test_valid_excel_header_guess(self):
+    schema = GuessFileHeaderSchema(file_path="/path/to/test.xlsx", file_type="excel", import_type="local", sheet_name="Sheet1")
+
+    assert schema.file_type == "excel"
+    assert schema.sheet_name == "Sheet1"
+
+  def test_valid_remote_file_header_guess(self):
+    schema = GuessFileHeaderSchema(file_path="s3a://bucket/test.csv", file_type="csv", import_type="remote")
+
+    assert schema.file_path == "s3a://bucket/test.csv"
+    assert schema.import_type == "remote"
+
+  def test_all_file_types(self):
+    valid_file_types = ["csv", "tsv", "delimiter_format"]
+
+    for file_type in valid_file_types:
+      schema = GuessFileHeaderSchema(file_path=f"/path/to/test.{file_type}", file_type=file_type, import_type="local")
+      assert schema.file_type == file_type
+
+  def test_invalid_file_type(self):
+    with pytest.raises(ValidationError) as exc_info:
+      GuessFileHeaderSchema(file_path="/path/to/test.pdf", file_type="pdf", import_type="local")
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert "file_type" in str(errors[0]["loc"])
+
+  def test_missing_required_fields(self):
+    with pytest.raises(ValidationError) as exc_info:
+      GuessFileHeaderSchema(file_path="/path/to/test.csv")
+
+    errors = exc_info.value.errors()
+    assert len(errors) >= 2  # At least file_type and import_type are missing
+
+  def test_invalid_file_path(self):
+    with pytest.raises(ValidationError) as exc_info:
+      GuessFileHeaderSchema(file_path="", file_type="csv", import_type="local")
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert "file_path" in str(errors[0]["loc"])

--- a/desktop/core/src/desktop/lib/importer/serializers.py
+++ b/desktop/core/src/desktop/lib/importer/serializers.py
@@ -14,11 +14,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 
+from pydantic import ValidationError
 from rest_framework import serializers
 
-from desktop.conf import IMPORTER
+from desktop.lib.importer.schemas import (
+  GuessFileHeaderSchema,
+  GuessFileMetadataSchema,
+  LocalFileUploadSchema,
+  PreviewFileSchema,
+  SqlTypeMapperSchema,
+)
 
 
 class LocalFileUploadSerializer(serializers.Serializer):
@@ -33,20 +39,14 @@ class LocalFileUploadSerializer(serializers.Serializer):
 
   file = serializers.FileField(required=True, help_text="CSV or Excel file to upload and process")
 
-  def validate_file(self, value):
-    # Check if the file type is restricted
-    _, file_type = os.path.splitext(value.name)
-    restricted_extensions = IMPORTER.RESTRICT_LOCAL_FILE_EXTENSIONS.get()
-    if restricted_extensions and file_type.lower() in [ext.lower() for ext in restricted_extensions]:
-      raise serializers.ValidationError(f'Uploading files with type "{file_type}" is not allowed. Hue is configured to restrict this type.')
-
-    # Check file size
-    max_size = IMPORTER.MAX_LOCAL_FILE_SIZE_UPLOAD_LIMIT.get()
-    if value.size > max_size:
-      max_size_mib = max_size / (1024 * 1024)
-      raise serializers.ValidationError(f"File too large. Maximum file size is {max_size_mib:.0f} MiB.")
-
-    return value
+  def validate(self, data):
+    uploaded_file = data["file"]
+    schema_data = {"file": uploaded_file, "filename": uploaded_file.name, "filesize": uploaded_file.size}
+    try:
+      # The serializer now directly returns the validated Pydantic model instance.
+      return LocalFileUploadSchema.model_validate(schema_data)
+    except ValidationError as e:
+      raise serializers.ValidationError(e.errors())
 
 
 class GuessFileMetadataSerializer(serializers.Serializer):
@@ -63,6 +63,12 @@ class GuessFileMetadataSerializer(serializers.Serializer):
   import_type = serializers.ChoiceField(
     choices=["local", "remote"], required=True, help_text="Whether the file is local or on a remote filesystem"
   )
+
+  def validate(self, data):
+    try:
+      return GuessFileMetadataSchema.model_validate(data)
+    except ValidationError as e:
+      raise serializers.ValidationError(e.errors())
 
 
 class PreviewFileSerializer(serializers.Serializer):
@@ -92,40 +98,18 @@ class PreviewFileSerializer(serializers.Serializer):
   sql_dialect = serializers.ChoiceField(
     choices=["hive", "impala", "trino", "phoenix", "sparksql"], required=True, help_text="SQL dialect for mapping column types"
   )
-
   has_header = serializers.BooleanField(required=True, help_text="Whether the file has a header row or not")
-
-  # Excel-specific fields
   sheet_name = serializers.CharField(required=False, help_text="Sheet name for Excel files")
-
-  # Delimited file-specific fields
   field_separator = serializers.CharField(required=False, help_text="Field separator character")
   quote_char = serializers.CharField(required=False, help_text="Quote character")
   record_separator = serializers.CharField(required=False, help_text="Record separator character")
 
   def validate(self, data):
-    """Validate the complete data set with interdependent field validation."""
-
-    if data.get("file_type") == "excel" and not data.get("sheet_name"):
-      raise serializers.ValidationError({"sheet_name": "Sheet name is required for Excel files."})
-
-    if data.get("file_type") in ["csv", "tsv", "delimiter_format"]:
-      if not data.get("field_separator"):
-        # If not provided, set default value based on file type
-        if data.get("file_type") == "csv":
-          data["field_separator"] = ","
-        elif data.get("file_type") == "tsv":
-          data["field_separator"] = "\t"
-        else:
-          raise serializers.ValidationError({"field_separator": "Field separator is required for delimited files"})
-
-      if not data.get("quote_char"):
-        data["quote_char"] = '"'  # Default quote character
-
-      if not data.get("record_separator"):
-        data["record_separator"] = "\n"  # Default record separator
-
-    return data
+    try:
+      # Pydantic will handle interdependent validation
+      return PreviewFileSchema.model_validate(data)
+    except ValidationError as e:
+      raise serializers.ValidationError(e.errors())
 
 
 class SqlTypeMapperSerializer(serializers.Serializer):
@@ -141,6 +125,12 @@ class SqlTypeMapperSerializer(serializers.Serializer):
   sql_dialect = serializers.ChoiceField(
     choices=["hive", "impala", "trino", "phoenix", "sparksql"], required=True, help_text="SQL dialect for mapping column types"
   )
+
+  def validate(self, data):
+    try:
+      return SqlTypeMapperSchema.model_validate(data)
+    except ValidationError as e:
+      raise serializers.ValidationError(e.errors())
 
 
 class GuessFileHeaderSerializer(serializers.Serializer):
@@ -162,14 +152,11 @@ class GuessFileHeaderSerializer(serializers.Serializer):
   import_type = serializers.ChoiceField(
     choices=["local", "remote"], required=True, help_text="Whether the file is local or on a remote filesystem"
   )
-
-  # Excel-specific fields
   sheet_name = serializers.CharField(required=False, help_text="Sheet name for Excel files")
 
   def validate(self, data):
-    """Validate the complete data set with interdependent field validation."""
-
-    if data.get("file_type") == "excel" and not data.get("sheet_name"):
-      raise serializers.ValidationError({"sheet_name": "Sheet name is required for Excel files."})
-
-    return data
+    try:
+      # Pydantic will handle interdependent validation
+      return GuessFileHeaderSchema.model_validate(data)
+    except ValidationError as e:
+      raise serializers.ValidationError(e.errors())

--- a/desktop/core/src/desktop/lib/importer/serializers.py
+++ b/desktop/core/src/desktop/lib/importer/serializers.py
@@ -100,9 +100,9 @@ class PreviewFileSerializer(serializers.Serializer):
   )
   has_header = serializers.BooleanField(required=True, help_text="Whether the file has a header row or not")
   sheet_name = serializers.CharField(required=False, help_text="Sheet name for Excel files")
-  field_separator = serializers.CharField(required=False, help_text="Field separator character")
-  quote_char = serializers.CharField(required=False, help_text="Quote character")
-  record_separator = serializers.CharField(required=False, help_text="Record separator character")
+  field_separator = serializers.CharField(required=False, allow_null=True, help_text="Field separator character")
+  quote_char = serializers.CharField(required=False, allow_null=True, help_text="Quote character")
+  record_separator = serializers.CharField(required=False, allow_null=True, help_text="Record separator character")
 
   def validate(self, data):
     try:


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Added Pydantic schemas for local file uploads, file metadata guessing, file previews, and SQL type mapping to improve data validation and structure.
- Updated the `local_file_upload`, `guess_file_metadata`, `preview_file`, `guess_file_header`, and `get_sql_type_mapping` functions to utilize these schemas, enhancing type safety and clarity.
- Refactored serializers to leverage Pydantic for validation, simplifying the validation logic and improving error handling.
- Included the `pydantic` dependency in requirements for schema validation support.

## How was this patch tested?

- Manually
- Running new and existing unit tests