### PR TITLE
[importer] Update SQL type mapping API to return unique SQL types as a sorted list and change its docs section

### DIFF
--- a/desktop/core/src/desktop/lib/importer/api.py
+++ b/desktop/core/src/desktop/lib/importer/api.py
@@ -203,18 +203,18 @@ def guess_file_header(request: Request) -> Response:
 @parser_classes([JSONParser])
 @api_error_handler
 def get_sql_type_mapping(request: Request) -> Response:
-  """Get mapping from Polars data types to SQL types for a specific dialect.
+  """Get SQL types supported by a specific dialect.
 
-  This API endpoint returns a dictionary mapping Polars data types to the corresponding
-  SQL types for a specific SQL dialect.
+  This API endpoint returns a sorted list of unique SQL types that are supported
+  by a specific SQL dialect.
 
   Args:
     request: Request object containing query parameters:
-      - sql_dialect: The SQL dialect to get mappings for (e.g., 'hive', 'impala', 'trino')
+      - sql_dialect: The SQL dialect to get types for (e.g., 'hive', 'impala', 'trino')
 
   Returns:
-    Response containing a mapping dictionary:
-      - A mapping from Polars data type names to SQL type names for the specified dialect
+    Response containing a list of SQL types:
+      - A sorted list of unique SQL type names supported by the specified dialect
   """
   serializer = SqlTypeMapperSerializer(data=request.query_params)
 

--- a/desktop/core/src/desktop/lib/importer/api_tests.py
+++ b/desktop/core/src/desktop/lib/importer/api_tests.py
@@ -619,7 +619,23 @@ class TestSqlTypeMappingAPI:
     mock_serializer = MagicMock(is_valid=MagicMock(return_value=True), validated_data=mock_schema)
     mock_serializer_class.return_value = mock_serializer
 
-    mock_get_sql_type_mapping.return_value = {"Int32": "INT", "Utf8": "STRING", "Float64": "DOUBLE", "Boolean": "BOOLEAN"}
+    mock_get_sql_type_mapping.return_value = [
+      "ARRAY",
+      "BIGINT",
+      "BINARY",
+      "BOOLEAN",
+      "DATE",
+      "DECIMAL",
+      "DOUBLE",
+      "FLOAT",
+      "INT",
+      "INTERVAL DAY TO SECOND",
+      "SMALLINT",
+      "STRING",
+      "STRUCT",
+      "TIMESTAMP",
+      "TINYINT",
+    ]
 
     request = APIRequestFactory().get("importer/sql_type_mapping/")
     request.user = MagicMock(username="test_user")
@@ -628,7 +644,23 @@ class TestSqlTypeMappingAPI:
     response = api.get_sql_type_mapping(request)
 
     assert response.status_code == status.HTTP_200_OK
-    assert response.data == {"Int32": "INT", "Utf8": "STRING", "Float64": "DOUBLE", "Boolean": "BOOLEAN"}
+    assert response.data == [
+      "ARRAY",
+      "BIGINT",
+      "BINARY",
+      "BOOLEAN",
+      "DATE",
+      "DECIMAL",
+      "DOUBLE",
+      "FLOAT",
+      "INT",
+      "INTERVAL DAY TO SECOND",
+      "SMALLINT",
+      "STRING",
+      "STRUCT",
+      "TIMESTAMP",
+      "TINYINT",
+    ]
     mock_get_sql_type_mapping.assert_called_once_with(mock_schema)
 
   @patch("desktop.lib.importer.api.SqlTypeMapperSerializer")

--- a/desktop/core/src/desktop/lib/importer/operations_tests.py
+++ b/desktop/core/src/desktop/lib/importer/operations_tests.py
@@ -585,42 +585,25 @@ class TestSqlTypeMapping:
 
     result = operations.get_sql_type_mapping(schema)
 
-    # Test all integer types (signed and unsigned)
-    assert result["Int8"] == "TINYINT"
-    assert result["Int16"] == "SMALLINT"
-    assert result["Int32"] == "INT"
-    assert result["Int64"] == "BIGINT"
-    assert result["UInt8"] == "TINYINT"  # Unsigned mapped to signed in Hive
-    assert result["UInt16"] == "SMALLINT"
-    assert result["UInt32"] == "INT"
-    assert result["UInt64"] == "BIGINT"
-
-    # Test floating point and decimal types
-    assert result["Float32"] == "FLOAT"
-    assert result["Float64"] == "DOUBLE"
-    assert result["Decimal"] == "DECIMAL"
-
-    # Test boolean, string, and binary types
-    assert result["Boolean"] == "BOOLEAN"
-    assert result["Utf8"] == "STRING"
-    assert result["String"] == "STRING"
-    assert result["Categorical"] == "STRING"
-    assert result["Enum"] == "STRING"
-    assert result["Binary"] == "BINARY"
-
-    # Test temporal types
-    assert result["Date"] == "DATE"
-    assert result["Time"] == "TIMESTAMP"  # No pure TIME type in Hive
-    assert result["Datetime"] == "TIMESTAMP"
-    assert result["Duration"] == "INTERVAL DAY TO SECOND"
-
-    # Test nested and other types
-    assert result["Array"] == "ARRAY"
-    assert result["List"] == "ARRAY"
-    assert result["Struct"] == "STRUCT"
-    assert result["Object"] == "STRING"
-    assert result["Null"] == "STRING"
-    assert result["Unknown"] == "STRING"
+    # Test that Hive returns the expected unique SQL types
+    expected_hive_types = [
+      "ARRAY",
+      "BIGINT",
+      "BINARY",
+      "BOOLEAN",
+      "DATE",
+      "DECIMAL",
+      "DOUBLE",
+      "FLOAT",
+      "INT",
+      "INTERVAL DAY TO SECOND",
+      "SMALLINT",
+      "STRING",
+      "STRUCT",
+      "TIMESTAMP",
+      "TINYINT",
+    ]
+    assert result == expected_hive_types
 
   def test_get_sql_type_mapping_trino(self):
     # Create schema object
@@ -628,26 +611,27 @@ class TestSqlTypeMapping:
 
     result = operations.get_sql_type_mapping(schema)
 
-    # Test Trino-specific overrides
-    assert result["Int32"] == "INTEGER"  # Not INT
-    assert result["UInt32"] == "INTEGER"  # Not INT
-    assert result["Float32"] == "REAL"  # Not FLOAT
-    assert result["Utf8"] == "VARCHAR"  # Not STRING
-    assert result["String"] == "VARCHAR"  # Not STRING
-    assert result["Binary"] == "VARBINARY"  # Not BINARY
-    assert result["Struct"] == "ROW"  # Not STRUCT
-    assert result["Object"] == "JSON"  # Not STRING
-    assert result["Duration"] == "INTERVAL DAY TO SECOND"
-
-    # Test types that remain the same as base mapping
-    assert result["Int8"] == "TINYINT"
-    assert result["Int16"] == "SMALLINT"
-    assert result["Int64"] == "BIGINT"
-    assert result["Float64"] == "DOUBLE"
-    assert result["Boolean"] == "BOOLEAN"
-    assert result["Date"] == "DATE"
-    assert result["Time"] == "TIMESTAMP"
-    assert result["Datetime"] == "TIMESTAMP"
+    # Test that Trino returns the expected unique SQL types
+    expected_trino_types = [
+      "ARRAY",
+      "BIGINT",
+      "BOOLEAN",
+      "DATE",
+      "DECIMAL",
+      "DOUBLE",
+      "INTEGER",
+      "INTERVAL DAY TO SECOND",
+      "JSON",
+      "REAL",
+      "ROW",
+      "SMALLINT",
+      "STRING",
+      "TIMESTAMP",
+      "TINYINT",
+      "VARBINARY",
+      "VARCHAR",
+    ]
+    assert result == expected_trino_types
 
   def test_get_sql_type_mapping_phoenix(self):
     # Create schema object
@@ -655,34 +639,29 @@ class TestSqlTypeMapping:
 
     result = operations.get_sql_type_mapping(schema)
 
-    # Test Phoenix-specific unsigned integer mappings
-    assert result["UInt8"] == "UNSIGNED_TINYINT"
-    assert result["UInt16"] == "UNSIGNED_SMALLINT"
-    assert result["UInt32"] == "UNSIGNED_INT"
-    assert result["UInt64"] == "UNSIGNED_LONG"
-
-    # Test other Phoenix-specific overrides
-    assert result["Utf8"] == "VARCHAR"  # Not STRING
-    assert result["String"] == "VARCHAR"  # Not STRING
-    assert result["Binary"] == "VARBINARY"  # Not BINARY
-    assert result["Duration"] == "STRING"  # Phoenix treats durations as strings
-    assert result["Struct"] == "STRING"  # No native STRUCT type
-    assert result["Object"] == "VARCHAR"  # Not STRING
-    assert result["Time"] == "TIME"  # Phoenix has its own TIME type
-    assert result["Decimal"] == "DECIMAL"
-
-    # Test signed integers (use base mapping)
-    assert result["Int8"] == "TINYINT"
-    assert result["Int16"] == "SMALLINT"
-    assert result["Int32"] == "INT"
-    assert result["Int64"] == "BIGINT"
-
-    # Test other types that remain the same
-    assert result["Float32"] == "FLOAT"
-    assert result["Float64"] == "DOUBLE"
-    assert result["Boolean"] == "BOOLEAN"
-    assert result["Date"] == "DATE"
-    assert result["Datetime"] == "TIMESTAMP"
+    # Test that Phoenix returns the expected unique SQL types
+    expected_phoenix_types = [
+      "ARRAY",
+      "BIGINT",
+      "BOOLEAN",
+      "DATE",
+      "DECIMAL",
+      "DOUBLE",
+      "FLOAT",
+      "INT",
+      "SMALLINT",
+      "STRING",
+      "TIME",
+      "TIMESTAMP",
+      "TINYINT",
+      "UNSIGNED_INT",
+      "UNSIGNED_LONG",
+      "UNSIGNED_SMALLINT",
+      "UNSIGNED_TINYINT",
+      "VARBINARY",
+      "VARCHAR",
+    ]
+    assert result == expected_phoenix_types
 
   def test_get_sql_type_mapping_impala(self):
     # Create schema object
@@ -690,30 +669,25 @@ class TestSqlTypeMapping:
 
     result = operations.get_sql_type_mapping(schema)
 
-    # Impala uses all base mappings (no overrides)
-    # Test a comprehensive set to ensure no overrides are applied
-    assert result["Int8"] == "TINYINT"
-    assert result["Int16"] == "SMALLINT"
-    assert result["Int32"] == "INT"
-    assert result["Int64"] == "BIGINT"
-    assert result["UInt8"] == "TINYINT"
-    assert result["UInt16"] == "SMALLINT"
-    assert result["UInt32"] == "INT"
-    assert result["UInt64"] == "BIGINT"
-    assert result["Float32"] == "FLOAT"
-    assert result["Float64"] == "DOUBLE"
-    assert result["Decimal"] == "DECIMAL"
-    assert result["Boolean"] == "BOOLEAN"
-    assert result["Utf8"] == "STRING"
-    assert result["String"] == "STRING"
-    assert result["Binary"] == "BINARY"
-    assert result["Date"] == "DATE"
-    assert result["Time"] == "TIMESTAMP"
-    assert result["Datetime"] == "TIMESTAMP"
-    assert result["Duration"] == "INTERVAL DAY TO SECOND"
-    assert result["Array"] == "ARRAY"
-    assert result["Struct"] == "STRUCT"
-    assert result["Object"] == "STRING"
+    # Test that Impala returns the expected unique SQL types
+    # Note: Impala doesn't support INTERVAL types, so Duration maps to STRING
+    expected_impala_types = [
+      "ARRAY",
+      "BIGINT",
+      "BINARY",
+      "BOOLEAN",
+      "DATE",
+      "DECIMAL",
+      "DOUBLE",
+      "FLOAT",
+      "INT",
+      "SMALLINT",
+      "STRING",
+      "STRUCT",
+      "TIMESTAMP",
+      "TINYINT",
+    ]
+    assert result == expected_impala_types
 
   def test_get_sql_type_mapping_sparksql(self):
     # Create schema object
@@ -721,73 +695,66 @@ class TestSqlTypeMapping:
 
     result = operations.get_sql_type_mapping(schema)
 
-    # SparkSQL uses all base mappings (no overrides)
-    # Test a comprehensive set to ensure no overrides are applied
-    assert result["Int8"] == "TINYINT"
-    assert result["Int16"] == "SMALLINT"
-    assert result["Int32"] == "INT"
-    assert result["Int64"] == "BIGINT"
-    assert result["UInt8"] == "TINYINT"
-    assert result["UInt16"] == "SMALLINT"
-    assert result["UInt32"] == "INT"
-    assert result["UInt64"] == "BIGINT"
-    assert result["Float32"] == "FLOAT"
-    assert result["Float64"] == "DOUBLE"
-    assert result["Decimal"] == "DECIMAL"
-    assert result["Boolean"] == "BOOLEAN"
-    assert result["Utf8"] == "STRING"
-    assert result["String"] == "STRING"
-    assert result["Binary"] == "BINARY"
-    assert result["Date"] == "DATE"
-    assert result["Time"] == "TIMESTAMP"
-    assert result["Datetime"] == "TIMESTAMP"
-    assert result["Duration"] == "INTERVAL DAY TO SECOND"
-    assert result["Array"] == "ARRAY"
-    assert result["Struct"] == "STRUCT"
-    assert result["Object"] == "STRING"
+    # Test that SparkSQL returns the expected unique SQL types (same as Hive)
+    expected_sparksql_types = [
+      "ARRAY",
+      "BIGINT",
+      "BINARY",
+      "BOOLEAN",
+      "DATE",
+      "DECIMAL",
+      "DOUBLE",
+      "FLOAT",
+      "INT",
+      "INTERVAL DAY TO SECOND",
+      "SMALLINT",
+      "STRING",
+      "STRUCT",
+      "TIMESTAMP",
+      "TINYINT",
+    ]
+    assert result == expected_sparksql_types
 
   def test_get_sql_type_mapping_all_dialects_consistency(self):
-    # Test that all dialects return mappings for all base types
+    # Test that all dialects return a non-empty list of SQL types
     dialects = ["hive", "impala", "sparksql", "trino", "phoenix"]
-    base_types = [
-      "Int8",
-      "Int16",
-      "Int32",
-      "Int64",
-      "UInt8",
-      "UInt16",
-      "UInt32",
-      "UInt64",
-      "Float32",
-      "Float64",
-      "Decimal",
-      "Boolean",
-      "Utf8",
-      "String",
-      "Categorical",
-      "Enum",
-      "Binary",
-      "Date",
-      "Time",
-      "Datetime",
-      "Duration",
-      "Array",
-      "List",
-      "Struct",
-      "Object",
-      "Null",
-      "Unknown",
-    ]
 
     for dialect in dialects:
       schema = SqlTypeMapperSchema(sql_dialect=dialect)
       result = operations.get_sql_type_mapping(schema)
 
-      # Ensure all base types have mappings
-      for base_type in base_types:
-        assert base_type in result, f"Missing mapping for {base_type} in {dialect} dialect"
-        assert isinstance(result[base_type], str), f"Invalid mapping type for {base_type} in {dialect} dialect"
-        assert len(result[base_type]) > 0, f"Empty mapping for {base_type} in {dialect} dialect"
+      # Ensure result is a list
+      assert isinstance(result, list), f"Result for {dialect} is not a list"
+
+      # Ensure the list is not empty
+      assert len(result) > 0, f"Empty result for {dialect} dialect"
+
+      # Ensure all items in the list are strings
+      for sql_type in result:
+        assert isinstance(sql_type, str), f"Invalid type in result for {dialect}: {sql_type}"
+        assert len(sql_type) > 0, f"Empty SQL type string in {dialect} dialect"
+
+  def test_get_polars_to_sql_mapping(self):
+    # Test the internal function that returns the full mapping
+
+    # Test Hive dialect
+    hive_mapping = operations._get_polars_to_sql_mapping("hive")
+    assert isinstance(hive_mapping, dict)
+    assert hive_mapping["Int32"] == "INT"
+    assert hive_mapping["Utf8"] == "STRING"
+    assert hive_mapping["Boolean"] == "BOOLEAN"
+
+    # Test Trino dialect with overrides
+    trino_mapping = operations._get_polars_to_sql_mapping("trino")
+    assert isinstance(trino_mapping, dict)
+    assert trino_mapping["Int32"] == "INTEGER"  # Override
+    assert trino_mapping["Float32"] == "REAL"  # Override
+    assert trino_mapping["Utf8"] == "VARCHAR"  # Override
+    assert trino_mapping["Boolean"] == "BOOLEAN"  # No override
+
+    # Test unsupported dialect
+    with pytest.raises(ValueError, match="Unsupported dialect"):
+      operations._get_polars_to_sql_mapping("unsupported_dialect")
 
   def test_map_polars_dtype_to_sql_type(self):
     # Test comprehensive type mapping for each dialect
@@ -816,6 +783,11 @@ class TestSqlTypeMapping:
     assert operations._map_polars_dtype_to_sql_type("phoenix", "Time") == "TIME"
     assert operations._map_polars_dtype_to_sql_type("phoenix", "Duration") == "STRING"
     assert operations._map_polars_dtype_to_sql_type("phoenix", "Struct") == "STRING"
+
+    # Impala dialect tests (with Duration override)
+    assert operations._map_polars_dtype_to_sql_type("impala", "Duration") == "STRING"
+    assert operations._map_polars_dtype_to_sql_type("impala", "Int32") == "INT"  # No override
+    assert operations._map_polars_dtype_to_sql_type("impala", "Utf8") == "STRING"  # No override
 
     # Test error for unknown type
     with pytest.raises(ValueError, match="No mapping for Polars dtype"):

--- a/docs/docs-site/content/developer/api/rest/_index.md
+++ b/docs/docs-site/content/developer/api/rest/_index.md
@@ -792,7 +792,7 @@ The `delimiter_format` file type should be used for custom delimited files that 
 
 ### Get SQL Type Mapping
 
-Get mapping from Polars data types to SQL types for a specific SQL dialect.
+Get the list of unique SQL data types supported by a specific SQL dialect.
 
 **Endpoint:** `/api/v1/importer/sql_type_mapping/`
 
@@ -815,23 +815,23 @@ curl -X GET \
 **Response:**
 
 ```json
-{
-  "Int8": "TINYINT",
-  "Int16": "SMALLINT",
-  "Int32": "INT",
-  "Int64": "BIGINT",
-  "UInt8": "TINYINT",
-  "UInt16": "SMALLINT",
-  "UInt32": "INT",
-  "UInt64": "BIGINT",
-  "Float32": "FLOAT",
-  "Float64": "DOUBLE",
-  "Boolean": "BOOLEAN",
-  "Utf8": "STRING",
-  "String": "STRING",
-  "Date": "DATE",
-  "Datetime": "TIMESTAMP"
-}
+[
+  "ARRAY",
+  "BIGINT",
+  "BINARY",
+  "BOOLEAN",
+  "DATE",
+  "DECIMAL",
+  "DOUBLE",
+  "FLOAT",
+  "INT",
+  "INTERVAL DAY TO SECOND",
+  "SMALLINT",
+  "STRING",
+  "STRUCT",
+  "TIMESTAMP",
+  "TINYINT"
+]
 ```
 
 ### Complete Workflow Example

--- a/docs/docs-site/content/developer/api/rest/importer.md
+++ b/docs/docs-site/content/developer/api/rest/importer.md
@@ -402,7 +402,7 @@ The `delimiter_format` file type allows you to process custom delimited files th
 
 ## Get SQL Type Mapping
 
-Get mapping from Polars data types to SQL types for a specific SQL dialect. This helps in translating detected column types to appropriate SQL data types when creating tables.
+Get the list of unique SQL data types supported by a specific SQL dialect. This helps in understanding what SQL types are available when creating tables in different SQL engines.
 
 **Endpoint:** `/api/v1/importer/sql_type_mapping/`
 
@@ -432,73 +432,137 @@ fetch('https://demo.gethue.com/api/v1/importer/sql_type_mapping/?sql_dialect=hiv
   }
 })
 .then(response => response.json())
-.then(typeMappings => {
-  console.log(typeMappings);
-  // Use type mappings to generate SQL schema
+.then(sqlTypes => {
+  console.log(sqlTypes);
+  // Use SQL types list for validation or UI display
 })
 .catch(error => console.error('Error:', error));
 ```
 
 **Response:**
 
+The response is a sorted list of unique SQL data types supported by the specified dialect.
+
+For Hive:
 ```json
-{
-  "Int8": "TINYINT",
-  "Int16": "SMALLINT",
-  "Int32": "INT",
-  "Int64": "BIGINT",
-  "UInt8": "TINYINT",
-  "UInt16": "SMALLINT",
-  "UInt32": "INT",
-  "UInt64": "BIGINT",
-  "Float32": "FLOAT",
-  "Float64": "DOUBLE",
-  "Decimal": "DECIMAL",
-  "Boolean": "BOOLEAN",
-  "Utf8": "STRING",
-  "String": "STRING",
-  "Binary": "BINARY",
-  "Date": "DATE",
-  "Time": "TIMESTAMP",
-  "Datetime": "TIMESTAMP",
-  "Duration": "INTERVAL DAY TO SECOND",
-  "Array": "ARRAY",
-  "List": "ARRAY",
-  "Struct": "STRUCT"
-}
+[
+  "ARRAY",
+  "BIGINT",
+  "BINARY",
+  "BOOLEAN",
+  "DATE",
+  "DECIMAL",
+  "DOUBLE",
+  "FLOAT",
+  "INT",
+  "INTERVAL DAY TO SECOND",
+  "SMALLINT",
+  "STRING",
+  "STRUCT",
+  "TIMESTAMP",
+  "TINYINT"
+]
 ```
 
-**Dialect-Specific Type Mappings**
+**Dialect-Specific SQL Types**
 
-Different SQL dialects have variations in type names. Here are some key differences:
+Different SQL dialects support different sets of SQL types. Here are the unique types for each dialect:
 
-**Trino Types (compared to Hive):**
+**Trino:**
 ```json
-{
-  "Int32": "INTEGER",
-  "UInt32": "INTEGER",
-  "Utf8": "VARCHAR",
-  "String": "VARCHAR",
-  "Binary": "VARBINARY",
-  "Float32": "REAL",
-  "Struct": "ROW",
-  "Object": "JSON"
-}
+[
+  "ARRAY",
+  "BIGINT",
+  "BOOLEAN",
+  "DATE",
+  "DECIMAL",
+  "DOUBLE",
+  "INTEGER",
+  "INTERVAL DAY TO SECOND",
+  "JSON",
+  "REAL",
+  "ROW",
+  "SMALLINT",
+  "STRING",
+  "TIMESTAMP",
+  "TINYINT",
+  "VARBINARY",
+  "VARCHAR"
+]
 ```
 
-**Phoenix Types (compared to Hive):**
+**Impala:**
 ```json
-{
-  "UInt8": "UNSIGNED_TINYINT",
-  "UInt16": "UNSIGNED_SMALLINT",
-  "UInt32": "UNSIGNED_INT",
-  "UInt64": "UNSIGNED_LONG",
-  "Utf8": "VARCHAR",
-  "String": "VARCHAR",
-  "Binary": "VARBINARY",
-  "Time": "TIME"
-}
+[
+  "ARRAY",
+  "BIGINT",
+  "BINARY",
+  "BOOLEAN",
+  "DATE",
+  "DECIMAL",
+  "DOUBLE",
+  "FLOAT",
+  "INT",
+  "SMALLINT",
+  "STRING",
+  "STRUCT",
+  "TIMESTAMP",
+  "TINYINT"
+]
 ```
+
+**Phoenix:**
+```json
+[
+  "ARRAY",
+  "BIGINT",
+  "BOOLEAN",
+  "DATE",
+  "DECIMAL",
+  "DOUBLE",
+  "FLOAT",
+  "INT",
+  "SMALLINT",
+  "STRING",
+  "TIME",
+  "TIMESTAMP",
+  "TINYINT",
+  "UNSIGNED_INT",
+  "UNSIGNED_LONG",
+  "UNSIGNED_SMALLINT",
+  "UNSIGNED_TINYINT",
+  "VARBINARY",
+  "VARCHAR"
+]
+```
+
+**Spark SQL:**
+```json
+[
+  "ARRAY",
+  "BIGINT",
+  "BINARY",
+  "BOOLEAN",
+  "DATE",
+  "DECIMAL",
+  "DOUBLE",
+  "FLOAT",
+  "INT",
+  "INTERVAL DAY TO SECOND",
+  "SMALLINT",
+  "STRING",
+  "STRUCT",
+  "TIMESTAMP",
+  "TINYINT"
+]
+```
+
+**Key Differences Between Dialects:**
+
+- **Impala**: Does not support `INTERVAL` types (uses `STRING` for duration data)
+- **Trino**: Uses `INTEGER` instead of `INT`, `REAL` instead of `FLOAT`, `VARCHAR` instead of `STRING`, `ROW` instead of `STRUCT`, and supports `JSON` type
+- **Phoenix**: Supports unsigned integer types (`UNSIGNED_INT`, `UNSIGNED_LONG`, etc.) and has a dedicated `TIME` type
+- **Spark SQL**: Similar to Hive but follows more standard SQL conventions
 
 **Status Codes:**
 


### PR DESCRIPTION
This pull request refactors the `get_sql_type_mapping` API to return a sorted list of unique SQL types supported by a specific SQL dialect, instead of a mapping from Polars data types to SQL types. The changes simplify the API response and improve consistency across dialects. The most important changes include updates to the API implementation, adjustments to tests to reflect the new response format, and updates to documentation to align with the revised behavior.

### API Implementation Changes:
* Refactored `get_sql_type_mapping` in `desktop/lib/importer/operations.py` to return a sorted list of unique SQL types instead of a mapping dictionary. Introduced a helper function `_get_polars_to_sql_mapping` for internal use. [[1]](diffhunk://#diff-de3428bd573ff885faf6d14a8a3477b38df24b4587493591f3cc0627e4b693afL630-R676) [[2]](diffhunk://#diff-de3428bd573ff885faf6d14a8a3477b38df24b4587493591f3cc0627e4b693afL666-R690)
* Updated SQL type overrides for Impala to map `Duration` to `STRING`, as Impala does not support `INTERVAL` types.

### Test Updates:
* Updated test cases in `api_tests.py` and `operations_tests.py` to validate the new response format (a sorted list of SQL types) instead of the mapping. Adjusted assertions and added new tests for dialect-specific behavior. [[1]](diffhunk://#diff-5096f92ebf36bfb14d37e780cbaf308e09414567f1516637434fc1e2e2ce5d28L622-R638) [[2]](diffhunk://#diff-5096f92ebf36bfb14d37e780cbaf308e09414567f1516637434fc1e2e2ce5d28L631-R663) [[3]](diffhunk://#diff-4b54df457b0eedf50de5bccda0514c08e734179ce5119c1b37207b192b8c70e6L588-R757) [[4]](diffhunk://#diff-4b54df457b0eedf50de5bccda0514c08e734179ce5119c1b37207b192b8c70e6R787-R791)

### Documentation Updates:
* Revised API documentation in `docs-site/content/developer/api/rest/_index.md` and `importer.md` to reflect the new response format and provide examples of SQL types for different dialects. Added explanations for key differences between dialects. [[1]](diffhunk://#diff-e72f9ba227dc26f85835d564db61efba668257a76e6154b8d28f3ee055982f17L795-R795) [[2]](diffhunk://#diff-e72f9ba227dc26f85835d564db61efba668257a76e6154b8d28f3ee055982f17L818-R834) [[3]](diffhunk://#diff-0fef689a53b0d1ccb4dc42d7e63f2c3e9d93a3b43e26e23bea9d0b1bb7057876L405-R405) [[4]](diffhunk://#diff-0fef689a53b0d1ccb4dc42d7e63f2c3e9d93a3b43e26e23bea9d0b1bb7057876L435-R566)

These changes ensure the API is easier to use and maintain while improving clarity for developers interacting with SQL dialects.