### PR TITLE
[editor] Prevent autocomplete Metastore full scan when no database is selected

### DIFF
--- a/apps/beeswax/src/beeswax/api.py
+++ b/apps/beeswax/src/beeswax/api.py
@@ -118,6 +118,10 @@ def _autocomplete(db, database=None, table=None, column=None, nested=None, query
       response['function'] = _get_function(db, database)
     elif database is None:
       response['databases'] = db.get_databases()
+    elif table is None and not database:
+      # An empty database name would be turned into a wildcard scan of all databases
+      response['code'] = 400
+      response['error'] = _('Database name is missing')
     elif table is None:
       tables_meta = db.get_tables_meta(database=database)
       response['tables_meta'] = tables_meta

--- a/apps/beeswax/src/beeswax/api_tests.py
+++ b/apps/beeswax/src/beeswax/api_tests.py
@@ -46,6 +46,14 @@ class TestApi:
 
     assert resp == {"code": 500, "error": "HTTPSConnectionPool(host='gethue.com', port=10001): Read timed out. (read timeout=120)"}
 
+  def test_autocomplete_empty_database_name(self):
+    db = Mock()
+
+    resp = _autocomplete(db, database="")
+
+    assert resp == {"code": 400, "error": "Database name is missing"}
+    assert not db.get_tables_meta.called
+
   def test_get_functions(self):
     # Mock db.get_functions() to return rows that escape_rows can process
     # Each row should be a list where row[0] is the function name

--- a/desktop/core/src/desktop/js/apps/editor/components/aceEditor/autocomplete/AutocompleteResults.test.ts
+++ b/desktop/core/src/desktop/js/apps/editor/components/aceEditor/autocomplete/AutocompleteResults.test.ts
@@ -362,6 +362,37 @@ describe('AutocompleteResults.ts', () => {
     expect(sourceMetaSpy).not.toHaveBeenCalled();
   });
 
+  it('should not fetch tables when there is no active database', async () => {
+    jest.spyOn(hueConfig, 'getLastKnownConfig').mockImplementation(
+      () =>
+        ({
+          app_config: {
+            editor: {
+              source_autocomplete_disabled: false
+            }
+          }
+        }) as HueConfig
+    );
+
+    const subject = createSubject();
+    subject.executor.database = (() => undefined) as unknown as Executor['database'];
+
+    const suggestions: Suggestion[] = [];
+    await subject.update(
+      {
+        lowerCase: false,
+        suggestTables: {}
+      } as AutocompleteParseResult,
+      suggestions
+    );
+
+    const tableFetches = sourceMetaSpy.mock.calls.filter(
+      ([options]) => options.entry.path.length === 1
+    );
+    expect(tableFetches).toHaveLength(0);
+    expect(suggestions).toHaveLength(0);
+  });
+
   it('should suggest columns for CTEs selecting all columns from a source table', async () => {
     mockSourceMetadata({
       foo: [

--- a/desktop/core/src/desktop/js/apps/editor/components/aceEditor/autocomplete/AutocompleteResults.ts
+++ b/desktop/core/src/desktop/js/apps/editor/components/aceEditor/autocomplete/AutocompleteResults.ts
@@ -667,6 +667,10 @@ class AutocompleteResults {
 
       const tableSuggestions: Suggestion[] = [];
 
+      if (!database) {
+        return tableSuggestions;
+      }
+
       try {
         const dbEntry = await new Promise<DataCatalogEntry>((resolve, reject) => {
           this.onCancelFunctions.push(reject);
@@ -1838,6 +1842,10 @@ class AutocompleteResults {
       suggestTables.identifierChain[0].name
         ? suggestTables.identifierChain[0].name
         : this.activeDatabase;
+
+    if (!db) {
+      return [];
+    }
 
     try {
       const entry = await new Promise<DataCatalogEntry>((resolve, reject) => {


### PR DESCRIPTION
Fixes #4364

When the editor has no active database (e.g. after typing a non-existing database name into the dropdown, `executor.database()` is `undefined`), autocomplete generated requests with an empty database segment: `POST /api/editor/autocomplete//`. The backend passed `database=""` to `get_tables_meta()`, and HiveServer2 treats an empty schema pattern as the match-all wildcard (`MetadataOperation.convertSchemaPattern()` turns it into `%`, sent to the Metastore as `*`) — resulting in a full `get_table_metas(*, *)` scan of the Hive Metastore on every keystroke. Full analysis in #4364.

This fixes it in two layers:

- **[editor]** `handleTables()` and `handlePopularTables()` now skip suggestions when no database is available instead of fetching with `path: [undefined]`.
- **[beeswax]** `_autocomplete()` returns an error response instead of scanning when tables are listed with an empty database name. The URL pattern `(?P<database>[^/?]*)` accepts an empty segment, so `""` bypassed the `database is None` check. This layer also protects the Metastore from stale frontend bundles or direct API calls. The check is scoped to the table-listing branch so that subquery autocomplete (the `source == 'query'` flow in the HiveServer2 connector, which intentionally passes `database=''` together with a `query`) keeps working.

An alternative considered for the backend was tightening the URL regex to `[^/?]+` (turning `//` into a 404). The explicit check in `_autocomplete()` was chosen instead so that every route sharing this function returns a clear error message.

Tests:
- jest: new case verifying no table fetch happens when there is no active database (`AutocompleteResults.test.ts`, 16 passed).
- pytest: new case verifying `_autocomplete(db, database="")` returns the error and `get_tables_meta` is not called (`apps/beeswax/src/beeswax/api_tests.py`).
