### PR TITLE
[django][saml] Fix SAML for Django 4 upgrade

### DIFF
--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -253,6 +253,14 @@ TEMPLATES = [
     ],
     'NAME': 'django',
     'APP_DIRS': True,
+    'OPTIONS': {
+      'context_processors': [
+        'django.template.context_processors.debug',
+        'django.template.context_processors.request',
+        'django.contrib.auth.context_processors.auth',
+        'django.contrib.messages.context_processors.messages',
+      ],
+    },
   },
 ]
 


### PR DESCRIPTION
Problem 1:
`request.csp_nonce` was not getting passed to the djangosaml template. Added request context processor to Django template backend to fix this.

Problem 2:
SAML authentication was causing infinite recursion. Our `update_user` method in `libsaml/backend.py` was not getting called. Renamed `update_user()` to `_update_user()`
Had to add additional checks for the first-time user login.

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
