### PR TITLE
[editor] Show the source table name in the row details modal title

### DIFF
--- a/desktop/core/src/desktop/js/apps/editor/components/resultGrid/ko.resultGrid.js
+++ b/desktop/core/src/desktop/js/apps/editor/components/resultGrid/ko.resultGrid.js
@@ -33,6 +33,7 @@ import {
 } from 'apps/editor/events';
 
 import { attachTracker } from 'apps/editor/components/executableStateHandler';
+import { inferRowDetailsSourceNameFromExecutable } from 'jquery/plugins/rowDetailsSource';
 
 export const RESULT_GRID_COMPONENT = 'result-grid';
 
@@ -388,7 +389,11 @@ class ResultGrid extends DisposableComponent {
         fixedFirstColumn: !this.notebookMode(),
         parentId: $resultTable.parents('.snippet').attr('id'),
         clonedContainerPosition: this.notebookMode() ? 'absolute' : 'fixed',
-        app: 'editor'
+        app: 'editor',
+        rowDetailsSourceName: () =>
+          inferRowDetailsSourceNameFromExecutable(
+            this.activeExecutable && this.activeExecutable()
+          )
       };
       if (!this.notebookMode()) {
         $resultTable.parents('.dataTables_wrapper').css('overflow-x', 'hidden');

--- a/desktop/core/src/desktop/js/apps/editor/components/resultGrid/ko.simpleResultGrid.js
+++ b/desktop/core/src/desktop/js/apps/editor/components/resultGrid/ko.simpleResultGrid.js
@@ -33,6 +33,7 @@ import {
 } from 'apps/editor/events';
 import { trackResult } from 'apps/editor/components/executableStateHandler';
 import { ExecutionStatus } from 'apps/editor/execution/sqlExecutable';
+import { inferRowDetailsSourceNameFromExecutable } from 'jquery/plugins/rowDetailsSource';
 
 export const SIMPLE_RESULT_GRID_COMPONENT = 'simple-result-grid';
 
@@ -180,7 +181,11 @@ class SimpleResultGrid extends DisposableComponent {
         fixedFirstColumn: true,
         parentId: this.id,
         clonedContainerPosition: 'fixed',
-        app: 'editor'
+        app: 'editor',
+        rowDetailsSourceName: () =>
+          inferRowDetailsSourceNameFromExecutable(
+            this.activeExecutable && this.activeExecutable()
+          )
       };
       this.getWrapperElement().css('overflow-x', 'hidden');
       const bannerTopHeight = window.BANNER_TOP_HTML ? 30 : 2;

--- a/desktop/core/src/desktop/js/apps/notebook/app.js
+++ b/desktop/core/src/desktop/js/apps/notebook/app.js
@@ -31,12 +31,29 @@ import {
 import { registerHueWorkers } from 'sql/workers/hueWorkerHandler';
 import huePubSub from 'utils/huePubSub';
 import I18n from 'utils/i18n';
+import {
+  inferRowDetailsSourceName,
+  inferRowDetailsSourceNameFromExecutable
+} from 'jquery/plugins/rowDetailsSource';
 import bootstrapRatios from 'utils/html/bootstrapRatios';
 import scrollbarWidth from 'utils/screen/scrollbarWidth';
 import waitForRendered from 'utils/timing/waitForRendered';
 import { SHOW_LEFT_ASSIST_EVENT } from 'ko/components/assist/events';
 
 window.Clipboard = Clipboard;
+
+const rowDetailsSourceNameFromSnippet = snippet => () => {
+  const executable =
+    (snippet.activeExecutable && snippet.activeExecutable()) ||
+    (snippet.executor && snippet.executor.activeExecutable);
+  if (executable) {
+    return inferRowDetailsSourceNameFromExecutable(executable);
+  }
+  return inferRowDetailsSourceName({
+    database: snippet.database && snippet.database(),
+    statement: snippet.statement && snippet.statement()
+  });
+};
 
 const HUE_PUB_SUB_EDITOR_ID =
   window.location.pathname.indexOf('notebook') > -1 ? 'notebook' : 'editor';
@@ -132,7 +149,8 @@ huePubSub.subscribe('app.dom.loaded', app => {
             stickToTopPosition: 48 + bannerTopHeight,
             parentId: 'snippet_' + snippet.id(),
             clonedContainerPosition: 'fixed',
-            app: 'editor'
+            app: 'editor',
+            rowDetailsSourceName: rowDetailsSourceNameFromSnippet(snippet)
           });
           $(el).jHueHorizontalScrollbar();
         } else {
@@ -141,7 +159,8 @@ huePubSub.subscribe('app.dom.loaded', app => {
             fixedFirstColumn: vm.editorMode(),
             parentId: 'snippet_' + snippet.id(),
             clonedContainerPosition: 'absolute',
-            app: 'editor'
+            app: 'editor',
+            rowDetailsSourceName: rowDetailsSourceNameFromSnippet(snippet)
           });
         }
       }, 0);

--- a/desktop/core/src/desktop/js/jquery/plugins/jquery.tableextender.js
+++ b/desktop/core/src/desktop/js/jquery/plugins/jquery.tableextender.js
@@ -18,6 +18,7 @@ import $ from 'jquery';
 
 import huePubSub from 'utils/huePubSub';
 import I18n from 'utils/i18n';
+import { resolveRowDetailsSourceName } from './rowDetailsSource';
 
 /*
  * jHue table extender plugin
@@ -291,9 +292,14 @@ Plugin.prototype.init = function () {
   });
   $(document).on('dblclick', '.dataTables_wrapper > table tbody tr', function () {
     if (huePubSub) {
+      const $table = $(this).parents('table');
+      const extender =
+        $table.data('plugin_jHueTableExtender2') || $table.data('plugin_jHueTableExtender');
+      const sourceOption = extender && extender.options && extender.options.rowDetailsSourceName;
       huePubSub.publish('table.row.show.details', {
         idx: $(this).index(),
-        table: $(this).parents('table')
+        table: $table,
+        sourceName: resolveRowDetailsSourceName(sourceOption)
       });
     }
   });

--- a/desktop/core/src/desktop/js/jquery/plugins/jquery.tableextender2.js
+++ b/desktop/core/src/desktop/js/jquery/plugins/jquery.tableextender2.js
@@ -19,6 +19,7 @@ import $ from 'jquery';
 import deXSS from 'utils/html/deXSS';
 import huePubSub from 'utils/huePubSub';
 import I18n from 'utils/i18n';
+import { resolveRowDetailsSourceName } from './rowDetailsSource';
 
 const PLUGIN_NAME = 'jHueTableExtender2';
 
@@ -34,6 +35,7 @@ const DEFAULT_OPTIONS = {
   mainScrollable: window,
   app: null,
   stickToTopPosition: -1,
+  rowDetailsSourceName: undefined,
   labels: {
     GO_TO_COLUMN: 'Go to column:',
     PLACEHOLDER: 'column name...',
@@ -467,7 +469,11 @@ Plugin.prototype.drawFirstColumn = function (repositionHeader) {
         .addClass('fa fa-expand pointer muted')
         .prependTo(cell)
         .on('click', () => {
-          huePubSub.publish('table.row.show.details', { idx: idx, table: self.$element });
+          huePubSub.publish('table.row.show.details', {
+            idx: idx,
+            table: self.$element,
+            sourceName: resolveRowDetailsSourceName(self.options.rowDetailsSourceName)
+          });
         })
         .attr('title', self.options.labels.ROW_DETAILS);
     });

--- a/desktop/core/src/desktop/js/jquery/plugins/rowDetailsSource.js
+++ b/desktop/core/src/desktop/js/jquery/plugins/rowDetailsSource.js
@@ -1,0 +1,106 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import I18n from 'utils/i18n';
+
+const SKIP_TABLE_NAMES = new Set([
+  'select',
+  'where',
+  'join',
+  'inner',
+  'left',
+  'right',
+  'full',
+  'cross',
+  'outer',
+  'on',
+  'as',
+  'values'
+]);
+
+const TABLE_REF_RE =
+  /\b(?:FROM|JOIN)\s+(?:(?:`([^`]+)`|([A-Za-z_][\w$]*))\s*\.\s*)?(?:`([^`]+)`|([A-Za-z_][\w$]*))/gi;
+
+const trimToUndefined = value => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const trimmed = String(value).trim();
+  return trimmed ? trimmed : undefined;
+};
+
+export const formatRowDetailsTitle = sourceName => {
+  const trimmed = trimToUndefined(sourceName);
+  if (!trimmed) {
+    return I18n('Row details');
+  }
+  return I18n('Row details - %s', trimmed);
+};
+
+export const resolveRowDetailsSourceName = value => {
+  try {
+    if (typeof value === 'function') {
+      return trimToUndefined(value());
+    }
+    return trimToUndefined(value);
+  } catch (e) {
+    return undefined;
+  }
+};
+
+export const inferRowDetailsSourceName = ({ database, statement } = {}) => {
+  const tables = [];
+  const seen = new Set();
+  const db = trimToUndefined(database);
+
+  if (statement) {
+    TABLE_REF_RE.lastIndex = 0;
+    let match;
+    while ((match = TABLE_REF_RE.exec(statement)) !== null) {
+      const qualifier = trimToUndefined(match[1] || match[2]);
+      const name = trimToUndefined(match[3] || match[4]);
+      if (!name || SKIP_TABLE_NAMES.has(name.toLowerCase())) {
+        continue;
+      }
+      const qualified = qualifier ? `${qualifier}.${name}` : db ? `${db}.${name}` : name;
+      const key = qualified.toLowerCase();
+      if (!seen.has(key)) {
+        seen.add(key);
+        tables.push(qualified);
+      }
+    }
+  }
+
+  if (tables.length === 0) {
+    return db;
+  }
+  if (tables.length <= 3) {
+    return tables.join(', ');
+  }
+  return `${tables.slice(0, 3).join(', ')}...`;
+};
+
+export const inferRowDetailsSourceNameFromExecutable = executable => {
+  if (!executable) {
+    return undefined;
+  }
+  const statement =
+    (typeof executable.getRawStatement === 'function' && executable.getRawStatement()) ||
+    (executable.parsedStatement && executable.parsedStatement.statement);
+  const database =
+    typeof executable.database === 'function' ? executable.database() : executable.database;
+  return inferRowDetailsSourceName({ database, statement });
+};

--- a/desktop/core/src/desktop/js/jquery/plugins/rowDetailsSource.test.js
+++ b/desktop/core/src/desktop/js/jquery/plugins/rowDetailsSource.test.js
@@ -1,0 +1,101 @@
+// Licensed to Cloudera, Inc. under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Cloudera, Inc. licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  formatRowDetailsTitle,
+  inferRowDetailsSourceName,
+  resolveRowDetailsSourceName
+} from './rowDetailsSource';
+
+describe('formatRowDetailsTitle', () => {
+  it('uses the default title when source name is missing', () => {
+    expect(formatRowDetailsTitle()).toEqual('Row details');
+    expect(formatRowDetailsTitle('')).toEqual('Row details');
+    expect(formatRowDetailsTitle('   ')).toEqual('Row details');
+  });
+
+  it('appends the source name', () => {
+    expect(formatRowDetailsTitle('default.customers')).toEqual('Row details - default.customers');
+  });
+});
+
+describe('resolveRowDetailsSourceName', () => {
+  it('returns trimmed strings and getter results', () => {
+    expect(resolveRowDetailsSourceName('  t  ')).toEqual('t');
+    expect(resolveRowDetailsSourceName(() => 'customers')).toEqual('customers');
+  });
+
+  it('returns undefined for empty, throwing, or missing values', () => {
+    expect(resolveRowDetailsSourceName(undefined)).toBeUndefined();
+    expect(resolveRowDetailsSourceName(() => '')).toBeUndefined();
+    expect(
+      resolveRowDetailsSourceName(() => {
+        throw new Error('boom');
+      })
+    ).toBeUndefined();
+  });
+});
+
+describe('inferRowDetailsSourceName', () => {
+  it('returns a single qualified table from a simple select', () => {
+    expect(
+      inferRowDetailsSourceName({
+        database: 'default',
+        statement: 'SELECT * FROM customers'
+      })
+    ).toEqual('default.customers');
+  });
+
+  it('keeps already qualified names from the Impala editor repro', () => {
+    expect(
+      inferRowDetailsSourceName({
+        database: 'default',
+        statement: 'select * from database.table_name limit 1;'
+      })
+    ).toEqual('database.table_name');
+  });
+
+  it('joins multiple FROM/JOIN tables', () => {
+    expect(
+      inferRowDetailsSourceName({
+        database: 'default',
+        statement: 'SELECT * FROM customers c JOIN orders o ON c.id = o.cid'
+      })
+    ).toEqual('default.customers, default.orders');
+  });
+
+  it('skips subqueries after FROM (', () => {
+    expect(
+      inferRowDetailsSourceName({
+        database: 'default',
+        statement: 'SELECT * FROM (SELECT 1) t'
+      })
+    ).toEqual('default');
+  });
+
+  it('falls back to database when there is no table', () => {
+    expect(
+      inferRowDetailsSourceName({
+        database: 'default',
+        statement: 'SELECT 1'
+      })
+    ).toEqual('default');
+  });
+
+  it('returns undefined when nothing is known', () => {
+    expect(inferRowDetailsSourceName({})).toBeUndefined();
+  });
+});

--- a/desktop/core/src/desktop/templates/common_header_footer_components.mako
+++ b/desktop/core/src/desktop/templates/common_header_footer_components.mako
@@ -278,6 +278,15 @@ else:
     var multiLineHandlers = [];
 
     huePubSub.subscribe('table.row.show.details', function (data) {
+      var defaultTitle = '${ _("Row details") }';
+      var titled = '${ _("Row details - %s") }';
+      var sourceName = data && data.sourceName ? String(data.sourceName).trim() : '';
+      var $title = $('#rowDetailsModal .modal-title');
+      if (sourceName) {
+        $title.text(titled.replace('%s', sourceName));
+      } else {
+        $title.text(defaultTitle);
+      }
       var $el = $(data.table);
       var $t = $('#rowDetailsModal').find('table');
       $t.html('');
@@ -316,6 +325,7 @@ else:
     });
 
     $('#rowDetailsModal').on('hidden', function () {
+      $('#rowDetailsModal .modal-title').text('${ _("Row details") }');
       multiLineHandlers.forEach(function (multiLineEllipsisHandler) {
         multiLineEllipsisHandler.dispose();
       });

--- a/desktop/core/src/desktop/templates/global_js_constants.mako
+++ b/desktop/core/src/desktop/templates/global_js_constants.mako
@@ -666,6 +666,8 @@
     'Show in Assist...': '${_('Show in Assist...')}',
     'Show more...': '${_('Show more...')}',
     'Show row details': '${_('Show row details')}',
+    'Row details': '${_('Row details')}',
+    'Row details - %s': '${_('Row details - %s')}',
     'Show sample': '${_('Show sample')}',
     'Show view SQL': '${_('Show view SQL')}',
     'Sidebar for navigation': '${_('Sidebar for navigation')}',


### PR DESCRIPTION
## What changes were proposed in this pull request?

 -  Adds the source table name next to the Row details modal title so it is easier to tell which table a result row belongs to ([#4262](https://github.com/cloudera/hue/issues/4262)).
-  On Editor result grids (Hive, Impala, and other SQL snippets), infers a display label from FROM / JOIN in the executed statement (for example select * from database.table_name limit 1; → Row details - database.table_name). Unqualified tables are prefixed with the selected database. If no table is found, the current database is used; if nothing is known, the title stays Row details.
-  Title copy is i18n’d (Row details / Row details - %s). The table name is set with .text() so it is not treated as HTM

## How was this patch tested?
- Unit tests in desktop/core/src/desktop/js/jquery/plugins/rowDetailsSource.test.js (simple SELECT, qualified database.table_name, joins, subquery FROM (, database fallback).
- Manual testing (In Progress)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
