### PR TITLE
[ui-storageBrowser] Add create bucket/volume/filesystem functionality

### DIFF
--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageDirectoryPage/StorageDirectoryActions/CreateAndUpload/CreateAndUploadAction.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageDirectoryPage/StorageDirectoryActions/CreateAndUpload/CreateAndUploadAction.tsx
@@ -195,9 +195,9 @@ const CreateAndUploadAction = ({
       children: actionConfig[ActionType.uploadFile].visible(currentPath)
         ? [
             {
-              icon: <ImportIcon />,
+              icon: actionConfig[ActionType.uploadFile].icon,
               key: ActionType.uploadFile,
-              label: t('Upload File'),
+              label: t(actionConfig[ActionType.uploadFile].label),
               onClick: () => fileInputRef.current?.click()
             }
           ]

--- a/desktop/core/src/desktop/js/utils/storageBrowserUtils.test.ts
+++ b/desktop/core/src/desktop/js/utils/storageBrowserUtils.test.ts
@@ -27,7 +27,8 @@ import {
   isOFSServiceID,
   isOFSVol,
   inTrash,
-  inRestorableTrash
+  inRestorableTrash,
+  isFileSystemRoot
 } from './storageBrowserUtils';
 
 describe('isHDFS function', () => {
@@ -221,5 +222,52 @@ describe('inRestorableTrash function', () => {
     expect(inRestorableTrash('/user/path/.Trash/Current')).toBe(true);
     expect(inRestorableTrash('/user/path/.Trash/Current/user')).toBe(true);
     expect(inRestorableTrash('/user/path/.Trash/Current/user/path')).toBe(true);
+  });
+});
+
+describe('isFileSystemRoot', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns true for non-root S3 path', () => {
+    expect(isFileSystemRoot('s3a://bucket/folder')).toBe(true);
+  });
+
+  it('returns false for S3 root path', () => {
+    expect(isFileSystemRoot('s3a://')).toBe(false);
+  });
+
+  it('returns true for non-root GS path', () => {
+    expect(isFileSystemRoot('gs://folder')).toBe(true);
+  });
+
+  it('returns false for GS root path', () => {
+    expect(isFileSystemRoot('gs://')).toBe(false);
+  });
+
+  it('returns true for non-root ABFS path', () => {
+    expect(isFileSystemRoot('abfs://folder')).toBe(true);
+  });
+
+  it('returns false for ABFS root path', () => {
+    expect(isFileSystemRoot('abfs://')).toBe(false);
+  });
+
+  it('returns true for OFS when not serviceID or volume', () => {
+    expect(isFileSystemRoot('ofs://service/volume/folder')).toBe(true);
+  });
+
+  it('returns false for OFS serviceID', () => {
+    expect(isFileSystemRoot('ofs://service')).toBe(false);
+  });
+
+  it('returns false for OFS volume', () => {
+    expect(isFileSystemRoot('ofs://service/vol')).toBe(false);
+  });
+
+  it('returns true for HDFS (default case)', () => {
+    expect(isFileSystemRoot('/hdfs')).toBe(true);
+    expect(isFileSystemRoot('/')).toBe(true);
   });
 });

--- a/desktop/core/src/desktop/js/utils/storageBrowserUtils.ts
+++ b/desktop/core/src/desktop/js/utils/storageBrowserUtils.ts
@@ -83,3 +83,20 @@ export const inTrash = (path: string): boolean => {
 export const inRestorableTrash = (path: string): boolean => {
   return path.match(/^\/user\/.+?\/\.Trash\/.+?/) !== null;
 };
+
+export const isFileSystemRoot = (path: string): boolean => {
+  if (isS3(path)) {
+    return !isS3Root(path);
+  }
+  if (isGS(path)) {
+    return !isGSRoot(path);
+  }
+  if (isABFS(path)) {
+    return !isABFSRoot(path);
+  }
+  if (isOFS(path)) {
+    return !isOFSServiceID(path) && !isOFSVol(path);
+  }
+  //in case of HDFS root and non root have same level of access. hence no check
+  return true;
+};


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Create bucket/volume/file systems based on current file path.
<img width="1643" height="369" alt="Screenshot 2025-08-22 at 3 00 58 AM" src="https://github.com/user-attachments/assets/4149259e-557e-46d0-a2ad-6e8a43258c6b" />
<img width="226" height="160" alt="Screenshot 2025-08-22 at 3 01 38 AM" src="https://github.com/user-attachments/assets/20ce273e-3c67-4f03-b6ef-666171221599" />
<img width="222" height="177" alt="Screenshot 2025-08-22 at 3 01 57 AM" src="https://github.com/user-attachments/assets/625647a2-c31c-4cc6-8986-506c649adc07" />
<img width="520" height="225" alt="Screenshot 2025-08-22 at 3 02 54 AM" src="https://github.com/user-attachments/assets/e25e7ad4-9463-4084-bff7-771be53f7612" />


## How was this patch tested?

- Manually
- Unit tests

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
