### PR TITLE
[ui-core] Fix left assist panel to use configured default home paths for S3/ABFS/OFS

### DIFF
--- a/desktop/core/src/desktop/js/config/hueConfig.ts
+++ b/desktop/core/src/desktop/js/config/hueConfig.ts
@@ -143,11 +143,14 @@ export const getRootFilePath = (connector: BrowserInterpreter): string => {
 
     // For ABFS and OFS, strip the scheme prefix as AssistStorageEntry adds it automatically
     // S3 doesn't have auto-prefixing logic, so keep the full path
-    if (connector.type === 'abfs' && decodedPath.startsWith('abfs://')) {
-      return decodedPath.substring(7); // Remove 'abfs://'
+    const abfsPrefix = 'abfs://';
+    if (connector.type === 'abfs' && decodedPath.startsWith(abfsPrefix)) {
+      return decodedPath.substring(abfsPrefix.length);
     }
-    if (connector.type === 'ofs' && decodedPath.startsWith('ofs://')) {
-      return decodedPath.substring(6); // Remove 'ofs://'
+
+    const ofsPrefix = 'ofs://';
+    if (connector.type === 'ofs' && decodedPath.startsWith(ofsPrefix)) {
+      return decodedPath.substring(ofsPrefix.length);
     }
 
     return decodedPath;

--- a/desktop/core/src/desktop/js/ko/components/assist/ko.assistStoragePanel.js
+++ b/desktop/core/src/desktop/js/ko/components/assist/ko.assistStoragePanel.js
@@ -251,7 +251,7 @@ class AssistStoragePanel {
 
     const currentEntry = new AssistStorageEntry({
       source: this.activeSource(),
-      rootPath: rootPath,
+      rootPath,
       definition: {
         name: rootPath,
         type: 'dir'


### PR DESCRIPTION
## Description
Fixes the left assist panel's Files section to respect configured default home paths for S3, ABFS, and OFS storage types instead of always defaulting to root path.

## Problem
In the left assist panel's Files section, when users clicked on S3, ABFS, or OFS sources, the panel always tried to access the root path (e.g., `s3a://`, `abfs://`, `ofs://`) regardless of configured default paths like `remote_storage_home` or `default_home_path`.

This caused failures in RAZ environments where users don't have access to the storage root, even though the main filebrowser worked correctly with the configured home paths.

## Solution
1. **Made `rootPath` a Knockout observable** to properly track and react to changes
2. **Fixed `getRootFilePath()`** to correctly extract and decode the full path from the connector's `page` URL
3. **Added scheme-stripping logic** for ABFS/OFS which have auto-prefixing behavior in `AssistStorageEntry`
4. **Updated default path logic** in `reload()` and `goHome()` handlers to use `rootPath()` instead of hardcoded `/`
5. **Enhanced home button visibility** to show for S3/ABFS when a default path is configured

## Storage Type Handling
| Type | Behavior | Example |
|------|----------|---------|
| S3 | Keep full scheme | `s3a://bucket/user/path` |
| GS | Keep full scheme | `gs://bucket/user/path` |
| ADLS | Keep full scheme | `adl://path` |
| ABFS | Strip scheme (auto-prefixed) | `container/user/path` → `abfs://container/user/path` |
| OFS | Strip scheme (auto-prefixed) | `volume/bucket/path` → `ofs://volume/bucket/path` |
| HDFS | Use `window.USER_HOME_DIR` | N/A |

## Testing
- S3 with `remote_storage_home` configured - loads correct home path
- ABFS with `default_home_path` configured - loads correct home path  
- OFS with configured path - works correctly
- Home button appears and functions for S3/ABFS when path is configured
- Works in RAZ environments with restricted S3 access - TBD

## Files Changed
- `desktop/core/src/desktop/js/config/hueConfig.ts` - Fixed path extraction and decoding
- `desktop/core/src/desktop/js/ko/components/assist/ko.assistStoragePanel.js` - Made rootPath observable and updated usage