### PR TITLE
[Core] remove --system-site-packages flag from virtualenv creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ $(BLD_DIR_ENV)/bin/python:
 	@mkdir -p $(BLD_DIR_ENV)
 	@$(SYS_PYTHON) -m pip install --upgrade pip==$(PIP_VERSION)
 	@$(SYS_PYTHON) -m pip install virtualenv==$(VIRTUAL_ENV_VERSION) virtualenv-make-relocatable==$(VIRTUAL_ENV_RELOCATABLE_VERSION)
-	@$(SYS_PYTHON) -m virtualenv --system-site-packages --copies -p $(PYTHON_VER) $(BLD_DIR_ENV)
+	@$(SYS_PYTHON) -m virtualenv --copies -p $(PYTHON_VER) $(BLD_DIR_ENV)
 	@$(ENV_PYTHON) -m pip install virtualenv==$(VIRTUAL_ENV_VERSION) virtualenv-make-relocatable==$(VIRTUAL_ENV_RELOCATABLE_VERSION)
 	@$(eval RELOCATABLE := $(shell which virtualenv-make-relocatable))
 	@echo "REQUIREMENT_FILE is $(REQUIREMENT_FILE)"


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Remove `--system-site-packages` flag to avoid package conflicts and ensure clean isolated environment for builds
 
## How was this patch tested?

- locally
- canary build