### PR TITLE
[security] Implement TLS 1.3 support across Hue components

### DIFF
--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -286,7 +286,7 @@ SSL_CERTIFICATE_CHAIN = Config(
 
 SSL_CIPHER_LIST = Config(
   key="ssl_cipher_list",
-  help=_("List of allowed and disallowed ciphers"),
+  help=_("List of allowed and disallowed ciphers for TLS 1.2 and earlier"),
 
   # Based on "Intermediate compatibility" recommendations from
   # https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
@@ -295,6 +295,10 @@ SSL_CIPHER_LIST = Config(
   default=':'.join([
     'ECDHE-RSA-AES128-GCM-SHA256',
     'ECDHE-RSA-AES256-GCM-SHA384',
+    'ECDHE-ECDSA-AES128-GCM-SHA256',
+    'ECDHE-ECDSA-AES256-GCM-SHA384',
+    'DHE-RSA-AES128-GCM-SHA256',
+    'DHE-RSA-AES256-GCM-SHA384',
     '!aNULL',
     '!eNULL',
     '!EXPORT',
@@ -307,6 +311,27 @@ SSL_CIPHER_LIST = Config(
     '!EDH-RSA-DES-CBC3-SHA',
     '!KRB5-DES-CBC3-SHA',
   ]))
+
+# TLS 1.3 Configuration
+def has_tls13_support():
+  """Check if TLS 1.3 is supported by the current Python/OpenSSL version."""
+  try:
+    import ssl
+    return hasattr(ssl, 'HAS_TLSv1_3') and ssl.HAS_TLSv1_3
+  except ImportError:
+    return False
+
+SSL_TLS13_ENABLED = Config(
+  key="ssl_tls13_enabled",
+  help=_("Enable TLS 1.3 support when available. Requires OpenSSL 1.1.1+ and Python 3.7+"),
+  type=coerce_bool,
+  dynamic_default=has_tls13_support)
+
+SSL_TLS12_ENABLED = Config(
+  key="ssl_tls12_enabled",
+  help=_("Enable TLS 1.2 support when available. This is the default behavior."),
+  type=coerce_bool,
+  default=True)
 
 
 def has_ssl_no_renegotiation():
@@ -390,7 +415,7 @@ SECURE_CONTENT_SECURITY_POLICY = Config(
 CSP_NONCE = Config(
   key="csp_nonce",
   help=_('Generates a unique nonce for each request to strengthen CSP by disallowing '
-        '‘unsafe-inline’ scripts and styles.'),
+        '"unsafe-inline" scripts and styles.'),
   type=coerce_bool,
   default=False)
 

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -286,7 +286,7 @@ SSL_CERTIFICATE_CHAIN = Config(
 
 SSL_CIPHER_LIST = Config(
   key="ssl_cipher_list",
-  help=_("List of allowed and disallowed ciphers for TLS 1.2 and earlier"),
+  help=_("List of allowed and disallowed ciphers for TLS 1.2"),
 
   # Based on "Intermediate compatibility" recommendations from
   # https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -318,6 +318,7 @@ SSL_CIPHER_LIST = Config(
     '!KRB5-DES-CBC3-SHA',
   ]))
 
+
 # TLS 1.3 Configuration
 def has_tls13_support():
   """Check if TLS 1.3 is supported by the current Python/OpenSSL version."""
@@ -326,6 +327,7 @@ def has_tls13_support():
     return hasattr(ssl, 'HAS_TLSv1_3') and ssl.HAS_TLSv1_3
   except ImportError:
     return False
+
 
 SSL_TLS13_ENABLED = Config(
   key="ssl_tls13_enabled",

--- a/desktop/core/src/desktop/lib/rest/http_client.py
+++ b/desktop/core/src/desktop/lib/rest/http_client.py
@@ -26,7 +26,7 @@ from django.utils.http import urlencode
 from requests import exceptions
 from requests.adapters import HTTPAdapter
 from requests.auth import AuthBase, HTTPBasicAuth, HTTPDigestAuth
-from requests_kerberos import DISABLED, OPTIONAL, REQUIRED, HTTPKerberosAuth
+from requests_kerberos import DISABLED, HTTPKerberosAuth, OPTIONAL, REQUIRED
 from urllib3.contrib import pyopenssl
 
 from desktop import conf

--- a/desktop/core/src/desktop/lib/rest/http_client.py
+++ b/desktop/core/src/desktop/lib/rest/http_client.py
@@ -16,21 +16,23 @@
 
 import logging
 import posixpath
+import ssl
 import threading
-import urllib.error
-import urllib.request
 from urllib.parse import quote as urllib_quote, urlparse as lib_urlparse
 
 import requests
 from django.utils.encoding import iri_to_uri, smart_str
 from django.utils.http import urlencode
 from requests import exceptions
+from requests.adapters import HTTPAdapter
 from requests.auth import AuthBase, HTTPBasicAuth, HTTPDigestAuth
 from requests_kerberos import DISABLED, OPTIONAL, REQUIRED, HTTPKerberosAuth
 from urllib3.contrib import pyopenssl
 
 from desktop import conf
+from desktop.lib.tls_utils import create_http_ssl_context
 
+# Configure default cipher list for pyopenssl with enhanced TLS support
 pyopenssl.DEFAULT_SSL_CIPHER_LIST = conf.SSL_CIPHER_LIST.get()
 
 __docformat__ = "epytext"
@@ -41,6 +43,45 @@ CACHE_SESSION = {}
 CACHE_SESSION_LOCK = threading.Lock()
 
 
+class TLS13HTTPAdapter(HTTPAdapter):
+  """
+  HTTP adapter with enhanced TLS 1.3 support for requests library.
+  """
+
+  def init_poolmanager(self, *args, **kwargs):
+    """
+    Initialize the urllib3 pool manager with TLS 1.3 support.
+    """
+    try:
+      # Create SSL context with TLS 1.3 support
+      ssl_context = create_http_ssl_context()
+
+      if ssl_context:
+        # Use our custom SSL context
+        kwargs['ssl_context'] = ssl_context
+        LOG.debug("Using custom TLS SSL context for HTTP adapter")
+      else:
+        # Fallback configuration
+        kwargs['cert_reqs'] = ssl.CERT_REQUIRED if conf.SSL_VALIDATE.get() else ssl.CERT_NONE
+
+        if conf.SSL_CACERTS.get():
+          kwargs['ca_certs'] = conf.SSL_CACERTS.get()
+
+        # Set cipher list for fallback
+        if hasattr(ssl, 'SSLContext'):
+          try:
+            kwargs['ssl_ciphers'] = conf.SSL_CIPHER_LIST.get()
+          except Exception:
+            pass
+
+        LOG.debug("Using fallback SSL configuration for HTTP adapter")
+
+    except Exception as e:
+      LOG.warning(f"Could not configure TLS 1.3 for HTTP adapter: {e}")
+
+    return super().init_poolmanager(*args, **kwargs)
+
+
 def get_request_session(url, logger):
   global CACHE_SESSION, CACHE_SESSION_LOCK
 
@@ -48,14 +89,25 @@ def get_request_session(url, logger):
     with CACHE_SESSION_LOCK:
       CACHE_SESSION[url] = requests.Session()
       logger.debug("Setting request Session")
-      CACHE_SESSION[url].mount(
-        url,
-        requests.adapters.HTTPAdapter(
-          pool_connections=conf.CHERRYPY_SERVER_THREADS.get(),
-          pool_maxsize=conf.CHERRYPY_SERVER_THREADS.get()
-        )
+
+      # Use TLS 1.3 supporting adapter
+      tls13_adapter = TLS13HTTPAdapter(
+        pool_connections=conf.CHERRYPY_SERVER_THREADS.get(),
+        pool_maxsize=conf.CHERRYPY_SERVER_THREADS.get()
       )
-      logger.debug("Setting session adapter for %s" % url)
+
+      # Mount the adapter for both HTTP and HTTPS
+      CACHE_SESSION[url].mount('https://', tls13_adapter)
+      CACHE_SESSION[url].mount('http://', tls13_adapter)
+
+      # Configure SSL verification
+      CACHE_SESSION[url].verify = conf.SSL_VALIDATE.get()
+
+      # Set CA certificates if configured
+      if conf.SSL_CACERTS.get() and conf.SSL_VALIDATE.get():
+        CACHE_SESSION[url].verify = conf.SSL_CACERTS.get()
+
+      logger.debug(f"Configured HTTP session with TLS 1.3 support for {url}")
 
   return CACHE_SESSION
 

--- a/desktop/core/src/desktop/lib/thrift_util.py
+++ b/desktop/core/src/desktop/lib/thrift_util.py
@@ -17,16 +17,16 @@
 #
 from __future__ import division
 
-import re
-import sys
-import math
-import time
-import queue
 import base64
+import logging
+import math
+import queue
+import re
 import socket
 import struct
-import logging
+import sys
 import threading
+import time
 from builtins import map, object, range
 
 from django.conf import settings
@@ -45,7 +45,7 @@ from desktop.lib.python_util import create_synchronous_io_multiplexer
 from desktop.lib.thrift_.http_client import THttpClient
 from desktop.lib.thrift_.TSSLSocketWithWildcardSAN import TSSLSocketWithWildcardSAN
 from desktop.lib.thrift_sasl import TSaslClientTransport
-from desktop.lib.tls_utils import get_ssl_protocol, create_thrift_ssl_context
+from desktop.lib.tls_utils import create_thrift_ssl_context, get_ssl_protocol
 
 LOG = logging.getLogger()
 

--- a/desktop/core/src/desktop/lib/tls_utils.py
+++ b/desktop/core/src/desktop/lib/tls_utils.py
@@ -1,0 +1,257 @@
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Common TLS utilities for Hue components.
+
+This module provides centralized TLS configuration functionality that can be used
+across different Hue components including Gunicorn server, HTTP client, and Thrift client.
+"""
+
+import logging
+
+LOG = logging.getLogger(__name__)
+
+
+def get_tls_settings():
+  """
+  Get TLS configuration settings based on Hue configuration.
+
+  Returns:
+    dict: Dictionary containing TLS configuration settings including:
+      - tls_minimum_version: Minimum TLS version (e.g., "TLSv1.2", "TLSv1.3")
+      - tls_maximum_version: Maximum TLS version (e.g., "TLSv1.2", "TLSv1.3")
+      - ciphers: Cipher list for TLS 1.2 (empty for TLS 1.3)
+      - ssl_version: SSL protocol constant name for compatibility
+      - error: Error message if SSL module not available
+  """
+  from desktop import conf
+
+  tls_settings = {}
+  try:
+    import ssl
+
+    # Check for both TLS 1.3 and TLS 1.2
+    tls13_enabled = conf.SSL_TLS13_ENABLED.get()
+    tls12_enabled = conf.SSL_TLS12_ENABLED.get()
+
+    # Set default values for minimum and maximum versions
+    min_version = "TLSv1.2"
+    max_version = "TLSv1.2"
+    ciphers = conf.SSL_CIPHER_LIST.get()
+
+    if tls13_enabled:
+      max_version = "TLSv1.3"
+      ciphers = ""  # Ciphers are not configurable for TLS 1.3
+    if tls13_enabled and tls12_enabled:
+      min_version = "TLSv1.2"
+    elif tls13_enabled and not tls12_enabled:
+      min_version = "TLSv1.3"
+
+    tls_settings["tls_maximum_version"] = max_version
+    tls_settings["tls_minimum_version"] = min_version
+    tls_settings["ciphers"] = ciphers
+
+    # Check for SSL version protocol and assign
+    if hasattr(ssl, "PROTOCOL_TLS"):
+      tls_settings["ssl_version"] = "PROTOCOL_TLS"
+    else:
+      tls_settings["ssl_version"] = "PROTOCOL_TLSv1_2"
+
+  except ImportError:
+    tls_settings["error"] = "SSL module not available"
+    LOG.error("SSL module not available")
+
+  return tls_settings
+
+
+def create_ssl_context(validate=True, ca_certs=None, keyfile=None, certfile=None):
+  """
+  Create an SSL context based on Hue TLS configuration.
+
+  Args:
+    validate: Whether to validate server certificates
+    ca_certs: Path to CA certificates file
+    keyfile: Path to client private key file
+    certfile: Path to client certificate file
+
+  Returns:
+    ssl.SSLContext: Configured SSL context or None if creation failed
+  """
+  try:
+    import ssl
+
+    # Get TLS settings from centralized configuration
+    tls_settings = get_tls_settings()
+
+    # Check for errors in TLS settings
+    if "error" in tls_settings:
+      LOG.error(f"TLS configuration error: {tls_settings['error']}")
+      return None
+
+    # Create SSL context with the best available protocol
+    if hasattr(ssl, 'create_default_context'):
+      context = ssl.create_default_context()
+    elif hasattr(ssl, 'SSLContext'):
+      # Use the SSL version from TLS settings
+      ssl_version = tls_settings.get("ssl_version", "PROTOCOL_TLSv1_2")
+      if ssl_version == "PROTOCOL_TLS" and hasattr(ssl, 'PROTOCOL_TLS'):
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+      else:
+        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+    else:
+      LOG.warning("SSLContext not available")
+      return None
+
+    # Configure ciphers from TLS settings
+    cipher_list = tls_settings.get("ciphers", "")
+    if cipher_list:
+      try:
+        context.set_ciphers(cipher_list)
+        LOG.debug(f"SSL context configured with ciphers: {cipher_list}")
+      except Exception as e:
+        LOG.debug(f"Could not set ciphers: {e}")
+
+    # Configure TLS 1.3 ciphersuites if TLS 1.3 is enabled
+    max_version = tls_settings.get("tls_maximum_version")
+    if (max_version == "TLSv1.3" and
+        hasattr(context, 'set_ciphersuites') and
+        hasattr(ssl, 'HAS_TLSv1_3') and
+        ssl.HAS_TLSv1_3):
+      try:
+        # Use standard TLS 1.3 ciphersuites
+        ciphersuites = 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384'
+        context.set_ciphersuites(ciphersuites)
+        LOG.debug(f"SSL context configured with TLS 1.3 ciphersuites: {ciphersuites}")
+      except Exception as e:
+        LOG.debug(f"Could not set TLS 1.3 ciphersuites: {e}")
+
+    # Configure protocol version limits from TLS settings
+    if hasattr(ssl, 'TLSVersion') and hasattr(context, 'minimum_version'):
+      try:
+        min_version = tls_settings.get("tls_minimum_version")
+        max_version = tls_settings.get("tls_maximum_version")
+
+        # Set minimum version
+        if min_version == "TLSv1.3" and hasattr(ssl.TLSVersion, 'TLSv1_3'):
+          context.minimum_version = ssl.TLSVersion.TLSv1_3
+        else:
+          context.minimum_version = ssl.TLSVersion.TLSv1_2
+
+        # Set maximum version
+        if max_version == "TLSv1.3" and hasattr(ssl.TLSVersion, 'TLSv1_3'):
+          context.maximum_version = ssl.TLSVersion.TLSv1_3
+        else:
+          context.maximum_version = ssl.TLSVersion.TLSv1_2
+
+      except Exception as e:
+        LOG.debug(f"Could not set TLS version limits: {e}")
+
+    # Configure certificate verification
+    if validate:
+      context.check_hostname = True
+      context.verify_mode = ssl.CERT_REQUIRED
+      if ca_certs:
+        context.load_verify_locations(ca_certs)
+    else:
+      context.check_hostname = False
+      context.verify_mode = ssl.CERT_NONE
+
+    # Load client certificate if provided
+    if keyfile and certfile:
+      try:
+        context.load_cert_chain(certfile, keyfile)
+        LOG.debug("Loaded client certificate for SSL context")
+      except Exception as e:
+        LOG.warning(f"Could not load client certificate: {e}")
+
+    min_ver = tls_settings.get('tls_minimum_version')
+    max_ver = tls_settings.get('tls_maximum_version')
+    LOG.info(f"SSL context created with TLS version range: {min_ver} to {max_ver}")
+    return context
+
+  except Exception as e:
+    LOG.error(f"Failed to create SSL context: {e}")
+    return None
+
+
+def get_ssl_protocol():
+  """
+  Get the optimal SSL protocol for connections based on configuration.
+
+  Returns:
+    ssl.PROTOCOL constant for the best available TLS version
+  """
+  from desktop import conf
+
+  try:
+    import ssl
+
+    # Check if TLS 1.3 is enabled and supported
+    if conf.SSL_TLS13_ENABLED.get() and hasattr(ssl, 'HAS_TLSv1_3') and ssl.HAS_TLSv1_3:
+      if hasattr(ssl, 'PROTOCOL_TLS'):
+        LOG.info("Using ssl.PROTOCOL_TLS with TLS 1.3 support")
+        return ssl.PROTOCOL_TLS
+      else:
+        LOG.warning("TLS 1.3 requested but PROTOCOL_TLS not available, using TLS 1.2")
+        return ssl.PROTOCOL_TLSv1_2
+    else:
+      LOG.info("Using TLS 1.2 (TLS 1.3 disabled or not supported)")
+      return ssl.PROTOCOL_TLSv1_2
+
+  except ImportError:
+    LOG.error("SSL module not available")
+    return 2  # Fallback to a basic SSL protocol
+
+
+def create_thrift_ssl_context(validate=True, ca_certs=None, keyfile=None, certfile=None):
+  """
+  Create an SSL context specifically configured for Thrift connections.
+
+  This is a specialized version of create_ssl_context that handles Thrift-specific
+  requirements like hostname validation.
+
+  Args:
+    validate: Whether to validate server certificates
+    ca_certs: Path to CA certificates
+    keyfile: Path to client private key
+    certfile: Path to client certificate
+
+  Returns:
+    ssl.SSLContext configured for Thrift connections or None if creation failed
+  """
+  context = create_ssl_context(validate, ca_certs, keyfile, certfile)
+
+  if context and validate:
+    # Thrift handles hostname validation separately
+    context.check_hostname = False
+
+  return context
+
+
+def create_http_ssl_context():
+  """
+  Create an SSL context specifically configured for HTTP client connections.
+
+  Returns:
+    ssl.SSLContext configured for HTTP client connections or None if creation failed
+  """
+  from desktop import conf
+
+  return create_ssl_context(
+    validate=conf.SSL_VALIDATE.get(),
+    ca_certs=conf.SSL_CACERTS.get() if conf.SSL_VALIDATE.get() else None
+  )

--- a/desktop/core/src/desktop/management/commands/rungunicornserver.py
+++ b/desktop/core/src/desktop/management/commands/rungunicornserver.py
@@ -42,6 +42,7 @@ from six import iteritems
 import desktop.log
 from desktop import conf
 from desktop.lib.paths import get_desktop_root
+from desktop.lib.tls_utils import get_tls_settings
 from filebrowser.utils import parse_broker_url
 
 GUNICORN_SERVER_HELP = r"""
@@ -215,6 +216,79 @@ def argprocessing(args=[], options={}):
 
 
 def rungunicornserver(args=[], options={}):
+  # Get TLS configuration
+  tls_settings = get_tls_settings()
+
+  def gunicorn_ssl_context(conf, default_ssl_context_factory):
+    """
+    Create and configure SSL context for Gunicorn based on TLS settings.
+
+    Args:
+        conf: Gunicorn configuration object
+        default_ssl_context_factory: Default SSL context factory function
+
+    Returns:
+        Configured SSL context
+    """
+    context = default_ssl_context_factory()
+
+    try:
+      # Validate TLS settings before applying
+      if "error" in tls_settings:
+        logging.warning(f"TLS configuration error: {tls_settings['error']}")
+        return context
+
+      # Configure maximum TLS version
+      max_version = tls_settings.get("tls_maximum_version")
+      if max_version == "TLSv1.3":
+        if hasattr(ssl, "HAS_TLSv1_3") and ssl.HAS_TLSv1_3 and hasattr(ssl, "TLSVersion"):
+          context.maximum_version = ssl.TLSVersion.TLSv1_3
+          logging.info("Set maximum TLS version to TLSv1.3")
+        else:
+          logging.warning("TLS 1.3 requested but not supported by system, falling back to TLS 1.2")
+          if hasattr(ssl, "TLSVersion"):
+            context.maximum_version = ssl.TLSVersion.TLSv1_2
+      elif max_version == "TLSv1.2":
+        if hasattr(ssl, "TLSVersion"):
+          context.maximum_version = ssl.TLSVersion.TLSv1_2
+          logging.info("Set maximum TLS version to TLSv1.2")
+
+      # Configure minimum TLS version
+      min_version = tls_settings.get("tls_minimum_version")
+      if min_version == "TLSv1.3":
+        if hasattr(ssl, "HAS_TLSv1_3") and ssl.HAS_TLSv1_3 and hasattr(ssl, "TLSVersion"):
+          context.minimum_version = ssl.TLSVersion.TLSv1_3
+          logging.info("Set minimum TLS version to TLSv1.3")
+        else:
+          logging.warning("TLS 1.3 minimum requested but not supported, falling back to TLS 1.2")
+          if hasattr(ssl, "TLSVersion"):
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
+      elif min_version == "TLSv1.2":
+        if hasattr(ssl, "TLSVersion"):
+          context.minimum_version = ssl.TLSVersion.TLSv1_2
+          logging.info("Set minimum TLS version to TLSv1.2")
+
+      # Configure ciphers (only for TLS 1.2)
+      ciphers = tls_settings.get("ciphers", "")
+      if ciphers and ciphers.strip():  # Only set if ciphers is not empty
+        try:
+          context.set_ciphers(ciphers)
+          logging.info(f"Successfully configured ciphers: {ciphers}")
+        except ssl.SSLError as e:
+          logging.error(f"Invalid cipher configuration '{ciphers}': {e}")
+        except Exception as e:
+          logging.error(f"Unexpected error setting ciphers '{ciphers}': {e}")
+      elif max_version == "TLSv1.3":
+        logging.info("TLS 1.3 enabled - cipher configuration handled automatically")
+      else:
+        logging.info("No custom ciphers configured, using system defaults")
+
+    except Exception as e:
+      logging.error(f"Error configuring SSL context: {e}")
+      logging.info("Using default SSL context configuration")
+
+    return context
+
   gunicorn_options = {
       'accesslog': "-",
       'access_log_format': "%({x-forwarded-for}i)s %(h)s %(l)s %(u)s %(t)s '%(r)s' %(s)s %(b)s '%(f)s' '%(a)s'",
@@ -226,7 +300,6 @@ def rungunicornserver(args=[], options={}):
       'certfile': conf.SSL_CERTIFICATE.get(),  # SSL certificate file
       'chdir': None,
       'check_config': None,
-      'ciphers': conf.SSL_CIPHER_LIST.get(),  # Ciphers to use (see stdlib ssl module)
       'config': None,
       'daemon': None,
       'do_handshake_on_connect': False,       # Whether to perform SSL handshake on socket connect.
@@ -257,7 +330,7 @@ def rungunicornserver(args=[], options={}):
       'reload_engine': None,
       'sendfile': True,
       'spew': None,
-      'ssl_version': ssl.PROTOCOL_TLSv1_2,    # SSL version to use
+      'ssl_context': gunicorn_ssl_context,
       'statsd_host': None,
       'statsd_prefix': None,
       'suppress_ragged_eofs': None,           # Suppress ragged EOFs (see stdlib ssl module)
@@ -277,6 +350,7 @@ def rungunicornserver(args=[], options={}):
       'post_worker_init': post_worker_init,
       'worker_int': worker_int
   }
+
   StandaloneApplication(handler_app, gunicorn_options).run()
 
 


### PR DESCRIPTION
- Add TLS 1.3 configuration options and enhanced cipher suites
- Implement TLS 1.3 support in Gunicorn server with optimal protocol selection
- Enhance HTTP client with TLS 1.3 support and custom SSL adapters
- Add TLS 1.3 support to Thrift client with graceful fallback
- Include comprehensive TLS 1.3 compliance test suite
- Maintain backward compatibility with TLS 1.2 systems

## How was this patch tested?

- Manually on the Hue server.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
