### PR TITLE
Fix kt_renewer startup crash due to directory creation race condition

### DIFF
--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -137,7 +137,7 @@ UPLOAD_CLASSES = {
 }
 
 if hasattr(ARCHIVE_UPLOAD_TEMPDIR, 'get') and not os.path.exists(ARCHIVE_UPLOAD_TEMPDIR.get()):
-  os.makedirs(ARCHIVE_UPLOAD_TEMPDIR.get())
+  os.makedirs(ARCHIVE_UPLOAD_TEMPDIR.get(), exist_ok=True)
 
 logger = logging.getLogger()
 

--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -136,7 +136,7 @@ UPLOAD_CLASSES = {
     'local': LocalFineUploaderChunkedUpload,
 }
 
-if hasattr(ARCHIVE_UPLOAD_TEMPDIR, 'get') and not os.path.exists(ARCHIVE_UPLOAD_TEMPDIR.get()):
+if hasattr(ARCHIVE_UPLOAD_TEMPDIR, 'get'):
   os.makedirs(ARCHIVE_UPLOAD_TEMPDIR.get(), exist_ok=True)
 
 logger = logging.getLogger()


### PR DESCRIPTION
## What changes were proposed in this pull request?
kt_renewer consistently crashes on first startup in CDH 7.3.1 but works when manually restarted.
Race condition between multiple Hue processes during startup:
1. Process 1 checks `os.path.exists('/tmp/hue_uploads')` → False
2. Process 2 checks `os.path.exists('/tmp/hue_uploads')` → False  
3. Process 1 calls `os.makedirs('/tmp/hue_uploads')` → Success
4. Process 2 calls `os.makedirs('/tmp/hue_uploads')` → FileExistsError

Add `exist_ok=True` parameter to `os.makedirs()` to make directory creation race-condition safe.

- (Please fill in changes proposed in this fix)

## How was this patch tested?

Tested on CM-CDH cluster.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
