### PR TITLE
[filebrowser] fix: preserve OFS File Browser routes across login redirects

### DIFF
--- a/desktop/core/src/desktop/middleware.py
+++ b/desktop/core/src/desktop/middleware.py
@@ -140,6 +140,17 @@ LOG = logging.getLogger()
 
 MIDDLEWARE_HEADER = "X-Hue-Middleware-Response"
 
+
+def _get_request_target(request, prefix=''):
+  target = request.path
+  if prefix and target != prefix and not target.startswith(prefix + '/'):
+    target = prefix + target
+  query_string = request.META.get('QUERY_STRING')
+  if query_string:
+    target += '?' + query_string
+  return target
+
+
 # Views inside Django that don't require login
 # (see LoginAndPermissionMiddleware)
 DJANGO_VIEW_AUTH_WHITELIST = [
@@ -495,11 +506,13 @@ class LoginAndPermissionMiddleware(Django4MiddlewareAdapterMixin):
           'url': "%s?%s=%s" % (
               settings.LOGIN_URL,
               REDIRECT_FIELD_NAME,
-              quote('/hue' + request.get_full_path().replace('is_embeddable=true', '').replace('&&', '&'))
+              quote(_get_request_target(request, '/hue').replace('is_embeddable=true', '').replace('&&', '&'))
           )
         })  # Remove embeddable so redirect from & to login works. Login page is not embeddable
       else:
-        return HttpResponseRedirect("%s?%s=%s" % (settings.LOGIN_URL, REDIRECT_FIELD_NAME, quote(request.get_full_path())))
+        redirect_url = "%s?%s=%s" % (
+            settings.LOGIN_URL, REDIRECT_FIELD_NAME, quote(_get_request_target(request)))
+        return HttpResponseRedirect(redirect_url)
 
   def process_response(self, request, response):
     if hasattr(request, 'ts') and hasattr(request, 'view_func'):

--- a/desktop/core/src/desktop/require_login_test.py
+++ b/desktop/core/src/desktop/require_login_test.py
@@ -20,6 +20,7 @@
 
 import sys
 from unittest.mock import Mock
+from urllib.parse import parse_qs, urlparse
 
 import django
 import pytest
@@ -40,6 +41,33 @@ def test_require_login():
   # And now we shouldn't need to be redirected.
   response = c.get('/', follow=True)
   assert 200 == response.status_code
+
+
+def test_require_login_preserves_ofs_route_delimiter():
+  c = Client()
+  response = c.get('/hue/filebrowser/view=ofs%3A%2F%2Fom%2Fhuevol%2Fhuebucket%2Fhue-demo.txt')
+
+  assert 302 == response.status_code
+  next_url = parse_qs(urlparse(response['Location']).query)['next'][0]
+  assert '/hue/filebrowser/view=ofs://om/huevol/huebucket/hue-demo.txt' == next_url
+
+
+def test_require_login_does_not_duplicate_hue_prefix_for_embeddable_route():
+  c = Client()
+  response = c.get('/hue/filebrowser/view=ofs%3A%2F%2Fom%2Fhuevol%2Fhuebucket%2Fhue-demo.txt?is_embeddable=true')
+
+  assert 200 == response.status_code
+  next_url = parse_qs(urlparse(response.json()['url']).query)['next'][0]
+  assert '/hue/filebrowser/view=ofs://om/huevol/huebucket/hue-demo.txt?' == next_url
+
+
+def test_require_login_preserves_encoded_query_string():
+  c = Client()
+  response = c.get('/profile?search=a%26b')
+
+  assert 302 == response.status_code
+  next_url = parse_qs(urlparse(response['Location']).query)['next'][0]
+  assert '/profile?search=a%26b' == next_url
 
 
 def test_ajax_require_login():


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes login redirects for Hue File Browser deep links containing OFS paths: https://github.com/cloudera/hue/issues/4350

When an unauthenticated user opens an OFS URL such as:

```
/hue/filebrowser/view=ofs%3A%2F%2Fom%2Fvolume%2Fbucket%2Ffile.txt
```

signing in previously redirected them to a corrupted `view%3Dofs://...` route. Hue then treated the route as an HDFS path and displayed the misleading error:

```
The HDFS REST service is not available.
```

### Root cause

`request.get_full_path()` already escapes characters in the path. Passing that result through `quote()` encoded the existing percent sign again:

```
request.path:            /hue/filebrowser/view=ofs://...
request.get_full_path(): /hue/filebrowser/view%3Dofs://...
quote(...):              /hue/filebrowser/view%253Dofs%3A//...
```

After authentication, one encoded layer remained and changed the File Browser route.

### Proposed Fix

Build the redirect target from:
- decoded request.path
- the original raw QUERY_STRING

The completed target is then quoted exactly once. This preserves the existing HTTP 302 login flow while retaining OFS route delimiters and already-encoded query values.

## How was this patch tested?

- Added regression coverage for:
  - Preserving view=ofs://... across an unauthenticated login redirect.
  - Preserving an encoded query value such as search=a%26b.
- Additional verification
  - Python compilation passed.
  - Source assertions passed.
  - Verified end-to-end using `gethue/hue:20250101-140101` with an Apache Ozone 2.1.1 cluster and Ozone HttpFS.
  - Confirmed that logout → OFS deep link → login opens the requested Ozone file.
  - Full Hue pytest/pylint execution was not available in the local environment.
