### PR TITLE
Bugfix saml logout

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -749,6 +749,18 @@ idle_session_timeout=-1
 # This can have any value that is not used by the other cookie names in your application.
 ## cookie_name=sessionid
 
+# The domain to use for session cookies. This is useful for cross-subdomain cookies.
+## cookie_domain=
+
+# The path to use for session cookies.
+## cookie_path=/
+
+# Name of the cookie used for SAML sessions (djangosaml2). See Django session settings.
+## session_cookie_name=saml_session
+
+# SameSite attribute for SAML session cookies (djangosaml2). See Django session settings.
+## session_cookie_samesite=None
+
 # Configuration to determine whether test cookie should be added determine whether the user's browser supports cookies
 # Should be disabled if django_session table is growing rapidly , Default value is true
 ## enable_test_cookie=true

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -751,6 +751,18 @@
     # This can have any value that is not used by the other cookie names in your application.
     ## cookie_name=sessionid
 
+    # The domain to use for session cookies. This is useful for cross-subdomain cookies.
+    ## cookie_domain=
+
+    # The path to use for session cookies.
+    ## cookie_path=/
+
+    # Name of the cookie used for SAML sessions (djangosaml2). See Django session settings.
+    ## session_cookie_name=saml_session
+
+    # SameSite attribute for SAML session cookies (djangosaml2). See Django session settings.
+    ## session_cookie_samesite=None
+
     # Configuration to determine whether test cookie should be added determine whether the user's browser supports cookies
     # Should be disabled if django_session table is growing rapidly , Default value is true
     ## enable_test_cookie=true

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -993,6 +993,30 @@ SESSION = ConfigSection(
       type=str,
       default="sessionid",
     ),
+    COOKIE_DOMAIN=Config(
+      key='cookie_domain',
+      help=_("The domain to use for session cookies. This is useful for cross-subdomain cookies."),
+      type=str,
+      default=None,
+    ),
+    COOKIE_PATH=Config(
+      key='cookie_path',
+      help=_("The path to use for session cookies."),
+      type=str,
+      default='/',
+    ),
+    SAML_COOKIE_NAME=Config(
+      key='session_cookie_name',
+      help=_("The name of the cookie to use for SAML sessions (djangosaml2). See Django session settings."),
+      type=str,
+      default="saml_session",
+    ),
+    SAML_COOKIE_SAMESITE=Config(
+      key='session_cookie_samesite',
+      help=_("The SameSite attribute for SAML session cookies (djangosaml2). See Django session settings."),
+      type=str,
+      default=None,
+    ),
     ENABLE_TEST_COOKIE=Config(
       key='enable_test_cookie',
       help=_("Configuration to determine whether test cookie should be added determine whether the user's browser supports cookies."),

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -473,6 +473,8 @@ if desktop.conf.TASK_SERVER_V2.ENABLED.get():
 
 # Configure sessions
 SESSION_COOKIE_NAME = desktop.conf.SESSION.COOKIE_NAME.get()
+SESSION_COOKIE_DOMAIN = desktop.conf.SESSION.COOKIE_DOMAIN.get()
+SESSION_COOKIE_PATH = desktop.conf.SESSION.COOKIE_PATH.get()
 SESSION_COOKIE_AGE = desktop.conf.SESSION.TTL.get()
 SESSION_COOKIE_SECURE = desktop.conf.SESSION.SECURE.get()
 SECURE_REFERRER_POLICY = None
@@ -595,6 +597,9 @@ if SAML_AUTHENTICATION:
   SESSION_EXPIRE_AT_BROWSER_CLOSE = True
   # Add required middleware for djangosaml2 1.9.3+
   MIDDLEWARE.append('djangosaml2.middleware.SamlSessionMiddleware')
+  # Set SAML session cookie name and SameSite attribute
+  SAML_SESSION_COOKIE_NAME = desktop.conf.SESSION.SAML_COOKIE_NAME.get()
+  SAML_SESSION_COOKIE_SAMESITE = desktop.conf.SESSION.SAML_COOKIE_SAMESITE.get()
 
 # Middleware classes.
 for middleware in desktop.conf.MIDDLEWARE.get():

--- a/desktop/libs/libsaml/src/libsaml/backend.py
+++ b/desktop/libs/libsaml/src/libsaml/backend.py
@@ -26,7 +26,7 @@ import logging
 from django.contrib.auth import logout as auth_logout
 from django.http import HttpResponse
 from djangosaml2.backends import Saml2Backend as _Saml2Backend
-from djangosaml2.views import LogoutView
+from djangosaml2.views import LogoutInitView
 
 from desktop.auth.backend import force_username_case, rewrite_user
 from desktop.conf import AUTH
@@ -117,9 +117,7 @@ class SAML2Backend(_Saml2Backend):
 
   def logout(self, request, next_page=None):
     if conf.LOGOUT_ENABLED.get():
-      response = LogoutView.as_view()(request)
-      auth_logout(request)
-      return response
+      return LogoutInitView.as_view()(request)
     elif conf.LOCAL_LOGOUT.get():
       auth_logout(request)
       LOG.debug("SAML local logout is called ...")

--- a/desktop/libs/libsaml/src/libsaml/urls.py
+++ b/desktop/libs/libsaml/src/libsaml/urls.py
@@ -22,10 +22,10 @@ from django.urls import re_path
 LOG = logging.getLogger()
 
 try:
-  from libsaml.views import AssertionConsumerServiceView, EchoAttributesView, local_logout, LoginView, LogoutView, MetadataView
+  from libsaml.views import AssertionConsumerServiceView, EchoAttributesView, local_logout, LoginView, LogoutView, LogoutInitView, MetadataView
 
   urlpatterns = [
-    re_path(r'^logout/$', LogoutView.as_view(), name='saml2_logout'),
+    re_path(r'^logout/$', LogoutInitView.as_view(), name='saml2_logout'),
     re_path(r'^ls/$', LogoutView.as_view(), name='saml2_ls'),
     re_path(r'^acs/$', AssertionConsumerServiceView.as_view(), name='saml2_acs'),
     re_path(r'^login/$', LoginView.as_view(), name='saml2_login'),

--- a/desktop/libs/libsaml/src/libsaml/views.py
+++ b/desktop/libs/libsaml/src/libsaml/views.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 from django.urls import reverse
 from django.utils.html import escape
-from djangosaml2.views import AssertionConsumerServiceView, EchoAttributesView, LoginView, LogoutView, MetadataView
+from djangosaml2.views import AssertionConsumerServiceView, EchoAttributesView, LoginView, LogoutView, LogoutInitView, MetadataView
 
 from desktop.lib.django_util import render
 
@@ -24,6 +24,7 @@ LoginView.dispatch.login_notrequired = True
 EchoAttributesView.dispatch.login_notrequired = True
 MetadataView.dispatch.login_notrequired = True
 LogoutView.dispatch.login_notrequired = True
+LogoutInitView.dispatch.login_notrequired = True
 AssertionConsumerServiceView.dispatch.login_notrequired = True
 
 try:


### PR DESCRIPTION
## What changes were proposed in this pull request?

### change LogoutView to LogoutInitView
In the current implementation, logout was handled using LogoutView, which is designed to process logout responses sent by the IdP (i.e., IdP → SP callback). However, our use case requires initiating the logout flow from the Service Provider (SP) side when a user clicks the logout button.

[According to the djangosaml2 documentation](https://github.com/IdentityPython/djangosaml2/blob/master/djangosaml2/views.py):
- LogoutView handles SAML LogoutResponse or LogoutRequest messages sent from the IdP.
- LogoutInitView initiates a SAML2 LogoutRequest from the SP to the IdP.

```
class LogoutView(SPConfigMixin, View):
    """SAML Logout Response endpoint

    The IdP will send the logout response to this view,
    which will process it with pysaml2 help and log the user
    out.
    Note that the IdP can request a logout even when
    we didn't initiate the process as a single logout
    request started by another SP.
    """
...
class LogoutInitView(LoginRequiredMixin, SPConfigMixin, View):
    """SAML Logout Request initiator

    This view initiates the SAML2 Logout request
    using the pysaml2 library to create the LogoutRequest.
    """
```

The issue we encountered was that the logout process stopped at the SP level and did not propagate to the IdP, because the SAML session information (saml_session) was missing. As a result, Single Logout (SLO) was not properly completed.

To resolve this:

I changed the logout entry point from LogoutView to LogoutInitView. This ensures that when the user clicks the logout button, the flow correctly starts from SP → IdP. The logout process now properly initiates a SAML LogoutRequest and completes the SLO flow. This change aligns the logout behavior with the intended SAML SLO flow and ensures IdP-level logout is triggered correctly.

### set cookie conf for djangosaml2

In djangosaml2.middleware.SamlSessionMiddleware, session information is:
- Stored in cookies during process_response
- Retrieved from cookies during process_request
However, in the latest version of Hue, there is no configurable way to set required cookie attributes such as COOKIE_DOMAIN, COOKIE_PATH. ([Source Code Link](https://github.com/IdentityPython/djangosaml2/blob/master/djangosaml2/middleware.py#L70-L80))

Without these attributes being correctly configured, the SAML session cookie is not properly stored in the browser. **As a result: saml_session is empty during logout.** The IdP logout step fails because required session information (e.g., subject_id) is missing.

To address this limitation:
I identified that properly configuring cookie settings would require modifying Hue source code.

This approach ensures consistent logout behavior even when Hue does not expose cookie configuration options for djangosaml2.

## How was this patch tested?

This patch was tested on the latest main branch of our company’s production Hue environment.
