### PR TITLE
[beeswax] Do not error on invalid session in request

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py
+++ b/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py
@@ -705,7 +705,7 @@ DROP TABLE IF EXISTS `%(table)s`;
         filters = {'id': session_id, 'application': 'beeswax' if type == 'hive' or type == 'llap' else type}
         if not is_admin(self.user):
           filters['owner'] = self.user
-        return Session.objects.get(**filters)
+        return Session.objects.filter(**filters).first()
 
   def _get_hive_execution_engine(self, notebook, snippet):
     # Get hive.execution.engine from snippet properties, if none, then get from session


### PR DESCRIPTION
If the frontend sends a request with session that is no longer in the db or malformed, the current `Session.object.get()` throws an error. The change to using `filter().first()` would get the session if found in db or `None` rather than throwing an exception. This would let the query proceed with a new session getting created.

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
