### PR TITLE
Update python requirements

### DIFF
--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -8,7 +8,7 @@ cffi==1.15.0
 channels==4.2.2
 channels-redis==4.2.1
 configobj==5.0.9
-cx-Oracle==8.3.0
+oracledb==1.0.3
 django-auth-ldap==4.3.0
 Django==4.2.23
 daphne==3.0.2

--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -8,7 +8,7 @@ cffi==1.15.0
 channels==4.2.2
 channels-redis==4.2.1
 configobj==5.0.9
-oracledb==1.0.3
+oracledb==2.0.0
 django-auth-ldap==4.3.0
 Django==4.2.23
 daphne==3.0.2

--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -10,7 +10,7 @@ channels-redis==4.2.1
 configobj==5.0.9
 oracledb==2.0.0
 django-auth-ldap==4.3.0
-Django==4.2.23
+Django==4.2.24
 daphne==3.0.2
 django-redis==5.4.0
 django-celery-beat==2.6.0

--- a/desktop/core/build-constraints.txt
+++ b/desktop/core/build-constraints.txt
@@ -1,4 +1,4 @@
 # Build-time constraints to prevent setuptools 82+ from breaking cx-Oracle
-# See: https://github.com/oracle/python-cx_Oracle/blob/main/setup.py (imports pkg_resources)
+# See: https://github.com/oracle/python-oracledb/blob/main/setup.py (imports pkg_resources)
 # setuptools 82+ removed pkg_resources, causing build failures
 setuptools<82

--- a/desktop/core/build-constraints.txt
+++ b/desktop/core/build-constraints.txt
@@ -1,4 +1,0 @@
-# Build-time constraints to prevent setuptools 82+ from breaking cx-Oracle
-# See: https://github.com/oracle/python-oracledb/blob/main/setup.py (imports pkg_resources)
-# setuptools 82+ removed pkg_resources, causing build failures
-setuptools<82

--- a/desktop/core/generate_requirements.py
+++ b/desktop/core/generate_requirements.py
@@ -54,7 +54,7 @@ class RequirementsGenerator:
       "channels==4.2.2",
       "channels-redis==4.2.1",
       "configobj==5.0.9",
-      "oracledb==1.0.3",
+      "oracledb==2.0.0",
       "daphne==3.0.2",
       "Django==4.2.23",
       "django-auth-ldap==4.3.0",

--- a/desktop/core/generate_requirements.py
+++ b/desktop/core/generate_requirements.py
@@ -56,7 +56,7 @@ class RequirementsGenerator:
       "configobj==5.0.9",
       "oracledb==2.0.0",
       "daphne==3.0.2",
-      "Django==4.2.23",
+      "Django==4.2.24",
       "django-auth-ldap==4.3.0",
       "django-celery-beat==2.6.0",
       "django-celery-results==2.5.1",

--- a/desktop/core/generate_requirements.py
+++ b/desktop/core/generate_requirements.py
@@ -54,7 +54,7 @@ class RequirementsGenerator:
       "channels==4.2.2",
       "channels-redis==4.2.1",
       "configobj==5.0.9",
-      "cx-Oracle==8.3.0",
+      "oracledb==1.0.3",
       "daphne==3.0.2",
       "Django==4.2.23",
       "django-auth-ldap==4.3.0",

--- a/desktop/core/src/desktop/metrics.py
+++ b/desktop/core/src/desktop/metrics.py
@@ -23,7 +23,7 @@ import threading
 from builtins import range
 from datetime import datetime, timedelta
 
-from cx_Oracle import DatabaseError as OracleDatabaseError
+from oracledb import DatabaseError as OracleDatabaseError
 from django.db import connection
 from django.db.utils import DatabaseError, OperationalError
 from future import standard_library

--- a/desktop/core/src/desktop/tests.py
+++ b/desktop/core/src/desktop/tests.py
@@ -794,22 +794,22 @@ def test_check_config_ajax():
   assert "misconfiguration" in response.content, response.content
 
 
-def test_cx_Oracle():
+def test_oracledb():
   """
-  Tests that cx_Oracle (external dependency) is built correctly.
+  Tests that oracledb (external dependency) is built correctly.
   """
   if 'ORACLE_HOME' not in os.environ and 'ORACLE_INSTANTCLIENT_HOME' not in os.environ:
     pytest.skip("Skipping Test")
 
   try:
-    import cx_Oracle
+    import oracledb
 
     return
   except ImportError as ex:
     if "No module named" in ex.message:
       assert (
         False,
-        "cx_Oracle skipped its build. This happens if "
+        "oracledb skipped its build. This happens if "
         "env var ORACLE_HOME or ORACLE_INSTANTCLIENT_HOME is not defined. "
         "So ignore this test failure if your build does not need to work "
         "with an oracle backend.",

--- a/desktop/libs/librdbms/src/librdbms/server/oracle_lib.py
+++ b/desktop/libs/librdbms/src/librdbms/server/oracle_lib.py
@@ -18,10 +18,10 @@
 import logging
 
 try:
-  import cx_Oracle as Database
+  import oracledb as Database
 except ImportError as e:
   from django.core.exceptions import ImproperlyConfigured
-  raise ImproperlyConfigured("Error loading cx_Oracle module: %s" % e)
+  raise ImproperlyConfigured("Error loading oracledb module: %s" % e)
 
 from librdbms.server.rdbms_base_lib import BaseRDBMSDataTable, BaseRDBMSResult, BaseRDMSClient
 

--- a/docs/docs-site/content/administrator/configuration/connectors/_index.md
+++ b/docs/docs-site/content/administrator/configuration/connectors/_index.md
@@ -204,7 +204,7 @@ Currently, only [basic LDAP authentication](https://github.com/trinodb/trino-pyt
 
 The dialect should be added to the Python system or Hue Python virtual environment:
 
-    ./build/env/bin/pip install cx_Oracle
+    ./build/env/bin/pip install oracledb
 
 Then give Hue the information about the database source:
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When installing cx_Oracle 8.3.0, the installation fails due to a compatibility issue with newer versions of setuptools.

Starting from setuptools v82.0.0, pkg_resources is no longer supported (see:
https://github.com/pypa/setuptools/blob/v82.0.0/NEWS.rst#deprecations-and-removals
).

Because of this removal, the installation process raises the following error:

`ModuleNotFoundError: No module named 'pkg_resources'`

According to the[ announcement “New major cx_Oracle release has a new name and repo: python-oracledb”,](https://github.com/oracle/python-cx_Oracle/issues/628) the cx_Oracle module has been replaced with python-oracledb.

As stated in the announcement, python-oracledb 1.0 is a new major release and the successor to cx_Oracle 8.3.
We have therefore updated the dependency to use python-oracledb version 2.0.0, which supports python3.11 while the 1.0 series don't support it.

## How was this patch tested?

- This patch was tested on the latest main branch of our company’s production Hue environment.

- The module replacement (cx_Oracle → python-oracledb) was applied and verified in a running production setup.