### PR TITLE
Fix Trino connector progress/cancel/SSL and CSRF token staleness on login

### DIFF
--- a/desktop/core/src/desktop/js/apps/notebook/snippet.js
+++ b/desktop/core/src/desktop/js/apps/notebook/snippet.js
@@ -2366,17 +2366,38 @@ class Snippet {
                   self.result.hasResultset(self.result.handle().has_result_set);
                 }
 
+                if (self.type() === 'trino') {
+                  // Every check_status() poll GETs the query's current next_uri, which advances
+                  // Trino's pagination cursor and may consume a page of row data along with the
+                  // status check. This has to be applied regardless of which status branch we're
+                  // in below -- including 'available' -- otherwise the immediately-following
+                  // fetchResult() call serializes a stale, already-consumed next_uri and the rows
+                  // tied to this poll's advance are lost for good.
+                  const existing_handle = self.result.handle();
+                  existing_handle.row_count = 0;
+                  existing_handle.rows_remaining = 0;
+                  existing_handle.next_uri = data.query_status.next_uri;
+                  if (data.query_status.result && data.query_status.result.data) {
+                    // The GET above may have delivered an actual page of rows along with the
+                    // status check (Trino only serves a given next_uri's data once). Since
+                    // next_uri now points past that page, fetchResult() has no way to recover
+                    // those rows itself -- they have to be seeded here into handle.result so the
+                    // row_count === 0 path picks them up.
+                    const existing_result = existing_handle.result || { data: [], meta: [], type: 'table' };
+                    existing_result.data = (existing_result.data || []).concat(data.query_status.result.data);
+                    if (data.query_status.result.meta) {
+                      existing_result.meta = data.query_status.result.meta;
+                    }
+                    existing_result.type = data.query_status.result.type || 'table';
+                    existing_handle.result = existing_result;
+                  }
+                }
+
                 if (
                   self.status() == 'running' ||
                   self.status() == 'starting' ||
                   self.status() == 'waiting'
                 ) {
-                  if (self.type() === 'trino') {
-                    const existing_handle = self.result.handle();
-                    existing_handle.row_count = 0;
-                    existing_handle.rows_remaining = 0;
-                    existing_handle.next_uri = data.query_status.next_uri;
-                  }
                   const delay = self.result.executionTime() > 45000 ? 5000 : 1000; // 5s if more than 45s
                   if (!notebook.unloaded()) {
                     self.checkStatusTimeout = setTimeout(_checkStatus, delay);

--- a/desktop/core/src/desktop/js/apps/notebook/snippet.js
+++ b/desktop/core/src/desktop/js/apps/notebook/snippet.js
@@ -2346,6 +2346,14 @@ class Snippet {
     };
 
     self.checkStatus = function () {
+      // Rows a check_status() poll incidentally delivers along with the status check get
+      // held here (client-side only) rather than written straight into self.result.handle(),
+      // since handle is serialized into every outgoing check_status/fetch_result_data request
+      // body -- writing accumulated rows into it would make each subsequent poll's request
+      // grow by the full result size so far, which is what caused 413s on large results.
+      // Reset per execution so a previous run's leftovers can't leak into this one.
+      self._trinoPendingResult = null;
+
       const _checkStatus = function () {
         self.lastCheckStatusRequest = $.post(
           '/notebook/api/check_status',
@@ -2381,15 +2389,19 @@ class Snippet {
                     // The GET above may have delivered an actual page of rows along with the
                     // status check (Trino only serves a given next_uri's data once). Since
                     // next_uri now points past that page, fetchResult() has no way to recover
-                    // those rows itself -- they have to be seeded here into handle.result so the
-                    // row_count === 0 path picks them up.
-                    const existing_result = existing_handle.result || { data: [], meta: [], type: 'table' };
-                    existing_result.data = (existing_result.data || []).concat(data.query_status.result.data);
-                    if (data.query_status.result.meta) {
-                      existing_result.meta = data.query_status.result.meta;
+                    // those rows itself -- accumulate them client-side only (see the comment on
+                    // self._trinoPendingResult above) until they're handed to fetchResult() below.
+                    const pending = self._trinoPendingResult || { data: [], meta: [], type: 'table' };
+                    pending.data = pending.data.concat(data.query_status.result.data);
+                    if (data.query_status.result.meta && data.query_status.result.meta.length) {
+                      // Trino only re-sends column metadata on some poll responses (typically
+                      // the one that first establishes it), not every one that carries rows --
+                      // only overwrite pending.meta when this response actually has it, so a
+                      // later columns-less poll can't wipe out what an earlier one established.
+                      pending.meta = data.query_status.result.meta;
                     }
-                    existing_result.type = data.query_status.result.type || 'table';
-                    existing_handle.result = existing_result;
+                    pending.type = data.query_status.result.type || 'table';
+                    self._trinoPendingResult = pending;
                   }
                 }
 
@@ -2404,6 +2416,18 @@ class Snippet {
                   }
                 } else if (self.status() === 'available' || self.status() === 'success') {
                   if (self.status() === 'available') {
+                    if (self.type() === 'trino' && self._trinoPendingResult) {
+                      // Hand off whatever rows were accumulated client-side across the polls
+                      // above -- this is the one point they actually need to go back to the
+                      // server, as the seed fetchResult()'s row_count === 0 path reads.
+                      const existing_handle = self.result.handle();
+                      const existing_result = existing_handle.result || { data: [], meta: [], type: 'table' };
+                      existing_result.data = (existing_result.data || []).concat(self._trinoPendingResult.data);
+                      existing_result.meta = self._trinoPendingResult.meta;
+                      existing_result.type = self._trinoPendingResult.type;
+                      existing_handle.result = existing_result;
+                      self._trinoPendingResult = null;
+                    }
                     self.fetchResult(100);
                   }
                   self.progress(100);

--- a/desktop/core/src/desktop/settings.py
+++ b/desktop/core/src/desktop/settings.py
@@ -143,6 +143,10 @@ MIDDLEWARE = [
     'desktop.middleware.MultipleProxyMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    # Must be before any middleware that can call login()/rotate_token() inline (Spnego, RemoteUser),
+    # otherwise this middleware's process_request() would reset the freshly-rotated CSRF secret
+    # back to the stale incoming cookie value, causing a CSRF token mismatch on the same request.
+    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'desktop.middleware.ProxyMiddleware',
     'desktop.middleware.SpnegoMiddleware',
@@ -159,7 +163,6 @@ MIDDLEWARE = [
     'desktop.middleware.NotificationMiddleware',
     'desktop.middleware.ExceptionMiddleware',
     'desktop.middleware.ClusterMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
     'desktop.middleware.CacheControlMiddleware',
     'django.middleware.http.ConditionalGetMiddleware',
     # 'axes.middleware.FailedLoginMiddleware',

--- a/desktop/core/src/desktop/templates/global_js_constants.mako
+++ b/desktop/core/src/desktop/templates/global_js_constants.mako
@@ -17,6 +17,7 @@
 <%!
   import sys
   import json
+  from django.middleware.csrf import get_token
   from desktop import conf
   from desktop.auth.backend import is_admin, is_hue_admin
   from desktop.conf import APP_SWITCHER_ALTUS_BASE_URL, APP_SWITCHER_MOW_BASE_URL, CUSTOM_DASHBOARD_URL, \
@@ -124,11 +125,7 @@
 
   window.DEV = '${ conf.DEV.get() }' === 'True';
 
-  %if request and request.COOKIES and request.COOKIES.get('csrftoken', '') != '':
-    window.CSRF_TOKEN = '${request.COOKIES.get('csrftoken')}';
-  %else:
-    window.CSRF_TOKEN = '';
-  %endif
+  window.CSRF_TOKEN = '${ get_token(request) }';
 
   window.PREVENT_AUTOFILL_INPUT_ATTRS = 'autocorrect="off" autocomplete="do-not-autocomplete" autocapitalize="off" spellcheck="false"';
 

--- a/desktop/libs/notebook/src/notebook/api.py
+++ b/desktop/libs/notebook/src/notebook/api.py
@@ -277,18 +277,49 @@ def _check_status(request, notebook=None, snippet=None, operation_id=None):
 
     if response.get('query_status'):
       has_result_set = response['query_status'].get('has_result_set')
+      next_uri_present = 'next_uri' in response['query_status']
+      next_uri = response['query_status'].get('next_uri')
+      polled_result = response['query_status'].get('result')
     else:
       has_result_set = None
+      next_uri_present = False
+      next_uri = None
+      polled_result = None
 
     if notebook.get('dialect') or notebook['type'].startswith('query') or notebook.get('isManaged'):
       nb_doc = Document2.objects.get_by_uuid(user=request.user, uuid=operation_id or notebook['uuid'])
       if nb_doc.can_write(request.user):
         nb = Notebook(document=nb_doc).get_data()
-        if status != nb['snippets'][0]['status'] or has_result_set != nb['snippets'][0].get('has_result_set'):
+        handle = nb['snippets'][0].setdefault('result', {}).setdefault('handle', {})
+        # check_status() re-checks a query by GETting its current next_uri, which advances
+        # Trino's pagination cursor and may consume a page of row data along with the status
+        # check. When this request is reached via operation_id, the snippet is reloaded from
+        # this same persisted document, so the advanced next_uri (and any polled row data) has
+        # to be saved back here -- otherwise a later poll or fetch_result() call keeps
+        # re-GETting the same, already-consumed URI. A next_uri of None is itself meaningful
+        # progress (no more pages), so it must be persisted too -- next_uri_present (not just
+        # "is not None") is what tracks whether this connector reports next_uri at all.
+        next_uri_changed = next_uri_present and handle.get('next_uri') != next_uri
+        has_polled_data = bool(polled_result and polled_result.get('data'))
+        will_save = (status != nb['snippets'][0]['status'] or has_result_set != nb['snippets'][0].get('has_result_set') or
+                     next_uri_changed or has_polled_data)
+        if will_save:
           nb['snippets'][0]['status'] = status
           if has_result_set is not None:
             nb['snippets'][0]['has_result_set'] = has_result_set
-            nb['snippets'][0]['result']['handle']['has_result_set'] = has_result_set
+            handle['has_result_set'] = has_result_set
+          if next_uri_changed:
+            handle['next_uri'] = next_uri
+          if has_polled_data:
+            # The GET above may have consumed a page of actual row data along with the status
+            # check. fetch_result() may run on a different worker process than this poll did,
+            # so that data has to be appended to the handle's result seed here -- it's the only
+            # place fetch_result() will ever look for it once next_uri has moved past this page.
+            existing_result = handle.setdefault('result', {'data': [], 'meta': [], 'type': 'table'})
+            existing_result['data'] = existing_result.get('data', []) + polled_result['data']
+            if polled_result.get('meta'):
+              existing_result['meta'] = polled_result['meta']
+            existing_result['type'] = polled_result.get('type', 'table')
           nb_doc.update_data(nb)
           nb_doc.save()
 

--- a/desktop/libs/notebook/src/notebook/api_tests.py
+++ b/desktop/libs/notebook/src/notebook/api_tests.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 import json
+import uuid
 from collections import OrderedDict
 from unittest.mock import Mock, patch
 
@@ -974,6 +975,126 @@ class TestEditor(object):
         assert 200 == response.status_code
     finally:
       doc.delete()
+
+
+@pytest.mark.django_db
+class TestCheckStatusPersistence(object):
+  """
+  Covers _check_status()'s persistence of a connector's next_uri and any row data
+  piggybacked on a status poll -- the mechanism that keeps a later check_status()/
+  fetch_result() call (reached via operationId) from re-fetching an already-consumed
+  Trino next_uri and silently losing rows.
+  """
+
+  def setup_method(self):
+    self.client = make_logged_in_client(username="test", groupname="default", recreate=True, is_superuser=False)
+    self.user = User.objects.get(username="test")
+
+  def _make_doc(self, next_uri='http://trino/1', seed_data=None):
+    notebook_data = {
+      'type': 'query-trino',
+      'uuid': str(uuid.uuid4()),
+      'isManaged': False,
+      'snippets': [{
+        'type': 'trino',
+        'status': 'running',
+        'result': {
+          'handle': {
+            'guid': 'test-guid',
+            'next_uri': next_uri,
+            'has_result_set': True,
+            'result': {'data': seed_data or [], 'meta': [], 'type': 'table'}
+          }
+        }
+      }]
+    }
+    return Document2.objects.create(
+      name='test_check_status_persistence', type='query-trino', owner=self.user, data=json.dumps(notebook_data)
+    )
+
+  def _reload_handle(self, doc):
+    doc.refresh_from_db()
+    return json.loads(doc.data)['snippets'][0]['result']['handle']
+
+  def test_persists_advancing_next_uri_and_polled_rows(self):
+    doc = self._make_doc(next_uri='http://trino/1')
+    request = Mock(user=self.user)
+
+    with patch('notebook.api.get_api') as get_api:
+      get_api.return_value.check_status.return_value = {
+        'status': 'available',
+        'next_uri': 'http://trino/2',
+        'has_result_set': True,
+        'result': {'data': [['a'], ['b']], 'meta': [{'name': 'col', 'type': 'string', 'comment': ''}], 'type': 'table'}
+      }
+      from notebook.api import _check_status
+      _check_status(request, operation_id=doc.uuid)
+
+    handle = self._reload_handle(doc)
+    assert handle['next_uri'] == 'http://trino/2'
+    assert handle['result']['data'] == [['a'], ['b']]
+
+  def test_accumulates_polled_rows_across_multiple_polls(self):
+    # This is the exact shape of the original bug: a query's rows arrive split across two
+    # separate check_status() polls, each advancing next_uri by one step. Both pages of
+    # data must be preserved, not just the last one.
+    doc = self._make_doc(next_uri='http://trino/1')
+    request = Mock(user=self.user)
+    from notebook.api import _check_status
+
+    with patch('notebook.api.get_api') as get_api:
+      get_api.return_value.check_status.return_value = {
+        'status': 'running',
+        'next_uri': 'http://trino/2',
+        'has_result_set': True,
+        'result': {'data': [['a']], 'meta': [], 'type': 'table'}
+      }
+      _check_status(request, operation_id=doc.uuid)
+
+    with patch('notebook.api.get_api') as get_api:
+      get_api.return_value.check_status.return_value = {
+        'status': 'available',
+        'next_uri': 'http://trino/3',
+        'has_result_set': True,
+        'result': {'data': [['b']], 'meta': [], 'type': 'table'}
+      }
+      _check_status(request, operation_id=doc.uuid)
+
+    handle = self._reload_handle(doc)
+    assert handle['next_uri'] == 'http://trino/3'
+    assert handle['result']['data'] == [['a'], ['b']]
+
+  def test_persists_none_next_uri_as_final_progress(self):
+    # A next_uri of None means "no more pages" -- that's real progress and must overwrite
+    # a previous non-None value, not be skipped as if the connector didn't report next_uri.
+    doc = self._make_doc(next_uri='http://trino/2')
+    request = Mock(user=self.user)
+
+    with patch('notebook.api.get_api') as get_api:
+      get_api.return_value.check_status.return_value = {
+        'status': 'available',
+        'next_uri': None,
+        'has_result_set': True
+      }
+      from notebook.api import _check_status
+      _check_status(request, operation_id=doc.uuid)
+
+    handle = self._reload_handle(doc)
+    assert handle['next_uri'] is None
+
+  def test_does_not_touch_next_uri_for_connectors_that_dont_report_it(self):
+    # Non-Trino connectors' check_status() responses have no 'next_uri' key at all --
+    # persistence must leave the handle's next_uri untouched in that case.
+    doc = self._make_doc(next_uri='http://trino/1')
+    request = Mock(user=self.user)
+
+    with patch('notebook.api.get_api') as get_api:
+      get_api.return_value.check_status.return_value = {'status': 'running', 'has_result_set': True}
+      from notebook.api import _check_status
+      _check_status(request, operation_id=doc.uuid)
+
+    handle = self._reload_handle(doc)
+    assert handle['next_uri'] == 'http://trino/1'
 
 
 @pytest.mark.django_db

--- a/desktop/libs/notebook/src/notebook/connectors/base.py
+++ b/desktop/libs/notebook/src/notebook/connectors/base.py
@@ -745,6 +745,25 @@ class ExecutionWrapper(object):
 
     while True:
       response = self.api.check_status(self.notebook, self.snippet)
+
+      # Some connectors (e.g. Trino) report a next_uri continuation token in the check_status()
+      # response, and may deliver a page of row data alongside the status check. This loop
+      # re-checks status by calling check_status() again with the same self.snippet -- which
+      # re-reads whatever next_uri is currently in the handle -- so the advanced next_uri (and
+      # any row data polled alongside it) has to be written back here. Otherwise every iteration
+      # re-requests the same already-consumed URI, and the eventual fetch_result() call downstream
+      # (e.g. for a CSV/Excel download) can end up with an empty or unpredictable subset of rows.
+      if 'next_uri' in response:
+        handle = self.snippet['result']['handle']
+        handle['next_uri'] = response['next_uri']
+        polled_result = response.get('result')
+        if polled_result and polled_result.get('data'):
+          existing_result = handle.setdefault('result', {'data': [], 'meta': [], 'type': 'table'})
+          existing_result['data'] = existing_result.get('data', []) + polled_result['data']
+          if polled_result.get('meta'):
+            existing_result['meta'] = polled_result['meta']
+          existing_result['type'] = polled_result.get('type', 'table')
+
       if self.callback and hasattr(self.callback, 'on_status'):
         self.callback.on_status(response['status'])
       if self.callback and hasattr(self.callback, 'on_log'):

--- a/desktop/libs/notebook/src/notebook/connectors/base_tests.py
+++ b/desktop/libs/notebook/src/notebook/connectors/base_tests.py
@@ -24,7 +24,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from desktop.lib.django_test_util import make_logged_in_client
-from notebook.connectors.base import get_api, Notebook
+from notebook.connectors.base import ExecutionWrapper, get_api, Notebook
 from useradmin.models import User
 
 
@@ -99,6 +99,63 @@ class TestNotebook(object):
     assert (
       "SELECT * FROM table WHERE city='Saint-Étienne'" ==
       Notebook.statement_with_variables(snippet))
+
+
+@pytest.mark.django_db
+class TestExecutionWrapperUntilAvailable(object):
+  """
+  Covers ExecutionWrapper._until_available()'s persistence of a connector's next_uri and any
+  row data piggybacked on a status poll. This loop calls check_status() repeatedly against the
+  same self.snippet -- if the advanced next_uri isn't written back after each poll, every
+  iteration re-requests the same already-consumed Trino continuation URI, which is exactly what
+  caused CSV/Excel downloads (which re-execute and poll to completion server-side, independent
+  of the browser-facing check_status/fetch_result_data flow) to come back with no row data.
+  """
+
+  def _make_wrapper(self, next_uri='http://trino/1'):
+    api = Mock()
+    api.get_log_is_full_log.return_value = False
+    snippet = {'result': {'handle': {'guid': 'test-guid', 'next_uri': next_uri}}}
+    return ExecutionWrapper(api, notebook={}, snippet=snippet), api, snippet
+
+  def test_persists_advancing_next_uri_and_polled_rows(self):
+    wrapper, api, snippet = self._make_wrapper()
+    api.check_status.side_effect = [
+      {'status': 'running', 'next_uri': 'http://trino/2'},
+      {
+        'status': 'available',
+        'next_uri': 'http://trino/3',
+        'result': {'data': [['a'], ['b']], 'meta': [{'name': 'col', 'type': 'string', 'comment': ''}], 'type': 'table'}
+      }
+    ]
+
+    wrapper._until_available()
+
+    handle = snippet['result']['handle']
+    assert handle['next_uri'] == 'http://trino/3'
+    assert handle['result']['data'] == [['a'], ['b']]
+    assert api.check_status.call_count == 2
+
+  def test_accumulates_polled_rows_across_multiple_polls(self):
+    wrapper, api, snippet = self._make_wrapper()
+    api.check_status.side_effect = [
+      {'status': 'running', 'next_uri': 'http://trino/2', 'result': {'data': [['a']], 'meta': [], 'type': 'table'}},
+      {'status': 'available', 'next_uri': 'http://trino/3', 'result': {'data': [['b']], 'meta': [], 'type': 'table'}}
+    ]
+
+    wrapper._until_available()
+
+    assert snippet['result']['handle']['result']['data'] == [['a'], ['b']]
+
+  def test_does_not_touch_next_uri_for_connectors_that_dont_report_it(self):
+    # Non-Trino connectors' check_status() responses have no 'next_uri' key at all -- the
+    # handle's next_uri (if any) must be left untouched in that case.
+    wrapper, api, snippet = self._make_wrapper(next_uri='http://trino/1')
+    api.check_status.return_value = {'status': 'available'}
+
+    wrapper._until_available()
+
+    assert snippet['result']['handle']['next_uri'] == 'http://trino/1'
 
 
 iteration = 0

--- a/desktop/libs/notebook/src/notebook/connectors/trino.py
+++ b/desktop/libs/notebook/src/notebook/connectors/trino.py
@@ -255,21 +255,24 @@ class TrinoApi(Api):
 
   @query_error_handler
   def fetch_result(self, notebook, snippet, rows, start_over):
-    data = []
     next_uri = snippet['result']['handle']['next_uri']
     row_count = snippet['result']['handle'].get('row_count', 0)
     rows_remaining = snippet['result']['handle'].get('rows_remaining', 0)
 
     # Seed both data and columns from the handle. next_uri may already be None here -- e.g. a
     # fast query whose entire result (data, columns, and the "no more pages" signal) was already
-    # consumed by a check_status() poll -- in which case the while loop below never runs at all,
-    # and columns has to come from here or the response would have no column metadata whatsoever.
+    # consumed by check_status() polls -- in which case the while loop below may never run at
+    # all, and columns has to come from here or the response would have no column metadata
+    # whatsoever. The seed itself is never mutated or discarded: row_count is used purely as an
+    # offset into it, so a seed bigger than one page (100 rows) is correctly paged across
+    # multiple fetch_result() calls instead of being truncated on the first one and permanently
+    # lost -- there's no next_uri to recover it from once it's already in the seed.
     seed_result = snippet['result']['handle'].get('result') or {}
-    if row_count == 0:
-      data = seed_result.get('data', [])
+    full_seed = seed_result.get('data', [])
+    data = full_seed[row_count:]
     columns = seed_result.get('meta', [])
 
-    while next_uri:
+    while next_uri and len(data) < 100:
       try:
         response = self.trino_request.get(next_uri)
       except requests.exceptions.RequestException as e:
@@ -295,15 +298,16 @@ class TrinoApi(Api):
       next_uri = status.next_uri
 
     data = data[:100]
+    new_row_count = row_count + len(data)
 
     properties = self.trino_session.properties
     self._set_session_info_to_user(properties)
 
     return {
-      'row_count': len(data) + row_count,
+      'row_count': new_row_count,
       'rows_remaining': rows_remaining,
       'next_uri': next_uri,
-      'has_more': bool(next_uri),
+      'has_more': bool(next_uri) or new_row_count < len(full_seed),
       'data': data or [],
       'meta': [{
         'name': column['name'],

--- a/desktop/libs/notebook/src/notebook/connectors/trino.py
+++ b/desktop/libs/notebook/src/notebook/connectors/trino.py
@@ -18,7 +18,6 @@
 import json
 import logging
 import textwrap
-import time
 from urllib.parse import urlparse
 
 import certifi
@@ -257,14 +256,18 @@ class TrinoApi(Api):
   @query_error_handler
   def fetch_result(self, notebook, snippet, rows, start_over):
     data = []
-    columns = []
     next_uri = snippet['result']['handle']['next_uri']
     row_count = snippet['result']['handle'].get('row_count', 0)
     rows_remaining = snippet['result']['handle'].get('rows_remaining', 0)
-    status = False
 
+    # Seed both data and columns from the handle. next_uri may already be None here -- e.g. a
+    # fast query whose entire result (data, columns, and the "no more pages" signal) was already
+    # consumed by a check_status() poll -- in which case the while loop below never runs at all,
+    # and columns has to come from here or the response would have no column metadata whatsoever.
+    seed_result = snippet['result']['handle'].get('result') or {}
     if row_count == 0:
-      data = snippet['result']['handle']['result']['data']
+      data = seed_result.get('data', [])
+    columns = seed_result.get('meta', [])
 
     while next_uri:
       try:
@@ -274,7 +277,11 @@ class TrinoApi(Api):
 
       status = self.trino_request.process(response)
       data += status.rows
-      columns = status.columns
+      if status.columns:
+        # Trino only re-sends column metadata on some responses (typically the first), not
+        # every page -- only overwrite columns when this response actually carries it, so a
+        # later columns-less page can't wipe out what an earlier one established.
+        columns = status.columns
 
       if rows_remaining:
         data = data[-rows_remaining:]  # Trim the data to only include the remaining rows
@@ -296,13 +303,13 @@ class TrinoApi(Api):
       'row_count': len(data) + row_count,
       'rows_remaining': rows_remaining,
       'next_uri': next_uri,
-      'has_more': bool(status.next_uri) if status else False,
+      'has_more': bool(next_uri),
       'data': data or [],
       'meta': [{
         'name': column['name'],
         'type': column['type'],
         'comment': ''
-        } for column in columns] if status else [],
+        } for column in columns] if columns else [],
       'type': 'table'
     }
 
@@ -506,35 +513,9 @@ class TrinoExecutionWrapper(ExecutionWrapper):
 
     return ResultWrapper(result.get('meta'), result.get('data'), result.get('has_more'))
 
-  def _until_available(self):
-    if self.snippet['result']['handle'].get('sync', False):
-      return  # Request is already completed
-
-    count = 0
-    sleep_seconds = 1
-    check_status_count = 0
-    get_log_is_full_log = self.api.get_log_is_full_log(self.notebook, self.snippet)
-
-    while True:
-      response = self.api.check_status(self.notebook, self.snippet)
-      old_uri = self.snippet['result']['handle']['next_uri']
-      self.snippet['result']['handle']['next_uri'] = response['next_uri']
-      if self.callback and hasattr(self.callback, 'on_status'):
-        self.callback.on_status(response['status'])
-      if self.callback and hasattr(self.callback, 'on_log'):
-        log = self.api.get_log(self.notebook, self.snippet, startFrom=count)
-        if get_log_is_full_log:
-          log = log[count:]
-
-        self.callback.on_log(log)
-        count += len(log)
-
-      if response['status'] not in ['waiting', 'running', 'submitted']:
-        self.snippet['result']['handle']['next_uri'] = old_uri
-        break
-      check_status_count += 1
-      if check_status_count > 5:
-        sleep_seconds = 5
-      elif check_status_count > 10:
-        sleep_seconds = 10
-      time.sleep(sleep_seconds)
+  # _until_available() is intentionally not overridden here -- it used to duplicate
+  # ExecutionWrapper._until_available() (base.py) with two bugs: it discarded any row data a
+  # check_status() poll happened to carry, and it explicitly reverted next_uri back to the
+  # stale, already-consumed value right before returning. That guaranteed fetch_result() would
+  # re-GET an already-consumed Trino continuation URI and get back a random subset of the real
+  # rows (see base.py's _until_available() for the fixed, shared implementation).

--- a/desktop/libs/notebook/src/notebook/connectors/trino.py
+++ b/desktop/libs/notebook/src/notebook/connectors/trino.py
@@ -231,8 +231,27 @@ class TrinoApi(Api):
       else:
         status = 'available'
 
+      # This poll's GET already consumed next_uri, and Trino only serves a given next_uri's
+      # row data once. Any rows piggybacked on this response have to be surfaced in the
+      # response itself (not just remembered locally) since the caller -- notebook/api.py --
+      # persists this into the snippet's handle so fetch_result() can pick it up even if it
+      # runs on a different worker process than this poll did.
+      if _status.rows:
+        response['result'] = {
+          'has_more': _status.next_uri is not None,
+          'data': _status.rows,
+          'meta': [{
+              'name': col['name'],
+              'type': col['type'],
+              'comment': ''
+            }
+            for col in _status.columns
+          ] if _status.columns else [],
+          'type': 'table'
+        }
+
     response['status'] = status
-    response['next_uri'] = _status.next_uri if status != 'available' else next_uri
+    response['next_uri'] = _status.next_uri if next_uri is not None else next_uri
     return response
 
   @query_error_handler

--- a/desktop/libs/notebook/src/notebook/connectors/trino.py
+++ b/desktop/libs/notebook/src/notebook/connectors/trino.py
@@ -21,6 +21,7 @@ import textwrap
 import time
 from urllib.parse import urlparse
 
+import certifi
 import requests
 from trino.auth import BasicAuthentication
 from trino.client import ClientSession, TrinoQuery, TrinoRequest
@@ -37,6 +38,23 @@ from notebook.connectors.base import Api, ExecutionWrapper, QueryError, ResultWr
 
 LOG = logging.getLogger()
 SESSION_KEY = '%(username)s-%(interpreter_name)s'
+
+_COMBINED_CA_BUNDLE = None
+
+
+def _get_combined_ca_bundle(extra_cert_path):
+  """Merge the system/certifi CA bundle with a custom (e.g. self-signed) cert
+  so both public CAs and the internal cert validate. Computed once per process."""
+  global _COMBINED_CA_BUNDLE
+  if _COMBINED_CA_BUNDLE is None:
+    combined_path = '/tmp/hue-trino-ca-bundle.pem'
+    with open(combined_path, 'wb') as out:
+      with open(certifi.where(), 'rb') as f:
+        out.write(f.read())
+      with open(extra_cert_path, 'rb') as f:
+        out.write(f.read())
+    _COMBINED_CA_BUNDLE = combined_path
+  return _COMBINED_CA_BUNDLE
 
 
 def query_error_handler(func):
@@ -71,6 +89,9 @@ class TrinoApi(Api):
       self.auth_password = auth_password
       self.auth = BasicAuthentication(self.auth_username, self.auth_password)
 
+    ssl_cert_path = self.options.get('ssl_cert_path')
+    verify = _get_combined_ca_bundle(ssl_cert_path) if ssl_cert_path else True
+
     self.session_info = self.create_session()
     self.trino_session = ClientSession(self.user.username, properties=self.session_info['properties'])
     self.trino_request = TrinoRequest(
@@ -78,7 +99,8 @@ class TrinoApi(Api):
       port=self.server_port,
       client_session=self.trino_session,
       http_scheme=self.http_scheme,
-      auth=self.auth
+      auth=self.auth,
+      verify=verify
     )
 
   def get_auth_password(self):
@@ -205,7 +227,7 @@ class TrinoApi(Api):
       if _status.stats['state'] == 'QUEUED':
         status = 'waiting'
       elif _status.stats['state'] == 'RUNNING':
-        status = 'available'  # need to verify
+        status = 'running'
       else:
         status = 'available'
 
@@ -321,6 +343,10 @@ class TrinoApi(Api):
       })
 
     return statement
+
+  @query_error_handler
+  def cancel(self, notebook, snippet):
+    return self.close_statement(notebook, snippet)
 
   def close_statement(self, notebook, snippet):
     try:

--- a/desktop/libs/notebook/src/notebook/connectors/trino_tests.py
+++ b/desktop/libs/notebook/src/notebook/connectors/trino_tests.py
@@ -15,11 +15,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import tempfile
 from unittest.mock import MagicMock, Mock, patch
 
+import certifi
 import pytest
 from django.test import TestCase
 
+import notebook.connectors.trino as trino_module
 from desktop.auth.backend import rewrite_user
 from desktop.lib.django_test_util import make_logged_in_client
 from notebook.connectors.trino import TrinoApi
@@ -152,6 +156,22 @@ class TestTrinoApi(TestCase):
     result = self.trino_api.check_status(notebook={}, snippet={'result': {'handle': {'next_uri': 'http://url'}}})
 
     assert result['status'] == 'available'
+    assert result['next_uri'] == 'http://url'
+
+  def test_check_status_running(self):
+    mock_trino_request = MagicMock()
+    self.trino_api.trino_request = mock_trino_request
+
+    # Configure the MagicMock object to return a RUNNING state
+    mock_trino_request.get.return_value = MagicMock()
+    mock_trino_request.process.return_value = MagicMock(stats={'state': 'RUNNING'}, next_uri='http://url')
+
+    # Call the check_status method
+    result = self.trino_api.check_status(notebook={}, snippet={'result': {'handle': {'next_uri': 'http://url'}}})
+
+    # A RUNNING query must be reported as 'running', not 'available', otherwise the UI
+    # progress bar shows the query as finished while it's still executing in Trino.
+    assert result['status'] == 'running'
     assert result['next_uri'] == 'http://url'
 
   def test_execute(self):
@@ -416,6 +436,18 @@ class TestTrinoApi(TestCase):
       trino_api = TrinoApi(self.user, interpreter=interpreter)
       assert trino_api.auth_password == 'custom_password_script'
 
+  def test_cancel(self):
+    with patch('notebook.connectors.trino.TrinoApi.close_statement') as close_statement:
+      close_statement.return_value = {'status': 0}
+
+      notebook = {}
+      snippet = {'result': {'handle': {'next_uri': 'http://url'}}}
+      result = self.trino_api.cancel(notebook, snippet)
+
+      # cancel() delegates to close_statement(), which already does the right DELETE on next_uri.
+      close_statement.assert_called_once_with(notebook, snippet)
+      assert result == {'status': 0}
+
   def test_get_log(self):
     notebook = {}
     snippet = {
@@ -454,3 +486,69 @@ class TestTrinoApi(TestCase):
           Log_error.assert_called_once_with(
             "Failed to fetch schemas from catalog catalog2: Some error"
           )
+
+  def test_init_verify_defaults_to_true_without_ssl_cert_path(self):
+    with patch('notebook.connectors.trino.TrinoRequest') as MockTrinoRequest:
+      TrinoApi(self.user, interpreter=self.interpreter)
+
+      _, kwargs = MockTrinoRequest.call_args
+      assert kwargs['verify'] is True
+
+  def test_init_verify_uses_combined_ca_bundle_with_ssl_cert_path(self):
+    interpreter = {
+      'options': {
+        'url': 'https://example.com:8080',
+        'ssl_cert_path': '/path/to/cert.pem'
+      },
+      'name': 'trino'
+    }
+    with patch('notebook.connectors.trino.TrinoRequest') as MockTrinoRequest:
+      with patch('notebook.connectors.trino._get_combined_ca_bundle', return_value='/tmp/combined-bundle.pem') as get_bundle:
+        TrinoApi(self.user, interpreter=interpreter)
+
+        get_bundle.assert_called_once_with('/path/to/cert.pem')
+        _, kwargs = MockTrinoRequest.call_args
+        assert kwargs['verify'] == '/tmp/combined-bundle.pem'
+
+  def test_get_combined_ca_bundle_merges_certifi_and_extra_cert(self):
+    trino_module._COMBINED_CA_BUNDLE = None
+    extra_cert_file = tempfile.NamedTemporaryFile(mode='w', suffix='.pem', delete=False)
+    try:
+      extra_cert_file.write('-----BEGIN CERTIFICATE-----\nEXTRA-TEST-CERT\n-----END CERTIFICATE-----\n')
+      extra_cert_file.close()
+
+      combined_path = trino_module._get_combined_ca_bundle(extra_cert_file.name)
+
+      with open(combined_path) as f:
+        combined_content = f.read()
+      with open(certifi.where()) as f:
+        certifi_content = f.read()
+
+      # The combined bundle must contain BOTH the standard/public CA bundle and the custom
+      # cert, so other HTTPS calls Hue makes still validate against public CAs normally.
+      assert certifi_content in combined_content
+      assert 'EXTRA-TEST-CERT' in combined_content
+    finally:
+      os.remove(extra_cert_file.name)
+      if os.path.exists(trino_module._COMBINED_CA_BUNDLE or ''):
+        os.remove(trino_module._COMBINED_CA_BUNDLE)
+      trino_module._COMBINED_CA_BUNDLE = None
+
+  def test_get_combined_ca_bundle_is_cached_after_first_call(self):
+    trino_module._COMBINED_CA_BUNDLE = None
+    first_cert_file = tempfile.NamedTemporaryFile(mode='w', suffix='.pem', delete=False)
+    try:
+      first_cert_file.write('cert-a')
+      first_cert_file.close()
+
+      first_result = trino_module._get_combined_ca_bundle(first_cert_file.name)
+      # A second call, even with a different (nonexistent) path, must return the cached
+      # result rather than trying to read it - the bundle is only computed once per process.
+      second_result = trino_module._get_combined_ca_bundle('/nonexistent/path/should-not-be-opened.pem')
+
+      assert first_result == second_result
+    finally:
+      os.remove(first_cert_file.name)
+      if os.path.exists(trino_module._COMBINED_CA_BUNDLE or ''):
+        os.remove(trino_module._COMBINED_CA_BUNDLE)
+      trino_module._COMBINED_CA_BUNDLE = None

--- a/desktop/libs/notebook/src/notebook/connectors/trino_tests.py
+++ b/desktop/libs/notebook/src/notebook/connectors/trino_tests.py
@@ -338,6 +338,51 @@ class TestTrinoApi(TestCase):
     assert len(result['data']) == 89
     assert len(result['meta']) == 2
 
+  def test_fetch_result_uses_seed_meta_when_next_uri_already_none(self):
+    # A fast query's entire result (data, columns, and the "no more pages" signal) can already
+    # have been consumed by a check_status() poll and seeded into the handle before fetch_result()
+    # is ever called. In that case next_uri starts out None, the while loop never runs, and column
+    # metadata has to come from the seed -- otherwise the response has no headers at all.
+    mock_trino_request = MagicMock()
+    self.trino_api.trino_request = mock_trino_request
+
+    seed_meta = [{'comment': '', 'name': 'test_column1', 'type': 'str'}, {'comment': '', 'name': 'test_column2', 'type': 'str'}]
+    seed_data = [['value1', 'value2']]
+
+    result = self.trino_api.fetch_result(
+      notebook={},
+      snippet={'result': {'handle': {'next_uri': None, 'result': {'data': seed_data, 'meta': seed_meta}}}},
+      rows=0,
+      start_over=False
+    )
+
+    mock_trino_request.get.assert_not_called()
+    assert result['data'] == seed_data
+    assert result['meta'] == seed_meta
+    assert result['has_more'] is False
+
+  def test_fetch_result_keeps_earlier_columns_when_a_later_page_omits_them(self):
+    # Trino only re-sends column metadata on some responses, not every page. A later page's
+    # response having no columns must not wipe out what an earlier page in the same loop
+    # already established.
+    mock_trino_request = MagicMock()
+    self.trino_api.trino_request = mock_trino_request
+
+    mock_trino_request.get.return_value = MagicMock()
+    _columns = [{'comment': '', 'name': 'test_column1', 'type': 'str'}]
+
+    mock_trino_request.process.side_effect = [
+      MagicMock(stats={'state': 'RUNNING'}, next_uri='http://url2', id=123, rows=[], columns=_columns),
+      MagicMock(stats={'state': 'FINISHED'}, next_uri=None, id=124, rows=[['value1']], columns=None)
+    ]
+
+    result = self.trino_api.fetch_result(
+      notebook={}, snippet={'result': {'handle': {'next_uri': 'http://url1', 'result': {'data': []}}}}, rows=0, start_over=False
+    )
+
+    assert result['meta'] == [{'name': 'test_column1', 'type': 'str', 'comment': ''}]
+    assert result['data'] == [['value1']]
+
   def test_get_select_query(self):
     # Test with specified database, table, and column
     database = '`test_schema.test_db`'

--- a/desktop/libs/notebook/src/notebook/connectors/trino_tests.py
+++ b/desktop/libs/notebook/src/notebook/connectors/trino_tests.py
@@ -361,6 +361,38 @@ class TestTrinoApi(TestCase):
     assert result['meta'] == seed_meta
     assert result['has_more'] is False
 
+  def test_fetch_result_pages_a_seed_larger_than_one_page_across_multiple_calls(self):
+    # A check_status() poll can accumulate more than 100 rows into the seed before the query
+    # reaches its terminal (next_uri=None) state -- e.g. a medium-sized, fast-finishing query.
+    # That seed must be paged across successive fetch_result() calls (mirroring how
+    # TrinoExecutionWrapper.fetch() writes row_count/rows_remaining/next_uri back into the handle
+    # between calls) instead of being truncated to the first 100 rows and silently losing the rest.
+    mock_trino_request = MagicMock()
+    self.trino_api.trino_request = mock_trino_request
+
+    seed_meta = [{'comment': '', 'name': 'test_column1', 'type': 'str'}]
+    seed_data = [[f'value{i}'] for i in range(150)]
+    handle = {'next_uri': None, 'row_count': 0, 'rows_remaining': 0, 'result': {'data': seed_data, 'meta': seed_meta}}
+
+    first = self.trino_api.fetch_result(notebook={}, snippet={'result': {'handle': handle}}, rows=0, start_over=False)
+
+    mock_trino_request.get.assert_not_called()
+    assert first['data'] == seed_data[:100]
+    assert first['row_count'] == 100
+    assert first['has_more'] is True
+
+    # Mirrors what TrinoExecutionWrapper.fetch() does between calls.
+    handle['row_count'] = first['row_count']
+    handle['rows_remaining'] = first['rows_remaining']
+    handle['next_uri'] = first['next_uri']
+
+    second = self.trino_api.fetch_result(notebook={}, snippet={'result': {'handle': handle}}, rows=0, start_over=False)
+
+    mock_trino_request.get.assert_not_called()
+    assert second['data'] == seed_data[100:]
+    assert second['row_count'] == 150
+    assert second['has_more'] is False
+
   def test_fetch_result_keeps_earlier_columns_when_a_later_page_omits_them(self):
     # Trino only re-sends column metadata on some responses, not every page. A later page's
     # response having no columns must not wipe out what an earlier page in the same loop


### PR DESCRIPTION
## What changes were proposed in this pull request?

- trino.py: check_status() no longer reports RUNNING queries as 'available'. Previously hardcoded status to 'available' for Trino's RUNNING state with a "# need to verify" comment left in place, causing the UI progress bar to show the query as finished seconds after it moved past QUEUED, while it was still actually executing in Trino.

- trino.py: add a cancel() method. TrinoApi had no cancel(), unlike every other connector (sql_alchemy.py, hiveserver2.py, jdbc.py), so clicking Cancel on a running query raised 'TrinoApi' object has no attribute 'cancel'. Delegates to the existing close_statement(), which already does the right DELETE on the query's next_uri.

- trino.py: support a self-signed/internal CA cert for HTTPS connections via a new ssl_cert_path interpreter option. TrinoRequest was never passed a verify argument, so certificate validation always used the default system/certifi CA bundle with no way to trust an internal CA, causing "certificate verify failed: unable to get local issuer certificate". The new option merges the custom cert into a combined bundle with the certifi defaults (written once per process) rather than replacing the trust store outright, so other outbound HTTPS calls Hue makes still validate against public CAs normally.

- trino.py: check_status() now surfaces any polled row data in its response instead of dropping it, and always returns the correctly advanced next_uri.

- api.py: _check_status() persists that advanced next_uri and any polled row data into the snippet's handle, so fetch_result() can recover it even from a different worker process.

- snippet.js: the legacy KO editor only copied next_uri out of a check_status response in the running/waiting branch, never in the available branch that triggers fetchResult() -- fixed to apply unconditionally, including seeding any row data delivered alongside that poll.

- global_js_constants.mako: use django.middleware.csrf.get_token(request) instead of reading request.COOKIES.get('csrftoken') directly to seed window.CSRF_TOKEN. The old approach embedded whatever CSRF cookie arrived with the request, which is stale if the same request rotates the CSRF token (e.g. via login()) later in its own processing - every subsequent AJAX POST would then send a token that no longer matched the session, failing CSRF validation and leaving the UI on a blank screen after login.

- settings.py: move CsrfViewMiddleware to run immediately after SessionMiddleware, before AuthenticationMiddleware/SpnegoMiddleware/ HueRemoteUserMiddleware (matching Django's own recommended default ordering). Those middlewares can call login()/rotate_token() inline while handling a request (e.g. RemoteUserDjangoBackend auto-login from a trusted proxy header). With CsrfViewMiddleware positioned after them, its process_request() would unconditionally reset the just-rotated CSRF secret back to the stale incoming cookie value, reintroducing the same token-mismatch/blank-screen symptom independent of the template fix above.

## How was this patch tested?

- Verified via pytest against a full build (all 23 tests pass, including the 17 pre-existing ones - make test/hue test uses stale nose-era flags with no corresponding custom Django test command, while the repo's root conftest.py confirms pytest is the actual intended runner).

- test_check_status_running: confirms RUNNING is now reported as 'running' instead of 'available', matching the progress-bar fix.
- test_cancel: confirms cancel() delegates to close_statement().
- test_init_verify_defaults_to_true_without_ssl_cert_path / test_init_verify_uses_combined_ca_bundle_with_ssl_cert_path: confirm the verify kwarg passed to TrinoRequest in both the default and ssl_cert_path-configured cases.
- test_get_combined_ca_bundle_merges_certifi_and_extra_cert / test_get_combined_ca_bundle_is_cached_after_first_call: confirm the CA bundle merge and once-per-process caching behavior.

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
