### PR TITLE
[ui-AdminServerPages-improvement] Ensure consistent grey background across all admin pages

### DIFF
--- a/desktop/core/src/desktop/js/apps/admin/Configuration/Configuration.scss
+++ b/desktop/core/src/desktop/js/apps/admin/Configuration/Configuration.scss
@@ -20,6 +20,7 @@
   .config-component {
     background-color: $fluidx-gray-100;
     padding: 24px;
+    min-height: 100vh;
 
     .config__section-dropdown-label {
       color: $fluidx-gray-700;

--- a/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.scss
+++ b/desktop/core/src/desktop/js/apps/admin/Metrics/Metrics.scss
@@ -19,6 +19,7 @@
 .metrics-component.antd.cuix {
   background-color: $fluidx-gray-100;
   padding: 24px;
+  min-height: 100vh;
 
   .metrics-heading {
     font-size: $font-size-base;

--- a/desktop/core/src/desktop/js/apps/admin/ServerLogs/ServerLogsTab.scss
+++ b/desktop/core/src/desktop/js/apps/admin/ServerLogs/ServerLogsTab.scss
@@ -20,6 +20,7 @@
   .hue-server-logs-component {
     background-color: $fluidx-gray-100;
     padding: 24px;
+    min-height: 100vh;
 
     .server__display-logs {
       overflow: auto;


### PR DESCRIPTION
## What changes were proposed in this pull request?

## Problem
Admin pages (Metrics, Configuration, ServerLogs, Overview) had inconsistent background styling:
- Some pages showed grey background only around content, not full viewport.

## Solution
- ✅ Added `min-height: 100vh` to all admin components for full viewport coverage
- ✅ Ensured consistent grey background (`$fluidx-gray-100`) across all admin pages

## How was this patch tested?
Manual Testing

PFA the updated admin pages:

https://github.com/user-attachments/assets/39641c74-0ad2-4a3e-b3fb-6698cc77fda3


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
