### PR TITLE
[ui-sb] moves the destination_path from FormData to query param

### DIFF
--- a/desktop/core/src/desktop/js/utils/hooks/useFileUpload/useRegularUpload.test.tsx
+++ b/desktop/core/src/desktop/js/utils/hooks/useFileUpload/useRegularUpload.test.tsx
@@ -107,15 +107,17 @@ describe('useRegularUpload', () => {
 
     const mockFormData = new FormData();
     mockFormData.append('file', mockFile.file);
-    mockFormData.append('destination_path', mockFile.filePath);
 
-    expect(mockSave).toHaveBeenCalledWith(
-      mockFormData,
-      expect.objectContaining({
-        onSuccess: expect.any(Function),
-        onError: expect.any(Function)
-      })
-    );
+    expect(mockSave).toHaveBeenCalledWith(mockFormData, {
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function),
+      postOptions: {
+        onUploadProgress: expect.any(Function),
+        params: {
+          destination_path: mockFile.filePath
+        }
+      }
+    });
     expect(mockUpdateFileVariables).toHaveBeenCalledWith(mockFile.uuid, {
       status: FileStatus.Uploading
     });

--- a/desktop/core/src/desktop/js/utils/hooks/useFileUpload/useRegularUpload.ts
+++ b/desktop/core/src/desktop/js/utils/hooks/useFileUpload/useRegularUpload.ts
@@ -21,13 +21,13 @@ import useSaveData from '../useSaveData/useSaveData';
 import { getItemProgress } from './utils';
 import { RegularFile, FileVariables, FileStatus } from './types';
 
-interface UseUploadQueueResponse {
-  addFiles: (item: RegularFile[]) => void;
+interface UseRegularUploadResponse {
+  addFiles: (items: RegularFile[], overwrite?: boolean) => void;
   cancelFile: (uuid: RegularFile['uuid']) => void;
   isLoading: boolean;
 }
 
-interface UploadQueueOptions {
+interface UseRegularUploadProps {
   concurrentProcess?: number;
   updateFileVariables: (item: RegularFile['uuid'], variables: FileVariables) => void;
   onComplete: () => void;
@@ -37,7 +37,7 @@ const useRegularUpload = ({
   concurrentProcess = DEFAULT_CONCURRENT_MAX_CONNECTIONS,
   updateFileVariables,
   onComplete
-}: UploadQueueOptions): UseUploadQueueResponse => {
+}: UseRegularUploadProps): UseRegularUploadResponse => {
   const { save } = useSaveData(UPLOAD_FILE_URL);
 
   const processRegularFile = async (item: RegularFile) => {
@@ -45,7 +45,6 @@ const useRegularUpload = ({
 
     const payload = new FormData();
     payload.append('file', item.file);
-    payload.append('destination_path', item.filePath);
 
     return save(payload, {
       onSuccess: () => {
@@ -55,6 +54,9 @@ const useRegularUpload = ({
         updateFileVariables(item.uuid, { status: FileStatus.Failed, error });
       },
       postOptions: {
+        params: {
+          destination_path: item.filePath
+        },
         onUploadProgress: progress => {
           const itemProgress = getItemProgress(progress);
           updateFileVariables(item.uuid, { progress: itemProgress });


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Moving the destination_path from FormData to query param, due to change in the backend API request schema

## How was this patch tested?

- Updated unit test

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
