### PR TITLE
[useradmin] Assign filebrowser permissions to the default group

### DIFF
--- a/apps/useradmin/src/useradmin/models.py
+++ b/apps/useradmin/src/useradmin/models.py
@@ -51,7 +51,6 @@ from desktop import appmanager
 from desktop.conf import ENABLE_CONNECTORS, ENABLE_ORGANIZATIONS
 from desktop.lib.connectors.models import _get_installed_connectors, Connector
 from desktop.lib.exceptions_renderable import PopupException
-from desktop.lib.idbroker.conf import is_idbroker_enabled
 from desktop.monkey_patches import monkey_patch_username_validator
 from useradmin.conf import DEFAULT_USER_GROUP
 from useradmin.permissions import GroupPermission, HuePermission, LdapGroup  # noqa: F401


### PR DESCRIPTION
## What changes were proposed in this pull request?

- This feature automatically grants File Browser permissions to the default user group.
- This simplifies the setup process by ensuring that users in the default group have immediate access to the File Browser without requiring manual permission adjustments.

## How was this patch tested?

- Manually
- Unittest