### PR TITLE
[ui-sb] fix: remove double decoding of url search params

### DIFF
--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserPage.tsx
@@ -31,8 +31,7 @@ import { getFileSystemAndPath } from '../../reactComponents/PathBrowser/PathBrow
 import { FileSystem } from './types';
 
 const StorageBrowserPage = (): JSX.Element => {
-  const urlSearchParams = new URLSearchParams(window.location.search);
-  const urlFilePath = decodeURIComponent(urlSearchParams.get('path') ?? '');
+  const urlFilePath = new URLSearchParams(window.location.search).get('path') ?? '';
   const { fileSystem: urlFileSystem } = getFileSystemAndPath(urlFilePath);
 
   const { t } = i18nReact.useTranslation();

--- a/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserTab/StorageBrowserTab.tsx
+++ b/desktop/core/src/desktop/js/apps/storageBrowser/StorageBrowserTab/StorageBrowserTab.tsx
@@ -50,9 +50,7 @@ const defaultProps = {
 };
 
 const StorageBrowserTab = ({ fileSystem, testId }: StorageBrowserTabProps): JSX.Element => {
-  const urlPathname = window.location.pathname;
-  const urlSearchParams = new URLSearchParams(window.location.search);
-  const urlFilePath = decodeURIComponent(urlSearchParams.get('path') ?? '');
+  const urlFilePath = new URLSearchParams(window.location.search).get('path') ?? '';
   const { fileSystem: urlFileSystem } = getFileSystemAndPath(urlFilePath);
   const initialFilePath =
     urlFileSystem === fileSystem.name ? urlFilePath : fileSystem.userHomeDirectory;
@@ -91,6 +89,7 @@ const StorageBrowserTab = ({ fileSystem, testId }: StorageBrowserTabProps): JSX.
   });
 
   useEffect(() => {
+    const urlPathname = window.location.pathname;
     const urlQueryParams = { path: filePath };
     const encodedSearchParams = new URLSearchParams(urlQueryParams).toString();
     if (filePath && urlFilePath && filePath !== urlFilePath) {
@@ -100,7 +99,7 @@ const StorageBrowserTab = ({ fileSystem, testId }: StorageBrowserTabProps): JSX.
     else if (encodedSearchParams !== window.location.search) {
       changeURL(urlPathname, urlQueryParams, true);
     }
-  }, [filePath, urlPathname, urlFilePath, window.location]);
+  }, [filePath, urlFilePath, window.location]);
 
   const errors = [
     {


### PR DESCRIPTION
## What changes were proposed in this pull request?

There was an unintentional double decoding of the URL search params.
1. `URLSearchParams` returns params with the decoded values
2. Decoding again using `decodeURIComponent`

hence, Removed decodeURIComponent

## How was this patch tested?

- Manually tested

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
