### PR TITLE
[ui-importer] Add Primary key column in bulk column modal

### DIFF
--- a/desktop/core/src/desktop/js/apps/newimporter/FilePreviewTab/EditColumnsModal/EditColumnsModal.scss
+++ b/desktop/core/src/desktop/js/apps/newimporter/FilePreviewTab/EditColumnsModal/EditColumnsModal.scss
@@ -38,4 +38,13 @@
     color: vars.$fluidx-gray-500;
     font-style: italic;
   }
+
+  &__primary-key {
+    text-align: center;
+    white-space: nowrap;
+
+    .ant-radio-wrapper {
+      margin: 0;
+    }
+  }
 }

--- a/desktop/core/src/desktop/js/apps/newimporter/types.ts
+++ b/desktop/core/src/desktop/js/apps/newimporter/types.ts
@@ -69,6 +69,7 @@ export interface FileMetaData {
 export interface BaseColumnProperties {
   type?: string;
   comment?: string;
+  isPrimaryKey?: boolean;
 }
 
 export interface FilePreviewTableColumn extends BaseColumnProperties {


### PR DESCRIPTION
## What changes were proposed in this pull request?
1) Add Primary key column in bulk column modal
2) Centre align the headings of the modal like Title, Type, Sample, Comment, etc.

## How was this patch tested?
Manual testing. Find the video of the change made attached.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
