### PR TITLE
[ui]: fix the undefined check resolving as true for scheduleTask tab

### DIFF
--- a/desktop/core/src/desktop/js/apps/jobBrowser/knockout/JobBrowserViewModel.js
+++ b/desktop/core/src/desktop/js/apps/jobBrowser/knockout/JobBrowserViewModel.js
@@ -76,7 +76,7 @@ export default class JobBrowserViewModel {
         !this.isMini() && schedulerInterfaceCondition();
 
       const schedulerBeatInterfaceCondition = () =>
-        this.appConfig()?.scheduler?.interpreter_names.indexOf('celery-beat') !== -1;
+        this.appConfig()?.scheduler?.interpreter_names.includes('celery-beat');
 
       const livyInterfaceCondition = () =>
         !this.isMini() &&


### PR DESCRIPTION
## What changes were proposed in this pull request?

- When the oozie is blacklisted, `this.appConfig()?.scheduler?.interpreter_names` is undefined which results in  `this.appConfig()?.scheduler?.interpreter_names.indexOf('celery-beat') !== -1` as `undefined != -1 ` as true.
- Fixing it by replacing indexOf with includes.

## How was this patch tested?

- Manually tested

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
