### PR TITLE
[backend] Fix HTTP client adapter selection when TLS is disabled

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -116,6 +116,12 @@ http_500_debug_mode=false
 # the client is always receiving the latest version of the resource.
 ## custom_cache_control=true
 
+# Enable TLS 1.3 support when available. Requires OpenSSL 1.1.1+ and Python 3.7+
+## ssl_tls13_enabled=true
+
+# Enable TLS 1.2 support when available. This is the default behavior.
+## ssl_tls12_enabled=true
+
 # Filename of SSL Certificate
 ## ssl_certificate=
 

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -121,6 +121,12 @@
   # that the client is always receiving the latest version of the resource.
   ## custom_cache_control=true
 
+  # Enable TLS 1.3 support when available. Requires OpenSSL 1.1.1+ and Python 3.7+
+  ## ssl_tls13_enabled=true
+
+  # Enable TLS 1.2 support when available. This is the default behavior.
+  ## ssl_tls12_enabled=true
+
   # Filename of SSL Certificate
   ## ssl_certificate=
 

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -331,7 +331,7 @@ def has_tls13_support():
   """Check if TLS 1.3 is supported by the current Python/OpenSSL version."""
   try:
     import ssl
-    return hasattr(ssl, 'HAS_TLSv1_3') and ssl.HAS_TLSv1_3
+    return hasattr(ssl, 'HAS_TLSv1_3') and ssl.HAS_TLSv1_3 and is_https_enabled()
   except ImportError:
     return False
 
@@ -346,7 +346,7 @@ SSL_TLS12_ENABLED = Config(
   key="ssl_tls12_enabled",
   help=_("Enable TLS 1.2 support when available. This is the default behavior."),
   type=coerce_bool,
-  default=True)
+  dynamic_default=is_https_enabled)
 
 
 def has_ssl_no_renegotiation():

--- a/desktop/core/src/desktop/lib/gunicorn_server_utils.py
+++ b/desktop/core/src/desktop/lib/gunicorn_server_utils.py
@@ -333,7 +333,6 @@ def create_gunicorn_options(options):
     'reload_engine': None,
     'sendfile': True,
     'spew': None,
-    'ssl_context': gunicorn_ssl_context,
     'statsd_host': None,
     'statsd_prefix': None,
     'suppress_ragged_eofs': None,      # Suppress ragged EOFs (see stdlib ssl module)
@@ -353,6 +352,9 @@ def create_gunicorn_options(options):
     'post_worker_init': post_worker_init,
     'worker_int': worker_int
   }
+
+  if tls_settings:
+    gunicorn_options.update({'ssl_context': gunicorn_ssl_context})
 
   return gunicorn_options
 


### PR DESCRIPTION
- Add conditional logic to use standard HTTPAdapter when create_http_ssl_context() returns None
- Prevent unnecessary TLS processing overhead when TLS 1.2/1.3 are both disabled
- Move SSL verification configuration to TLS-enabled path only
- Mount standard adapter to specific URL instead of protocol prefixes when TLS is off

## How was this patch tested?

- Tested manually

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
