### PR TITLE
[cve] Upgrade setuptools to 80.9.0 for Python 3.9+ to fix CVE-2025-47273

### DIFF
--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -1,4 +1,3 @@
-setuptools==70.0.0
 apache-ranger==0.0.3
 requests-gssapi==1.2.3
 asn1crypto==0.24.0

--- a/desktop/core/generate_requirements.py
+++ b/desktop/core/generate_requirements.py
@@ -110,7 +110,6 @@ class RequirementsGenerator:
       "requests-kerberos==0.14.0",
       "rsa==4.7.2",
       "ruff==0.11.10",
-      "setuptools==70.0.0",
       "six==1.16.0",
       "slack-sdk==3.31.0",
       "SQLAlchemy==1.3.8",
@@ -130,6 +129,7 @@ class RequirementsGenerator:
         "numpy==1.24.4",
         "pandas==2.0.3",
         "sasl==0.3.1",
+        "setuptools==70.0.0",
       ],
       "3.9": [
         "decorator==5.1.1",
@@ -139,6 +139,7 @@ class RequirementsGenerator:
         "pandas==2.0.3",
         "pyopenssl==22.1.0",
         "sasl==0.3.1",
+        "setuptools==80.9.0",
       ],
       "3.11": [
         "async-timeout==5.0.1",
@@ -148,6 +149,7 @@ class RequirementsGenerator:
         "numpy==1.24.4",
         "pandas==2.0.3",
         "pure-sasl==0.6.2",
+        "setuptools==80.9.0",
       ],
     }
 
@@ -158,6 +160,7 @@ class RequirementsGenerator:
         "Markdown==3.1",
         "numpy==1.24.4",
         "pandas==2.0.3",
+        "setuptools==70.0.0",
       ],
       "3.9": [
         "decorator==5.1.1",
@@ -167,6 +170,7 @@ class RequirementsGenerator:
         "pandas==2.0.3",
         "pyopenssl==22.1.0",
         "sasl==0.3.1",
+        "setuptools==80.9.0",
       ],
       "3.11": [
         "async-timeout==5.0.1",
@@ -176,6 +180,7 @@ class RequirementsGenerator:
         "numpy==1.24.4",
         "pandas==2.0.3",
         "pure-sasl==0.6.2",
+        "setuptools==80.9.0",
       ],
     }
     self.arch_requirements_map = {

--- a/desktop/core/generate_requirements_test.py
+++ b/desktop/core/generate_requirements_test.py
@@ -113,9 +113,11 @@ class TestRequirementsGenerator:
       generator = RequirementsGenerator()
       generator.arch = "x86_64"
       generator.python_version_string = "3.9"
-      generator.requirements = ["setuptools==70.0.0", "Django==4.1.13"]
+      generator.requirements = ["Django==4.1.13"]
       generator.local_requirements = []
-      generator.arch_requirements_map = {"x86_64": {"default": ["cryptography==42.0.8"], "3.9": ["Markdown==3.8", "numpy==1.24.4"]}}
+      generator.arch_requirements_map = {
+        "x86_64": {"default": ["cryptography==42.0.8"], "3.9": ["Markdown==3.8", "numpy==1.24.4", "setuptools==80.9.0"]}
+      }
 
       # Mock copy_local_requirements for test isolation
       generator.copy_local_requirements = mock.MagicMock(return_value=[])
@@ -126,7 +128,7 @@ class TestRequirementsGenerator:
       mock_open.assert_called_once_with(f"{self.temp_dir}/requirements-x86_64-3.9.txt", "w")
 
       # Verify correct requirements were written
-      expected_requirements = "\n".join(["setuptools==70.0.0", "Django==4.1.13", "Markdown==3.8", "numpy==1.24.4"])
+      expected_requirements = "\n".join(["Django==4.1.13", "Markdown==3.8", "numpy==1.24.4", "setuptools==80.9.0"])
       mock_open().write.assert_called_once_with(expected_requirements)
 
   @mock.patch("generate_requirements.this_dir")
@@ -176,9 +178,9 @@ class TestRequirementsGenerator:
       generator = RequirementsGenerator()
       generator.arch = "x86_64"
       generator.python_version_string = "3.9"
-      generator.requirements = ["setuptools==70.0.0"]
+      generator.requirements = []
       generator.local_requirements = ["boto-2.49.0", "django-axes-5.13.0"]
-      generator.arch_requirements_map = {"x86_64": {"default": [], "3.9": ["Markdown==3.8"]}}
+      generator.arch_requirements_map = {"x86_64": {"default": [], "3.9": ["Markdown==3.8", "setuptools==80.9.0"]}}
 
       # Mock copy_local_requirements to return file paths
       local_reqs = [f"file://{self.temp_dir}/3.9/boto-2.49.0", f"file://{self.temp_dir}/3.9/django-axes-5.13.0"]
@@ -189,7 +191,7 @@ class TestRequirementsGenerator:
       mock_open.assert_called_once_with(f"{self.temp_dir}/requirements-x86_64-3.9.txt", "w")
 
       expected_requirements = "\n".join(
-        ["setuptools==70.0.0", "Markdown==3.8", f"file://{self.temp_dir}/3.9/boto-2.49.0", f"file://{self.temp_dir}/3.9/django-axes-5.13.0"]
+        ["Markdown==3.8", "setuptools==80.9.0", f"file://{self.temp_dir}/3.9/boto-2.49.0", f"file://{self.temp_dir}/3.9/django-axes-5.13.0"]
       )
 
       mock_open().write.assert_called_once_with(expected_requirements)


### PR DESCRIPTION
## Security Fix

This PR upgrades setuptools to address **CVE-2025-47273** with a Python version-specific approach.

## Summary

- **Python 3.8**: Keeps `setuptools==70.0.0` (unchanged)
- **Python 3.9**: Upgrades to `setuptools==80.9.0`
- **Python 3.11**: Upgrades to `setuptools==80.9.0`

## Why This Approach?

PyPI requires setuptools 80.9.0 to have Python >=3.9, so we implement version-specific requirements in `generate_requirements.py` to:
1. Maintain backward compatibility for Python 3.8 users
2. Provide security fixes for Python 3.9+ users
3. Respect PyPI package constraints

## Changes

### Modified Files
- `desktop/core/generate_requirements.py`: Move setuptools to architecture-specific requirements
- `desktop/core/generate_requirements_test.py`: Update tests to use correct setuptools versions
- `desktop/core/base_requirements.txt`: Remove old version

### Implementation Details
```python
# Before: setuptools in base requirements
self.requirements = [
    "setuptools==70.0.0",  # All Python versions
    ...
]

# After: setuptools in version-specific requirements
self.x86_64_requirements = {
    "default": [..., "setuptools==70.0.0"],  # Python 3.8
    "3.9": [..., "setuptools==80.9.0"],      # Python 3.9+
    "3.11": [..., "setuptools==80.9.0"],     # Python 3.9+
}
```

## Testing

### Verification Steps
- [x] Python syntax validation passed
- [x] Requirements generation tested for all supported versions
- [x] Unit tests updated and verified
- [x] Manual testing of generated requirements files

### Test Results
```bash
✓ Python 3.8 (default): setuptools==70.0.0
✓ Python 3.9:          setuptools==80.9.0
✓ Python 3.11:         setuptools==80.9.0
```

### How to Test
```bash
# Generate requirements
cd desktop/core
python3 generate_requirements.py

# Verify setuptools version
grep setuptools requirements-*.txt
```

```bash
# Clean build
cd ../..
make clean && make apps

# Verify installed version
pip show setuptools
```

## Impact Assessment

| Aspect | Impact | Notes |
|--------|--------|-------|
| **Python 3.8 Users** | Setup upgrade required | Same version (70.0.0) |
| **Python 3.9+ Users** | CVE Fixed | Upgraded to 80.9.0 |
| **Build Process** | No Change | Dynamic generation unchanged |
| **Dependencies** | No Conflicts | Tested with all deps |
| **Breaking Changes** | None | Backward compatible |

## Security

- **CVE ID**: CVE-2025-47273
- **Severity**: High
- **Fixed Version**: setuptools 78.1.1 and above
- **Affected Versions**: below setuptools 78.1.1

## References

- PyPI setuptools: https://pypi.org/project/setuptools/80.9.0/
- CVE Details: CVE-2025-47273
- Python Version Support: Python 3.8, 3.9, 3.11