### PR TITLE
docs: fix typo (occured -> occurred) in supervisor comment

### DIFF
--- a/desktop/core/src/desktop/supervisor.py
+++ b/desktop/core/src/desktop/supervisor.py
@@ -247,7 +247,7 @@ def drop_privileges():
 
   N.B. DO NOT USE THE logging MODULE FROM WITHIN THIS FUNCTION.
   This function is run in forked processes right before it calls
-  exec, but the fork may have occured while a different thread
+  exec, but the fork may have occurred while a different thread
   had locked the log. Since it's a forked process, the log will
   be locked forever in the subprocess and thus a logging.X may
   block forever.


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Fixes 'occured' -> 'occurred' typo in a comment inside `desktop/core/src/desktop/supervisor.py`.

## How was this patch tested?

- Comment-only change, no runtime impact. Existing tests remain unchanged.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
