### PR TITLE
[filebrowser] Implement better file extension restrictions for uploads

### DIFF
--- a/apps/filebrowser/src/filebrowser/conf.py
+++ b/apps/filebrowser/src/filebrowser/conf.py
@@ -18,7 +18,7 @@
 from django.utils.translation import gettext_lazy as _
 
 from desktop.conf import ENABLE_DOWNLOAD, is_oozie_enabled
-from desktop.lib.conf import Config, coerce_bool, coerce_csv
+from desktop.lib.conf import coerce_bool, coerce_csv, Config
 
 MAX_SNAPPY_DECOMPRESSION_SIZE = Config(
   key="max_snappy_decompression_size", help=_("Max snappy decompression size in bytes."), private=True, default=1024 * 1024 * 25, type=int
@@ -104,10 +104,18 @@ FILE_DOWNLOAD_CACHE_CONTROL = Config(
 )
 
 RESTRICT_FILE_EXTENSIONS = Config(
-  key='restrict_file_extensions',
+  key="restrict_file_extensions",
+  default=None,
+  type=coerce_csv,
+  help=_("Specify file extensions that are not allowed, separated by commas. For example: .exe, .zip, .rar, .tar, .gz"),
+)
+
+ALLOW_FILE_EXTENSIONS = Config(
+  key="allow_file_extensions",
   default=None,
   type=coerce_csv,
   help=_(
-    'Specify file extensions that are not allowed, separated by commas. For example: .exe, .zip, .rar, .tar, .gz'
+    "Specify file extensions that are allowed, separated by commas."
+    "When set, only these extensions will be permitted. For example: .tsv, .csv, .xlsx"
   ),
 )

--- a/apps/filebrowser/src/filebrowser/utils.py
+++ b/apps/filebrowser/src/filebrowser/utils.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import io
-import os
 import logging
+import os
 from datetime import datetime
 from urllib.parse import urlparse
 
@@ -23,7 +23,7 @@ import redis
 
 from desktop.conf import TASK_SERVER_V2
 from desktop.lib.django_util import JsonResponse
-from filebrowser.conf import ARCHIVE_UPLOAD_TEMPDIR
+from filebrowser.conf import ALLOW_FILE_EXTENSIONS, ARCHIVE_UPLOAD_TEMPDIR, RESTRICT_FILE_EXTENSIONS
 
 LOG = logging.getLogger()
 
@@ -130,3 +130,41 @@ def release_reserved_space_for_file_uploads(uuid):
     LOG.exception("Failed to release reserved space: %s", str(e))
   finally:
     redis_client.close()
+
+
+def is_file_upload_allowed(file_name):
+  """
+  Check if a file upload is allowed based on file extension restrictions.
+
+  Args:
+    file_name: The name of the file being uploaded
+
+  Returns:
+    tuple: (is_allowed, error_message)
+      - is_allowed: Boolean indicating if the file upload is allowed
+      - error_message: String with error message if not allowed, None otherwise
+  """
+  if not file_name:
+    return True, None
+
+  _, file_type = os.path.splitext(file_name)
+  if file_type:
+    file_type = file_type.lower()
+
+  # Check allow list first - if set, only these extensions are allowed
+  allow_list = ALLOW_FILE_EXTENSIONS.get()
+  if allow_list:
+    # Normalize extensions to lowercase with dots
+    normalized_allow_list = [ext.lower() if ext.startswith(".") else f".{ext.lower()}" for ext in allow_list]
+    if file_type not in normalized_allow_list:
+      return False, f'File type "{file_type}" is not permitted. Modify file upload settings to allow this type.'
+
+  # Check restrict list - if set, these extensions are not allowed
+  restrict_list = RESTRICT_FILE_EXTENSIONS.get()
+  if restrict_list:
+    # Normalize extensions to lowercase with dots
+    normalized_restrict_list = [ext.lower() if ext.startswith(".") else f".{ext.lower()}" for ext in restrict_list]
+    if file_type in normalized_restrict_list:
+      return False, f'File type "{file_type}" is restricted. Update file upload restrictions to allow this type.'
+
+  return True, None

--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -1768,6 +1768,9 @@ submit_to=True
 # Specify file extensions that are not allowed, separated by commas.
 ## restrict_file_extensions=.exe, .zip, .rar, .tar, .gz
 
+# Specify file extensions that are allowed, separated by commas.
+## allow_file_extensions=.tsv, .csv, .xlsx
+
 ###########################################################################
 # Settings to configure Pig
 ###########################################################################

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -1750,6 +1750,8 @@
   # Specify file extensions that are not allowed, separated by commas.
   ## restrict_file_extensions=.exe, .zip, .rar, .tar, .gz
 
+  # Specify file extensions that are allowed, separated by commas.
+  ## allow_file_extensions=.tsv, .csv, .xlsx
 
 ###########################################################################
 # Settings to configure Pig

--- a/desktop/core/src/desktop/lib/fs/gc/upload.py
+++ b/desktop/core/src/desktop/lib/fs/gc/upload.py
@@ -21,7 +21,6 @@ Classes for a custom upload handler to stream into GS.
 See http://docs.djangoproject.com/en/1.9/topics/http/file-uploads/
 """
 
-import os
 import logging
 from io import BytesIO as stream_io
 
@@ -31,7 +30,7 @@ from django.core.files.uploadhandler import FileUploadHandler, StopFutureHandler
 from desktop.lib.fs.gc import parse_uri
 from desktop.lib.fs.gc.gs import GSFileSystemException
 from desktop.lib.fsmanager import get_client
-from filebrowser.conf import RESTRICT_FILE_EXTENSIONS
+from filebrowser.utils import is_file_upload_allowed
 
 LOG = logging.getLogger()
 
@@ -59,6 +58,7 @@ class GSFileUploadHandler(FileUploadHandler):
     self._request = request
     self._mp = None
     self._part_num = 1
+    self._upload_rejected = False
 
     if self._is_gs_upload():
       self._fs = get_client(fs='gs', user=request.user.username)
@@ -76,11 +76,13 @@ class GSFileUploadHandler(FileUploadHandler):
     if self._is_gs_upload():
       LOG.info('Using GSFileUploadHandler to handle file upload.')
 
-      _, file_type = os.path.splitext(file_name)
-      if RESTRICT_FILE_EXTENSIONS.get() and file_type.lower() in [ext.lower() for ext in RESTRICT_FILE_EXTENSIONS.get()]:
-        err_message = f'Uploading files with type "{file_type}" is not allowed. Hue is configured to restrict this type.'
+      # Check file extension restrictions
+      is_allowed, err_message = is_file_upload_allowed(file_name)
+      if not is_allowed:
         LOG.error(err_message)
-        raise Exception(err_message)
+        self.request.META['upload_failed'] = err_message
+        self._upload_rejected = True
+        return None
 
       super().new_file(field_name, file_name, *args, **kwargs)
 
@@ -106,6 +108,8 @@ class GSFileUploadHandler(FileUploadHandler):
 
     This method is called for each data chunk received during the upload process.
     """
+    if self._upload_rejected:
+      return None
     if self._is_gs_upload():
       try:
         LOG.debug("GSFileUploadHandler uploading file part: %d" % self._part_num)
@@ -125,6 +129,8 @@ class GSFileUploadHandler(FileUploadHandler):
 
     This method is called when the entire file has been uploaded.
     """
+    if self._upload_rejected:
+      return None
     if self._is_gs_upload():
       LOG.info("GSFileUploadHandler has completed file upload to GS, total file size is: %d." % file_size)
       self._mp.complete_upload()

--- a/desktop/libs/aws/src/aws/s3/upload.py
+++ b/desktop/libs/aws/src/aws/s3/upload.py
@@ -21,13 +21,12 @@ Classes for a custom upload handler to stream into S3.
 See http://docs.djangoproject.com/en/1.9/topics/http/file-uploads/
 """
 
-import os
 import logging
 import unicodedata
 from io import BytesIO as stream_io
 
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.files.uploadhandler import FileUploadHandler, SkipFile, StopFutureHandlers, StopUpload, UploadFileException
+from django.core.files.uploadhandler import FileUploadHandler, StopFutureHandlers, StopUpload, UploadFileException
 from django.utils.translation import gettext as _
 
 from aws.s3 import parse_uri
@@ -35,8 +34,7 @@ from aws.s3.s3fs import S3FileSystemException
 from desktop.conf import TASK_SERVER_V2
 from desktop.lib.exceptions_renderable import PopupException
 from desktop.lib.fsmanager import get_client
-from filebrowser.conf import RESTRICT_FILE_EXTENSIONS
-from filebrowser.utils import calculate_total_size, generate_chunks
+from filebrowser.utils import calculate_total_size, generate_chunks, is_file_upload_allowed
 
 DEFAULT_WRITE_SIZE = 1024 * 1024 * 128  # TODO: set in configuration (currently 128 MiB)
 
@@ -148,6 +146,7 @@ class S3FileUploadHandler(FileUploadHandler):
     self._request = request
     self._mp = None
     self._part_num = 1
+    self._upload_rejected = False
 
     if self._is_s3_upload():
       self._fs = get_client(fs='s3a', user=request.user.username)
@@ -160,11 +159,13 @@ class S3FileUploadHandler(FileUploadHandler):
     if self._is_s3_upload():
       LOG.info('Using S3FileUploadHandler to handle file upload.')
 
-      _, file_type = os.path.splitext(file_name)
-      if RESTRICT_FILE_EXTENSIONS.get() and file_type.lower() in [ext.lower() for ext in RESTRICT_FILE_EXTENSIONS.get()]:
-        err_message = f'Uploading files with type "{file_type}" is not allowed. Hue is configured to restrict this type.'
+      # Check file extension restrictions
+      is_allowed, err_message = is_file_upload_allowed(file_name)
+      if not is_allowed:
         LOG.error(err_message)
-        raise Exception(err_message)
+        self.request.META['upload_failed'] = err_message
+        self._upload_rejected = True
+        return None
 
       super(S3FileUploadHandler, self).new_file(field_name, file_name, *args, **kwargs)
 
@@ -184,6 +185,8 @@ class S3FileUploadHandler(FileUploadHandler):
         raise StopUpload()
 
   def receive_data_chunk(self, raw_data, start):
+    if self._upload_rejected:
+      return None
     if self._is_s3_upload():
       try:
         LOG.debug("S3FileUploadHandler uploading file part: %d" % self._part_num)
@@ -199,6 +202,8 @@ class S3FileUploadHandler(FileUploadHandler):
       return raw_data
 
   def file_complete(self, file_size):
+    if self._upload_rejected:
+      return None
     if self._is_s3_upload():
       # Finish the upload
       LOG.info("S3FileUploadHandler has completed file upload to S3, total file size is: %d." % file_size)


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Added configuration options for allowed and restricted file extensions in file uploads.
- Introduced a new utility function, is_file_upload_allowed, to validate file extensions against the configured lists.
- Updated upload handlers across various storage backends (GCS, S3, ABFS, Ozone, HDFS) to utilize the new validation logic.
- Enhanced documentation in configuration templates to reflect the new options for file extension management.

## How was this patch tested?

- Manually