### PR TITLE
[core][s3] Add support for S3-compatible object stores with Boto3 migration

### DIFF
--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -2876,6 +2876,98 @@ def is_gs_enabled():
     conf_idbroker.is_idbroker_enabled('gs')
 
 
+PERMISSION_ACTION_S3 = "s3_access"
+
+S3_OBJECT_STORES = UnspecifiedConfigSection(
+  's3_object_stores',
+  help=_('One entry for each S3-compatible object store instance'),
+  each=ConfigSection(
+    help=_('Information about a single S3-compatible object store instance'),
+    members=dict(
+      NAME=Config(
+        key='name',
+        type=str,
+        default=None,
+        help=_('Display name of the object store instance')
+      ),
+      PROVIDER=Config(
+        key='provider',
+        type=str,
+        default='aws',  # aws, netapp, dell, generic
+        help=_('Object store provider type')
+      ),
+      REGION=Config(
+        key='region',
+        type=str,
+        default=None,
+        help=_('Default region for the object store')
+      ),
+      ENDPOINT=Config(
+        key='endpoint',
+        type=str,
+        default=None,
+        help=_('Custom endpoint URL for S3-compatible stores')
+      ),
+      AUTH_TYPE=Config(
+        key='auth_type',
+        type=str,
+        default='key',  # key, iam, raz, idbroker
+        help=_('Authentication type to use')
+      ),
+      ACCESS_KEY_ID=Config(
+        key='access_key_id',
+        type=str,
+        default=None,
+        help=_('Access key ID for key-based auth')
+      ),
+      SECRET_KEY=Config(
+        key='secret_key',
+        type=str,
+        private=True,
+        default=None,
+        help=_('Secret key for key-based auth')
+      ),
+      IAM_ROLE=Config(
+        key='iam_role',
+        type=str,
+        default=None,
+        help=_('IAM role to assume for AWS IAM auth')
+      ),
+      RAZ_URL=Config(
+        key='raz_url',
+        type=str,
+        default=None,
+        help=_('RAZ server URL for RAZ auth')
+      ),
+      IDBROKER_URL=Config(
+        key='idbroker_url',
+        type=str,
+        default=None,
+        help=_('IDBroker URL for IDBroker auth')
+      ),
+      BUCKET_REGION_MAP=Config(
+        key='bucket_region_map',
+        type=coerce_json_dict,
+        default='{}',
+        help=_('JSON mapping of bucket names to their regions')
+      ),
+      DEFAULT_HOME_PATH=Config(
+        key="default_home_path",
+        type=str,
+        default=None,
+        help=_("Default home directory path. e.g. s3a://gethue")
+      ),
+      OPTIONS=Config(
+        key='options',
+        type=coerce_json_dict,
+        default='{}',
+        help=_('Additional provider-specific options as JSON')
+      )
+    )
+  )
+)
+
+
 def has_gs_access(user):
   from desktop.auth.backend import is_admin
   return user.is_authenticated and user.is_active and (

--- a/desktop/core/src/desktop/lib/fs/s3/__init__.py
+++ b/desktop/core/src/desktop/lib/fs/s3/__init__.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/desktop/core/src/desktop/lib/fs/s3/clients/__init__.py
+++ b/desktop/core/src/desktop/lib/fs/s3/clients/__init__.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from desktop.lib.fs.s3.clients.auth.iam import IAMAuthProvider
+from desktop.lib.fs.s3.clients.auth.idbroker import IDBrokerAuthProvider
+from desktop.lib.fs.s3.clients.auth.key import KeyAuthProvider
+from desktop.lib.fs.s3.clients.auth.raz import RazAuthProvider
+from desktop.lib.fs.s3.clients.aws import AWSS3Client
+from desktop.lib.fs.s3.clients.factory import S3ClientFactory
+from desktop.lib.fs.s3.clients.generic import GenericS3Client
+
+# Register provider implementations
+S3ClientFactory.register_provider("aws", AWSS3Client)
+S3ClientFactory.register_provider("netapp", GenericS3Client)
+S3ClientFactory.register_provider("dell", GenericS3Client)
+S3ClientFactory.register_provider("generic", GenericS3Client)
+
+# Register auth providers
+S3ClientFactory.register_auth_provider("key", KeyAuthProvider)
+S3ClientFactory.register_auth_provider("iam", IAMAuthProvider)
+S3ClientFactory.register_auth_provider("raz", RazAuthProvider)
+S3ClientFactory.register_auth_provider("idbroker", IDBrokerAuthProvider)

--- a/desktop/core/src/desktop/lib/fs/s3/clients/auth/__init__.py
+++ b/desktop/core/src/desktop/lib/fs/s3/clients/auth/__init__.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/desktop/core/src/desktop/lib/fs/s3/clients/auth/iam.py
+++ b/desktop/core/src/desktop/lib/fs/s3/clients/auth/iam.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+import boto3
+from botocore.credentials import Credentials
+
+from desktop.lib.fs.s3.clients.base import S3AuthProvider
+
+LOG = logging.getLogger(__name__)
+
+
+class IAMAuthProvider(S3AuthProvider):
+  """
+  Authentication provider using AWS IAM roles.
+  Supports:
+  1. EC2 instance profiles
+  2. ECS task roles
+  3. Explicit IAM role assumption
+  """
+
+  def __init__(self, provider_id: str, user: str):
+    super().__init__(provider_id, user)
+    self._credentials = None
+    self._sts_client = None
+    self._role_arn = self.config.IAM_ROLE.get()
+    self._session_name = f"hue-{user}-session"
+    self._init_sts()
+
+  def _init_sts(self) -> None:
+    """Initialize STS client for role assumption if needed"""
+    try:
+      # Create STS client using instance/task credentials
+      self._sts_client = boto3.client("sts")
+
+      if self._role_arn:
+        # Assume the specified role
+        response = self._sts_client.assume_role(RoleArn=self._role_arn, RoleSessionName=self._session_name)
+        self._credentials = {
+          "access_key_id": response["Credentials"]["AccessKeyId"],
+          "secret_access_key": response["Credentials"]["SecretAccessKey"],
+          "session_token": response["Credentials"]["SessionToken"],
+          "expiration": response["Credentials"]["Expiration"],
+        }
+      else:
+        # Use instance/task credentials directly
+        instance_creds = boto3.Session().get_credentials()
+        if instance_creds:
+          self._credentials = {
+            "access_key_id": instance_creds.access_key,
+            "secret_access_key": instance_creds.secret_key,
+            "session_token": instance_creds.token,
+            "expiration": getattr(instance_creds, "_expiry_time", None),
+          }
+        else:
+          raise Exception("No instance credentials found")
+    except Exception as e:
+      LOG.error(f"Failed to initialize IAM credentials: {e}")
+      raise
+
+  def get_credentials(self) -> Dict[str, Any]:
+    """Get current IAM credentials"""
+    if self._should_refresh():
+      self.refresh()
+    return self._credentials
+
+  def get_session_kwargs(self) -> Dict[str, Any]:
+    """Get kwargs for creating boto3 session"""
+    creds = self.get_credentials()
+    return {
+      "aws_access_key_id": creds["access_key_id"],
+      "aws_secret_access_key": creds["secret_access_key"],
+      "aws_session_token": creds.get("session_token"),
+      "region_name": self.config.REGION.get(),
+    }
+
+  def _should_refresh(self) -> bool:
+    """Check if credentials need refresh"""
+    if not self._credentials:
+      return True
+    if "expiration" not in self._credentials:
+      return False
+
+    # Refresh if less than 5 minutes remaining
+    now = datetime.utcnow()
+    expiry = self._credentials["expiration"]
+    return (expiry - now).total_seconds() < 300
+
+  def refresh(self) -> None:
+    """Refresh IAM credentials"""
+    self._init_sts()

--- a/desktop/core/src/desktop/lib/fs/s3/clients/auth/idbroker.py
+++ b/desktop/core/src/desktop/lib/fs/s3/clients/auth/idbroker.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from desktop.lib.fs.s3.clients.base import S3AuthProvider
+from desktop.lib.idbroker import conf as conf_idbroker
+from desktop.lib.idbroker.client import IDBroker
+
+LOG = logging.getLogger(__name__)
+
+
+class IDBrokerAuthProvider(S3AuthProvider):
+  """
+  Authentication provider using IDBroker service.
+  IDBroker provides temporary credentials for S3 access.
+  """
+
+  def __init__(self, provider_id: str, user: str):
+    super().__init__(provider_id, user)
+    self._credentials = None
+    self._idbroker = None
+    self._init_idbroker()
+
+  def _init_idbroker(self) -> None:
+    """Initialize IDBroker client"""
+    try:
+      self._idbroker = IDBroker.from_core_site("s3a", self.user)
+      self._load_credentials()
+    except Exception as e:
+      LOG.error(f"Failed to initialize IDBroker: {e}")
+      raise
+
+  def _load_credentials(self) -> None:
+    """Load credentials from IDBroker"""
+    try:
+      cab = self._idbroker.get_cab()
+      if not cab or "Credentials" not in cab:
+        raise Exception("No credentials in IDBroker response")
+
+      creds = cab["Credentials"]
+      self._credentials = {
+        "access_key_id": creds.get("AccessKeyId"),
+        "secret_access_key": creds.get("SecretAccessKey"),
+        "session_token": creds.get("SessionToken"),
+        "expiration": creds.get("Expiration"),
+      }
+
+      if not self._credentials["access_key_id"] or not self._credentials["secret_access_key"]:
+        raise Exception("Missing required credentials from IDBroker")
+
+    except Exception as e:
+      LOG.error(f"Failed to load credentials from IDBroker: {e}")
+      raise
+
+  def get_credentials(self) -> Dict[str, Any]:
+    """Get current credentials"""
+    if self._should_refresh():
+      self.refresh()
+    return self._credentials
+
+  def get_session_kwargs(self) -> Dict[str, Any]:
+    """Get kwargs for creating boto3 session"""
+    creds = self.get_credentials()
+    return {
+      "aws_access_key_id": creds["access_key_id"],
+      "aws_secret_access_key": creds["secret_access_key"],
+      "aws_session_token": creds.get("session_token"),
+      "region_name": self.config.REGION.get(),
+    }
+
+  def _should_refresh(self) -> bool:
+    """Check if credentials need refresh"""
+    if not self._credentials:
+      return True
+    if "expiration" not in self._credentials:
+      return False
+
+    # Refresh if less than 5 minutes remaining
+    now = datetime.utcnow()
+    expiry = self._credentials["expiration"]
+    return (expiry - now).total_seconds() < 300
+
+  def refresh(self) -> None:
+    """Refresh credentials from IDBroker"""
+    self._load_credentials()
+
+  @classmethod
+  def is_enabled(cls) -> bool:
+    """Check if IDBroker is enabled"""
+    return conf_idbroker.is_idbroker_enabled("s3a")

--- a/desktop/core/src/desktop/lib/fs/s3/clients/auth/key.py
+++ b/desktop/core/src/desktop/lib/fs/s3/clients/auth/key.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict
+
+from desktop.lib.fs.s3.clients.base import S3AuthProvider
+
+
+class KeyAuthProvider(S3AuthProvider):
+  """
+  Authentication provider using access key and secret key.
+  Simple static credentials without refresh.
+  """
+
+  def __init__(self, provider_id: str, user: str):
+    super().__init__(provider_id, user)
+    self._credentials = None
+    self._load_credentials()
+
+  def _load_credentials(self) -> None:
+    """Load credentials from config"""
+    self._credentials = {"access_key_id": self.config.ACCESS_KEY_ID.get(), "secret_access_key": self.config.SECRET_KEY.get()}
+
+    if not self._credentials["access_key_id"] or not self._credentials["secret_access_key"]:
+      raise ValueError(f"Missing access key or secret key for provider {self.provider_id}")
+
+  def get_credentials(self) -> Dict[str, Any]:
+    """Get static credentials"""
+    return self._credentials
+
+  def get_session_kwargs(self) -> Dict[str, Any]:
+    """Get kwargs for creating boto3 session"""
+    return {
+      "aws_access_key_id": self._credentials["access_key_id"],
+      "aws_secret_access_key": self._credentials["secret_access_key"],
+      "region_name": self.config.REGION.get(),
+    }
+
+  def refresh(self) -> None:
+    """No refresh needed for static credentials"""
+    pass

--- a/desktop/core/src/desktop/lib/fs/s3/clients/auth/raz.py
+++ b/desktop/core/src/desktop/lib/fs/s3/clients/auth/raz.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Any, Dict, Optional
+from urllib.parse import urlencode, urlparse
+
+import boto3
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+from botocore.hooks import EventAliaser, HierarchicalEmitter
+from botocore.model import ServiceModel
+
+from desktop.lib.fs.s3.clients.base import S3AuthProvider
+from desktop.lib.raz.raz_client import get_raz_client
+
+LOG = logging.getLogger(__name__)
+
+
+class RazEventHandler:
+  """
+  Handles RAZ integration with boto3's event system.
+  Intercepts requests before they're signed and sent to S3.
+  """
+
+  def __init__(self, user: str, raz_url: str):
+    self.user = user
+    self.raz_client = get_raz_client(raz_url=raz_url, username=user)
+    self.event_emitter = self._create_event_emitter()
+
+  def _create_event_emitter(self) -> HierarchicalEmitter:
+    """Create boto3 event emitter with RAZ handlers"""
+    emitter = HierarchicalEmitter()
+
+    # Register event handlers
+    emitter.register("before-sign.*.*", self._handle_before_sign)
+    emitter.register("before-send.*.*", self._handle_before_send)
+
+    # Create aliaser for compatibility
+    return EventAliaser(emitter)
+
+  def _handle_before_sign(self, request: AWSRequest, **kwargs) -> None:
+    """
+    Handle before-sign event.
+    This is called before boto3 would normally sign the request.
+    We intercept here to get RAZ to sign instead.
+    """
+    try:
+      # Get request details
+      url = self._get_request_url(request)
+      method = request.method
+      headers = dict(request.headers)
+      data = request.body
+
+      # Get RAZ signed headers
+      raz_headers = self.raz_client.get_url(action=method, url=url, headers=headers, data=data)
+
+      if not raz_headers:
+        raise Exception("RAZ returned no signed headers")
+
+      # Update request headers with RAZ signed headers
+      request.headers.update(raz_headers)
+
+      # Mark request as pre-signed to skip boto3 signing
+      request.context["pre_signed"] = True
+
+    except Exception as e:
+      LOG.error(f"Failed to sign request with RAZ: {e}")
+      raise
+
+  def _handle_before_send(self, request: AWSRequest, **kwargs) -> None:
+    """
+    Handle before-send event.
+    This is called after signing but before sending.
+    We clean up any leftover AWS headers here.
+    """
+    # Remove any AWS specific headers that RAZ doesn't need
+    aws_headers = ["X-Amz-Security-Token", "X-Amz-Date", "X-Amz-Content-SHA256", "Authorization"]
+
+    for header in aws_headers:
+      request.headers.pop(header, None)
+
+  def _get_request_url(self, request: AWSRequest) -> str:
+    """
+    Get full request URL including query parameters.
+    Handles virtual hosted and path style URLs.
+    """
+    url_parts = list(urlparse(request.url))
+
+    # Add query parameters
+    if request.params:
+      query = urlencode(request.params)
+      url_parts[4] = query
+
+    # Handle virtual hosted style URLs
+    if "s3." in url_parts[1] and request.context.get("bucket_name"):
+      bucket = request.context["bucket_name"]
+      url_parts[1] = f"{bucket}.{url_parts[1]}"
+      # Remove bucket from path
+      url_parts[2] = url_parts[2].replace(f"/{bucket}", "", 1)
+
+    return urlparse.urlunparse(url_parts)
+
+
+class RazAuthProvider(S3AuthProvider):
+  """
+  Authentication provider using RAZ for request signing.
+  Uses boto3's event system to intercept and sign requests.
+  """
+
+  def __init__(self, provider_id: str, user: str):
+    super().__init__(provider_id, user)
+
+    self.raz_handler = RazEventHandler(user=user, raz_url=self.config.RAZ_URL.get())
+
+    # Store boto3 session with RAZ event handlers
+    self.session = boto3.Session(aws_access_key_id="dummy", aws_secret_access_key="dummy", region_name=self.config.REGION.get())
+    self.session.events = self.raz_handler.event_emitter
+
+  def get_credentials(self) -> Dict[str, Any]:
+    """
+    Return dummy credentials.
+    Real signing is done via event handlers.
+    """
+    return {"access_key_id": "dummy", "secret_access_key": "dummy"}
+
+  def get_session_kwargs(self) -> Dict[str, Any]:
+    """
+    Get kwargs for creating boto3 session.
+    Returns pre-configured session with RAZ event handlers.
+    """
+    return {"aws_access_key_id": "dummy", "aws_secret_access_key": "dummy", "region_name": self.config.REGION.get()}
+
+  def refresh(self) -> None:
+    """No refresh needed as we sign per-request"""
+    pass

--- a/desktop/core/src/desktop/lib/fs/s3/clients/aws.py
+++ b/desktop/core/src/desktop/lib/fs/s3/clients/aws.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Any, Optional
+
+import boto3
+from boto3.session import Session
+from botocore.credentials import Credentials
+from botocore.exceptions import ClientError
+
+from desktop.lib.fs.s3.clients.base import S3ClientInterface
+from desktop.lib.fs.s3.constants import DEFAULT_REGION
+
+LOG = logging.getLogger(__name__)
+
+
+class AWSS3Client(S3ClientInterface):
+  """
+  AWS S3 client implementation.
+  Handles AWS-specific features and optimizations.
+  """
+
+  def __init__(self, provider_id: str, user: str):
+    super().__init__(provider_id, user)
+
+    # AWS specific config
+    self.client_config.signature_version = "s3v4"
+    self.client_config.s3.update(
+      {
+        "use_accelerate_endpoint": self.config.OPTIONS.get().get("use_accelerate", False),
+        "payload_signing_enabled": True,
+        "use_dualstack_endpoint": self.config.OPTIONS.get().get("use_dualstack", False),
+      }
+    )
+
+  def _create_session(self) -> Session:
+    """Create boto3 session with credentials from auth provider"""
+    session_kwargs = self.auth_provider.get_session_kwargs()
+    return boto3.Session(**session_kwargs)
+
+  def _create_client(self) -> Any:
+    """Create boto3 S3 client"""
+    return self.session.client("s3", config=self.client_config, endpoint_url=self.config.ENDPOINT.get())
+
+  def _create_resource(self) -> Any:
+    """Create boto3 S3 resource"""
+    return self.session.resource("s3", config=self.client_config, endpoint_url=self.config.ENDPOINT.get())
+
+  def get_credentials(self) -> Optional[Credentials]:
+    """Get current credentials"""
+    return self.session.get_credentials()
+
+  def get_delegation_token(self) -> Optional[str]:
+    """Get delegation token (not supported for AWS)"""
+    return None
+
+  def get_region(self, bucket: str) -> str:
+    """
+    Get region for a bucket.
+    Checks:
+    1. Bucket region map from config
+    2. Bucket location constraint
+    3. Default region
+    """
+    # Check bucket region map first
+    region_map = self.config.BUCKET_REGION_MAP.get()
+    if bucket in region_map:
+      return region_map[bucket]
+
+    try:
+      # Try to get region from bucket location
+      response = self.s3_client.get_bucket_location(Bucket=bucket)
+      region = response.get("LocationConstraint")
+
+      # Handle special cases
+      if region is None:
+        # US East 1 returns None
+        return "us-east-1"
+      elif region == "EU":
+        # Legacy EU region
+        return "eu-west-1"
+
+      return region
+    except ClientError as e:
+      LOG.warning(f"Failed to get region for bucket {bucket}: {e}")
+      # Fall back to default region
+      return self.config.REGION.get() or DEFAULT_REGION
+
+  def validate_region(self, bucket: str) -> bool:
+    """
+    Validate that we're using the correct region for a bucket.
+    Important for signature v4 compatibility.
+    """
+    actual_region = self.get_region(bucket)
+    current_region = self.config.REGION.get() or DEFAULT_REGION
+
+    if actual_region != current_region:
+      LOG.warning(f"Bucket {bucket} is in region {actual_region} but client is configured for {current_region}")
+      return False
+    return True

--- a/desktop/core/src/desktop/lib/fs/s3/clients/base.py
+++ b/desktop/core/src/desktop/lib/fs/s3/clients/base.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional, Union
+
+from boto3.session import Session
+from botocore.client import Config
+from botocore.credentials import Credentials
+
+from desktop.conf import S3_OBJECT_STORES
+from desktop.lib.fs.s3.constants import CLIENT_CONFIG, TRANSFER_CONFIG
+
+
+class S3ClientInterface(ABC):
+  """
+  Base interface for S3 clients. All provider-specific clients must implement this interface.
+  """
+
+  def __init__(self, provider_id: str, user: str):
+    self.provider_id = provider_id
+    self.user = user
+    self.config = S3_OBJECT_STORES[provider_id]
+
+    # Initialize boto3 client config
+    self.client_config = Config(
+      **{
+        **CLIENT_CONFIG,
+        "region_name": self.config.REGION.get(),
+        "endpoint_url": self.config.ENDPOINT.get(),
+        "s3": {
+          "addressing_style": "path"  # Use path style for compatibility
+        },
+      }
+    )
+
+    # Initialize transfer config
+    self.transfer_config = TRANSFER_CONFIG.copy()
+
+    # Initialize session and clients
+    self.session = self._create_session()
+    self.s3_client = self._create_client()
+    self.s3_resource = self._create_resource()
+
+  @abstractmethod
+  def _create_session(self) -> Session:
+    """Create and return a boto3 session with appropriate credentials"""
+    pass
+
+  @abstractmethod
+  def _create_client(self) -> Any:
+    """Create and return a boto3 S3 client"""
+    pass
+
+  @abstractmethod
+  def _create_resource(self) -> Any:
+    """Create and return a boto3 S3 resource"""
+    pass
+
+  @abstractmethod
+  def get_credentials(self) -> Optional[Credentials]:
+    """Get credentials for the client"""
+    pass
+
+  @abstractmethod
+  def get_delegation_token(self) -> Optional[str]:
+    """Get delegation token if supported"""
+    pass
+
+  @abstractmethod
+  def get_region(self, bucket: str) -> str:
+    """Get region for a bucket"""
+    pass
+
+
+class S3AuthProvider(ABC):
+  """
+  Base interface for S3 authentication providers.
+  Each auth method (key, IAM, RAZ) must implement this interface.
+  """
+
+  def __init__(self, provider_id: str, user: str):
+    self.provider_id = provider_id
+    self.user = user
+    self.config = S3_OBJECT_STORES[provider_id]
+
+  @abstractmethod
+  def get_credentials(self) -> Dict[str, Any]:
+    """
+    Get credentials for S3 access.
+    Returns dict with keys:
+    - access_key_id
+    - secret_access_key
+    - session_token (optional)
+    - expiration (optional)
+    """
+    pass
+
+  @abstractmethod
+  def get_session_kwargs(self) -> Dict[str, Any]:
+    """Get kwargs for creating boto3 session"""
+    pass
+
+  @abstractmethod
+  def refresh(self) -> None:
+    """Refresh credentials if needed"""
+    pass

--- a/desktop/core/src/desktop/lib/fs/s3/clients/factory.py
+++ b/desktop/core/src/desktop/lib/fs/s3/clients/factory.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Type
+
+from desktop.conf import S3_OBJECT_STORES
+from desktop.lib.fs.s3.clients.base import S3AuthProvider, S3ClientInterface
+
+
+@dataclass
+class ClientConfig:
+  """Configuration for a single client instance"""
+
+  provider_id: str
+  name: str
+  provider_type: str
+  auth_type: str
+  endpoint: Optional[str]
+  region: Optional[str]
+
+
+class S3ClientFactory:
+  """Factory for creating S3 clients"""
+
+  _PROVIDER_MAP = {}  # Will be populated by register_provider
+  _AUTH_PROVIDER_MAP = {}  # Will be populated by register_auth_provider
+
+  @classmethod
+  def get_available_clients(cls, user: str) -> List[ClientConfig]:
+    """Get list of all available client configurations"""
+    configs = []
+
+    for provider_id, provider_conf in S3_OBJECT_STORES.items():
+      configs.append(
+        ClientConfig(
+          provider_id=provider_id,
+          name=provider_conf.NAME.get(),
+          provider_type=provider_conf.PROVIDER.get().lower(),
+          auth_type=provider_conf.AUTH_TYPE.get(),
+          endpoint=provider_conf.ENDPOINT.get(),
+          region=provider_conf.REGION.get(),
+        )
+      )
+
+    return configs
+
+  @classmethod
+  def get_client(cls, provider_id: str, user: str) -> S3ClientInterface:
+    """Get S3 client instance for given provider"""
+    if provider_id not in S3_OBJECT_STORES:
+      raise ValueError(f"Unknown provider ID: {provider_id}")
+
+    provider_conf = S3_OBJECT_STORES[provider_id]
+    provider_type = provider_conf.PROVIDER.get().lower()
+    auth_type = provider_conf.AUTH_TYPE.get()
+
+    # Validate provider and auth type
+    if provider_type not in cls._PROVIDER_MAP:
+      raise ValueError(f"Unknown provider type: {provider_type}")
+    if auth_type not in cls._AUTH_PROVIDER_MAP:
+      raise ValueError(f"Unknown auth type: {auth_type}")
+
+    # Create client with auth provider
+    client_class = cls._PROVIDER_MAP[provider_type]
+    auth_provider_class = cls._AUTH_PROVIDER_MAP[auth_type]
+
+    client = client_class(provider_id, user)
+    client.auth_provider = auth_provider_class(provider_id, user)
+
+    return client
+
+  @classmethod
+  def register_provider(cls, provider_type: str, client_class: Type[S3ClientInterface]) -> None:
+    """Register a new provider type"""
+    cls._PROVIDER_MAP[provider_type.lower()] = client_class
+
+  @classmethod
+  def register_auth_provider(cls, auth_type: str, auth_provider_class: Type[S3AuthProvider]) -> None:
+    """Register a new auth provider type"""
+    cls._AUTH_PROVIDER_MAP[auth_type.lower()] = auth_provider_class

--- a/desktop/core/src/desktop/lib/fs/s3/clients/generic.py
+++ b/desktop/core/src/desktop/lib/fs/s3/clients/generic.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Any, Dict, Optional
+
+import boto3
+from boto3.session import Session
+from botocore.credentials import Credentials
+from botocore.exceptions import ClientError
+
+from desktop.lib.fs.s3.clients.base import S3ClientInterface
+from desktop.lib.fs.s3.constants import DEFAULT_REGION
+
+LOG = logging.getLogger(__name__)
+
+
+class GenericS3Client(S3ClientInterface):
+  """
+  Generic S3 client for S3-compatible storage systems.
+  Supports any storage that implements the S3 API (Netapp, Dell, etc).
+  """
+
+  def __init__(self, provider_id: str, user: str):
+    super().__init__(provider_id, user)
+
+    # Override client config for generic providers
+    self.client_config.signature_version = self._get_signature_version()
+    self.client_config.s3.update(
+      {
+        "addressing_style": "path",  # Always use path style
+        "payload_signing_enabled": True,
+      }
+    )
+
+    # Apply provider-specific settings
+    self._setup_provider_specific_config()
+
+  def _get_signature_version(self) -> str:
+    """Get signature version based on provider"""
+    provider = self.config.PROVIDER.get().lower()
+    options = self.config.OPTIONS.get()
+
+    # Allow override via options
+    if "signature_version" in options:
+      return options["signature_version"]
+
+    # Provider-specific defaults
+    if provider == "netapp":
+      return "s3v4"  # NetApp StorageGRID uses v4
+    elif provider == "dell":
+      return "s3"  # Dell ECS defaults to v2
+    else:
+      return "s3v4"  # Default to v4
+
+  def _setup_provider_specific_config(self) -> None:
+    """Setup provider-specific configurations"""
+    provider = self.config.PROVIDER.get().lower()
+    options = self.config.OPTIONS.get()
+
+    if provider == "netapp":
+      self._setup_netapp_config(options)
+    elif provider == "dell":
+      self._setup_dell_config(options)
+    # Add more providers as needed
+
+  def _setup_netapp_config(self, options: Dict[str, Any]) -> None:
+    """Setup Netapp StorageGRID specific config"""
+    # SSL verification
+    if "ssl_verify" in options:
+      self.client_config.verify = options["ssl_verify"]
+
+    # Custom headers
+    if "custom_headers" in options:
+      self.client_config.s3["custom_headers"] = options["custom_headers"]
+
+  def _setup_dell_config(self, options: Dict[str, Any]) -> None:
+    """Setup Dell ECS specific config"""
+    # Namespace support
+    if "namespace" in options:
+      self.client_config.s3["namespace"] = options["namespace"]
+
+    # Multipart settings
+    if "multipart_threshold" in options:
+      self.transfer_config["multipart_threshold"] = options["multipart_threshold"]
+    if "multipart_chunksize" in options:
+      self.transfer_config["multipart_chunksize"] = options["multipart_chunksize"]
+
+  def _create_session(self) -> Session:
+    """Create boto3 session"""
+    session_kwargs = self.auth_provider.get_session_kwargs()
+    return boto3.Session(**session_kwargs)
+
+  def _create_client(self) -> Any:
+    """Create boto3 S3 client"""
+    return self.session.client(
+      "s3", config=self.client_config, endpoint_url=self.config.ENDPOINT.get(), verify=getattr(self.client_config, "verify", None)
+    )
+
+  def _create_resource(self) -> Any:
+    """Create boto3 S3 resource"""
+    return self.session.resource(
+      "s3", config=self.client_config, endpoint_url=self.config.ENDPOINT.get(), verify=getattr(self.client_config, "verify", None)
+    )
+
+  def get_credentials(self) -> Optional[Credentials]:
+    """Get current credentials"""
+    return self.session.get_credentials()
+
+  def get_delegation_token(self) -> Optional[str]:
+    """Get delegation token (not supported for generic providers)"""
+    return None
+
+  def get_region(self, bucket: str) -> str:
+    """
+    Get region for a bucket.
+    Most S3-compatible systems don't use regions,
+    so return configured region or default.
+    """
+    # Check bucket region map first
+    region_map = self.config.BUCKET_REGION_MAP.get()
+    if bucket in region_map:
+      return region_map[bucket]
+
+    return self.config.REGION.get() or DEFAULT_REGION
+
+  def validate_region(self, bucket: str) -> bool:
+    """
+    Validate region configuration.
+    Most S3-compatible systems don't use regions,
+    so always return True.
+    """
+    return True

--- a/desktop/core/src/desktop/lib/fs/s3/constants.py
+++ b/desktop/core/src/desktop/lib/fs/s3/constants.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+# Multipart upload settings
+DEFAULT_CHUNK_SIZE = 1024 * 1024 * 8  # 8MB
+MULTIPART_THRESHOLD = DEFAULT_CHUNK_SIZE  # Start multipart upload if file size > threshold
+MAX_POOL_CONNECTIONS = 10
+MAX_RETRIES = 3
+
+# Timeouts (in seconds)
+CONNECT_TIMEOUT = 30
+READ_TIMEOUT = 30
+
+# S3 specific constants
+S3_DELIMITER = "/"
+DEFAULT_REGION = "us-east-1"
+
+# Error retry settings
+RETRY_EXCEPTIONS = ("RequestTimeout", "ConnectionError", "HTTPClientError")
+
+# Client config defaults
+CLIENT_CONFIG = {
+  "max_pool_connections": MAX_POOL_CONNECTIONS,
+  "connect_timeout": CONNECT_TIMEOUT,
+  "read_timeout": READ_TIMEOUT,
+  "retries": {
+    "max_attempts": MAX_RETRIES,
+    "mode": "standard",  # standard/adaptive
+  },
+}
+
+# Transfer config defaults
+TRANSFER_CONFIG = {
+  "multipart_threshold": MULTIPART_THRESHOLD,
+  "multipart_chunksize": DEFAULT_CHUNK_SIZE,
+  "max_concurrency": MAX_POOL_CONNECTIONS,
+  "use_threads": True,
+}

--- a/desktop/core/src/desktop/lib/fs/s3/core/__init__.py
+++ b/desktop/core/src/desktop/lib/fs/s3/core/__init__.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/desktop/core/src/desktop/lib/fs/s3/core/file.py
+++ b/desktop/core/src/desktop/lib/fs/s3/core/file.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import os
+from typing import BinaryIO, Callable, Optional, Union
+
+from botocore.exceptions import ClientError
+
+from desktop.lib.fs.s3.constants import DEFAULT_CHUNK_SIZE
+from desktop.lib.fs.s3.core.path import S3Path
+
+
+class S3File:
+  """
+  File-like object for S3.
+  Supports both reading and writing with buffering.
+  """
+
+  def __init__(self, fs: "S3FileSystem", path: Union[str, S3Path], mode: str = "rb"):
+    """
+    Initialize S3File.
+
+    Args:
+        fs: Parent S3FileSystem instance
+        path: File path
+        mode: File mode ('rb' or 'wb')
+
+    Raises:
+        ValueError: If mode is not supported
+    """
+    if mode not in ("rb", "wb"):
+      raise ValueError(f"Unsupported file mode: {mode}")
+
+    self.fs = fs
+    self.path = S3Path.from_path(path) if isinstance(path, str) else path
+    self.mode = mode
+    self.closed = False
+
+    # Initialize buffers
+    self._read_buffer = io.BytesIO()
+    self._write_buffer = io.BytesIO()
+    self._buffer_size = DEFAULT_CHUNK_SIZE
+
+    # Initialize position tracking
+    self._position = 0
+    self._size = None
+
+    if mode == "rb":
+      self._load_size()
+
+  def _load_size(self) -> None:
+    """Load file size for reading"""
+    try:
+      response = self.fs.s3_client.head_object(Bucket=self.path.bucket, Key=self.path.key)
+      self._size = response["ContentLength"]
+    except ClientError as e:
+      if e.response["Error"]["Code"] == "404":
+        raise FileNotFoundError(f"File not found: {self.path}")
+      elif e.response["Error"]["Code"] == "403":
+        raise PermissionError(f"Access denied to file: {self.path}")
+      raise
+
+  def read(self, size: int = -1) -> bytes:
+    """
+    Read from file.
+
+    Args:
+        size: Number of bytes to read (-1 for all)
+
+    Returns:
+        Bytes read
+
+    Raises:
+        ValueError: If file is closed
+        IOError: If file not open for reading
+    """
+    if self.closed:
+      raise ValueError("I/O operation on closed file")
+    if self.mode != "rb":
+      raise IOError("File not open for reading")
+
+    # Handle full file read
+    if size < 0:
+      size = self._size - self._position
+
+    # Read from buffer first
+    data = self._read_buffer.read(size)
+    read_size = len(data)
+
+    # If we need more data
+    if read_size < size:
+      try:
+        # Calculate range
+        start = self._position + read_size
+        end = start + (size - read_size) - 1
+
+        # Get data from S3
+        response = self.fs.s3_client.get_object(Bucket=self.path.bucket, Key=self.path.key, Range=f"bytes={start}-{end}")
+
+        # Add to buffer
+        new_data = response["Body"].read()
+        self._read_buffer = io.BytesIO(new_data)
+        data += self._read_buffer.read(size - read_size)
+
+      except ClientError as e:
+        if e.response["Error"]["Code"] == "404":
+          raise FileNotFoundError(f"File not found: {self.path}")
+        elif e.response["Error"]["Code"] == "403":
+          raise PermissionError(f"Access denied to file: {self.path}")
+        raise
+
+    self._position += len(data)
+    return data
+
+  def write(self, data: Union[bytes, bytearray]) -> int:
+    """
+    Write to file.
+
+    Args:
+        data: Data to write
+
+    Returns:
+        Number of bytes written
+
+    Raises:
+        ValueError: If file is closed
+        IOError: If file not open for writing
+    """
+    if self.closed:
+      raise ValueError("I/O operation on closed file")
+    if self.mode != "wb":
+      raise IOError("File not open for writing")
+
+    # Write to buffer
+    bytes_written = self._write_buffer.write(data)
+    self._position += bytes_written
+
+    # Flush if buffer is full
+    if self._write_buffer.tell() >= self._buffer_size:
+      self.flush()
+
+    return bytes_written
+
+  def flush(self) -> None:
+    """
+    Flush write buffer to S3.
+
+    Raises:
+        ValueError: If file is closed
+    """
+    if self.closed:
+      raise ValueError("I/O operation on closed file")
+
+    if self.mode == "wb" and self._write_buffer.tell() > 0:
+      try:
+        # Upload buffer contents
+        self._write_buffer.seek(0)
+        self.fs.s3_client.put_object(Bucket=self.path.bucket, Key=self.path.key, Body=self._write_buffer.read())
+
+        # Reset buffer
+        self._write_buffer = io.BytesIO()
+
+      except ClientError as e:
+        if e.response["Error"]["Code"] == "403":
+          raise PermissionError(f"Access denied to file: {self.path}")
+        raise
+
+  def seek(self, offset: int, whence: int = os.SEEK_SET) -> int:
+    """
+    Seek to position in file.
+
+    Args:
+        offset: Offset in bytes
+        whence: Reference point (SEEK_SET, SEEK_CUR, SEEK_END)
+
+    Returns:
+        New position
+
+    Raises:
+        ValueError: If file is closed
+        IOError: If seeking is not supported
+    """
+    if self.closed:
+      raise ValueError("I/O operation on closed file")
+
+    if self.mode == "wb":
+      raise IOError("Seek not supported in write mode")
+
+    # Calculate new position
+    if whence == os.SEEK_SET:
+      new_pos = offset
+    elif whence == os.SEEK_CUR:
+      new_pos = self._position + offset
+    elif whence == os.SEEK_END:
+      new_pos = self._size + offset
+    else:
+      raise ValueError(f"Invalid whence value: {whence}")
+
+    # Validate position
+    if new_pos < 0:
+      raise ValueError("Negative seek position")
+
+    # Update position
+    self._position = new_pos
+    return self._position
+
+  def tell(self) -> int:
+    """
+    Get current position in file.
+
+    Returns:
+        Current position
+
+    Raises:
+        ValueError: If file is closed
+    """
+    if self.closed:
+      raise ValueError("I/O operation on closed file")
+    return self._position
+
+  def close(self) -> None:
+    """Close file and flush buffers"""
+    if not self.closed:
+      if self.mode == "wb":
+        self.flush()
+      self.closed = True
+
+  def __enter__(self) -> "S3File":
+    """Context manager enter"""
+    return self
+
+  def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    """Context manager exit"""
+    self.close()
+
+  def __iter__(self) -> "S3File":
+    """Iterator interface"""
+    return self
+
+  def __next__(self) -> bytes:
+    """Get next line"""
+    line = self.readline()
+    if not line:
+      raise StopIteration
+    return line
+
+  def readline(self, size: int = -1) -> bytes:
+    """Read a line from file"""
+    if self.mode != "rb":
+      raise IOError("File not open for reading")
+
+    # Read until newline or size
+    line = b""
+    while size < 0 or len(line) < size:
+      byte = self.read(1)
+      if not byte:
+        break
+      line += byte
+      if byte == b"\n":
+        break
+
+    return line

--- a/desktop/core/src/desktop/lib/fs/s3/core/path.py
+++ b/desktop/core/src/desktop/lib/fs/s3/core/path.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+from urllib.parse import unquote, urlparse
+
+from desktop.lib.fs.s3.constants import S3_DELIMITER
+
+
+@dataclass
+class S3Path:
+  """
+  Represents an S3 path with bucket and key components.
+  Handles path parsing, normalization, and manipulation.
+  """
+
+  bucket: Optional[str]
+  key: Optional[str]
+
+  @classmethod
+  def from_path(cls, path: str) -> "S3Path":
+    """
+    Create S3Path from string path.
+
+    Args:
+        path: S3 path (s3://bucket/key or s3a://bucket/key)
+
+    Returns:
+        S3Path instance
+
+    Raises:
+        ValueError: If path is not a valid S3 path
+    """
+    if path in ("s3://", "s3a://"):
+      return cls(bucket=None, key=None)
+
+    parsed = urlparse(path)
+    if parsed.scheme not in ("s3", "s3a"):
+      raise ValueError(f"Invalid S3 path: {path}")
+
+    # Split path into bucket and key
+    parts = parsed.path.lstrip("/").split("/", 1)
+    bucket = unquote(parts[0]) if parts else None
+    key = unquote(parts[1]) if len(parts) > 1 else None
+
+    # Normalize empty strings to None
+    bucket = bucket if bucket else None
+    key = key if key else None
+
+    return cls(bucket=bucket, key=key)
+
+  def is_root(self) -> bool:
+    """Check if path is root (s3:// or s3a://)"""
+    return self.bucket is None
+
+  def is_bucket(self) -> bool:
+    """Check if path is a bucket (s3://bucket/)"""
+    return self.bucket is not None and self.key is None
+
+  def join(self, *components: str) -> "S3Path":
+    """
+    Join path components.
+
+    Args:
+        *components: Path components to join
+
+    Returns:
+        New S3Path with joined components
+    """
+    if self.is_root() and not components:
+      return self
+
+    # Start with current path components
+    parts = []
+    if self.bucket:
+      parts.append(self.bucket)
+    if self.key:
+      parts.append(self.key)
+
+    # Add new components
+    for comp in components:
+      # Skip empty components
+      if not comp:
+        continue
+
+      # Handle absolute paths
+      if comp.startswith("s3://") or comp.startswith("s3a://"):
+        return S3Path.from_path(comp)
+
+      # Add component
+      parts.append(comp.strip("/"))
+
+    # Reconstruct path
+    if not parts:
+      return S3Path(None, None)
+
+    return S3Path(bucket=parts[0], key=S3_DELIMITER.join(parts[1:]) if len(parts) > 1 else None)
+
+  def parent(self) -> "S3Path":
+    """Get parent path"""
+    if self.is_root():
+      return self
+    if self.is_bucket():
+      return S3Path(None, None)
+
+    # Split key into components
+    key_parts = self.key.rstrip("/").split("/")
+    if len(key_parts) == 1:
+      # Key is in bucket root
+      return S3Path(self.bucket, None)
+
+    # Remove last component
+    return S3Path(bucket=self.bucket, key="/".join(key_parts[:-1]))
+
+  def name(self) -> str:
+    """Get path name (last component)"""
+    if self.is_root():
+      return ""
+    if self.is_bucket():
+      return self.bucket
+
+    return self.key.rstrip("/").split("/")[-1]
+
+  def add_suffix(self, suffix: str) -> "S3Path":
+    """Add suffix to path name"""
+    if self.is_root() or self.is_bucket():
+      raise ValueError("Cannot add suffix to root or bucket")
+
+    return S3Path(bucket=self.bucket, key=f"{self.key.rstrip('/')}{suffix}")
+
+  def with_trailing_slash(self) -> "S3Path":
+    """Ensure path ends with slash"""
+    if self.is_root() or self.is_bucket():
+      return self
+
+    if not self.key.endswith("/"):
+      return S3Path(bucket=self.bucket, key=f"{self.key}/")
+    return self
+
+  def without_trailing_slash(self) -> "S3Path":
+    """Remove trailing slash"""
+    if self.is_root() or self.is_bucket():
+      return self
+
+    return S3Path(bucket=self.bucket, key=self.key.rstrip("/"))
+
+  def __str__(self) -> str:
+    """Convert to string path"""
+    if self.is_root():
+      return "s3a://"
+    elif self.is_bucket():
+      return f"s3a://{self.bucket}"
+    else:
+      return f"s3a://{self.bucket}/{self.key}"
+
+  def __eq__(self, other: object) -> bool:
+    """Compare paths"""
+    if not isinstance(other, S3Path):
+      return NotImplemented
+    return self.bucket == other.bucket and self.key == other.key
+
+  def __hash__(self) -> int:
+    """Hash path"""
+    return hash((self.bucket, self.key))

--- a/desktop/core/src/desktop/lib/fs/s3/core/s3fs.py
+++ b/desktop/core/src/desktop/lib/fs/s3/core/s3fs.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, BinaryIO, Dict, List, Optional, Tuple, Union
+
+from botocore.exceptions import ClientError
+
+from desktop.lib.fs.s3.clients.factory import S3ClientFactory
+from desktop.lib.fs.s3.constants import DEFAULT_CHUNK_SIZE, MAX_POOL_CONNECTIONS, S3_DELIMITER
+from desktop.lib.fs.s3.core.file import S3File
+from desktop.lib.fs.s3.core.path import S3Path
+from desktop.lib.fs.s3.core.stat import S3Stat
+
+LOG = logging.getLogger(__name__)
+
+
+class S3FileSystem:
+  """
+  S3FileSystem implementation using boto3.
+  Supports multiple providers and auth methods.
+  """
+
+  def __init__(self, provider_id: str, user: str):
+    """
+    Initialize S3FileSystem.
+
+    Args:
+        provider_id: ID from S3_OBJECT_STORES config
+        user: Username for operations
+    """
+    self.provider_id = provider_id
+    self.user = user
+
+    # Initialize client
+    self.client = S3ClientFactory.get_client(provider_id, user)
+
+    # Get boto3 clients
+    self.s3_client = self.client.s3_client
+    self.s3_resource = self.client.s3_resource
+
+    # Initialize thread pool for parallel operations
+    self.thread_pool = ThreadPoolExecutor(max_workers=MAX_POOL_CONNECTIONS)
+
+  def _get_bucket(self, bucket_name: str, validate: bool = True):
+    """Get bucket by name"""
+    try:
+      bucket = self.s3_resource.Bucket(bucket_name)
+      if validate:
+        # Force validation of bucket
+        self.s3_client.head_bucket(Bucket=bucket_name)
+      return bucket
+    except ClientError as e:
+      error_code = e.response["Error"]["Code"]
+      if error_code == "404":
+        raise FileNotFoundError(f"Bucket not found: {bucket_name}")
+      elif error_code == "403":
+        raise PermissionError(f"Access denied to bucket: {bucket_name}")
+      raise
+
+  def _get_object(self, path: Union[str, S3Path], validate: bool = True):
+    """Get object by path"""
+    if isinstance(path, str):
+      path = S3Path.from_path(path)
+
+    try:
+      obj = self.s3_resource.Object(path.bucket, path.key)
+      if validate:
+        obj.load()
+      return obj
+    except ClientError as e:
+      error_code = e.response["Error"]["Code"]
+      if error_code == "404":
+        raise FileNotFoundError(f"Object not found: {path}")
+      elif error_code == "403":
+        raise PermissionError(f"Access denied to object: {path}")
+      raise
+
+  def open(self, path: Union[str, S3Path], mode: str = "rb") -> S3File:
+    """Open file for reading or writing"""
+    return S3File(self, path, mode)
+
+  def read(self, path: Union[str, S3Path], offset: int = 0, length: int = -1) -> bytes:
+    """Read file contents"""
+    with self.open(path, "rb") as f:
+      f.seek(offset)
+      return f.read(length)
+
+  def write(self, path: Union[str, S3Path], data: Union[bytes, BinaryIO], overwrite: bool = False) -> None:
+    """Write data to file"""
+    if not overwrite and self.exists(path):
+      raise FileExistsError(f"File already exists: {path}")
+
+    with self.open(path, "wb") as f:
+      if isinstance(data, bytes):
+        f.write(data)
+      else:
+        while True:
+          chunk = data.read(DEFAULT_CHUNK_SIZE)
+          if not chunk:
+            break
+          f.write(chunk)
+
+  def exists(self, path: Union[str, S3Path]) -> bool:
+    """Check if path exists"""
+    try:
+      self.stats(path)
+      return True
+    except (FileNotFoundError, PermissionError):
+      return False
+
+  def stats(self, path: Union[str, S3Path]) -> S3Stat:
+    """Get path stats"""
+    if isinstance(path, str):
+      path = S3Path.from_path(path)
+
+    if path.is_root():
+      return S3Stat.for_root()
+
+    try:
+      if path.is_bucket():
+        bucket = self._get_bucket(path.bucket)
+        return S3Stat.from_bucket(bucket)
+      else:
+        obj = self._get_object(path)
+        return S3Stat.from_object(obj)
+    except FileNotFoundError:
+      # Check if it's a prefix (directory)
+      try:
+        response = self.s3_client.list_objects_v2(Bucket=path.bucket, Prefix=path.key, Delimiter=S3_DELIMITER, MaxKeys=1)
+        if response.get("CommonPrefixes") or response.get("Contents"):
+          return S3Stat.for_directory(path)
+        raise FileNotFoundError(f"Path not found: {path}")
+      except ClientError as e:
+        if e.response["Error"]["Code"] == "403":
+          raise PermissionError(f"Access denied to path: {path}")
+        raise
+
+  def isfile(self, path: Union[str, S3Path]) -> bool:
+    """Check if path is a file"""
+    try:
+      stats = self.stats(path)
+      return not stats.is_dir
+    except FileNotFoundError:
+      return False
+
+  def isdir(self, path: Union[str, S3Path]) -> bool:
+    """Check if path is a directory"""
+    try:
+      stats = self.stats(path)
+      return stats.is_dir
+    except FileNotFoundError:
+      return False
+
+  def listdir_stats(self, path: Union[str, S3Path], glob_pattern: Optional[str] = None) -> List[S3Stat]:
+    """List directory with stats"""
+    if isinstance(path, str):
+      path = S3Path.from_path(path)
+
+    if path.is_root():
+      # List buckets
+      buckets = self.s3_client.list_buckets()["Buckets"]
+      return [S3Stat.from_bucket(self.s3_resource.Bucket(b["Name"])) for b in buckets]
+
+    # List objects with prefix
+    prefix = path.key if path.key else ""
+    if prefix and not prefix.endswith(S3_DELIMITER):
+      prefix += S3_DELIMITER
+
+    paginator = self.s3_client.get_paginator("list_objects_v2")
+
+    stats = []
+    try:
+      for page in paginator.paginate(Bucket=path.bucket, Prefix=prefix, Delimiter=S3_DELIMITER):
+        # Add common prefixes (directories)
+        for prefix_dict in page.get("CommonPrefixes", []):
+          prefix_path = S3Path(bucket=path.bucket, key=prefix_dict["Prefix"])
+          stats.append(S3Stat.for_directory(prefix_path))
+
+        # Add objects (files)
+        for obj_dict in page.get("Contents", []):
+          if obj_dict["Key"] == prefix:
+            continue  # Skip current directory marker
+          obj = self.s3_resource.Object(path.bucket, obj_dict["Key"])
+          stats.append(S3Stat.from_object(obj))
+
+    except ClientError as e:
+      if e.response["Error"]["Code"] == "403":
+        raise PermissionError(f"Access denied to path: {path}")
+      raise
+
+    return stats
+
+  def listdir(self, path: Union[str, S3Path], glob_pattern: Optional[str] = None) -> List[str]:
+    """List directory contents"""
+    stats = self.listdir_stats(path, glob_pattern)
+    return [stat.name for stat in stats]
+
+  def mkdir(self, path: Union[str, S3Path]) -> None:
+    """Create directory (empty object with trailing slash)"""
+    if isinstance(path, str):
+      path = S3Path.from_path(path)
+
+    if path.is_root():
+      raise ValueError("Cannot create root directory")
+
+    try:
+      if path.is_bucket():
+        # Create bucket
+        self.s3_client.create_bucket(Bucket=path.bucket)
+      else:
+        # Create directory marker
+        key = path.key.rstrip("/") + "/"
+        self.s3_client.put_object(Bucket=path.bucket, Key=key, Body=b"")
+    except ClientError as e:
+      if e.response["Error"]["Code"] == "403":
+        raise PermissionError(f"Access denied to create: {path}")
+      raise
+
+  def remove(self, path: Union[str, S3Path], skip_trash: bool = True) -> None:
+    """Remove file or empty directory"""
+    if not skip_trash:
+      raise NotImplementedError("Trash not supported for S3")
+
+    if isinstance(path, str):
+      path = S3Path.from_path(path)
+
+    try:
+      if path.is_bucket():
+        # Delete bucket
+        bucket = self._get_bucket(path.bucket)
+        bucket.delete()
+      else:
+        # Delete object
+        self.s3_client.delete_object(Bucket=path.bucket, Key=path.key)
+    except ClientError as e:
+      if e.response["Error"]["Code"] == "403":
+        raise PermissionError(f"Access denied to delete: {path}")
+      raise
+
+  def rmtree(self, path: Union[str, S3Path], skip_trash: bool = True) -> None:
+    """Remove directory and contents recursively"""
+    if not skip_trash:
+      raise NotImplementedError("Trash not supported for S3")
+
+    if isinstance(path, str):
+      path = S3Path.from_path(path)
+
+    try:
+      bucket = self._get_bucket(path.bucket)
+
+      if path.is_bucket():
+        # Delete entire bucket
+        bucket.objects.all().delete()
+        bucket.delete()
+      else:
+        # Delete prefix
+        prefix = path.key
+        if not prefix.endswith("/"):
+          prefix += "/"
+
+        # Use bulk delete for efficiency
+        bucket.objects.filter(Prefix=prefix).delete()
+    except ClientError as e:
+      if e.response["Error"]["Code"] == "403":
+        raise PermissionError(f"Access denied to delete: {path}")
+      raise
+
+  def copy(self, src: Union[str, S3Path], dst: Union[str, S3Path], recursive: bool = False) -> None:
+    """Copy file or directory"""
+    if isinstance(src, str):
+      src = S3Path.from_path(src)
+    if isinstance(dst, str):
+      dst = S3Path.from_path(dst)
+
+    if not recursive and self.isdir(src):
+      raise IsADirectoryError(f"Source is a directory: {src}")
+
+    try:
+      if self.isfile(src):
+        # Copy single file
+        copy_source = {"Bucket": src.bucket, "Key": src.key}
+        self.s3_client.copy(copy_source, dst.bucket, dst.key)
+      else:
+        # Copy directory
+        src_prefix = src.key.rstrip("/") + "/"
+        dst_prefix = dst.key.rstrip("/") + "/"
+
+        paginator = self.s3_client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=src.bucket, Prefix=src_prefix):
+          for obj in page.get("Contents", []):
+            src_key = obj["Key"]
+            dst_key = dst_prefix + src_key[len(src_prefix) :]
+
+            copy_source = {"Bucket": src.bucket, "Key": src_key}
+            self.s3_client.copy(copy_source, dst.bucket, dst_key)
+    except ClientError as e:
+      if e.response["Error"]["Code"] == "403":
+        raise PermissionError(f"Access denied for copy operation")
+      raise
+
+  def rename(self, old: Union[str, S3Path], new: Union[str, S3Path]) -> None:
+    """Rename/move file or directory"""
+    self.copy(old, new, recursive=True)
+    self.rmtree(old)
+
+  def upload(self, src_file: BinaryIO, dst_path: Union[str, S3Path], callback: Optional[callable] = None) -> None:
+    """Upload file with progress callback"""
+    if isinstance(dst_path, str):
+      dst_path = S3Path.from_path(dst_path)
+
+    try:
+      if callback:
+
+        def _callback(bytes_transferred):
+          callback(bytes_transferred)
+
+        self.s3_client.upload_fileobj(src_file, dst_path.bucket, dst_path.key, Callback=_callback)
+      else:
+        self.s3_client.upload_fileobj(src_file, dst_path.bucket, dst_path.key)
+    except ClientError as e:
+      if e.response["Error"]["Code"] == "403":
+        raise PermissionError(f"Access denied to upload to: {dst_path}")
+      raise
+
+  def download(self, src_path: Union[str, S3Path], dst_file: BinaryIO, callback: Optional[callable] = None) -> None:
+    """Download file with progress callback"""
+    if isinstance(src_path, str):
+      src_path = S3Path.from_path(src_path)
+
+    try:
+      if callback:
+
+        def _callback(bytes_transferred):
+          callback(bytes_transferred)
+
+        self.s3_client.download_fileobj(src_path.bucket, src_path.key, dst_file, Callback=_callback)
+      else:
+        self.s3_client.download_fileobj(src_path.bucket, src_path.key, dst_file)
+    except ClientError as e:
+      if e.response["Error"]["Code"] == "403":
+        raise PermissionError(f"Access denied to download from: {src_path}")
+      raise
+
+  def get_presigned_url(self, path: Union[str, S3Path], method: str = "GET", expiration: int = 3600) -> str:
+    """Get presigned URL for object"""
+    if isinstance(path, str):
+      path = S3Path.from_path(path)
+
+    try:
+      return self.s3_client.generate_presigned_url(
+        "get_object" if method == "GET" else "put_object", Params={"Bucket": path.bucket, "Key": path.key}, ExpiresIn=expiration
+      )
+    except ClientError as e:
+      if e.response["Error"]["Code"] == "403":
+        raise PermissionError(f"Access denied to generate URL for: {path}")
+      raise

--- a/desktop/core/src/desktop/lib/fs/s3/core/stat.py
+++ b/desktop/core/src/desktop/lib/fs/s3/core/stat.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import stat
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Optional, Union
+
+from desktop.lib.fs.s3.core.path import S3Path
+
+
+@dataclass
+class S3Stat:
+  """
+  File/directory statistics for S3 objects.
+  Compatible with os.stat_result interface.
+  """
+
+  path: str  # Full path
+  name: str  # File/directory name
+  size: int  # Size in bytes
+  mtime: Optional[datetime]  # Last modified time
+  is_dir: bool  # True if directory
+
+  # Optional S3-specific attributes
+  etag: Optional[str] = None
+  version_id: Optional[str] = None
+  storage_class: Optional[str] = None
+  metadata: Optional[Dict[str, str]] = None
+
+  @property
+  def mode(self) -> int:
+    """Get file mode (permissions)"""
+    if self.is_dir:
+      return stat.S_IFDIR | 0o777  # rwxrwxrwx
+    return stat.S_IFREG | 0o666  # rw-rw-rw-
+
+  @property
+  def type(self) -> str:
+    """Get file type"""
+    return "DIRECTORY" if self.is_dir else "FILE"
+
+  @classmethod
+  def for_root(cls) -> "S3Stat":
+    """Create stats for root directory"""
+    return cls(path="s3a://", name="S3", size=0, mtime=None, is_dir=True)
+
+  @classmethod
+  def from_bucket(cls, bucket) -> "S3Stat":
+    """
+    Create stats from bucket.
+
+    Args:
+        bucket: boto3 Bucket object
+
+    Returns:
+        S3Stat instance
+    """
+    return cls(
+      path=f"s3a://{bucket.name}",
+      name=bucket.name,
+      size=0,
+      mtime=None,  # Buckets don't have mtime
+      is_dir=True,
+    )
+
+  @classmethod
+  def from_object(cls, obj) -> "S3Stat":
+    """
+    Create stats from S3 object.
+
+    Args:
+        obj: boto3 Object object
+
+    Returns:
+        S3Stat instance
+    """
+    return cls(
+      path=f"s3a://{obj.bucket_name}/{obj.key}",
+      name=obj.key.rstrip("/").split("/")[-1],
+      size=obj.content_length,
+      mtime=obj.last_modified,
+      is_dir=obj.key.endswith("/"),
+      etag=obj.e_tag.strip('"') if obj.e_tag else None,
+      version_id=obj.version_id,
+      storage_class=obj.storage_class,
+      metadata=obj.metadata,
+    )
+
+  @classmethod
+  def from_head(cls, head_response: Dict[str, Any], path: Union[str, S3Path]) -> "S3Stat":
+    """
+    Create stats from head_object response.
+
+    Args:
+        head_response: Response from head_object API call
+        path: S3 path
+
+    Returns:
+        S3Stat instance
+    """
+    if isinstance(path, str):
+      path = S3Path.from_path(path)
+
+    return cls(
+      path=str(path),
+      name=path.name(),
+      size=head_response["ContentLength"],
+      mtime=head_response["LastModified"],
+      is_dir=path.key.endswith("/"),
+      etag=head_response.get("ETag", "").strip('"'),
+      version_id=head_response.get("VersionId"),
+      storage_class=head_response.get("StorageClass"),
+      metadata=head_response.get("Metadata"),
+    )
+
+  @classmethod
+  def for_directory(cls, path: Union[str, S3Path]) -> "S3Stat":
+    """
+    Create stats for directory path.
+
+    Args:
+        path: S3 path
+
+    Returns:
+        S3Stat instance
+    """
+    if isinstance(path, str):
+      path = S3Path.from_path(path)
+
+    return cls(path=str(path), name=path.name(), size=0, mtime=None, is_dir=True)
+
+  def to_json(self) -> Dict[str, Any]:
+    """Convert to JSON-serializable dict"""
+    return {
+      "path": self.path,
+      "name": self.name,
+      "size": self.size,
+      "mtime": self.mtime.isoformat() if self.mtime else None,
+      "type": self.type,
+      "mode": self.mode,
+      "etag": self.etag,
+      "version_id": self.version_id,
+      "storage_class": self.storage_class,
+      "metadata": self.metadata,
+    }
+
+  def __eq__(self, other: object) -> bool:
+    """Compare stats"""
+    if not isinstance(other, S3Stat):
+      return NotImplemented
+    return self.path == other.path and self.size == other.size and self.mtime == other.mtime and self.is_dir == other.is_dir


### PR DESCRIPTION
- Introduced a new configuration section for S3-compatible object stores, allowing users to define multiple instances with various parameters such as name, provider, region, endpoint, and authentication details.
- This enhancement facilitates integration with different S3 providers and improves flexibility in managing object storage options.

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
