### PR TITLE
[ui-filebrowser] remove redundant Error keyword from alert

### DIFF
--- a/desktop/core/src/desktop/static/desktop/js/listdir-inline.js
+++ b/desktop/core/src/desktop/static/desktop/js/listdir-inline.js
@@ -1448,7 +1448,7 @@ var FileBrowserModel = function (files, page, breadcrumbs, currentDirPath) {
               onComplete: function (id, fileName, response) {
                 self.pendingUploads(self.pendingUploads() - 1);
                 if (response.status != 0) {
-                  huePubSub.publish('hue.global.error', {message: window.I18n('Error: ') + response.data});
+                  huePubSub.publish('hue.global.error', {message: response.data});
                 }
                 else {
                   var task_id = response.task_id;
@@ -1562,7 +1562,7 @@ var FileBrowserModel = function (files, page, breadcrumbs, currentDirPath) {
               onComplete: function (id, fileName, response) {
                 self.pendingUploads(self.pendingUploads() - 1);
                 if (response.status != 0) {
-                  huePubSub.publish('hue.global.error', {message: window.I18n('Error: ') + response.data});
+                  huePubSub.publish('hue.global.error', {message: response.data});
                 }
                 else {
                   huePubSub.publish('hue.global.info', {message: response.path + window.I18n(' uploaded successfully.')});
@@ -1628,7 +1628,7 @@ var FileBrowserModel = function (files, page, breadcrumbs, currentDirPath) {
           onComplete: function (id, fileName, response) {
             self.pendingUploads(self.pendingUploads() - 1);
             if (response.status != 0) {
-              huePubSub.publish('hue.global.error', {message: window.I18n('Error: ') + response.data});
+              huePubSub.publish('hue.global.error', {message: response.data});
               
             }
             else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Removed redundant "Error:" keyword in the alert of the old file browser.

## How was this patch tested?

- Manually tested

current state:
![image](https://github.com/user-attachments/assets/7072dc90-8e0c-46fc-a855-ab5067fd682f)

New state:
![image](https://github.com/user-attachments/assets/64df89dc-b16a-44a6-a50a-5c4a62384d2a)


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
