### PR TITLE
Fix on Enable SAML certificate creation with passphrase support

### DIFF
--- a/desktop/core/ext-py3/pysaml2-7.3.1/src/saml2/sigver.py
+++ b/desktop/core/ext-py3/pysaml2-7.3.1/src/saml2/sigver.py
@@ -481,7 +481,7 @@ def import_rsa_key_from_file(filename, passphrase=None):
     with open(filename, "rb") as fd:
         data = fd.read()
     passphrase = bytes(passphrase, 'ascii') if passphrase else None
-    key = saml2.cryptography.asymmetric.load_pem_private_key(data)
+    key = saml2.cryptography.asymmetric.load_pem_private_key(data, passphrase)
     return key
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Fix of the load_pem_private_key method call, including the passphrase parameter, to enable reading encrypted .pem files. 

## How was this patch tested?

- This code line was likely left incorrect after the upgrade to Python 3, where some commits were lost and had to be recreated.
- The correct version was already available in this commit: 7b8e2b408b788303284ccbc1afc461c0f083f443.
- However, the current version is based on an older commit: 4bc796ba19d6c7b7b7262a4bc95d11032433428b.
- The code was tested at a customer environment. Before applying this fix, we were seeing the error “Password was not given but private key is encrypted”, because the passphrase was never actually used when loading the PEM file. 
After applying the correction, it is now possible to use an encrypted PEM file without any issues.
