### PR TITLE
  [core] fix: eliminate duplicate config call in audit logger

### DIFF
--- a/desktop/core/src/desktop/log/__init__.py
+++ b/desktop/core/src/desktop/log/__init__.py
@@ -83,7 +83,8 @@ def get_audit_logger():
 
   audit_logger = logging.getLogger("audit")
   if not [hclass for hclass in audit_logger.handlers if isinstance(hclass, AuditHandler)]:  # Don't add handler twice
-    size, unit = int(AUDIT_LOG_MAX_FILE_SIZE.get()[:-2]), AUDIT_LOG_MAX_FILE_SIZE.get()[-2:]
+    audit_file_size = AUDIT_LOG_MAX_FILE_SIZE.get()
+    size, unit = int(audit_file_size[:-2]), audit_file_size[-2:]
     maxBytes = size * 1024 ** (1 if unit == "KB" else 2 if unit == "MB" else 3)
 
     audit_handler = AuditHandler(AUDIT_EVENT_LOG_DIR.get(), maxBytes=maxBytes, backupCount=50)


### PR DESCRIPTION
 ## Description
  Fix performance issue where
  `AUDIT_LOG_MAX_FILE_SIZE.get()` was called twice in the  same expression.

  ## Problem
  The `get_audit_logger()` function in
  `desktop/core/src/desktop/log/__init__.py` line 85 was making duplicate calls to the configuration system:
  ```python
  # Inefficient - calls .get() twice
  size, unit = int(AUDIT_LOG_MAX_FILE_SIZE.get()[:-2]),
  AUDIT_LOG_MAX_FILE_SIZE.get()[-2:]

  Solution

  Cache the configuration value in a local variable:
  # Efficient - calls .get() once
  audit_file_size = AUDIT_LOG_MAX_FILE_SIZE.get()
  size, unit = int(audit_file_size[:-2]),
  audit_file_size[-2:]

  Impact

  - Reduces unnecessary overhead in audit logger
  initialization
  - Improves code readability and maintainability
  - Follows Python best practices for avoiding redundant
  calls

  Testing

  - Verified the function logic remains unchanged
  - Confirmed audit logging still works correctly
  - No breaking changes to existing functionality

  Type of Change

  - Bug fix (non-breaking change which fixes an issue)
  - Performance improvement
  - New feature
  - Breaking change
  - Documentation update