### PR TITLE
Make gunicorn max_requests configurable

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -78,6 +78,12 @@ http_500_debug_mode=false
 # Workers still alive after the timeout (starting from the receipt of the restart signal) are force killed.
 # gunicorn_worker_graceful_timeout=900
 
+# The maximum number of requests a worker will process before restarting.
+# gunicorn_max_requests=1200
+
+# The maximum jitter to add to the max_requests setting.
+# gunicorn_max_requests_jitter=0
+
 # Name of the Unix Domain Socket file for log listener communication.
 ## log_listener_socket_name=hue.uds
 

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -83,6 +83,12 @@
   # Workers still alive after the timeout (starting from the receipt of the restart signal) are force killed.
   # gunicorn_worker_graceful_timeout=900
 
+  # The maximum number of requests a worker will process before restarting.
+  # gunicorn_max_requests=1200
+
+  # The maximum jitter to add to the max_requests setting.
+  # gunicorn_max_requests_jitter=0
+
   # Name of the Unix Domain Socket file for log listener communication.
   ## log_listener_socket_name=hue.uds
 

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -170,6 +170,18 @@ def is_custom_jwt_auth_enabled():
   return bool(AUTH.JWT.KEY_SERVER_URL.get())
 
 
+GUNICORN_MAX_REQUESTS = Config(
+  key="gunicorn_max_requests",
+  help=_("The maximum number of requests a worker will process before restarting."),
+  type=int,
+  default=1200)
+
+GUNICORN_MAX_REQUESTS_JITTER = Config(
+  key="gunicorn_max_requests_jitter",
+  help=_("The maximum jitter to add to the max_requests setting."),
+  type=int,
+  default=0)
+
 USE_CHERRYPY_SERVER = Config(
   key="use_cherrypy_server",
   help=_("If set to true, CherryPy will be used. Otherwise, Gunicorn will be used as the webserver."),

--- a/desktop/core/src/desktop/lib/gunicorn_server_utils.py
+++ b/desktop/core/src/desktop/lib/gunicorn_server_utils.py
@@ -318,8 +318,9 @@ def create_gunicorn_options(options):
     'limit_request_fields': conf.LIMIT_REQUEST_FIELDS.get(),
     'limit_request_line': conf.LIMIT_REQUEST_LINE.get(),
     'loglevel': 'DEBUG' if conf.DJANGO_DEBUG_MODE.get() else 'INFO',
-    'max_requests': 1200,          # The maximum number of requests a worker will process before restarting.
-    'max_requests_jitter': 0,
+    # The maximum number of requests a worker will process before restarting.
+    'max_requests': conf.GUNICORN_MAX_REQUESTS.get(),
+    'max_requests_jitter': conf.GUNICORN_MAX_REQUESTS_JITTER.get(),
     'paste': None,
     'pidfile': None,
     'preload_app': False,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This Pull Request makes `gunicorn_max_requests` and `gunicorn_max_requests_jitter` properties configurable.

I'm recreating the PR after the old one was closed automatically: https://github.com/cloudera/hue/pull/4265

## How was this patch tested?

- Tested manually.
