### PR TITLE
[filebrowser] fix: normalize paths in copy/move same-path guard

### DIFF
--- a/apps/filebrowser/src/filebrowser/views.py
+++ b/apps/filebrowser/src/filebrowser/views.py
@@ -1379,7 +1379,9 @@ def move(request):
 
   def bulk_move(*args, **kwargs):
     for arg in args:
-      if arg['src_path'] == arg['dest_path']:
+      # Normalize before comparing so that semantically identical paths that differ only by a
+      # trailing slash (e.g. /user/test/tmp vs /user/test/tmp/) are still detected as the same.
+      if request.fs.normpath(arg['src_path']) == request.fs.normpath(arg['dest_path']):
         raise PopupException(_('Source path and destination path cannot be same'))
       request.fs.rename(
           arg['src_path'].encode('utf-8') if not isinstance(arg['src_path'], str) else arg['src_path'],
@@ -1399,7 +1401,11 @@ def copy(request):
   def bulk_copy(*args, **kwargs):
     ofs_skip_files = ''
     for arg in args:
-      if arg['src_path'] == arg['dest_path']:
+      # Normalize before comparing so that semantically identical paths that differ only by a
+      # trailing slash (e.g. /user/test/tmp vs /user/test/tmp/) are still detected as the same.
+      # Otherwise the raw string comparison passes and request.fs.copy ends up copying a directory
+      # into itself, creating an infinitely nested copy.
+      if request.fs.normpath(arg['src_path']) == request.fs.normpath(arg['dest_path']):
         raise PopupException(_('Source path and destination path cannot be same'))
 
       # Copy method for OFS returns a string of skipped files if their size is greater than chunk size.

--- a/apps/filebrowser/src/filebrowser/views_test.py
+++ b/apps/filebrowser/src/filebrowser/views_test.py
@@ -18,6 +18,7 @@
 import json
 import logging
 import os
+import posixpath
 import re
 import stat
 import tempfile
@@ -110,6 +111,61 @@ class TestFileBrowser:
         assert 200 == response.status_code
         dir_listing = response.context[0]['files']
         assert 1 == len(dir_listing)
+
+  def test_copy_same_path_trailing_slash_is_rejected(self):
+    # Copying a directory onto itself where the only difference is a trailing slash must be rejected.
+    # Without normalization the raw string comparison passes and request.fs.copy ends up copying the
+    # directory into itself (e.g. /user/systest/tmp -> /user/systest/tmp/tmp), nesting infinitely.
+    with patch('desktop.middleware.fsmanager.get_filesystem') as get_filesystem:
+      mock_fs = Mock(
+        normpath=Mock(side_effect=lambda p: posixpath.normpath(p)),
+      )
+      get_filesystem.return_value = mock_fs
+
+      response = self.client.post('/filebrowser/copy', dict(src_path=['/user/systest/tmp'], dest_path='/user/systest/tmp/'))
+
+      # The guard should fire and copy should never be attempted.
+      assert mock_fs.copy.call_count == 0
+      assert b'Source path and destination path cannot be same' in response.content
+
+  def test_copy_different_path_is_allowed(self):
+    # Sanity check: a genuinely different destination still performs the copy.
+    with patch('desktop.middleware.fsmanager.get_filesystem') as get_filesystem:
+      mock_fs = Mock(
+        normpath=Mock(side_effect=lambda p: posixpath.normpath(p)),
+      )
+      get_filesystem.return_value = mock_fs
+
+      self.client.post('/filebrowser/copy', dict(src_path=['/user/systest/tmp'], dest_path='/user/systest/dest'))
+
+      assert mock_fs.copy.call_count == 1
+
+  def test_move_same_path_trailing_slash_is_rejected(self):
+    # Moving a path onto itself where the only difference is a trailing slash must be rejected;
+    # the raw string comparison alone would let it through to request.fs.rename.
+    with patch('desktop.middleware.fsmanager.get_filesystem') as get_filesystem:
+      mock_fs = Mock(
+        normpath=Mock(side_effect=lambda p: posixpath.normpath(p)),
+      )
+      get_filesystem.return_value = mock_fs
+
+      response = self.client.post('/filebrowser/move', dict(src_path=['/user/systest/tmp'], dest_path='/user/systest/tmp/'))
+
+      # The guard should fire and rename should never be attempted.
+      assert mock_fs.rename.call_count == 0
+      assert b'Source path and destination path cannot be same' in response.content
+
+  def test_move_different_path_is_allowed(self):
+    # Sanity check: a genuinely different destination still performs the move.
+    with patch('desktop.middleware.fsmanager.get_filesystem') as get_filesystem:
+      mock_fs = Mock(
+        normpath=Mock(side_effect=lambda p: posixpath.normpath(p)),
+      )
+      get_filesystem.return_value = mock_fs
+
+      self.client.post('/filebrowser/move', dict(src_path=['/user/systest/tmp'], dest_path='/user/systest/dest'))
+
+      assert mock_fs.rename.call_count == 1
 
   def test_listdir_paged_with_non_ascii(self):
     parent_dir = Mock(


### PR DESCRIPTION
Copying or moving a directory to the same path with only a trailing-slash difference (e.g. /user/systest/tmp -> /user/systest/tmp/) bypassed the raw string equality guard. webhdfs then normalized the slash away, appended the source basename to the existing destination dir, and recursed into the freshly created subdirectory, producing an infinitely nested copy.

Compare request.fs.normpath() of both paths so semantically identical paths are detected as the same. Add tests covering the trailing-slash rejection and the genuinely-different-destination happy path for both copy and move.

## What changes were proposed in this pull request?

- instead of simply comparing strinv values of src and dest, use normpath() method

## How was this patch tested?

- manual test has been done

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
