### PR TITLE
[ui-core] upgrade axios from 0.28.0 to 1.8.2 to fix CVE-2025-27152

### DIFF
--- a/desktop/core/src/desktop/js/jest/jest.init.js
+++ b/desktop/core/src/desktop/js/jest/jest.init.js
@@ -111,6 +111,11 @@ $.ajaxSetup({
   }
 });
 
+/**
+ * Interceptor for axios requests in tests
+ * @param {import('axios').InternalAxiosRequestConfig} config
+ * @returns {import('axios').InternalAxiosRequestConfig}
+ */
 const axiosConfigInterceptor = config => {
   console.warn('Actual axios ajax request made to url: ' + config.url);
   console.trace();

--- a/docs/designs/hue5.md
+++ b/docs/designs/hue5.md
@@ -98,7 +98,7 @@ A live demo with the SQL Scratchpad is coming. In the meantime:
         // Util to check if cached token is still valid before asking to auth for a new one
         axios.post('v1/iam/verify/auth-token/', {token: data['data']['token']});
 
-        axios.defaults.headers.common['Authorization'] = 'JWT ' + data['data']['token'];
+        axios.defaults.headers['Authorization'] = 'JWT ' + data['data']['token'];
       }).then(function() {
         axios.post('/v1/editor/query/sqlite', {snippet: "{\"statement\":\"SELECT 1000, 1001\""}).then(function(data) {
           console.log(data['data']);

--- a/docs/docs-site/content/developer/api/rest/_index.md
+++ b/docs/docs-site/content/developer/api/rest/_index.md
@@ -96,7 +96,7 @@ In the meantime, with Axios:
         // Util to check if cached token is still valid before asking to auth for a new one
         axios.post('api/v1/token/verify/', {token: data['access']});
 
-        axios.defaults.headers.common['Authorization'] = 'Bearer ' + data['access'];
+        axios.defaults.headers['Authorization'] = 'Bearer ' + data['access'];
       }).then(function() {
         axios.post('api/v1/query/sqlite', {statement:"SELECT 1000, 1001"}).then(function(data) {
           console.log(data['data']);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@gethue/sql-formatter": "4.0.3",
         "@selectize/selectize": "0.14.0",
         "antd": "4.24.5",
-        "axios": "0.28.0",
+        "axios": "1.8.2",
         "classnames": "2.3.2",
         "clipboard": "1.7.1",
         "copy-to-clipboard": "3.3.3",
@@ -5596,11 +5596,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
-      "integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@gethue/sql-formatter": "4.0.3",
     "@selectize/selectize": "0.14.0",
     "antd": "4.24.5",
-    "axios": "0.28.0",
+    "axios": "1.8.2",
     "classnames": "2.3.2",
     "clipboard": "1.7.1",
     "copy-to-clipboard": "3.3.3",


### PR DESCRIPTION
## What changes were proposed in this pull request?
Upgrades axios HTTP client from 0.28 to 1.8.2, addressing all breaking changes introduced in axios 1.0.0. Migrates from deprecated `CancelToken` to standard `AbortController` API and updates type definitions for interceptors.

### Core API (`desktop/core/src/desktop/js/api/utils.ts`)
- Updated request interceptor types: `AxiosRequestConfig` → `InternalAxiosRequestConfig`
- Migrated cancellation: `CancelToken` → `AbortController`
- Replaced `getCancelToken()` → `getAbortController()`
- Updated `sendApiRequest()` and `get()` functions to use `signal`/`abort()` instead of `cancelToken`/`cancel()`

### Tests (`desktop/core/src/desktop/js/jest/jest.init.js`)
- Added JSDoc type annotations for `InternalAxiosRequestConfig`

### Documentation
- Updated `docs/docs-site/content/developer/api/rest/_index.md` - Fixed header examples
- Updated `docs/designs/hue5.md` - Fixed header examples

### Dependencies
- `package.json`: axios 0.28 → 1.8.2
- `package-lock.json`: Updated dependency tree

## How was this patch tested?

###  Automated Tests
- All existing tests pass with no regressions.

### Manual Testing
Created and executed test plan covering:
- [x] - SQL query execution & cancellation
- [x] - File browser operations
- [x] - CSRF token injection (XHR compatibility)
- [x] - Error handling 
- [x] - Knox base URL rewriting - mock
- [ ] - Knox base URL rewriting - real Knox (To be tesedt in bug bash)
